### PR TITLE
Refactor call ABI: direct/indirect calls and frame-local setup

### DIFF
--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -149,6 +149,9 @@ struct StackifyCodegen<'ctx, 'obj> {
     /// Maps MIR Local -> stack slot index (only for Real locals).
     local_slots: HashMap<Local, usize>,
 
+    /// Number of extra local slots required for this function frame.
+    real_local_count: usize,
+
     /// Maps `BlockId` -> bytecode instruction index (for jump patching).
     block_addresses: HashMap<BlockId, usize>,
 
@@ -194,6 +197,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             objects: ctx.objects,
             analysis,
             local_slots: HashMap::new(),
+            real_local_count: 0,
             block_addresses: HashMap::new(),
             pending_jumps: Vec::new(),
             pending_jump_tables: Vec::new(),
@@ -299,6 +303,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         Function {
             name: mir.name.to_string(),
             arity: mir.arity,
+            real_local_count: self.real_local_count,
             bytecode: self.bytecode,
             kind: FunctionKind::Bytecode,
             locals_in_scope: Self::build_locals_in_scope(mir, &self.local_slots),
@@ -334,6 +339,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
     /// Virtual locals don't get slots - they're inlined at use sites.
     fn allocate_real_locals(&mut self, mir: &MirFunction) {
         self.local_slots.clear();
+        self.real_local_count = 0;
         let arity = mir.arity;
 
         // Count how many real locals we need to pre-allocate
@@ -366,10 +372,8 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             }
         }
 
-        // Pre-allocate only the real locals (not virtuals)
-        if slots_to_allocate > 0 {
-            self.emit(Instruction::InitLocals(slots_to_allocate));
-        }
+        // VM pre-allocates these slots when entering the frame.
+        self.real_local_count = slots_to_allocate;
     }
 
     /// Get current program counter (next instruction index).
@@ -760,8 +764,23 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 target,
                 unwind: _,
             } => {
-                unwrap_infallible(pull_semantics::walk_invoke_operands(self, callee, args));
-                self.emit(Instruction::Call(args.len()));
+                let global_callee = pull_semantics::resolve_constant_function_name(
+                    callee,
+                    &self.analysis.classifications,
+                    &self.analysis.def_use,
+                )
+                .and_then(|name| self.globals.get(&name).copied())
+                .map(GlobalIndex::from_raw);
+
+                if let Some(global_callee) = global_callee {
+                    unwrap_infallible(pull_semantics::walk_call_direct_args(self, args));
+                    self.emit(Instruction::Call(global_callee));
+                } else {
+                    unwrap_infallible(pull_semantics::walk_call_indirect_operands(
+                        self, callee, args,
+                    ));
+                    self.emit(Instruction::CallIndirect);
+                }
                 self.emit_store_place(destination);
                 self.emit_jump_unless_fallthrough(*target);
             }
@@ -1271,9 +1290,8 @@ impl PullSink for StackifyCodegen<'_, '_> {
             .get("baml.Array.length")
             .copied()
             .unwrap_or_else(|| panic!("undefined function: baml.Array.length"));
-        self.emit(Instruction::LoadGlobal(GlobalIndex::from_raw(global_idx)));
         pull_semantics::walk_place_pull(self, place)?;
-        self.emit(Instruction::Call(1));
+        self.emit(Instruction::Call(GlobalIndex::from_raw(global_idx)));
         Ok(())
     }
 

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -353,6 +353,7 @@ pub fn compile_files(
         let builtin_fn = Function {
             name: builtin.path.to_string(),
             arity: builtin.arity(),
+            real_local_count: 0,
             bytecode: Bytecode::default(),
             kind,
             locals_in_scope: Vec::new(),
@@ -409,6 +410,7 @@ pub fn compile_files(
                         Function {
                             name: signature.name.to_string(),
                             arity: params.len(),
+                            real_local_count: 0,
                             bytecode: Bytecode::new(),
                             kind: FunctionKind::Bytecode,
                             locals_in_scope: vec![

--- a/baml_language/crates/baml_compiler_emit/src/pull_semantics.rs
+++ b/baml_language/crates/baml_compiler_emit/src/pull_semantics.rs
@@ -6,12 +6,14 @@
 //!
 //! Keeping a single traversal avoids semantic drift between emitter and analysis.
 
+use std::collections::{HashMap, HashSet};
+
 use baml_compiler_mir::{
     AggregateKind, BinOp, Constant, IndexKind, Local, Operand, Place, Rvalue, UnaryOp,
 };
 use baml_type::Ty;
 
-use crate::analysis::LocalClassification;
+use crate::analysis::{LocalClassification, LocalDefUse};
 
 /// What to do when pulling a local.
 pub(crate) enum LocalPullAction {
@@ -172,7 +174,9 @@ pub(crate) fn walk_assert_statement<S: StackEffectSink>(
     sink.assert_top()
 }
 
-/// Shared pull order for call-like terminators: `callee`, then each arg.
+/// Shared pull order for call-like terminators that consume `[callee, args...]`.
+///
+/// This remains the order used by `DispatchFuture`.
 pub(crate) fn walk_invoke_operands<S: PullSink>(
     sink: &mut S,
     callee: &Operand,
@@ -183,6 +187,90 @@ pub(crate) fn walk_invoke_operands<S: PullSink>(
         walk_operand_pull(sink, arg)?;
     }
     Ok(())
+}
+
+/// Shared pull order for direct calls: each arg only.
+pub(crate) fn walk_call_direct_args<S: PullSink>(
+    sink: &mut S,
+    args: &[Operand],
+) -> Result<(), S::Error> {
+    for arg in args {
+        walk_operand_pull(sink, arg)?;
+    }
+    Ok(())
+}
+
+/// Shared pull order for indirect calls: `args..., callee`.
+pub(crate) fn walk_call_indirect_operands<S: PullSink>(
+    sink: &mut S,
+    callee: &Operand,
+    args: &[Operand],
+) -> Result<(), S::Error> {
+    walk_call_direct_args(sink, args)?;
+    walk_operand_pull(sink, callee)
+}
+
+/// Resolve a call operand to a statically-known function name through
+/// `Virtual`/`CopyOf` forwarding chains.
+pub(crate) fn resolve_constant_function_name(
+    operand: &Operand,
+    classifications: &HashMap<Local, LocalClassification>,
+    def_use: &HashMap<Local, LocalDefUse>,
+) -> Option<String> {
+    resolve_constant_function_name_inner(operand, classifications, def_use, &mut HashSet::new())
+}
+
+fn resolve_constant_function_name_inner(
+    operand: &Operand,
+    classifications: &HashMap<Local, LocalClassification>,
+    def_use: &HashMap<Local, LocalDefUse>,
+    visited_locals: &mut HashSet<Local>,
+) -> Option<String> {
+    match operand {
+        Operand::Constant(Constant::Function(qn)) => Some(qn.to_runtime_string()),
+        Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local)) => {
+            if !visited_locals.insert(*local) {
+                return None;
+            }
+
+            match classifications.get(local).copied() {
+                Some(LocalClassification::Virtual) => {
+                    let def = def_use.get(local).and_then(|du| du.def.as_ref())?;
+                    let Rvalue::Use(inner) = &def.rvalue else {
+                        return None;
+                    };
+                    resolve_constant_function_name_inner(
+                        inner,
+                        classifications,
+                        def_use,
+                        visited_locals,
+                    )
+                }
+                Some(LocalClassification::CopyOf) => {
+                    let def = def_use.get(local).and_then(|du| du.def.as_ref())?;
+                    let Rvalue::Use(copy_operand) = &def.rvalue else {
+                        return None;
+                    };
+                    let source = match copy_operand {
+                        Operand::Copy(Place::Local(source))
+                        | Operand::Move(Place::Local(source)) => *source,
+                        _ => return None,
+                    };
+                    if source == *local {
+                        return None;
+                    }
+                    resolve_constant_function_name_inner(
+                        &Operand::copy_local(source),
+                        classifications,
+                        def_use,
+                        visited_locals,
+                    )
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 /// Shared pull for `Return` value place (`_0`).

--- a/baml_language/crates/baml_compiler_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler_emit/src/stack_carry.rs
@@ -435,18 +435,35 @@ fn simulate_terminator_stack(
             destination,
             ..
         } => {
-            let mut sink = StackCarryPullSink {
-                sim,
-                carried_local,
-                classifications,
-                def_use,
-            };
-            if pull_semantics::walk_invoke_operands(&mut sink, callee, args).is_err() {
-                return false;
-            }
-
-            if !sim.pop_n(args.len() + 1) {
-                return false;
+            let direct_call =
+                pull_semantics::resolve_constant_function_name(callee, classifications, def_use)
+                    .is_some();
+            if direct_call {
+                let mut sink = StackCarryPullSink {
+                    sim,
+                    carried_local,
+                    classifications,
+                    def_use,
+                };
+                if pull_semantics::walk_call_direct_args(&mut sink, args).is_err() {
+                    return false;
+                }
+                if !sim.pop_n(args.len()) {
+                    return false;
+                }
+            } else {
+                let mut sink = StackCarryPullSink {
+                    sim,
+                    carried_local,
+                    classifications,
+                    def_use,
+                };
+                if pull_semantics::walk_call_indirect_operands(&mut sink, callee, args).is_err() {
+                    return false;
+                }
+                if !sim.pop_n(args.len() + 1) {
+                    return false;
+                }
             }
             sim.push();
             simulate_store_place_stack(destination, sim, classifications)
@@ -693,10 +710,9 @@ impl PullSink for StackCarryPullSink<'_> {
     }
 
     fn len_of_place(&mut self, place: &Place) -> Result<(), Self::Error> {
-        // Emitter lowers Len as: LoadGlobal(length), <place>, Call(1).
-        self.sim.push(); // LoadGlobal pushes callee.
+        // Emitter lowers Len as: <place>, Call(length, 1).
         pull_semantics::walk_place_pull(self, place)?;
-        if !self.sim.pop_n(2) {
+        if !self.sim.pop_n(1) {
             return Err(());
         }
         self.sim.push();

--- a/baml_language/crates/baml_compiler_emit/tests/analysis_soundness.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/analysis_soundness.rs
@@ -21,7 +21,6 @@ fn virtual_cross_block_soundness_codegen() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::InitLocals(2),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("a".to_string()),
                 Instruction::LoadVar("a".to_string()),
@@ -52,7 +51,6 @@ fn virtual_cross_block_param_mutation_soundness_codegen() -> anyhow::Result<()> 
         expected: vec![(
             "main",
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadVar("p".to_string()),
                 Instruction::StoreVar("x".to_string()),
                 Instruction::LoadVar("c".to_string()),
@@ -79,7 +77,6 @@ fn copy_of_mutable_param_soundness_codegen() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadVar("x".to_string()),
                 Instruction::StoreVar("y".to_string()),
                 Instruction::LoadConst(Value::Int(2)),
@@ -107,7 +104,6 @@ fn virtual_cross_block_transitive_param_mutation_soundness_codegen() -> anyhow::
         expected: vec![(
             "main",
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadVar("p".to_string()),
                 Instruction::StoreVar("x".to_string()),
                 Instruction::LoadVar("c".to_string()),
@@ -149,9 +145,7 @@ fn virtual_multiple_defs_preserve_side_effects_codegen() -> anyhow::Result<()> {
             (
                 "main",
                 vec![
-                    Instruction::InitLocals(1),
-                    Instruction::LoadGlobal(Value::function("fail")),
-                    Instruction::Call(0),
+                    Instruction::Call("fail".to_string()),
                     Instruction::StoreVar("x".to_string()),
                     Instruction::LoadConst(Value::Int(2)),
                     Instruction::StoreVar("x".to_string()),

--- a/baml_language/crates/baml_compiler_emit/tests/builtins.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/builtins.rs
@@ -20,12 +20,11 @@ fn builtin_method_call() -> anyhow::Result<()> {
             // Method call arr.length() desugars to baml.Array.length(arr).
             // ReturnPhi: call result stays on stack for return.
             vec![
-                Instruction::LoadGlobal(Value::function("baml.Array.length")),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::LoadConst(Value::Int(2)),
                 Instruction::LoadConst(Value::Int(3)),
                 Instruction::AllocArray(3),
-                Instruction::Call(1),
+                Instruction::Call("baml.Array.length".to_string()),
                 Instruction::Return,
             ],
         )],

--- a/baml_language/crates/baml_compiler_emit/tests/classes.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/classes.rs
@@ -93,9 +93,7 @@ fn class_constructor_with_spread_operator() -> anyhow::Result<()> {
             // All fields come from the spread (last assignment wins).
             // Spread is stored to temp local, then accessed for each field.
             vec![
-                Instruction::InitLocals(1),
-                Instruction::LoadGlobal(Value::function("default_point")),
-                Instruction::Call(0),
+                Instruction::Call("default_point".to_string()),
                 Instruction::StoreVar("_2".to_string()),
                 Instruction::AllocInstance(Value::class("Point")),
                 Instruction::Copy(0),
@@ -141,7 +139,6 @@ fn nested_class_construction() -> anyhow::Result<()> {
             // Stackification with fall-through elimination:
             // o is assigned but never read (dead store)
             vec![
-                Instruction::InitLocals(1),
                 Instruction::AllocInstance(Value::class("Outer")),
                 Instruction::Copy(0),
                 Instruction::AllocInstance(Value::class("Inner")),
@@ -183,7 +180,6 @@ fn nested_class_with_multiple_fields() -> anyhow::Result<()> {
             // Stackification with fall-through elimination:
             // o is assigned but never read (dead store)
             vec![
-                Instruction::InitLocals(1),
                 Instruction::AllocInstance(Value::class("Outer")),
                 Instruction::Copy(0),
                 Instruction::AllocInstance(Value::class("Inner")),
@@ -298,9 +294,7 @@ fn class_constructor_with_spread_before_named_fields() -> anyhow::Result<()> {
             // Spread is at position 0, named fields x,y at positions 1,2.
             // x and y from named (override spread), z and w from spread.
             vec![
-                Instruction::InitLocals(1),
-                Instruction::LoadGlobal(Value::function("default_point")),
-                Instruction::Call(0),
+                Instruction::Call("default_point".to_string()),
                 Instruction::StoreVar("_2".to_string()),
                 Instruction::AllocInstance(Value::class("Point")),
                 Instruction::Copy(0),
@@ -348,9 +342,7 @@ fn class_constructor_with_spread_after_named_fields() -> anyhow::Result<()> {
             // Spread at position 2 overrides named fields at positions 0,1.
             // All fields from spread.
             vec![
-                Instruction::InitLocals(1),
-                Instruction::LoadGlobal(Value::function("default_point")),
-                Instruction::Call(0),
+                Instruction::Call("default_point".to_string()),
                 Instruction::StoreVar("_2".to_string()),
                 Instruction::AllocInstance(Value::class("Point")),
                 Instruction::Copy(0),
@@ -410,12 +402,9 @@ fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
                 // ...x_one() at pos 0, ...xy_one() at pos 1
                 // xy_one wins for all fields; x_one called but result popped (unused)
                 vec![
-                    Instruction::InitLocals(1),
-                    Instruction::LoadGlobal(Value::function("x_one")),
-                    Instruction::Call(0),
+                    Instruction::Call("x_one".to_string()),
                     Instruction::Pop(1),
-                    Instruction::LoadGlobal(Value::function("xy_one")),
-                    Instruction::Call(0),
+                    Instruction::Call("xy_one".to_string()),
                     Instruction::StoreVar("_4".to_string()),
                     Instruction::AllocInstance(Value::class("Point")),
                     Instruction::Copy(0),
@@ -442,12 +431,9 @@ fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
                 // ...xy_one() at pos 0, ...x_one() at pos 1
                 // x_one wins for all fields; xy_one called but result popped (unused)
                 vec![
-                    Instruction::InitLocals(1),
-                    Instruction::LoadGlobal(Value::function("xy_one")),
-                    Instruction::Call(0),
+                    Instruction::Call("xy_one".to_string()),
                     Instruction::Pop(1),
-                    Instruction::LoadGlobal(Value::function("x_one")),
-                    Instruction::Call(0),
+                    Instruction::Call("x_one".to_string()),
                     Instruction::StoreVar("_4".to_string()),
                     Instruction::AllocInstance(Value::class("Point")),
                     Instruction::Copy(0),
@@ -500,9 +486,7 @@ fn class_constructor_with_spread_operator_does_not_break_locals() -> anyhow::Res
             // 'p' is assigned but never used (dead store, but still generated).
             // 'x' is a constant, inlined.
             vec![
-                Instruction::InitLocals(2),
-                Instruction::LoadGlobal(Value::function("default_point")),
-                Instruction::Call(0),
+                Instruction::Call("default_point".to_string()),
                 Instruction::StoreVar("_2".to_string()),
                 Instruction::AllocInstance(Value::class("Point")),
                 Instruction::Copy(0),

--- a/baml_language/crates/baml_compiler_emit/tests/for_loops.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/for_loops.rs
@@ -31,14 +31,12 @@ fn for_loop_sum() -> anyhow::Result<()> {
             // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
                 // Pre-allocate locals (4: result, _len, _i, x)
-                Instruction::InitLocals(4),
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
                 // _len = baml.Array.length(xs) - using param directly
-                Instruction::LoadGlobal(Value::function("baml.Array.length")),
                 Instruction::LoadVar("xs".to_string()),
-                Instruction::Call(1),
+                Instruction::Call("baml.Array.length".to_string()),
                 Instruction::StoreVar("_len".to_string()),
                 // _i = 0
                 Instruction::LoadConst(Value::Int(0)),
@@ -97,14 +95,12 @@ fn for_with_break() -> anyhow::Result<()> {
             // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
                 // Pre-allocate locals (4: result, _len, _i, x)
-                Instruction::InitLocals(4),
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
                 // _len = baml.Array.length(xs) - using param directly
-                Instruction::LoadGlobal(Value::function("baml.Array.length")),
                 Instruction::LoadVar("xs".to_string()),
-                Instruction::Call(1),
+                Instruction::Call("baml.Array.length".to_string()),
                 Instruction::StoreVar("_len".to_string()),
                 // _i = 0
                 Instruction::LoadConst(Value::Int(0)),
@@ -169,14 +165,12 @@ fn for_with_continue() -> anyhow::Result<()> {
             // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
                 // Pre-allocate locals (4: result, _len, _i, x)
-                Instruction::InitLocals(4),
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
                 // _len = baml.Array.length(xs) - using param directly
-                Instruction::LoadGlobal(Value::function("baml.Array.length")),
                 Instruction::LoadVar("xs".to_string()),
-                Instruction::Call(1),
+                Instruction::Call("baml.Array.length".to_string()),
                 Instruction::StoreVar("_len".to_string()),
                 // _i = 0
                 Instruction::LoadConst(Value::Int(0)),
@@ -244,14 +238,12 @@ fn for_nested() -> anyhow::Result<()> {
             // Note: _iter and _iter1 are eliminated by copy propagation (use params directly)
             vec![
                 // Pre-allocate locals (7: result, _len, _i, a, _len1, _i1, b)
-                Instruction::InitLocals(7),
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
                 // _len = baml.Array.length(as) - using param directly
-                Instruction::LoadGlobal(Value::function("baml.Array.length")),
                 Instruction::LoadVar("as".to_string()),
-                Instruction::Call(1),
+                Instruction::Call("baml.Array.length".to_string()),
                 Instruction::StoreVar("_len".to_string()),
                 // _i = 0
                 Instruction::LoadConst(Value::Int(0)),
@@ -276,9 +268,8 @@ fn for_nested() -> anyhow::Result<()> {
                 Instruction::BinOp(BinOp::Add),
                 Instruction::StoreVar("_i".to_string()),
                 // _len1 = baml.Array.length(bs) - using param directly
-                Instruction::LoadGlobal(Value::function("baml.Array.length")),
                 Instruction::LoadVar("bs".to_string()),
-                Instruction::Call(1),
+                Instruction::Call("baml.Array.length".to_string()),
                 Instruction::StoreVar("_len1".to_string()),
                 // _i1 = 0
                 Instruction::LoadConst(Value::Int(0)),
@@ -287,7 +278,7 @@ fn for_nested() -> anyhow::Result<()> {
                 Instruction::LoadVar("_i1".to_string()),
                 Instruction::LoadVar("_len1".to_string()),
                 Instruction::CmpOp(CmpOp::Lt),
-                Instruction::PopJumpIfFalse(-24),
+                Instruction::PopJumpIfFalse(-23),
                 // Inner loop body: b = bs[_i1] - using param directly
                 Instruction::LoadVar("bs".to_string()),
                 Instruction::LoadVar("_i1".to_string()),

--- a/baml_language/crates/baml_compiler_emit/tests/functions.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/functions.rs
@@ -79,11 +79,7 @@ fn return_function_call() -> anyhow::Result<()> {
             (
                 "main",
                 // ReturnPhi optimization: Call result goes directly to stack, no Store/Load
-                vec![
-                    Instruction::LoadGlobal(Value::function("one")),
-                    Instruction::Call(0),
-                    Instruction::Return,
-                ],
+                vec![Instruction::Call("one".to_string()), Instruction::Return],
             ),
         ],
     })
@@ -112,11 +108,7 @@ fn call_function_assign_to_variable() -> anyhow::Result<()> {
                 "main",
                 // CallResultImmediate optimization: Call result stays on stack,
                 // used immediately as return value (no Store/Load)
-                vec![
-                    Instruction::LoadGlobal(Value::function("two")),
-                    Instruction::Call(0),
-                    Instruction::Return,
-                ],
+                vec![Instruction::Call("two".to_string()), Instruction::Return],
             ),
         ],
     })
@@ -145,7 +137,6 @@ fn mutable_variables() -> anyhow::Result<()> {
                 "DeclareMutableInFunction",
                 // Multi-def locals are kept real (not virtualized)
                 vec![
-                    Instruction::InitLocals(1),
                     Instruction::LoadConst(Value::Int(3)),
                     Instruction::StoreVar("y".to_string()),
                     Instruction::LoadConst(Value::Int(5)),

--- a/baml_language/crates/baml_compiler_emit/tests/if_else.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/if_else.rs
@@ -313,9 +313,8 @@ fn if_else_with_function_call_in_branch() -> anyhow::Result<()> {
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(3),
                 Instruction::LoadConst(Value::Int(0)),
-                Instruction::Jump(3),
-                Instruction::LoadGlobal(Value::function("get_value")),
-                Instruction::Call(0),
+                Instruction::Jump(2),
+                Instruction::Call("get_value".to_string()),
                 Instruction::Return,
             ],
         )],
@@ -425,7 +424,6 @@ fn if_else_in_arithmetic() -> anyhow::Result<()> {
             // RHS if-expression is materialized into a local because binary-op pull order
             // would otherwise consume the left operand first.
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(4),
@@ -455,20 +453,15 @@ fn if_else_as_function_arg() -> anyhow::Result<()> {
         ",
         expected: vec![(
             "main",
-            // If-expression result is materialized into a local before the call argument pull.
+            // If-expression result is kept on stack and consumed directly by call arg pull.
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Bool(false)),
                 Instruction::PopJumpIfFalse(2),
-                Instruction::Jump(4),
-                Instruction::LoadConst(Value::Int(20)),
-                Instruction::StoreVar("_2".to_string()),
                 Instruction::Jump(3),
+                Instruction::LoadConst(Value::Int(20)),
+                Instruction::Jump(2),
                 Instruction::LoadConst(Value::Int(10)),
-                Instruction::StoreVar("_2".to_string()),
-                Instruction::LoadGlobal(Value::function("identity")),
-                Instruction::LoadVar("_2".to_string()),
-                Instruction::Call(1),
+                Instruction::Call("identity".to_string()),
                 Instruction::Return,
             ],
         )],
@@ -488,20 +481,15 @@ fn if_else_assigned_then_passed_to_call() -> anyhow::Result<()> {
         ",
         expected: vec![(
             "main",
-            // tmp is a real local and is loaded for the call.
+            // tmp is optimized away here: the if-expression result is consumed directly.
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Bool(false)),
                 Instruction::PopJumpIfFalse(2),
-                Instruction::Jump(4),
-                Instruction::LoadConst(Value::Int(20)),
-                Instruction::StoreVar("tmp".to_string()),
                 Instruction::Jump(3),
+                Instruction::LoadConst(Value::Int(20)),
+                Instruction::Jump(2),
                 Instruction::LoadConst(Value::Int(10)),
-                Instruction::StoreVar("tmp".to_string()),
-                Instruction::LoadGlobal(Value::function("identity")),
-                Instruction::LoadVar("tmp".to_string()),
-                Instruction::Call(1),
+                Instruction::Call("identity".to_string()),
                 Instruction::Return,
             ],
         )],
@@ -521,7 +509,6 @@ fn parenthesized_if_else_in_arithmetic() -> anyhow::Result<()> {
             "main",
             // Both if-expression results are materialized to preserve pull order in binary-op.
             vec![
-                Instruction::InitLocals(2),
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(4),
@@ -559,7 +546,6 @@ fn chained_if_else_in_arithmetic() -> anyhow::Result<()> {
             "main",
             // Both if-expression results are materialized to preserve pull order in binary-op.
             vec![
-                Instruction::InitLocals(2),
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(4),
@@ -631,7 +617,6 @@ fn if_without_else_statement() -> anyhow::Result<()> {
             // Stackification with fall-through elimination:
             // if-without-else is void - no temporary needed
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("x".to_string()),
                 Instruction::LoadConst(Value::Bool(true)),
@@ -663,7 +648,6 @@ fn if_without_else_with_local_var() -> anyhow::Result<()> {
             "main",
             // 'result' is Virtual (single-use, inlined as 0). 'temp' is Real (assigned but unused):
             vec![
-                Instruction::InitLocals(1), // Pre-allocate for 'temp'
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(3),
                 Instruction::LoadConst(Value::Int(10)),
@@ -718,7 +702,6 @@ fn consecutive_if_without_else() -> anyhow::Result<()> {
             // Stackification with fall-through elimination:
             // Both if-without-else are void - no temporaries needed
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("x".to_string()),
                 Instruction::LoadConst(Value::Bool(true)),
@@ -828,25 +811,22 @@ fn if_else_normal_statement() -> anyhow::Result<()> {
             // Only unused user-named variables (x in else, y in then) need slots
             vec![
                 // Pre-allocate 2 slots for unused user-named variables
-                Instruction::InitLocals(2),
                 // Check condition b
                 Instruction::LoadVar("b".to_string()),
                 Instruction::PopJumpIfFalse(2),
-                Instruction::Jump(8),
+                Instruction::Jump(7),
                 // Else branch: x = 3 (unused, stored), identity(4) (y inlined)
                 Instruction::LoadConst(Value::Int(3)),
                 Instruction::StoreVar("x".to_string()),
-                Instruction::LoadGlobal(Value::function("identity")),
                 Instruction::LoadConst(Value::Int(4)), // y inlined
-                Instruction::Call(1),
+                Instruction::Call("identity".to_string()),
                 Instruction::Pop(1), // discard unused call result
-                Instruction::Jump(7),
+                Instruction::Jump(6),
                 // Then branch: y = 2 (unused, stored), identity(1) (x inlined)
                 Instruction::LoadConst(Value::Int(2)),
                 Instruction::StoreVar("y".to_string()),
-                Instruction::LoadGlobal(Value::function("identity")),
                 Instruction::LoadConst(Value::Int(1)), // x inlined
-                Instruction::Call(1),
+                Instruction::Call("identity".to_string()),
                 Instruction::Pop(1), // discard unused call result
                 // Return a (inlined as 1)
                 Instruction::LoadConst(Value::Int(1)),
@@ -916,7 +896,6 @@ fn else_if_assignment() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate result
-                Instruction::InitLocals(1),
                 // Check condition a
                 Instruction::LoadVar("a".to_string()),
                 Instruction::PopJumpIfFalse(2),
@@ -969,7 +948,6 @@ fn else_if_assignment_with_locals() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate result
-                Instruction::InitLocals(1),
                 // Check condition a
                 Instruction::LoadVar("a".to_string()),
                 Instruction::PopJumpIfFalse(2),
@@ -1023,7 +1001,6 @@ fn nested_block_expr_with_ending_normal_if() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate a
-                Instruction::InitLocals(1),
                 // a = 1
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("a".to_string()),

--- a/baml_language/crates/baml_compiler_emit/tests/maps.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/maps.rs
@@ -34,8 +34,7 @@ fn create_and_access() -> anyhow::Result<()> {
                 // CallResultImmediate optimization: Call result stays on stack,
                 // used immediately for map access (no Store/Load)
                 vec![
-                    Instruction::LoadGlobal(Value::function("CreateMap")),
-                    Instruction::Call(0),
+                    Instruction::Call("CreateMap".to_string()),
                     Instruction::LoadConst(Value::string("hello")),
                     Instruction::LoadMapElement,
                     Instruction::Return,
@@ -73,8 +72,7 @@ fn access_no_key() -> anyhow::Result<()> {
                 // CallResultImmediate optimization: Call result stays on stack,
                 // used immediately for map access (no Store/Load)
                 vec![
-                    Instruction::LoadGlobal(Value::function("CreateMap")),
-                    Instruction::Call(0),
+                    Instruction::Call("CreateMap".to_string()),
                     Instruction::LoadConst(Value::string("world")),
                     Instruction::LoadMapElement,
                     Instruction::Return,
@@ -114,16 +112,13 @@ fn contains() -> anyhow::Result<()> {
                 "UseMapContains",
                 vec![
                     // Init local for map (return value is PhiLike, _3 is CallResultImmediate)
-                    Instruction::InitLocals(1),
                     // let map = CreateMapJSON();
-                    Instruction::LoadGlobal(Value::function("CreateMapJSON")),
-                    Instruction::Call(0),
+                    Instruction::Call("CreateMapJSON".to_string()),
                     Instruction::StoreVar("map".to_string()),
                     // map.has("hello") - method call, result stays on stack (CallResultImmediate)
-                    Instruction::LoadGlobal(Value::function("baml.Map.has")),
                     Instruction::LoadVar("map".to_string()),
                     Instruction::LoadConst(Value::string("hello")),
-                    Instruction::Call(2),
+                    Instruction::Call("baml.Map.has".to_string()),
                     // if condition - Call result used directly from stack
                     Instruction::PopJumpIfFalse(2),
                     Instruction::Jump(3),
@@ -159,7 +154,6 @@ fn modify() -> anyhow::Result<()> {
             "EditMapKey",
             vec![
                 // Init local for map (return value is ReturnPhi, no slot needed)
-                Instruction::InitLocals(1),
                 // let map = { "hi": 123 }; (values first, then keys)
                 Instruction::LoadConst(Value::Int(123)),
                 Instruction::LoadConst(Value::string("hi")),
@@ -207,7 +201,6 @@ fn len() -> anyhow::Result<()> {
             "Len",
             vec![
                 // Method call on map literal
-                Instruction::LoadGlobal(Value::function("baml.Map.length")),
                 // Map literal: values first, then keys
                 // { "hi": 123, "it_works": 456 }
                 Instruction::LoadConst(Value::Int(123)),
@@ -215,7 +208,7 @@ fn len() -> anyhow::Result<()> {
                 Instruction::LoadConst(Value::string("hi")),
                 Instruction::LoadConst(Value::string("it_works")),
                 Instruction::AllocMap(2),
-                Instruction::Call(1),
+                Instruction::Call("baml.Map.length".to_string()),
                 Instruction::Return,
             ],
         )],

--- a/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
@@ -129,7 +129,6 @@ fn match_typed_pattern_single_class() -> anyhow::Result<()> {
             // Wildcard elimination: _ binding is unused so eliminated
             // Scrutinee optimization: result is reused directly (no temp created)
             vec![
-                Instruction::InitLocals(1), // slot for result
                 // let result = Success { data: "hello" }
                 Instruction::AllocInstance(Value::class("Success")),
                 Instruction::Copy(0),
@@ -170,7 +169,6 @@ fn match_typed_pattern_two_classes() -> anyhow::Result<()> {
             // because else_block is unreachable (we know it must be Failure)
             // Scrutinee optimization: result is reused directly (no temp created)
             vec![
-                Instruction::InitLocals(1), // slot for result
                 // let result = Success { data: "ok" }
                 Instruction::AllocInstance(Value::class("Success")),
                 Instruction::Copy(0),
@@ -2157,8 +2155,7 @@ fn match_function_call_scrutinee() -> anyhow::Result<()> {
                 // Function call result stays on stack
                 vec![
                     // Call helper() - result stays on stack
-                    Instruction::LoadGlobal(Value::function("helper")),
-                    Instruction::Call(0),
+                    Instruction::Call("helper".to_string()),
                     // First arm: 42
                     Instruction::Copy(0),
                     Instruction::LoadConst(Value::Int(42)),

--- a/baml_language/crates/baml_compiler_emit/tests/operators.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/operators.rs
@@ -26,9 +26,8 @@ fn basic_and() -> anyhow::Result<()> {
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(3),
                 Instruction::LoadConst(Value::Bool(false)),
-                Instruction::Jump(3),
-                Instruction::LoadGlobal(Value::function("ret_bool")),
-                Instruction::Call(0),
+                Instruction::Jump(2),
+                Instruction::Call("ret_bool".to_string()),
                 Instruction::Return,
             ],
         )],
@@ -53,9 +52,8 @@ fn basic_or() -> anyhow::Result<()> {
             vec![
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(2),
-                Instruction::Jump(4),
-                Instruction::LoadGlobal(Value::function("ret_bool")),
-                Instruction::Call(0),
+                Instruction::Jump(3),
+                Instruction::Call("ret_bool".to_string()),
                 Instruction::Jump(2),
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::Return,
@@ -101,7 +99,6 @@ fn basic_assign_add() -> anyhow::Result<()> {
             // x is Real (used 3 times: init, compound assign read, return)
             // Compound assignment x += 2 expands to x = x + 2
             vec![
-                Instruction::InitLocals(1), // slot for x
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("x".to_string()), // let x = 1
                 Instruction::LoadVar("x".to_string()),  // read x

--- a/baml_language/crates/baml_compiler_emit/tests/watch.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/watch.rs
@@ -22,7 +22,6 @@ fn watch_primitive() -> anyhow::Result<()> {
             "primitive",
             vec![
                 // Initialize locals with null (only "value" needs a slot now, _0 is ReturnPhi)
-                Instruction::InitLocals(1),
                 // Initialize watched variable
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("value".to_string()),
@@ -96,7 +95,6 @@ fn viz_header_before_while_emits_viz_enter_exit() -> anyhow::Result<()> {
         expected: vec![(
             "header_before_while",
             vec![
-                Instruction::InitLocals(1),            // local x init
                 Instruction::LoadConst(Value::Int(0)), // x = 0
                 Instruction::StoreVar("x".to_string()),
                 Instruction::NotifyBlock(0), // //# LoopHeader

--- a/baml_language/crates/baml_compiler_emit/tests/while_loops.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/while_loops.rs
@@ -87,7 +87,6 @@ fn while_loop_with_ending_if() -> anyhow::Result<()> {
             // Stackification with dead store elimination:
             // a is user variable, dead compiler temps (_5 for if result) are eliminated
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("a".to_string()),
                 Instruction::LoadVar("a".to_string()),
@@ -132,7 +131,6 @@ fn while_loop_with_break() -> anyhow::Result<()> {
             // Stackification with dead store elimination:
             // a is user variable, dead compiler temps (_5 for if result) are eliminated
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("a".to_string()),
                 Instruction::LoadVar("a".to_string()),
@@ -177,7 +175,6 @@ fn break_factorial() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate result local
-                Instruction::InitLocals(1),
                 // Initialize result = 1
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("result".to_string()),
@@ -238,7 +235,6 @@ fn continue_factorial() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate locals
-                Instruction::InitLocals(2),
                 // Initialize result = 1
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("result".to_string()),
@@ -341,7 +337,6 @@ fn break_nested() -> anyhow::Result<()> {
             // Stackification with dead store elimination:
             // a is user variable, dead compiler temps are eliminated
             vec![
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(5)),
                 Instruction::StoreVar("a".to_string()),
                 Instruction::LoadConst(Value::Bool(true)),
@@ -392,7 +387,6 @@ fn break_nested_with_variable_conditions() -> anyhow::Result<()> {
             "Nested",
             vec![
                 // let a = 5
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(5)),
                 Instruction::StoreVar("a".to_string()),
                 // outer while (x) - condition check
@@ -445,7 +439,6 @@ fn while_loop_with_conditional_break() -> anyhow::Result<()> {
             "CountDown",
             vec![
                 // let result = 0
-                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
                 // while (true) - condition

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
@@ -8,663 +8,616 @@ Objects: 82
 Globals: 62
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -8,693 +8,642 @@ Objects: 89
 Globals: 66
 
 Function GetMixedList (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("GetMixedList")
-     2   ALLOC_MAP 0      
-     3   CALL 2           
-     4   RETURN           
+     0   LOAD_CONST 0   ("GetMixedList")
+     1   ALLOC_MAP 0    
+     2   CALL 59        (<fn baml.llm.call_llm_function>)
+     3   RETURN         
 
 Function GetMixedMap (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("GetMixedMap")
-     2   ALLOC_MAP 0      
-     3   CALL 2           
-     4   RETURN           
+     0   LOAD_CONST 0   ("GetMixedMap")
+     1   ALLOC_MAP 0    
+     2   CALL 59        (<fn baml.llm.call_llm_function>)
+     3   RETURN         
 
 Function GetStatus (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("GetStatus")
-     2   ALLOC_MAP 0      
-     3   CALL 2           
-     4   RETURN           
+     0   LOAD_CONST 0   ("GetStatus")
+     1   ALLOC_MAP 0    
+     2   CALL 59        (<fn baml.llm.call_llm_function>)
+     3   RETURN         
 
 Function GetUser (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("GetUser")
-     2   LOAD_VAR 1       (id)
-     3   LOAD_CONST 1     ("id")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("GetUser")
+     1   LOAD_VAR 1     (id)
+     2   LOAD_CONST 1   ("id")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/big_t_type_annotation/baml_tests__big_t_type_annotation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/big_t_type_annotation/baml_tests__big_t_type_annotation__06_codegen.snap
@@ -8,673 +8,625 @@ Objects: 78
 Globals: 63
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
-
-Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
-
-Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
-     85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
-
-Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
-
-Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
      12   RETURN              
 
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
+
+Function baml.llm.execute_client (arity: 3, kind: Bytecode):
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
+
+Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
+     85    LOAD_FIELD 0            
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
+
+Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
+
+Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN              
+
 Function test_big_t_type (arity: 1, kind: Bytecode):
-     0   INIT_LOCALS 1       
-     1   LOAD_GLOBAL 47      (<fn baml.llm.get_return_type>)
-     2   LOAD_VAR 1          (function_name)
-     3   DISPATCH_FUTURE 1   
-     4   AWAIT               
-     5   STORE_VAR 2         (t)
-     6   LOAD_CONST 0        ("ok")
-     7   RETURN
+     0   LOAD_GLOBAL 47      (<fn baml.llm.get_return_type>)
+     1   LOAD_VAR 1          (function_name)
+     2   DISPATCH_FUTURE 1   
+     3   AWAIT               
+     4   STORE_VAR 2         (t)
+     5   LOAD_CONST 0        ("ok")
+     6   RETURN

--- a/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
@@ -8,169 +8,160 @@ Objects: 102
 Globals: 73
 
 Function ChainCommands (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 27      (<fn baml.sys.shell>)
-     2    LOAD_CONST 0        ("pwd")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (result1)
-     6    LOAD_GLOBAL 27      (<fn baml.sys.shell>)
-     7    LOAD_CONST 1        ("whoami")
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   STORE_VAR 2         (result2)
-     11   LOAD_VAR 1          (result1)
-     12   LOAD_CONST 2        (" - ")
-     13   BIN_OP +            
-     14   LOAD_VAR 2          (result2)
-     15   BIN_OP +            
-     16   RETURN              
+     0    LOAD_GLOBAL 27      (<fn baml.sys.shell>)
+     1    LOAD_CONST 0        ("pwd")
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 1         (result1)
+     5    LOAD_GLOBAL 27      (<fn baml.sys.shell>)
+     6    LOAD_CONST 1        ("whoami")
+     7    DISPATCH_FUTURE 1   
+     8    AWAIT               
+     9    STORE_VAR 2         (result2)
+     10   LOAD_VAR 1          (result1)
+     11   LOAD_CONST 2        (" - ")
+     12   BIN_OP +            
+     13   LOAD_VAR 2          (result2)
+     14   BIN_OP +            
+     15   RETURN              
 
 Function ConnectAndRead (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 32      (<fn baml.net.connect>)
-     2    LOAD_CONST 0        ("127.0.0.1:8080")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (sock)
-     6    LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
-     7    LOAD_VAR 1          (sock)
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   RETURN              
+     0   LOAD_GLOBAL 32      (<fn baml.net.connect>)
+     1   LOAD_CONST 0        ("127.0.0.1:8080")
+     2   DISPATCH_FUTURE 1   
+     3   AWAIT               
+     4   STORE_VAR 1         (sock)
+     5   LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
+     6   LOAD_VAR 1          (sock)
+     7   DISPATCH_FUTURE 1   
+     8   AWAIT               
+     9   RETURN              
 
 Function ConnectAndReadInline (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 32      (<fn baml.net.connect>)
-     2    LOAD_CONST 0        ("localhost:3000")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (_1)
-     6    LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
-     7    LOAD_VAR 1          (_1)
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   RETURN              
+     0   LOAD_GLOBAL 32      (<fn baml.net.connect>)
+     1   LOAD_CONST 0        ("localhost:3000")
+     2   DISPATCH_FUTURE 1   
+     3   AWAIT               
+     4   STORE_VAR 1         (_1)
+     5   LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
+     6   LOAD_VAR 1          (_1)
+     7   DISPATCH_FUTURE 1   
+     8   AWAIT               
+     9   RETURN              
 
 Function ConnectReadAndClose (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 32      (<fn baml.net.connect>)
-     2    LOAD_CONST 0        ("127.0.0.1:8080")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (sock)
-     6    LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
-     7    LOAD_VAR 1          (sock)
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   STORE_VAR 2         (data)
-     11   LOAD_GLOBAL 31      (<fn baml.net.Socket.close>)
-     12   LOAD_VAR 1          (sock)
-     13   DISPATCH_FUTURE 1   
-     14   AWAIT               
-     15   POP 1               
-     16   LOAD_VAR 2          (data)
-     17   RETURN              
+     0    LOAD_GLOBAL 32      (<fn baml.net.connect>)
+     1    LOAD_CONST 0        ("127.0.0.1:8080")
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 1         (sock)
+     5    LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
+     6    LOAD_VAR 1          (sock)
+     7    DISPATCH_FUTURE 1   
+     8    AWAIT               
+     9    STORE_VAR 2         (data)
+     10   LOAD_GLOBAL 31      (<fn baml.net.Socket.close>)
+     11   LOAD_VAR 1          (sock)
+     12   DISPATCH_FUTURE 1   
+     13   AWAIT               
+     14   POP 1               
+     15   LOAD_VAR 2          (data)
+     16   RETURN              
 
 Function MultipleConnections (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 32      (<fn baml.net.connect>)
-     2    LOAD_CONST 0        ("server1:80")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (s1)
-     6    LOAD_GLOBAL 32      (<fn baml.net.connect>)
-     7    LOAD_CONST 1        ("server2:80")
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   STORE_VAR 2         (s2)
-     11   LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
-     12   LOAD_VAR 1          (s1)
-     13   DISPATCH_FUTURE 1   
-     14   AWAIT               
-     15   STORE_VAR 3         (data1)
-     16   LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
-     17   LOAD_VAR 2          (s2)
-     18   DISPATCH_FUTURE 1   
-     19   AWAIT               
-     20   STORE_VAR 4         (data2)
-     21   LOAD_VAR 3          (data1)
-     22   LOAD_VAR 4          (data2)
-     23   BIN_OP +            
-     24   RETURN              
+     0    LOAD_GLOBAL 32      (<fn baml.net.connect>)
+     1    LOAD_CONST 0        ("server1:80")
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 1         (s1)
+     5    LOAD_GLOBAL 32      (<fn baml.net.connect>)
+     6    LOAD_CONST 1        ("server2:80")
+     7    DISPATCH_FUTURE 1   
+     8    AWAIT               
+     9    STORE_VAR 2         (s2)
+     10   LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
+     11   LOAD_VAR 1          (s1)
+     12   DISPATCH_FUTURE 1   
+     13   AWAIT               
+     14   STORE_VAR 3         (data1)
+     15   LOAD_GLOBAL 30      (<fn baml.net.Socket.read>)
+     16   LOAD_VAR 2          (s2)
+     17   DISPATCH_FUTURE 1   
+     18   AWAIT               
+     19   STORE_VAR 4         (data2)
+     20   LOAD_VAR 3          (data1)
+     21   LOAD_VAR 4          (data2)
+     22   BIN_OP +            
+     23   RETURN              
 
 Function ReadAndClose (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     2    LOAD_CONST 0        ("example.txt")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (f)
-     6    LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     7    LOAD_VAR 1          (f)
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   STORE_VAR 2         (content)
-     11   LOAD_GLOBAL 25      (<fn baml.fs.File.close>)
-     12   LOAD_VAR 1          (f)
-     13   DISPATCH_FUTURE 1   
-     14   AWAIT               
-     15   POP 1               
-     16   LOAD_VAR 2          (content)
-     17   RETURN              
+     0    LOAD_GLOBAL 26      (<fn baml.fs.open>)
+     1    LOAD_CONST 0        ("example.txt")
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 1         (f)
+     5    LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
+     6    LOAD_VAR 1          (f)
+     7    DISPATCH_FUTURE 1   
+     8    AWAIT               
+     9    STORE_VAR 2         (content)
+     10   LOAD_GLOBAL 25      (<fn baml.fs.File.close>)
+     11   LOAD_VAR 1          (f)
+     12   DISPATCH_FUTURE 1   
+     13   AWAIT               
+     14   POP 1               
+     15   LOAD_VAR 2          (content)
+     16   RETURN              
 
 Function ReadFile (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     2    LOAD_CONST 0        ("example.txt")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (f)
-     6    LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     7    LOAD_VAR 1          (f)
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   RETURN              
+     0   LOAD_GLOBAL 26      (<fn baml.fs.open>)
+     1   LOAD_CONST 0        ("example.txt")
+     2   DISPATCH_FUTURE 1   
+     3   AWAIT               
+     4   STORE_VAR 1         (f)
+     5   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
+     6   LOAD_VAR 1          (f)
+     7   DISPATCH_FUTURE 1   
+     8   AWAIT               
+     9   RETURN              
 
 Function ReadFileInline (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     2    LOAD_CONST 0        ("data.json")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (_1)
-     6    LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     7    LOAD_VAR 1          (_1)
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   RETURN              
+     0   LOAD_GLOBAL 26      (<fn baml.fs.open>)
+     1   LOAD_CONST 0        ("data.json")
+     2   DISPATCH_FUTURE 1   
+     3   AWAIT               
+     4   STORE_VAR 1         (_1)
+     5   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
+     6   LOAD_VAR 1          (_1)
+     7   DISPATCH_FUTURE 1   
+     8   AWAIT               
+     9   RETURN              
 
 Function ReadMultipleFiles (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     2    LOAD_CONST 0        ("file1.txt")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (f1)
-     6    LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     7    LOAD_CONST 1        ("file2.txt")
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   STORE_VAR 2         (f2)
-     11   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     12   LOAD_VAR 1          (f1)
-     13   DISPATCH_FUTURE 1   
-     14   AWAIT               
-     15   STORE_VAR 3         (content1)
-     16   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     17   LOAD_VAR 2          (f2)
-     18   DISPATCH_FUTURE 1   
-     19   AWAIT               
-     20   STORE_VAR 4         (content2)
-     21   LOAD_VAR 3          (content1)
-     22   LOAD_VAR 4          (content2)
-     23   BIN_OP +            
-     24   RETURN              
+     0    LOAD_GLOBAL 26      (<fn baml.fs.open>)
+     1    LOAD_CONST 0        ("file1.txt")
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 1         (f1)
+     5    LOAD_GLOBAL 26      (<fn baml.fs.open>)
+     6    LOAD_CONST 1        ("file2.txt")
+     7    DISPATCH_FUTURE 1   
+     8    AWAIT               
+     9    STORE_VAR 2         (f2)
+     10   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
+     11   LOAD_VAR 1          (f1)
+     12   DISPATCH_FUTURE 1   
+     13   AWAIT               
+     14   STORE_VAR 3         (content1)
+     15   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
+     16   LOAD_VAR 2          (f2)
+     17   DISPATCH_FUTURE 1   
+     18   AWAIT               
+     19   STORE_VAR 4         (content2)
+     20   LOAD_VAR 3          (content1)
+     21   LOAD_VAR 4          (content2)
+     22   BIN_OP +            
+     23   RETURN              
 
 Function RunCommand (arity: 0, kind: Bytecode):
      0   LOAD_GLOBAL 27      (<fn baml.sys.shell>)
@@ -187,663 +178,616 @@ Function RunCommandWithVar (arity: 0, kind: Bytecode):
      4   RETURN              
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
@@ -8,693 +8,645 @@ Objects: 91
 Globals: 63
 
 Function OpenRouterMistralSmall3_1_24b.resolve (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 49      (<fn env.get_or_panic>)
-     2    LOAD_CONST 0        ("OPENROUTER_API_KEY")
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 1         (_13)
-     6    LOAD_GLOBAL 42      (<fn baml.llm.build_primitive_client>)
-     7    LOAD_CONST 1        ("OpenRouterMistralSmall3_1_24b")
-     8    LOAD_CONST 2        ("unknown")
-     9    LOAD_CONST 3        ("user")
-     10   LOAD_CONST 4        ("user")
-     11   LOAD_CONST 5        ("assistant")
-     12   LOAD_CONST 6        ("system")
-     13   ALLOC_ARRAY 3       
-     14   LOAD_CONST 7        ("https://openrouter.ai/api/v1")
-     15   LOAD_VAR 1          (_13)
-     16   LOAD_CONST 8        ("mistralai/mistral-small-3.1-24b-instruct")
-     17   LOAD_CONST 9        (0.1)
-     18   ALLOC_MAP 0         
-     19   LOAD_CONST 10       ("base_url")
-     20   LOAD_CONST 11       ("api_key")
-     21   LOAD_CONST 12       ("model")
-     22   LOAD_CONST 13       ("temperature")
-     23   LOAD_CONST 14       ("headers")
-     24   ALLOC_MAP 5         
-     25   DISPATCH_FUTURE 5   
-     26   AWAIT               
-     27   RETURN              
+     0    LOAD_GLOBAL 49      (<fn env.get_or_panic>)
+     1    LOAD_CONST 0        ("OPENROUTER_API_KEY")
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 1         (_13)
+     5    LOAD_GLOBAL 42      (<fn baml.llm.build_primitive_client>)
+     6    LOAD_CONST 1        ("OpenRouterMistralSmall3_1_24b")
+     7    LOAD_CONST 2        ("unknown")
+     8    LOAD_CONST 3        ("user")
+     9    LOAD_CONST 4        ("user")
+     10   LOAD_CONST 5        ("assistant")
+     11   LOAD_CONST 6        ("system")
+     12   ALLOC_ARRAY 3       
+     13   LOAD_CONST 7        ("https://openrouter.ai/api/v1")
+     14   LOAD_VAR 1          (_13)
+     15   LOAD_CONST 8        ("mistralai/mistral-small-3.1-24b-instruct")
+     16   LOAD_CONST 9        (0.1)
+     17   ALLOC_MAP 0         
+     18   LOAD_CONST 10       ("base_url")
+     19   LOAD_CONST 11       ("api_key")
+     20   LOAD_CONST 12       ("model")
+     21   LOAD_CONST 13       ("temperature")
+     22   LOAD_CONST 14       ("headers")
+     23   ALLOC_MAP 5         
+     24   DISPATCH_FUTURE 5   
+     25   AWAIT               
+     26   RETURN              
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -8,22 +8,20 @@ Objects: 89
 Globals: 65
 
 Function CommentAfterArrow (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("CommentAfterArrow")
-     2   ALLOC_MAP 0      
-     3   CALL 2           
-     4   RETURN           
+     0   LOAD_CONST 0   ("CommentAfterArrow")
+     1   ALLOC_MAP 0    
+     2   CALL 59        (<fn baml.llm.call_llm_function>)
+     3   RETURN         
 
 Function FunctionWithComments (arity: 2, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("FunctionWithComments")
-     2   LOAD_VAR 1       (a)
-     3   LOAD_VAR 2       (b)
-     4   LOAD_CONST 1     ("a")
-     5   LOAD_CONST 2     ("b")
-     6   ALLOC_MAP 2      
-     7   CALL 2           
-     8   RETURN           
+     0   LOAD_CONST 0   ("FunctionWithComments")
+     1   LOAD_VAR 1     (a)
+     2   LOAD_VAR 2     (b)
+     3   LOAD_CONST 1   ("a")
+     4   LOAD_CONST 2   ("b")
+     5   ALLOC_MAP 2    
+     6   CALL 59        (<fn baml.llm.call_llm_function>)
+     7   RETURN         
 
 Function TestClient.resolve (arity: 0, kind: Bytecode):
      0    LOAD_GLOBAL 42      (<fn baml.llm.build_primitive_client>)
@@ -40,663 +38,616 @@ Function TestClient.resolve (arity: 0, kind: Bytecode):
      11   RETURN              
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
@@ -94,663 +94,616 @@ Function MyClient.resolve (arity: 0, kind: Bytecode):
      79   RETURN              
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
@@ -8,663 +8,616 @@ Objects: 78
 Globals: 62
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
@@ -8,10 +8,9 @@ Objects: 85
 Globals: 68
 
 Function Bar (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 65   (<fn Foo>)
-     1   LOAD_CONST 0     (1)
-     2   CALL 1           
-     3   RETURN           
+     0   LOAD_CONST 0   (1)
+     1   CALL 65        (<fn Foo>)
+     2   RETURN         
 
 Function Baz.Greeting (arity: 1, kind: Bytecode):
      0   LOAD_CONST 0   ("Hello, ")
@@ -29,684 +28,635 @@ Function Foo (arity: 1, kind: Bytecode):
      3   RETURN         
 
 Function GreetBaz (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 67      (<fn Baz.Greeting>)
-     1   ALLOC_INSTANCE 12   (<class Baz>)
-     2   COPY 0              
-     3   LOAD_VAR 1          (n)
-     4   STORE_FIELD 0       
-     5   CALL 1              
-     6   RETURN              
+     0   ALLOC_INSTANCE 12   (<class Baz>)
+     1   COPY 0              
+     2   LOAD_VAR 1          (n)
+     3   STORE_FIELD 0       
+     4   CALL 67             (<fn Baz.Greeting>)
+     5   RETURN              
 
 Function array_length (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 0   (<fn baml.Array.length>)
-     1   LOAD_CONST 0    (1)
-     2   LOAD_CONST 1    (2)
-     3   LOAD_CONST 2    (3)
-     4   ALLOC_ARRAY 3   
-     5   CALL 1          
-     6   RETURN          
+     0   LOAD_CONST 0    (1)
+     1   LOAD_CONST 1    (2)
+     2   LOAD_CONST 2    (3)
+     3   ALLOC_ARRAY 3   
+     4   CALL 0          (<fn baml.Array.length>)
+     5   RETURN          
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN              
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN              
 
 Function param_in_if_statement (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1             (b)

--- a/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
@@ -12,663 +12,616 @@ Function GetTransform (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -8,670 +8,622 @@ Objects: 79
 Globals: 63
 
 Function GetUser (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("GetUser")
-     2   ALLOC_MAP 0      
-     3   CALL 2           
-     4   RETURN           
+     0   LOAD_CONST 0   ("GetUser")
+     1   ALLOC_MAP 0    
+     2   CALL 59        (<fn baml.llm.call_llm_function>)
+     3   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -8,13 +8,12 @@ Objects: 89
 Globals: 64
 
 Function FetchDatax (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("FetchDatax")
-     2   LOAD_VAR 1       (user_id)
-     3   LOAD_CONST 1     ("user_id")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("FetchDatax")
+     1   LOAD_VAR 1     (user_id)
+     2   LOAD_CONST 1   ("user_id")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function VertexGCP.resolve (arity: 0, kind: Bytecode):
      0    LOAD_GLOBAL 42      (<fn baml.llm.build_primitive_client>)
@@ -33,663 +32,616 @@ Function VertexGCP.resolve (arity: 0, kind: Bytecode):
      13   RETURN              
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
@@ -48,76 +48,73 @@ Function HeadersAndComments (arity: 0, kind: Bytecode):
      4   RETURN           
 
 Function HeadersAroundExpressions (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 4          
-     1    NOTIFY_BLOCK 0         (BeforeLet)
-     2    NOTIFY_BLOCK 1         (AfterLet)
-     3    NOTIFY_BLOCK 2         (BeforeIf)
-     4    VIZ_ENTER 0            (BeforeIf)
-     5    LOAD_CONST 0           (5)
-     6    LOAD_CONST 1           (0)
-     7    CMP_OP >               
-     8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +3                (to 12)
-     10   NOTIFY_BLOCK 3         (InsideElse)
-     11   JUMP +2                (to 13)
-     12   NOTIFY_BLOCK 4         (InsideIf)
-     13   VIZ_EXIT 0             (BeforeIf)
-     14   NOTIFY_BLOCK 5         (AfterIf)
-     15   NOTIFY_BLOCK 6         (BeforeFor)
-     16   LOAD_CONST 2           (1)
-     17   LOAD_CONST 3           (2)
-     18   LOAD_CONST 4           (3)
-     19   ALLOC_ARRAY 3          
-     20   STORE_VAR 1            (_iter)
-     21   LOAD_GLOBAL 0          (<fn baml.Array.length>)
-     22   LOAD_VAR 1             (_iter)
-     23   CALL 1                 
-     24   STORE_VAR 2            (_len)
-     25   LOAD_CONST 1           (0)
-     26   STORE_VAR 3            (_i)
-     27   VIZ_ENTER 1            (BeforeFor)
-     28   LOAD_VAR 3             (_i)
-     29   LOAD_VAR 2             (_len)
-     30   CMP_OP <               
-     31   POP_JUMP_IF_FALSE +2   (to 33)
-     32   JUMP +6                (to 38)
-     33   VIZ_EXIT 1             (BeforeFor)
-     34   NOTIFY_BLOCK 7         (AfterFor)
-     35   NOTIFY_BLOCK 8         (FinalSection)
-     36   LOAD_CONST 0           (5)
-     37   RETURN                 
-     38   LOAD_VAR 1             (_iter)
-     39   LOAD_VAR 3             (_i)
-     40   LOAD_ARRAY_ELEMENT     
-     41   STORE_VAR 4            (i)
-     42   LOAD_VAR 3             (_i)
-     43   LOAD_CONST 2           (1)
-     44   BIN_OP +               
-     45   STORE_VAR 3            (_i)
-     46   NOTIFY_BLOCK 9         (InsideFor)
-     47   JUMP -19               (to 28)
+     0    NOTIFY_BLOCK 0         (BeforeLet)
+     1    NOTIFY_BLOCK 1         (AfterLet)
+     2    NOTIFY_BLOCK 2         (BeforeIf)
+     3    VIZ_ENTER 0            (BeforeIf)
+     4    LOAD_CONST 0           (5)
+     5    LOAD_CONST 1           (0)
+     6    CMP_OP >               
+     7    POP_JUMP_IF_FALSE +2   (to 9)
+     8    JUMP +3                (to 11)
+     9    NOTIFY_BLOCK 3         (InsideElse)
+     10   JUMP +2                (to 12)
+     11   NOTIFY_BLOCK 4         (InsideIf)
+     12   VIZ_EXIT 0             (BeforeIf)
+     13   NOTIFY_BLOCK 5         (AfterIf)
+     14   NOTIFY_BLOCK 6         (BeforeFor)
+     15   LOAD_CONST 2           (1)
+     16   LOAD_CONST 3           (2)
+     17   LOAD_CONST 4           (3)
+     18   ALLOC_ARRAY 3          
+     19   STORE_VAR 1            (_iter)
+     20   LOAD_VAR 1             (_iter)
+     21   CALL 0                 (<fn baml.Array.length>)
+     22   STORE_VAR 2            (_len)
+     23   LOAD_CONST 1           (0)
+     24   STORE_VAR 3            (_i)
+     25   VIZ_ENTER 1            (BeforeFor)
+     26   LOAD_VAR 3             (_i)
+     27   LOAD_VAR 2             (_len)
+     28   CMP_OP <               
+     29   POP_JUMP_IF_FALSE +2   (to 31)
+     30   JUMP +6                (to 36)
+     31   VIZ_EXIT 1             (BeforeFor)
+     32   NOTIFY_BLOCK 7         (AfterFor)
+     33   NOTIFY_BLOCK 8         (FinalSection)
+     34   LOAD_CONST 0           (5)
+     35   RETURN                 
+     36   LOAD_VAR 1             (_iter)
+     37   LOAD_VAR 3             (_i)
+     38   LOAD_ARRAY_ELEMENT     
+     39   STORE_VAR 4            (i)
+     40   LOAD_VAR 3             (_i)
+     41   LOAD_CONST 2           (1)
+     42   BIN_OP +               
+     43   STORE_VAR 3            (_i)
+     44   NOTIFY_BLOCK 9         (InsideFor)
+     45   JUMP -19               (to 26)
 
 Function HeadersInComplexNesting (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1          
-     1    NOTIFY_BLOCK 0         (MainFunction)
-     2    NOTIFY_BLOCK 1         (InsideBlockExpression)
-     3    VIZ_ENTER 0            (InsideBlockExpression)
-     4    LOAD_CONST 0           (true)
-     5    POP_JUMP_IF_FALSE +2   (to 7)
-     6    JUMP +4                (to 10)
-     7    NOTIFY_BLOCK 2         (InsideElse)
-     8    LOAD_CONST 1           ("else value")
-     9    JUMP +5                (to 14)
-     10   NOTIFY_BLOCK 3         (InsideIfTrue)
-     11   NOTIFY_BLOCK 4         (VeryDeepBlock)
-     12   NOTIFY_BLOCK 5         (BacktoIfLevel)
-     13   LOAD_CONST 2           ("deep value")
-     14   VIZ_EXIT 0             (InsideBlockExpression)
-     15   NOTIFY_BLOCK 6         (BacktoBlockLevel)
-     16   STORE_VAR 1            (result)
-     17   NOTIFY_BLOCK 7         (BacktoFunctionLevel)
-     18   LOAD_VAR 1             (result)
-     19   RETURN                 
+     0    NOTIFY_BLOCK 0         (MainFunction)
+     1    NOTIFY_BLOCK 1         (InsideBlockExpression)
+     2    VIZ_ENTER 0            (InsideBlockExpression)
+     3    LOAD_CONST 0           (true)
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +4                (to 9)
+     6    NOTIFY_BLOCK 2         (InsideElse)
+     7    LOAD_CONST 1           ("else value")
+     8    JUMP +5                (to 13)
+     9    NOTIFY_BLOCK 3         (InsideIfTrue)
+     10   NOTIFY_BLOCK 4         (VeryDeepBlock)
+     11   NOTIFY_BLOCK 5         (BacktoIfLevel)
+     12   LOAD_CONST 2           ("deep value")
+     13   VIZ_EXIT 0             (InsideBlockExpression)
+     14   NOTIFY_BLOCK 6         (BacktoBlockLevel)
+     15   STORE_VAR 1            (result)
+     16   NOTIFY_BLOCK 7         (BacktoFunctionLevel)
+     17   LOAD_VAR 1             (result)
+     18   RETURN                 
 
 Function HeadersWithSpecialChars (arity: 0, kind: Bytecode):
      0   NOTIFY_BLOCK 0   (Header-With-Dashes)
@@ -152,663 +149,616 @@ Function VeryLongHeaderTitle (arity: 0, kind: Bytecode):
      3   RETURN           
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
-assertion_line: 7762
 expression: output
 ---
 === BYTECODE ===
@@ -764,28 +763,27 @@ Function MatchComplexScrutinee (arity: 1, kind: Bytecode):
      23   RETURN                 
 
 Function MatchFunctionCallScrutinee (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 103        (<fn GetStatus>)
-     1    CALL 0                 
-     2    DISCRIMINANT           
-     3    COPY 0                 
-     4    LOAD_CONST 0           (0)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +3   (to 9)
-     7    POP 1                  
-     8    JUMP +12               (to 20)
-     9    COPY 0                 
-     10   LOAD_CONST 1           (1)
-     11   CMP_OP ==              
-     12   POP_JUMP_IF_FALSE +3   (to 15)
-     13   POP 1                  
-     14   JUMP +4                (to 18)
-     15   POP 1                  
-     16   LOAD_CONST 2           ("pending")
-     17   JUMP +4                (to 21)
-     18   LOAD_CONST 3           ("inactive")
-     19   JUMP +2                (to 21)
-     20   LOAD_CONST 4           ("active")
-     21   RETURN                 
+     0    CALL 103               (<fn GetStatus>)
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +12               (to 19)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (1)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +4                (to 17)
+     14   POP 1                  
+     15   LOAD_CONST 2           ("pending")
+     16   JUMP +4                (to 20)
+     17   LOAD_CONST 3           ("inactive")
+     18   JUMP +2                (to 20)
+     19   LOAD_CONST 4           ("active")
+     20   RETURN                 
 
 Function MixedPatterns (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (x)
@@ -1510,663 +1508,616 @@ Function WrongLiteralTypeIntWithString (arity: 1, kind: Bytecode):
      5   RETURN                 
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
@@ -8,663 +8,616 @@ Objects: 77
 Globals: 62
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
@@ -8,666 +8,619 @@ Objects: 105
 Globals: 74
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN              
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN              
 
 Function boolArray (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0    (true)

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -33,663 +33,616 @@ Function NextFunction (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
@@ -8,762 +8,711 @@ Objects: 84
 Globals: 66
 
 Function Calculate (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2   
-     1    LOAD_CONST 0    (1)
-     2    LOAD_CONST 1    (2)
-     3    BIN_OP +        
-     4    STORE_VAR 1     (a)
-     5    LOAD_VAR 1      (a)
-     6    LOAD_CONST 2    (3)
-     7    BIN_OP *        
-     8    STORE_VAR 2     (b)
-     9    LOAD_VAR 1      (a)
-     10   LOAD_VAR 2      (b)
-     11   BIN_OP +        
-     12   LOAD_VAR 2      (b)
-     13   LOAD_CONST 1    (2)
-     14   BIN_OP /        
-     15   LOAD_CONST 0    (1)
-     16   BIN_OP -        
-     17   BIN_OP *        
-     18   RETURN          
+     0    LOAD_CONST 0   (1)
+     1    LOAD_CONST 1   (2)
+     2    BIN_OP +       
+     3    STORE_VAR 1    (a)
+     4    LOAD_VAR 1     (a)
+     5    LOAD_CONST 2   (3)
+     6    BIN_OP *       
+     7    STORE_VAR 2    (b)
+     8    LOAD_VAR 1     (a)
+     9    LOAD_VAR 2     (b)
+     10   BIN_OP +       
+     11   LOAD_VAR 2     (b)
+     12   LOAD_CONST 1   (2)
+     13   BIN_OP /       
+     14   LOAD_CONST 0   (1)
+     15   BIN_OP -       
+     16   BIN_OP *       
+     17   RETURN         
 
 Function FieldAccess (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 3        
-     1    LOAD_VAR 1           (user)
-     2    LOAD_FIELD 0         
-     3    STORE_VAR 2          (name)
-     4    LOAD_VAR 1           (user)
-     5    LOAD_FIELD 1         
-     6    LOAD_FIELD 0         
-     7    STORE_VAR 3          (bio)
-     8    LOAD_VAR 1           (user)
-     9    LOAD_FIELD 2         
-     10   LOAD_CONST 0         (0)
-     11   LOAD_ARRAY_ELEMENT   
-     12   STORE_VAR 4          (firstTag)
-     13   LOAD_VAR 1           (user)
+     0    LOAD_VAR 1           (user)
+     1    LOAD_FIELD 0         
+     2    STORE_VAR 2          (name)
+     3    LOAD_VAR 1           (user)
+     4    LOAD_FIELD 1         
+     5    LOAD_FIELD 0         
+     6    STORE_VAR 3          (bio)
+     7    LOAD_VAR 1           (user)
+     8    LOAD_FIELD 2         
+     9    LOAD_CONST 0         (0)
+     10   LOAD_ARRAY_ELEMENT   
+     11   STORE_VAR 4          (firstTag)
+     12   LOAD_VAR 1           (user)
+     13   LOAD_FIELD 1         
      14   LOAD_FIELD 1         
-     15   LOAD_FIELD 1         
-     16   LOAD_FIELD 0         
-     17   RETURN               
+     15   LOAD_FIELD 0         
+     16   RETURN               
 
 Function IndexAccess (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 3        
-     1    LOAD_VAR 1           (users)
-     2    LOAD_CONST 0         (0)
-     3    LOAD_ARRAY_ELEMENT   
-     4    STORE_VAR 2          (first)
-     5    LOAD_VAR 1           (users)
-     6    LOAD_CONST 1         (1)
-     7    LOAD_ARRAY_ELEMENT   
-     8    STORE_VAR 3          (second)
-     9    LOAD_VAR 1           (users)
-     10   LOAD_CONST 0         (0)
-     11   LOAD_ARRAY_ELEMENT   
-     12   LOAD_FIELD 2         
-     13   LOAD_CONST 0         (0)
-     14   LOAD_ARRAY_ELEMENT   
-     15   STORE_VAR 4          (tag)
-     16   LOAD_VAR 1           (users)
-     17   LOAD_CONST 0         (0)
-     18   LOAD_ARRAY_ELEMENT   
-     19   LOAD_FIELD 0         
-     20   RETURN               
+     0    LOAD_VAR 1           (users)
+     1    LOAD_CONST 0         (0)
+     2    LOAD_ARRAY_ELEMENT   
+     3    STORE_VAR 2          (first)
+     4    LOAD_VAR 1           (users)
+     5    LOAD_CONST 1         (1)
+     6    LOAD_ARRAY_ELEMENT   
+     7    STORE_VAR 3          (second)
+     8    LOAD_VAR 1           (users)
+     9    LOAD_CONST 0         (0)
+     10   LOAD_ARRAY_ELEMENT   
+     11   LOAD_FIELD 2         
+     12   LOAD_CONST 0         (0)
+     13   LOAD_ARRAY_ELEMENT   
+     14   STORE_VAR 4          (tag)
+     15   LOAD_VAR 1           (users)
+     16   LOAD_CONST 0         (0)
+     17   LOAD_ARRAY_ELEMENT   
+     18   LOAD_FIELD 0         
+     19   RETURN               
 
 Function TestPrecedence (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_CONST 0           (2)
-     2    LOAD_CONST 1           (3)
-     3    BIN_OP *               
-     4    LOAD_CONST 2           (4)
-     5    BIN_OP +               
-     6    STORE_VAR 1            (c)
-     7    LOAD_CONST 0           (2)
-     8    LOAD_CONST 1           (3)
-     9    LOAD_CONST 2           (4)
-     10   BIN_OP *               
-     11   BIN_OP +               
-     12   LOAD_CONST 3           (10)
-     13   LOAD_CONST 0           (2)
-     14   BIN_OP +               
-     15   CMP_OP >               
-     16   STORE_VAR 2            (b)
-     17   LOAD_CONST 4           (true)
-     18   POP_JUMP_IF_FALSE +2   (to 20)
-     19   JUMP +10               (to 29)
-     20   LOAD_CONST 5           (false)
-     21   POP_JUMP_IF_FALSE +2   (to 23)
-     22   JUMP +4                (to 26)
-     23   LOAD_CONST 5           (false)
-     24   STORE_VAR 3            (d)
-     25   JUMP +6                (to 31)
-     26   LOAD_CONST 5           (false)
-     27   STORE_VAR 3            (d)
-     28   JUMP +3                (to 31)
-     29   LOAD_CONST 4           (true)
-     30   STORE_VAR 3            (d)
-     31   LOAD_VAR 3             (d)
-     32   RETURN                 
+     0    LOAD_CONST 0           (2)
+     1    LOAD_CONST 1           (3)
+     2    BIN_OP *               
+     3    LOAD_CONST 2           (4)
+     4    BIN_OP +               
+     5    STORE_VAR 1            (c)
+     6    LOAD_CONST 0           (2)
+     7    LOAD_CONST 1           (3)
+     8    LOAD_CONST 2           (4)
+     9    BIN_OP *               
+     10   BIN_OP +               
+     11   LOAD_CONST 3           (10)
+     12   LOAD_CONST 0           (2)
+     13   BIN_OP +               
+     14   CMP_OP >               
+     15   STORE_VAR 2            (b)
+     16   LOAD_CONST 4           (true)
+     17   POP_JUMP_IF_FALSE +2   (to 19)
+     18   JUMP +10               (to 28)
+     19   LOAD_CONST 5           (false)
+     20   POP_JUMP_IF_FALSE +2   (to 22)
+     21   JUMP +4                (to 25)
+     22   LOAD_CONST 5           (false)
+     23   STORE_VAR 3            (d)
+     24   JUMP +6                (to 30)
+     25   LOAD_CONST 5           (false)
+     26   STORE_VAR 3            (d)
+     27   JUMP +3                (to 30)
+     28   LOAD_CONST 4           (true)
+     29   STORE_VAR 3            (d)
+     30   LOAD_VAR 3             (d)
+     31   RETURN                 
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -8,90 +8,84 @@ Objects: 102
 Globals: 70
 
 Function Ambiguous (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Ambiguous")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Ambiguous")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function AnotherLLM (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("AnotherLLM")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("AnotherLLM")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function ChainedProcess (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("ChainedProcess")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("ChainedProcess")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function ExtractData (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("ExtractData")
-     2   LOAD_VAR 1       (text)
-     3   LOAD_CONST 1     ("text")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("ExtractData")
+     1   LOAD_VAR 1     (text)
+     2   LOAD_CONST 1   ("text")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function LLMAnalyze (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("LLMAnalyze")
-     2   LOAD_VAR 1       (text)
-     3   LOAD_CONST 1     ("text")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("LLMAnalyze")
+     1   LOAD_VAR 1     (text)
+     2   LOAD_CONST 1   ("text")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function ProcessAnalysis (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1          
-     1    LOAD_VAR 1             (analysis)
-     2    LOAD_FIELD 2           
-     3    STORE_VAR 2            (score)
-     4    LOAD_VAR 2             (score)
-     5    LOAD_CONST 0           (0.8)
-     6    CMP_OP >               
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +26               (to 34)
-     9    LOAD_VAR 2             (score)
-     10   LOAD_CONST 1           (0.5)
-     11   CMP_OP >               
-     12   POP_JUMP_IF_FALSE +2   (to 14)
-     13   JUMP +16               (to 29)
-     14   LOAD_VAR 2             (score)
-     15   LOAD_CONST 2           (0.2)
-     16   CMP_OP >               
-     17   POP_JUMP_IF_FALSE +2   (to 19)
-     18   JUMP +6                (to 24)
-     19   LOAD_CONST 3           ("Negative: ")
-     20   LOAD_VAR 1             (analysis)
-     21   LOAD_FIELD 0           
-     22   BIN_OP +               
-     23   RETURN                 
-     24   LOAD_CONST 4           ("Neutral: ")
-     25   LOAD_VAR 1             (analysis)
-     26   LOAD_FIELD 0           
-     27   BIN_OP +               
-     28   RETURN                 
-     29   LOAD_CONST 5           ("Positive: ")
-     30   LOAD_VAR 1             (analysis)
-     31   LOAD_FIELD 0           
-     32   BIN_OP +               
-     33   RETURN                 
-     34   LOAD_CONST 6           ("Very positive: ")
-     35   LOAD_VAR 1             (analysis)
-     36   LOAD_FIELD 0           
-     37   BIN_OP +               
-     38   RETURN                 
+     0    LOAD_VAR 1             (analysis)
+     1    LOAD_FIELD 2           
+     2    STORE_VAR 2            (score)
+     3    LOAD_VAR 2             (score)
+     4    LOAD_CONST 0           (0.8)
+     5    CMP_OP >               
+     6    POP_JUMP_IF_FALSE +2   (to 8)
+     7    JUMP +26               (to 33)
+     8    LOAD_VAR 2             (score)
+     9    LOAD_CONST 1           (0.5)
+     10   CMP_OP >               
+     11   POP_JUMP_IF_FALSE +2   (to 13)
+     12   JUMP +16               (to 28)
+     13   LOAD_VAR 2             (score)
+     14   LOAD_CONST 2           (0.2)
+     15   CMP_OP >               
+     16   POP_JUMP_IF_FALSE +2   (to 18)
+     17   JUMP +6                (to 23)
+     18   LOAD_CONST 3           ("Negative: ")
+     19   LOAD_VAR 1             (analysis)
+     20   LOAD_FIELD 0           
+     21   BIN_OP +               
+     22   RETURN                 
+     23   LOAD_CONST 4           ("Neutral: ")
+     24   LOAD_VAR 1             (analysis)
+     25   LOAD_FIELD 0           
+     26   BIN_OP +               
+     27   RETURN                 
+     28   LOAD_CONST 5           ("Positive: ")
+     29   LOAD_VAR 1             (analysis)
+     30   LOAD_FIELD 0           
+     31   BIN_OP +               
+     32   RETURN                 
+     33   LOAD_CONST 6           ("Very positive: ")
+     34   LOAD_VAR 1             (analysis)
+     35   LOAD_FIELD 0           
+     36   BIN_OP +               
+     37   RETURN                 
 
 Function ProcessData (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (data)
@@ -117,663 +111,616 @@ Function SimpleCalc (arity: 2, kind: Bytecode):
      5   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
@@ -26,700 +26,651 @@ Function ConditionalLogic (arity: 1, kind: Bytecode):
      15   RETURN                 
 
 Function add_assign (arity: 0, kind: Bytecode):
-     0   INIT_LOCALS 1   
-     1   LOAD_CONST 0    (10)
-     2   STORE_VAR 1     (x)
-     3   LOAD_VAR 1      (x)
-     4   LOAD_CONST 1    (5)
-     5   BIN_OP +        
-     6   STORE_VAR 1     (x)
-     7   LOAD_VAR 1      (x)
-     8   RETURN          
+     0   LOAD_CONST 0   (10)
+     1   STORE_VAR 1    (x)
+     2   LOAD_VAR 1     (x)
+     3   LOAD_CONST 1   (5)
+     4   BIN_OP +       
+     5   STORE_VAR 1    (x)
+     6   LOAD_VAR 1     (x)
+     7   RETURN         
 
 Function assign_in_loop (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2          
-     1    LOAD_CONST 0           (0)
-     2    STORE_VAR 1            (sum)
-     3    LOAD_CONST 0           (0)
-     4    STORE_VAR 2            (i)
-     5    LOAD_VAR 2             (i)
-     6    LOAD_CONST 1           (5)
-     7    CMP_OP <               
-     8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +3                (to 12)
-     10   LOAD_VAR 1             (sum)
-     11   RETURN                 
-     12   LOAD_VAR 1             (sum)
-     13   LOAD_VAR 2             (i)
-     14   BIN_OP +               
-     15   STORE_VAR 1            (sum)
-     16   LOAD_VAR 2             (i)
-     17   LOAD_CONST 2           (1)
-     18   BIN_OP +               
-     19   STORE_VAR 2            (i)
-     20   JUMP -15               (to 5)
+     0    LOAD_CONST 0           (0)
+     1    STORE_VAR 1            (sum)
+     2    LOAD_CONST 0           (0)
+     3    STORE_VAR 2            (i)
+     4    LOAD_VAR 2             (i)
+     5    LOAD_CONST 1           (5)
+     6    CMP_OP <               
+     7    POP_JUMP_IF_FALSE +2   (to 9)
+     8    JUMP +3                (to 11)
+     9    LOAD_VAR 1             (sum)
+     10   RETURN                 
+     11   LOAD_VAR 1             (sum)
+     12   LOAD_VAR 2             (i)
+     13   BIN_OP +               
+     14   STORE_VAR 1            (sum)
+     15   LOAD_VAR 2             (i)
+     16   LOAD_CONST 2           (1)
+     17   BIN_OP +               
+     18   STORE_VAR 2            (i)
+     19   JUMP -15               (to 4)
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN              
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN              
 
 Function block_with_tail (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -736,160 +687,151 @@ Function break_in_for (arity: 0, kind: Bytecode):
      5   RETURN                 
 
 Function break_with_locals (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2          
-     1    LOAD_CONST 0           (true)
-     2    POP_JUMP_IF_FALSE +7   (to 9)
-     3    LOAD_CONST 1           (1)
-     4    STORE_VAR 1            (x)
-     5    LOAD_CONST 0           (true)
-     6    POP_JUMP_IF_FALSE -5   (to 1)
-     7    LOAD_CONST 2           (2)
-     8    STORE_VAR 2            (y)
-     9    LOAD_CONST 3           (4)
-     10   RETURN                 
+     0   LOAD_CONST 0           (true)
+     1   POP_JUMP_IF_FALSE +7   (to 8)
+     2   LOAD_CONST 1           (1)
+     3   STORE_VAR 1            (x)
+     4   LOAD_CONST 0           (true)
+     5   POP_JUMP_IF_FALSE -5   (to 0)
+     6   LOAD_CONST 2           (2)
+     7   STORE_VAR 2            (y)
+     8   LOAD_CONST 3           (4)
+     9   RETURN                 
 
 Function c_style_for_loop (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2          
-     1    LOAD_CONST 0           (0)
-     2    STORE_VAR 1            (result)
-     3    LOAD_CONST 0           (0)
-     4    STORE_VAR 2            (i)
-     5    LOAD_VAR 2             (i)
-     6    LOAD_CONST 1           (10)
-     7    CMP_OP <               
-     8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +3                (to 12)
-     10   LOAD_VAR 1             (result)
-     11   RETURN                 
-     12   LOAD_VAR 1             (result)
-     13   LOAD_VAR 2             (i)
-     14   BIN_OP +               
-     15   STORE_VAR 1            (result)
-     16   LOAD_VAR 2             (i)
-     17   LOAD_CONST 2           (1)
-     18   BIN_OP +               
-     19   STORE_VAR 2            (i)
-     20   JUMP -15               (to 5)
+     0    LOAD_CONST 0           (0)
+     1    STORE_VAR 1            (result)
+     2    LOAD_CONST 0           (0)
+     3    STORE_VAR 2            (i)
+     4    LOAD_VAR 2             (i)
+     5    LOAD_CONST 1           (10)
+     6    CMP_OP <               
+     7    POP_JUMP_IF_FALSE +2   (to 9)
+     8    JUMP +3                (to 11)
+     9    LOAD_VAR 1             (result)
+     10   RETURN                 
+     11   LOAD_VAR 1             (result)
+     12   LOAD_VAR 2             (i)
+     13   BIN_OP +               
+     14   STORE_VAR 1            (result)
+     15   LOAD_VAR 2             (i)
+     16   LOAD_CONST 2           (1)
+     17   BIN_OP +               
+     18   STORE_VAR 2            (i)
+     19   JUMP -15               (to 4)
 
 Function continue_in_for (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1          
-     1    LOAD_CONST 0           (0)
-     2    STORE_VAR 1            (i)
-     3    LOAD_VAR 1             (i)
-     4    LOAD_CONST 1           (10)
-     5    CMP_OP <               
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +3                (to 10)
-     8    LOAD_CONST 2           (2)
-     9    RETURN                 
-     10   LOAD_VAR 1             (i)
-     11   LOAD_CONST 3           (1)
-     12   BIN_OP +               
-     13   STORE_VAR 1            (i)
-     14   JUMP -11               (to 3)
+     0    LOAD_CONST 0           (0)
+     1    STORE_VAR 1            (i)
+     2    LOAD_VAR 1             (i)
+     3    LOAD_CONST 1           (10)
+     4    CMP_OP <               
+     5    POP_JUMP_IF_FALSE +2   (to 7)
+     6    JUMP +3                (to 9)
+     7    LOAD_CONST 2           (2)
+     8    RETURN                 
+     9    LOAD_VAR 1             (i)
+     10   LOAD_CONST 3           (1)
+     11   BIN_OP +               
+     12   STORE_VAR 1            (i)
+     13   JUMP -11               (to 2)
 
 Function continue_with_locals (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2          
-     1    LOAD_CONST 0           (true)
-     2    POP_JUMP_IF_FALSE +2   (to 4)
-     3    JUMP +3                (to 6)
-     4    LOAD_CONST 1           (5)
-     5    RETURN                 
-     6    LOAD_CONST 2           (1)
-     7    STORE_VAR 1            (x)
-     8    LOAD_CONST 0           (true)
-     9    POP_JUMP_IF_FALSE -8   (to 1)
-     10   LOAD_CONST 3           (2)
-     11   STORE_VAR 2            (y)
-     12   JUMP -11               (to 1)
+     0    LOAD_CONST 0           (true)
+     1    POP_JUMP_IF_FALSE +2   (to 3)
+     2    JUMP +3                (to 5)
+     3    LOAD_CONST 1           (5)
+     4    RETURN                 
+     5    LOAD_CONST 2           (1)
+     6    STORE_VAR 1            (x)
+     7    LOAD_CONST 0           (true)
+     8    POP_JUMP_IF_FALSE -8   (to 0)
+     9    LOAD_CONST 3           (2)
+     10   STORE_VAR 2            (y)
+     11   JUMP -11               (to 0)
 
 Function iterator_style_for_loop (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 5          
-     1    LOAD_CONST 0           (0)
-     2    STORE_VAR 1            (result)
-     3    LOAD_CONST 1           (1)
-     4    LOAD_CONST 2           (2)
-     5    LOAD_CONST 3           (3)
-     6    ALLOC_ARRAY 3          
-     7    STORE_VAR 2            (_iter)
-     8    LOAD_GLOBAL 0          (<fn baml.Array.length>)
-     9    LOAD_VAR 2             (_iter)
-     10   CALL 1                 
-     11   STORE_VAR 3            (_len)
-     12   LOAD_CONST 0           (0)
-     13   STORE_VAR 4            (_i)
-     14   LOAD_VAR 4             (_i)
-     15   LOAD_VAR 3             (_len)
-     16   CMP_OP <               
-     17   POP_JUMP_IF_FALSE +2   (to 19)
-     18   JUMP +3                (to 21)
-     19   LOAD_VAR 1             (result)
-     20   RETURN                 
-     21   LOAD_VAR 2             (_iter)
-     22   LOAD_VAR 4             (_i)
-     23   LOAD_ARRAY_ELEMENT     
-     24   STORE_VAR 5            (i)
-     25   LOAD_VAR 4             (_i)
-     26   LOAD_CONST 1           (1)
-     27   BIN_OP +               
-     28   STORE_VAR 4            (_i)
-     29   LOAD_VAR 1             (result)
-     30   LOAD_VAR 5             (i)
-     31   BIN_OP +               
-     32   STORE_VAR 1            (result)
-     33   JUMP -19               (to 14)
+     0    LOAD_CONST 0           (0)
+     1    STORE_VAR 1            (result)
+     2    LOAD_CONST 1           (1)
+     3    LOAD_CONST 2           (2)
+     4    LOAD_CONST 3           (3)
+     5    ALLOC_ARRAY 3          
+     6    STORE_VAR 2            (_iter)
+     7    LOAD_VAR 2             (_iter)
+     8    CALL 0                 (<fn baml.Array.length>)
+     9    STORE_VAR 3            (_len)
+     10   LOAD_CONST 0           (0)
+     11   STORE_VAR 4            (_i)
+     12   LOAD_VAR 4             (_i)
+     13   LOAD_VAR 3             (_len)
+     14   CMP_OP <               
+     15   POP_JUMP_IF_FALSE +2   (to 17)
+     16   JUMP +3                (to 19)
+     17   LOAD_VAR 1             (result)
+     18   RETURN                 
+     19   LOAD_VAR 2             (_iter)
+     20   LOAD_VAR 4             (_i)
+     21   LOAD_ARRAY_ELEMENT     
+     22   STORE_VAR 5            (i)
+     23   LOAD_VAR 4             (_i)
+     24   LOAD_CONST 1           (1)
+     25   BIN_OP +               
+     26   STORE_VAR 4            (_i)
+     27   LOAD_VAR 1             (result)
+     28   LOAD_VAR 5             (i)
+     29   BIN_OP +               
+     30   STORE_VAR 1            (result)
+     31   JUMP -19               (to 12)
 
 Function let_statements (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 4       
-     1    LOAD_CONST 0        (1)
-     2    STORE_VAR 1         (x)
-     3    LOAD_CONST 1        (2)
-     4    STORE_VAR 2         (y)
-     5    LOAD_CONST 0        (1)
-     6    LOAD_CONST 1        (2)
-     7    LOAD_CONST 2        (3)
-     8    ALLOC_ARRAY 3       
-     9    STORE_VAR 3         (z)
-     10   ALLOC_INSTANCE 12   (<class Point>)
-     11   COPY 0              
-     12   LOAD_CONST 0        (1)
-     13   STORE_FIELD 0       
-     14   COPY 0              
-     15   LOAD_CONST 1        (2)
-     16   STORE_FIELD 1       
-     17   STORE_VAR 4         (point)
-     18   LOAD_VAR 4          (point)
-     19   LOAD_FIELD 0        
-     20   LOAD_VAR 4          (point)
-     21   LOAD_FIELD 1        
-     22   BIN_OP +            
-     23   RETURN              
+     0    LOAD_CONST 0        (1)
+     1    STORE_VAR 1         (x)
+     2    LOAD_CONST 1        (2)
+     3    STORE_VAR 2         (y)
+     4    LOAD_CONST 0        (1)
+     5    LOAD_CONST 1        (2)
+     6    LOAD_CONST 2        (3)
+     7    ALLOC_ARRAY 3       
+     8    STORE_VAR 3         (z)
+     9    ALLOC_INSTANCE 12   (<class Point>)
+     10   COPY 0              
+     11   LOAD_CONST 0        (1)
+     12   STORE_FIELD 0       
+     13   COPY 0              
+     14   LOAD_CONST 1        (2)
+     15   STORE_FIELD 1       
+     16   STORE_VAR 4         (point)
+     17   LOAD_VAR 4          (point)
+     18   LOAD_FIELD 0        
+     19   LOAD_VAR 4          (point)
+     20   LOAD_FIELD 1        
+     21   BIN_OP +            
+     22   RETURN              
 
 Function mul_assign (arity: 0, kind: Bytecode):
-     0   INIT_LOCALS 1   
-     1   LOAD_CONST 0    (3)
-     2   STORE_VAR 1     (x)
-     3   LOAD_VAR 1      (x)
-     4   LOAD_CONST 1    (4)
-     5   BIN_OP *        
-     6   STORE_VAR 1     (x)
-     7   LOAD_VAR 1      (x)
-     8   RETURN          
+     0   LOAD_CONST 0   (3)
+     1   STORE_VAR 1    (x)
+     2   LOAD_VAR 1     (x)
+     3   LOAD_CONST 1   (4)
+     4   BIN_OP *       
+     5   STORE_VAR 1    (x)
+     6   LOAD_VAR 1     (x)
+     7   RETURN         
 
 Function multi_assign (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 2   
-     1    LOAD_CONST 0    (1)
-     2    STORE_VAR 1     (a)
-     3    LOAD_CONST 1    (2)
-     4    STORE_VAR 2     (b)
-     5    LOAD_CONST 2    (10)
-     6    STORE_VAR 1     (a)
-     7    LOAD_CONST 3    (20)
-     8    STORE_VAR 2     (b)
-     9    LOAD_VAR 1      (a)
-     10   LOAD_VAR 2      (b)
-     11   BIN_OP +        
-     12   RETURN          
+     0    LOAD_CONST 0   (1)
+     1    STORE_VAR 1    (a)
+     2    LOAD_CONST 1   (2)
+     3    STORE_VAR 2    (b)
+     4    LOAD_CONST 2   (10)
+     5    STORE_VAR 1    (a)
+     6    LOAD_CONST 3   (20)
+     7    STORE_VAR 2    (b)
+     8    LOAD_VAR 1     (a)
+     9    LOAD_VAR 2     (b)
+     10   BIN_OP +       
+     11   RETURN         
 
 Function nested_break (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0           (true)
@@ -900,95 +842,90 @@ Function nested_break (arity: 0, kind: Bytecode):
      5   RETURN                 
 
 Function nested_for_loop (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 9           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 1             (result)
-     3    LOAD_CONST 1            (1)
-     4    LOAD_CONST 2            (2)
-     5    LOAD_CONST 3            (3)
-     6    ALLOC_ARRAY 3           
-     7    STORE_VAR 2             (_iter)
-     8    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     9    LOAD_VAR 2              (_iter)
-     10   CALL 1                  
-     11   STORE_VAR 3             (_len)
-     12   LOAD_CONST 0            (0)
-     13   STORE_VAR 4             (_i)
-     14   LOAD_VAR 4              (_i)
-     15   LOAD_VAR 3              (_len)
-     16   CMP_OP <                
-     17   POP_JUMP_IF_FALSE +2    (to 19)
-     18   JUMP +3                 (to 21)
-     19   LOAD_VAR 1              (result)
-     20   RETURN                  
-     21   LOAD_VAR 2              (_iter)
-     22   LOAD_VAR 4              (_i)
-     23   LOAD_ARRAY_ELEMENT      
-     24   STORE_VAR 5             (i)
-     25   LOAD_VAR 4              (_i)
-     26   LOAD_CONST 1            (1)
-     27   BIN_OP +                
-     28   STORE_VAR 4             (_i)
-     29   LOAD_CONST 4            (4)
-     30   LOAD_CONST 5            (5)
-     31   LOAD_CONST 6            (6)
-     32   ALLOC_ARRAY 3           
-     33   STORE_VAR 6             (_iter1)
-     34   LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     35   LOAD_VAR 6              (_iter1)
-     36   CALL 1                  
-     37   STORE_VAR 7             (_len1)
-     38   LOAD_CONST 0            (0)
-     39   STORE_VAR 8             (_i1)
-     40   LOAD_VAR 8              (_i1)
-     41   LOAD_VAR 7              (_len1)
-     42   CMP_OP <                
-     43   POP_JUMP_IF_FALSE -29   (to 14)
-     44   LOAD_VAR 6              (_iter1)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 1             (result)
+     2    LOAD_CONST 1            (1)
+     3    LOAD_CONST 2            (2)
+     4    LOAD_CONST 3            (3)
+     5    ALLOC_ARRAY 3           
+     6    STORE_VAR 2             (_iter)
+     7    LOAD_VAR 2              (_iter)
+     8    CALL 0                  (<fn baml.Array.length>)
+     9    STORE_VAR 3             (_len)
+     10   LOAD_CONST 0            (0)
+     11   STORE_VAR 4             (_i)
+     12   LOAD_VAR 4              (_i)
+     13   LOAD_VAR 3              (_len)
+     14   CMP_OP <                
+     15   POP_JUMP_IF_FALSE +2    (to 17)
+     16   JUMP +3                 (to 19)
+     17   LOAD_VAR 1              (result)
+     18   RETURN                  
+     19   LOAD_VAR 2              (_iter)
+     20   LOAD_VAR 4              (_i)
+     21   LOAD_ARRAY_ELEMENT      
+     22   STORE_VAR 5             (i)
+     23   LOAD_VAR 4              (_i)
+     24   LOAD_CONST 1            (1)
+     25   BIN_OP +                
+     26   STORE_VAR 4             (_i)
+     27   LOAD_CONST 4            (4)
+     28   LOAD_CONST 5            (5)
+     29   LOAD_CONST 6            (6)
+     30   ALLOC_ARRAY 3           
+     31   STORE_VAR 6             (_iter1)
+     32   LOAD_VAR 6              (_iter1)
+     33   CALL 0                  (<fn baml.Array.length>)
+     34   STORE_VAR 7             (_len1)
+     35   LOAD_CONST 0            (0)
+     36   STORE_VAR 8             (_i1)
+     37   LOAD_VAR 8              (_i1)
+     38   LOAD_VAR 7              (_len1)
+     39   CMP_OP <                
+     40   POP_JUMP_IF_FALSE -28   (to 12)
+     41   LOAD_VAR 6              (_iter1)
+     42   LOAD_VAR 8              (_i1)
+     43   LOAD_ARRAY_ELEMENT      
+     44   STORE_VAR 9             (j)
      45   LOAD_VAR 8              (_i1)
-     46   LOAD_ARRAY_ELEMENT      
-     47   STORE_VAR 9             (j)
-     48   LOAD_VAR 8              (_i1)
-     49   LOAD_CONST 1            (1)
-     50   BIN_OP +                
-     51   STORE_VAR 8             (_i1)
-     52   LOAD_VAR 1              (result)
-     53   LOAD_VAR 5              (i)
-     54   LOAD_VAR 9              (j)
-     55   BIN_OP *                
-     56   BIN_OP +                
-     57   STORE_VAR 1             (result)
-     58   JUMP -18                (to 40)
+     46   LOAD_CONST 1            (1)
+     47   BIN_OP +                
+     48   STORE_VAR 8             (_i1)
+     49   LOAD_VAR 1              (result)
+     50   LOAD_VAR 5              (i)
+     51   LOAD_VAR 9              (j)
+     52   BIN_OP *                
+     53   BIN_OP +                
+     54   STORE_VAR 1             (result)
+     55   JUMP -18                (to 37)
 
 Function nested_while_loop (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1           
-     1    LOAD_CONST 0            (0)
-     2    LOAD_CONST 1            (10)
-     3    CMP_OP <                
-     4    POP_JUMP_IF_FALSE +2    (to 6)
-     5    JUMP +3                 (to 8)
-     6    LOAD_CONST 0            (0)
-     7    RETURN                  
-     8    LOAD_CONST 0            (0)
-     9    STORE_VAR 1             (j)
-     10   LOAD_VAR 1              (j)
-     11   LOAD_CONST 1            (10)
-     12   CMP_OP <                
-     13   POP_JUMP_IF_FALSE -12   (to 1)
-     14   LOAD_VAR 1              (j)
-     15   LOAD_CONST 2            (1)
-     16   BIN_OP +                
-     17   STORE_VAR 1             (j)
-     18   JUMP -8                 (to 10)
+     0    LOAD_CONST 0            (0)
+     1    LOAD_CONST 1            (10)
+     2    CMP_OP <                
+     3    POP_JUMP_IF_FALSE +2    (to 5)
+     4    JUMP +3                 (to 7)
+     5    LOAD_CONST 0            (0)
+     6    RETURN                  
+     7    LOAD_CONST 0            (0)
+     8    STORE_VAR 1             (j)
+     9    LOAD_VAR 1              (j)
+     10   LOAD_CONST 1            (10)
+     11   CMP_OP <                
+     12   POP_JUMP_IF_FALSE -12   (to 0)
+     13   LOAD_VAR 1              (j)
+     14   LOAD_CONST 2            (1)
+     15   BIN_OP +                
+     16   STORE_VAR 1             (j)
+     17   JUMP -8                 (to 9)
 
 Function simple_assign (arity: 0, kind: Bytecode):
-     0   INIT_LOCALS 1   
-     1   LOAD_CONST 0    (1)
-     2   STORE_VAR 1     (x)
-     3   LOAD_CONST 1    (5)
-     4   STORE_VAR 1     (x)
-     5   LOAD_VAR 1      (x)
-     6   RETURN          
+     0   LOAD_CONST 0   (1)
+     1   STORE_VAR 1    (x)
+     2   LOAD_CONST 1   (5)
+     3   STORE_VAR 1    (x)
+     4   LOAD_VAR 1     (x)
+     5   RETURN         
 
 Function simple_break (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0           (true)
@@ -1004,29 +941,27 @@ Function simple_continue (arity: 0, kind: Bytecode):
      4   RETURN                 
 
 Function simple_while_loop (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1          
-     1    LOAD_CONST 0           (0)
-     2    STORE_VAR 1            (i)
-     3    LOAD_VAR 1             (i)
-     4    LOAD_CONST 1           (10)
-     5    CMP_OP <               
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +3                (to 10)
-     8    LOAD_VAR 1             (i)
-     9    RETURN                 
-     10   LOAD_VAR 1             (i)
-     11   LOAD_CONST 2           (1)
-     12   BIN_OP +               
-     13   STORE_VAR 1            (i)
-     14   JUMP -11               (to 3)
+     0    LOAD_CONST 0           (0)
+     1    STORE_VAR 1            (i)
+     2    LOAD_VAR 1             (i)
+     3    LOAD_CONST 1           (10)
+     4    CMP_OP <               
+     5    POP_JUMP_IF_FALSE +2   (to 7)
+     6    JUMP +3                (to 9)
+     7    LOAD_VAR 1             (i)
+     8    RETURN                 
+     9    LOAD_VAR 1             (i)
+     10   LOAD_CONST 2           (1)
+     11   BIN_OP +               
+     12   STORE_VAR 1            (i)
+     13   JUMP -11               (to 2)
 
 Function sub_assign (arity: 0, kind: Bytecode):
-     0   INIT_LOCALS 1   
-     1   LOAD_CONST 0    (10)
-     2   STORE_VAR 1     (x)
-     3   LOAD_VAR 1      (x)
-     4   LOAD_CONST 1    (3)
-     5   BIN_OP -        
-     6   STORE_VAR 1     (x)
-     7   LOAD_VAR 1      (x)
-     8   RETURN
+     0   LOAD_CONST 0   (10)
+     1   STORE_VAR 1    (x)
+     2   LOAD_VAR 1     (x)
+     3   LOAD_CONST 1   (3)
+     4   BIN_OP -       
+     5   STORE_VAR 1    (x)
+     6   LOAD_VAR 1     (x)
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -8,28 +8,26 @@ Objects: 1486
 Globals: 165
 
 Function BodyTorture (arity: 0, kind: Bytecode):
-     0    INIT_LOCALS 1          
-     1    LOAD_CONST 0           (null)
-     2    STORE_VAR 1            (x)
-     3    LOAD_VAR 1             (x)
-     4    LOAD_CONST 1           (1)
-     5    BIN_OP +               
-     6    STORE_VAR 1            (x)
-     7    LOAD_CONST 0           (null)
-     8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +3                (to 12)
-     10   LOAD_CONST 0           (null)
-     11   RETURN                 
-     12   LOAD_VAR 1             (x)
-     13   LOAD_CONST 1           (1)
-     14   BIN_OP +               
-     15   STORE_VAR 1            (x)
-     16   JUMP -13               (to 3)
+     0    LOAD_CONST 0           (null)
+     1    STORE_VAR 1            (x)
+     2    LOAD_VAR 1             (x)
+     3    LOAD_CONST 1           (1)
+     4    BIN_OP +               
+     5    STORE_VAR 1            (x)
+     6    LOAD_CONST 0           (null)
+     7    POP_JUMP_IF_FALSE +2   (to 9)
+     8    JUMP +3                (to 11)
+     9    LOAD_CONST 0           (null)
+     10   RETURN                 
+     11   LOAD_VAR 1             (x)
+     12   LOAD_CONST 1           (1)
+     13   BIN_OP +               
+     14   STORE_VAR 1            (x)
+     15   JUMP -13               (to 2)
 
 Function ComplexType (arity: 0, kind: Bytecode):
-     0   INIT_LOCALS 1   
-     1   LOAD_VAR 1      (_0)
-     2   RETURN          
+     0   LOAD_VAR 1   (_0)
+     1   RETURN       
 
 Function DeepExpression (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0   (1)
@@ -54,1563 +52,1416 @@ Function DeepExpression (arity: 0, kind: Bytecode):
      19   RETURN         
 
 Function Process1 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process1")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process1")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process10 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process10")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process10")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process100 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process100")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process100")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process11 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process11")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process11")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process12 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process12")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process12")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process13 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process13")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process13")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process14 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process14")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process14")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process15 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process15")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process15")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process16 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process16")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process16")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process17 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process17")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process17")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process18 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process18")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process18")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process19 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process19")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process19")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process2 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process2")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process2")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process20 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process20")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process20")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process21 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process21")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process21")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process22 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process22")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process22")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process23 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process23")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process23")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process24 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process24")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process24")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process25 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process25")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process25")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process26 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process26")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process26")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process27 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process27")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process27")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process28 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process28")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process28")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process29 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process29")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process29")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process3 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process3")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process3")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process30 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process30")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process30")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process31 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process31")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process31")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process32 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process32")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process32")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process33 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process33")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process33")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process34 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process34")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process34")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process35 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process35")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process35")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process36 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process36")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process36")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process37 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process37")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process37")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process38 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process38")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process38")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process39 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process39")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process39")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process4 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process4")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process4")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process40 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process40")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process40")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process41 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process41")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process41")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process42 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process42")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process42")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process43 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process43")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process43")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process44 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process44")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process44")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process45 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process45")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process45")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process46 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process46")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process46")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process47 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process47")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process47")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process48 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process48")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process48")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process49 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process49")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process49")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process5 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process5")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process5")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process50 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process50")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process50")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process51 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process51")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process51")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process52 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process52")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process52")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process53 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process53")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process53")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process54 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process54")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process54")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process55 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process55")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process55")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process56 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process56")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process56")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process57 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process57")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process57")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process58 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process58")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process58")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process59 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process59")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process59")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process6 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process6")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process6")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process60 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process60")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process60")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process61 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process61")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process61")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process62 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process62")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process62")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process63 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process63")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process63")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process64 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process64")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process64")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process65 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process65")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process65")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process66 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process66")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process66")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process67 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process67")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process67")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process68 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process68")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process68")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process69 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process69")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process69")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process7 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process7")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process7")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process70 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process70")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process70")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process71 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process71")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process71")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process72 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process72")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process72")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process73 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process73")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process73")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process74 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process74")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process74")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process75 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process75")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process75")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process76 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process76")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process76")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process77 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process77")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process77")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process78 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process78")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process78")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process79 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process79")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process79")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process8 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process8")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process8")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process80 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process80")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process80")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process81 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process81")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process81")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process82 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process82")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process82")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process83 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process83")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process83")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process84 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process84")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process84")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process85 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process85")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process85")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process86 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process86")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process86")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process87 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process87")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process87")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process88 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process88")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process88")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process89 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process89")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process89")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process9 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process9")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process9")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process90 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process90")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process90")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process91 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process91")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process91")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process92 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process92")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process92")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process93 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process93")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process93")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process94 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process94")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process94")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process95 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process95")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process95")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process96 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process96")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process96")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process97 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process97")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process97")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process98 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process98")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process98")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function Process99 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Process99")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("Process99")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -8,13 +8,12 @@ Objects: 95
 Globals: 66
 
 Function FormatMessage (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("FormatMessage")
-     2   LOAD_VAR 1       (name)
-     3   LOAD_CONST 1     ("name")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("FormatMessage")
+     1   LOAD_VAR 1     (name)
+     2   LOAD_CONST 1   ("name")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function GPT4.resolve (arity: 0, kind: Bytecode):
      0    LOAD_GLOBAL 42      (<fn baml.llm.build_primitive_client>)
@@ -35,672 +34,624 @@ Function GetRole (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function ProcessText (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("ProcessText")
-     2   LOAD_VAR 1       (input)
-     3   LOAD_CONST 1     ("input")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("ProcessText")
+     1   LOAD_VAR 1     (input)
+     2   LOAD_CONST 1   ("input")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -8,679 +8,630 @@ Objects: 83
 Globals: 64
 
 Function BadParam (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("BadParam")
-     2   LOAD_VAR 1       (x)
-     3   LOAD_CONST 1     ("x")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("BadParam")
+     1   LOAD_VAR 1     (x)
+     2   LOAD_CONST 1   ("x")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function BadReturnType (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("BadReturnType")
-     2   ALLOC_MAP 0      
-     3   CALL 2           
-     4   RETURN           
+     0   LOAD_CONST 0   ("BadReturnType")
+     1   ALLOC_MAP 0    
+     2   CALL 59        (<fn baml.llm.call_llm_function>)
+     3   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
@@ -24,663 +24,616 @@ Function MyClient.resolve (arity: 0, kind: Bytecode):
      13   RETURN              
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -8,672 +8,624 @@ Objects: 80
 Globals: 63
 
 Function HelloWorld (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("HelloWorld")
-     2   LOAD_VAR 1       (name)
-     3   LOAD_CONST 1     ("name")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("HelloWorld")
+     1   LOAD_VAR 1     (name)
+     2   LOAD_CONST 1   ("name")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
@@ -14,663 +14,616 @@ Function Foo (arity: 0, kind: Bytecode):
      3   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
@@ -12,663 +12,616 @@ Function Foo (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
@@ -8,663 +8,616 @@ Objects: 76
 Globals: 62
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
@@ -32,663 +32,616 @@ Function MakeJSON (arity: 1, kind: Bytecode):
      2   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -8,672 +8,624 @@ Objects: 80
 Globals: 63
 
 Function TypeBuilderFn (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("TypeBuilderFn")
-     2   LOAD_VAR 1       (from_text)
-     3   LOAD_CONST 1     ("from_text")
-     4   ALLOC_MAP 1      
-     5   CALL 2           
-     6   RETURN           
+     0   LOAD_CONST 0   ("TypeBuilderFn")
+     1   LOAD_VAR 1     (from_text)
+     2   LOAD_CONST 1   ("from_text")
+     3   ALLOC_MAP 1    
+     4   CALL 59        (<fn baml.llm.call_llm_function>)
+     5   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -8,670 +8,622 @@ Objects: 80
 Globals: 63
 
 Function Fn (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 59   (<fn baml.llm.call_llm_function>)
-     1   LOAD_CONST 0     ("Fn")
-     2   ALLOC_MAP 0      
-     3   CALL 2           
-     4   RETURN           
+     0   LOAD_CONST 0   ("Fn")
+     1   ALLOC_MAP 0    
+     2   CALL 59        (<fn baml.llm.call_llm_function>)
+     3   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
@@ -20,663 +20,616 @@ Function Foo (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 5           
-     1    LOAD_CONST 0            (0)
-     2    STORE_VAR 3             (offset)
-     3    LOAD_VAR 1              (self)
-     4    LOAD_FIELD 0            
-     5    STORE_VAR 4             (_iter)
-     6    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     7    LOAD_VAR 4              (_iter)
-     8    CALL 1                  
-     9    STORE_VAR 5             (_len)
-     10   LOAD_CONST 0            (0)
-     11   STORE_VAR 6             (_i)
-     12   LOAD_VAR 6              (_i)
-     13   LOAD_VAR 5              (_len)
-     14   CMP_OP <                
-     15   POP_JUMP_IF_FALSE +2    (to 17)
-     16   JUMP +3                 (to 19)
-     17   LOAD_VAR 3              (offset)
-     18   RETURN                  
-     19   LOAD_VAR 4              (_iter)
-     20   LOAD_VAR 6              (_i)
-     21   LOAD_ARRAY_ELEMENT      
-     22   STORE_VAR 7             (seen_name)
-     23   LOAD_VAR 6              (_i)
-     24   LOAD_CONST 1            (1)
-     25   BIN_OP +                
-     26   STORE_VAR 6             (_i)
-     27   LOAD_VAR 7              (seen_name)
-     28   LOAD_VAR 2              (client_name)
-     29   CMP_OP ==               
-     30   POP_JUMP_IF_FALSE -18   (to 12)
-     31   LOAD_VAR 3              (offset)
-     32   LOAD_CONST 1            (1)
-     33   BIN_OP +                
-     34   STORE_VAR 3             (offset)
-     35   JUMP -23                (to 12)
+     0    LOAD_CONST 0            (0)
+     1    STORE_VAR 3             (offset)
+     2    LOAD_VAR 1              (self)
+     3    LOAD_FIELD 0            
+     4    STORE_VAR 4             (_iter)
+     5    LOAD_VAR 4              (_iter)
+     6    CALL 0                  (<fn baml.Array.length>)
+     7    STORE_VAR 5             (_len)
+     8    LOAD_CONST 0            (0)
+     9    STORE_VAR 6             (_i)
+     10   LOAD_VAR 6              (_i)
+     11   LOAD_VAR 5              (_len)
+     12   CMP_OP <                
+     13   POP_JUMP_IF_FALSE +2    (to 15)
+     14   JUMP +3                 (to 17)
+     15   LOAD_VAR 3              (offset)
+     16   RETURN                  
+     17   LOAD_VAR 4              (_iter)
+     18   LOAD_VAR 6              (_i)
+     19   LOAD_ARRAY_ELEMENT      
+     20   STORE_VAR 7             (seen_name)
+     21   LOAD_VAR 6              (_i)
+     22   LOAD_CONST 1            (1)
+     23   BIN_OP +                
+     24   STORE_VAR 6             (_i)
+     25   LOAD_VAR 7              (seen_name)
+     26   LOAD_VAR 2              (client_name)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE -18   (to 10)
+     29   LOAD_VAR 3              (offset)
+     30   LOAD_CONST 1            (1)
+     31   BIN_OP +                
+     32   STORE_VAR 3             (offset)
+     33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 60      (<fn baml.llm.PlannerState.rr_local_offset>)
-     2    LOAD_VAR 1          (self)
-     3    LOAD_VAR 2          (client_name)
-     4    CALL 2              
-     5    STORE_VAR 4         (local_offset)
-     6    LOAD_GLOBAL 1       (<fn baml.Array.push>)
-     7    LOAD_VAR 1          (self)
-     8    LOAD_FIELD 0        
-     9    LOAD_VAR 2          (client_name)
-     10   CALL 2              
-     11   POP 1               
-     12   LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
-     13   LOAD_VAR 2          (client_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   LOAD_VAR 4          (local_offset)
-     17   BIN_OP +            
-     18   LOAD_VAR 3          (sub_client_count)
-     19   BIN_OP %            
-     20   RETURN              
+     0    LOAD_VAR 1          (self)
+     1    LOAD_VAR 2          (client_name)
+     2    CALL 60             (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4         (local_offset)
+     4    LOAD_VAR 1          (self)
+     5    LOAD_FIELD 0        
+     6    LOAD_VAR 2          (client_name)
+     7    CALL 1              (<fn baml.Array.push>)
+     8    POP 1               
+     9    LOAD_GLOBAL 46      (<fn baml.llm.round_robin_peek>)
+     10   LOAD_VAR 2          (client_name)
+     11   DISPATCH_FUTURE 1   
+     12   AWAIT               
+     13   LOAD_VAR 4          (local_offset)
+     14   BIN_OP +            
+     15   LOAD_VAR 3          (sub_client_count)
+     16   BIN_OP %            
+     17   RETURN              
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 50      (<fn baml.llm.build_attempt_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 50             (<fn baml.llm.build_attempt_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 14          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +98                (to 107)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +37                (to 52)
-     16    POP 1                   
-     17    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 2            
-     20    CALL 1                  
-     21    LOAD_CONST 0            (0)
-     22    CMP_OP ==               
-     23    POP_JUMP_IF_FALSE +2    (to 25)
-     24    JUMP +26                (to 50)
-     25    LOAD_VAR 1              (llm_client)
-     26    LOAD_FIELD 0            
-     27    STORE_VAR 14            (_69)
-     28    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    CALL 1                  
-     32    STORE_VAR 15            (_71)
-     33    LOAD_GLOBAL 61          (<fn baml.llm.PlannerState.rr_pick_index>)
-     34    LOAD_VAR 2              (planner_state)
-     35    LOAD_VAR 14             (_69)
-     36    LOAD_VAR 15             (_71)
-     37    CALL 3                  
-     38    STORE_VAR 13            (idx)
-     39    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     40    LOAD_VAR 1              (llm_client)
-     41    LOAD_FIELD 2            
-     42    LOAD_VAR 13             (idx)
-     43    CALL 2                  
-     44    STORE_VAR 16            (_77)
-     45    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     46    LOAD_VAR 16             (_77)
-     47    LOAD_VAR 2              (planner_state)
-     48    CALL 2                  
-     49    JUMP +73                (to 122)
-     50    ALLOC_ARRAY 0           
-     51    JUMP +71                (to 122)
-     52    ALLOC_ARRAY 0           
-     53    STORE_VAR 4             (steps)
-     54    LOAD_VAR 1              (llm_client)
-     55    LOAD_FIELD 2            
-     56    STORE_VAR 5             (_iter)
-     57    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     58    LOAD_VAR 5              (_iter)
-     59    CALL 1                  
-     60    STORE_VAR 6             (_len)
-     61    LOAD_CONST 0            (0)
-     62    STORE_VAR 7             (_i)
-     63    LOAD_VAR 7              (_i)
-     64    LOAD_VAR 6              (_len)
-     65    CMP_OP <                
-     66    POP_JUMP_IF_FALSE +2    (to 68)
-     67    JUMP +3                 (to 70)
-     68    LOAD_VAR 4              (steps)
-     69    JUMP +53                (to 122)
-     70    LOAD_VAR 5              (_iter)
-     71    LOAD_VAR 7              (_i)
-     72    LOAD_ARRAY_ELEMENT      
-     73    STORE_VAR 8             (sub)
-     74    LOAD_VAR 7              (_i)
-     75    LOAD_CONST 1            (1)
-     76    BIN_OP +                
-     77    STORE_VAR 7             (_i)
-     78    LOAD_GLOBAL 51          (<fn baml.llm.build_plan_with_state>)
-     79    LOAD_VAR 8              (sub)
-     80    LOAD_VAR 2              (planner_state)
-     81    CALL 2                  
-     82    STORE_VAR 9             (_iter1)
-     83    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     84    LOAD_VAR 9              (_iter1)
-     85    CALL 1                  
-     86    STORE_VAR 10            (_len1)
-     87    LOAD_CONST 0            (0)
-     88    STORE_VAR 11            (_i1)
-     89    LOAD_VAR 11             (_i1)
-     90    LOAD_VAR 10             (_len1)
-     91    CMP_OP <                
-     92    POP_JUMP_IF_FALSE -29   (to 63)
-     93    LOAD_VAR 9              (_iter1)
-     94    LOAD_VAR 11             (_i1)
-     95    LOAD_ARRAY_ELEMENT      
-     96    STORE_VAR 12            (step)
-     97    LOAD_VAR 11             (_i1)
-     98    LOAD_CONST 1            (1)
-     99    BIN_OP +                
-     100   STORE_VAR 11            (_i1)
-     101   LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     102   LOAD_VAR 4              (steps)
-     103   LOAD_VAR 12             (step)
-     104   CALL 2                  
-     105   POP 1                   
-     106   JUMP -17                (to 89)
-     107   LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     108   LOAD_VAR 1              (llm_client)
-     109   LOAD_FIELD 0            
-     110   DISPATCH_FUTURE 1       
-     111   AWAIT                   
-     112   CALL 0                  
-     113   STORE_VAR 3             (primitive)
-     114   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     115   COPY 0                  
-     116   LOAD_VAR 3              (primitive)
-     117   STORE_FIELD 0           
-     118   COPY 0                  
-     119   LOAD_CONST 0            (0)
-     120   STORE_FIELD 1           
-     121   ALLOC_ARRAY 1           
-     122   RETURN                  
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +87                (to 95)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +30                (to 44)
+     15    POP 1                   
+     16    LOAD_VAR 1              (llm_client)
+     17    LOAD_FIELD 2            
+     18    CALL 0                  (<fn baml.Array.length>)
+     19    LOAD_CONST 0            (0)
+     20    CMP_OP ==               
+     21    POP_JUMP_IF_FALSE +2    (to 23)
+     22    JUMP +20                (to 42)
+     23    LOAD_VAR 1              (llm_client)
+     24    LOAD_FIELD 0            
+     25    STORE_VAR 14            (_69)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    CALL 0                  (<fn baml.Array.length>)
+     29    STORE_VAR 15            (_71)
+     30    LOAD_VAR 2              (planner_state)
+     31    LOAD_VAR 14             (_69)
+     32    LOAD_VAR 15             (_71)
+     33    CALL 61                 (<fn baml.llm.PlannerState.rr_pick_index>)
+     34    STORE_VAR 13            (idx)
+     35    LOAD_VAR 1              (llm_client)
+     36    LOAD_FIELD 2            
+     37    LOAD_VAR 13             (idx)
+     38    CALL 2                  (<fn baml.Array.at>)
+     39    LOAD_VAR 2              (planner_state)
+     40    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     41    JUMP +69                (to 110)
+     42    ALLOC_ARRAY 0           
+     43    JUMP +67                (to 110)
+     44    ALLOC_ARRAY 0           
+     45    STORE_VAR 4             (steps)
+     46    LOAD_VAR 1              (llm_client)
+     47    LOAD_FIELD 2            
+     48    STORE_VAR 5             (_iter)
+     49    LOAD_VAR 5              (_iter)
+     50    CALL 0                  (<fn baml.Array.length>)
+     51    STORE_VAR 6             (_len)
+     52    LOAD_CONST 0            (0)
+     53    STORE_VAR 7             (_i)
+     54    LOAD_VAR 7              (_i)
+     55    LOAD_VAR 6              (_len)
+     56    CMP_OP <                
+     57    POP_JUMP_IF_FALSE +2    (to 59)
+     58    JUMP +3                 (to 61)
+     59    LOAD_VAR 4              (steps)
+     60    JUMP +50                (to 110)
+     61    LOAD_VAR 5              (_iter)
+     62    LOAD_VAR 7              (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 8             (sub)
+     65    LOAD_VAR 7              (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 7             (_i)
+     69    LOAD_VAR 8              (sub)
+     70    LOAD_VAR 2              (planner_state)
+     71    CALL 51                 (<fn baml.llm.build_plan_with_state>)
+     72    STORE_VAR 9             (_iter1)
+     73    LOAD_VAR 9              (_iter1)
+     74    CALL 0                  (<fn baml.Array.length>)
+     75    STORE_VAR 10            (_len1)
+     76    LOAD_CONST 0            (0)
+     77    STORE_VAR 11            (_i1)
+     78    LOAD_VAR 11             (_i1)
+     79    LOAD_VAR 10             (_len1)
+     80    CMP_OP <                
+     81    POP_JUMP_IF_FALSE -27   (to 54)
+     82    LOAD_VAR 9              (_iter1)
+     83    LOAD_VAR 11             (_i1)
+     84    LOAD_ARRAY_ELEMENT      
+     85    STORE_VAR 12            (step)
+     86    LOAD_VAR 11             (_i1)
+     87    LOAD_CONST 1            (1)
+     88    BIN_OP +                
+     89    STORE_VAR 11            (_i1)
+     90    LOAD_VAR 4              (steps)
+     91    LOAD_VAR 12             (step)
+     92    CALL 1                  (<fn baml.Array.push>)
+     93    POP 1                   
+     94    JUMP -16                (to 78)
+     95    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     96    LOAD_VAR 1              (llm_client)
+     97    LOAD_FIELD 0            
+     98    DISPATCH_FUTURE 1       
+     99    AWAIT                   
+     100   CALL_INDIRECT           
+     101   STORE_VAR 3             (primitive)
+     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     103   COPY 0                  
+     104   LOAD_VAR 3              (primitive)
+     105   STORE_FIELD 0           
+     106   COPY 0                  
+     107   LOAD_CONST 0            (0)
+     108   STORE_FIELD 1           
+     109   ALLOC_ARRAY 1           
+     110   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 51      (<fn baml.llm.build_plan_with_state>)
-     1   LOAD_VAR 1          (llm_client)
-     2   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
-     3   COPY 0              
-     4   ALLOC_ARRAY 0       
-     5   STORE_FIELD 0       
-     6   CALL 2              
-     7   RETURN              
+     0   LOAD_VAR 1          (llm_client)
+     1   ALLOC_INSTANCE 10   (<class baml.llm.PlannerState>)
+     2   COPY 0              
+     3   ALLOC_ARRAY 0       
+     4   STORE_FIELD 0       
+     5   CALL 51             (<fn baml.llm.build_plan_with_state>)
+     6   RETURN              
 
 Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
-     0     INIT_LOCALS 11          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 3            
-     3     STORE_VAR 3             (_3)
-     4     LOAD_VAR 3              (_3)
-     5     LOAD_CONST 0            (null)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +2    (to 9)
-     8     JUMP +93                (to 101)
-     9     LOAD_VAR 3              (_3)
-     10    STORE_VAR 4             (r)
-     11    ALLOC_ARRAY 0           
-     12    STORE_VAR 5             (result)
-     13    LOAD_VAR 4              (r)
-     14    LOAD_FIELD 1            
-     15    LOAD_CONST 1            (0)
-     16    BIN_OP +                
-     17    STORE_VAR 6             (current_delay)
-     18    LOAD_CONST 2            (0)
-     19    STORE_VAR 7             (attempt)
-     20    LOAD_VAR 7              (attempt)
-     21    LOAD_VAR 4              (r)
-     22    LOAD_FIELD 0            
-     23    CMP_OP <=               
-     24    POP_JUMP_IF_FALSE +2    (to 26)
-     25    JUMP +3                 (to 28)
-     26    LOAD_VAR 5              (result)
-     27    JUMP +78                (to 105)
-     28    LOAD_CONST 2            (0)
-     29    STORE_VAR 8             (delay)
-     30    LOAD_VAR 7              (attempt)
-     31    LOAD_CONST 2            (0)
-     32    CMP_OP >                
-     33    POP_JUMP_IF_FALSE +26   (to 59)
-     34    LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     35    LOAD_VAR 6              (current_delay)
-     36    CALL 1                  
-     37    STORE_VAR 8             (delay)
-     38    LOAD_VAR 6              (current_delay)
-     39    LOAD_VAR 4              (r)
-     40    LOAD_FIELD 2            
-     41    BIN_OP *                
-     42    STORE_VAR 9             (next)
-     43    LOAD_VAR 9              (next)
-     44    LOAD_VAR 4              (r)
-     45    LOAD_FIELD 3            
-     46    LOAD_CONST 1            (0)
-     47    BIN_OP +                
-     48    CMP_OP >                
-     49    POP_JUMP_IF_FALSE +2    (to 51)
-     50    JUMP +4                 (to 54)
-     51    LOAD_VAR 9              (next)
-     52    STORE_VAR 6             (current_delay)
-     53    JUMP +6                 (to 59)
-     54    LOAD_VAR 4              (r)
-     55    LOAD_FIELD 3            
-     56    LOAD_CONST 1            (0)
-     57    BIN_OP +                
-     58    STORE_VAR 6             (current_delay)
-     59    LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     60    LOAD_VAR 1              (llm_client)
-     61    LOAD_VAR 2              (planner_state)
-     62    CALL 2                  
-     63    STORE_VAR 10            (_iter)
-     64    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     65    LOAD_VAR 10             (_iter)
-     66    CALL 1                  
-     67    STORE_VAR 11            (_len)
-     68    LOAD_CONST 2            (0)
-     69    STORE_VAR 12            (_i)
-     70    LOAD_VAR 12             (_i)
-     71    LOAD_VAR 11             (_len)
-     72    CMP_OP <                
-     73    POP_JUMP_IF_FALSE +2    (to 75)
-     74    JUMP +6                 (to 80)
-     75    LOAD_VAR 7              (attempt)
-     76    LOAD_CONST 3            (1)
-     77    BIN_OP +                
-     78    STORE_VAR 7             (attempt)
-     79    JUMP -59                (to 20)
-     80    LOAD_VAR 10             (_iter)
-     81    LOAD_VAR 12             (_i)
-     82    LOAD_ARRAY_ELEMENT      
-     83    STORE_VAR 13            (step)
-     84    LOAD_VAR 12             (_i)
-     85    LOAD_CONST 3            (1)
-     86    BIN_OP +                
-     87    STORE_VAR 12            (_i)
-     88    LOAD_GLOBAL 1           (<fn baml.Array.push>)
-     89    LOAD_VAR 5              (result)
-     90    ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     91    COPY 0                  
-     92    LOAD_VAR 13             (step)
-     93    LOAD_FIELD 0            
-     94    STORE_FIELD 0           
-     95    COPY 0                  
-     96    LOAD_VAR 8              (delay)
-     97    STORE_FIELD 1           
-     98    CALL 2                  
-     99    POP 1                   
-     100   JUMP -30                (to 70)
-     101   LOAD_GLOBAL 50          (<fn baml.llm.build_attempt_with_state>)
-     102   LOAD_VAR 1              (llm_client)
-     103   LOAD_VAR 2              (planner_state)
-     104   CALL 2                  
-     105   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 3             (_3)
+     3    LOAD_VAR 3              (_3)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +89                (to 96)
+     8    LOAD_VAR 3              (_3)
+     9    STORE_VAR 4             (r)
+     10   ALLOC_ARRAY 0           
+     11   STORE_VAR 5             (result)
+     12   LOAD_VAR 4              (r)
+     13   LOAD_FIELD 1            
+     14   LOAD_CONST 1            (0)
+     15   BIN_OP +                
+     16   STORE_VAR 6             (current_delay)
+     17   LOAD_CONST 2            (0)
+     18   STORE_VAR 7             (attempt)
+     19   LOAD_VAR 7              (attempt)
+     20   LOAD_VAR 4              (r)
+     21   LOAD_FIELD 0            
+     22   CMP_OP <=               
+     23   POP_JUMP_IF_FALSE +2    (to 25)
+     24   JUMP +3                 (to 27)
+     25   LOAD_VAR 5              (result)
+     26   JUMP +73                (to 99)
+     27   LOAD_CONST 2            (0)
+     28   STORE_VAR 8             (delay)
+     29   LOAD_VAR 7              (attempt)
+     30   LOAD_CONST 2            (0)
+     31   CMP_OP >                
+     32   POP_JUMP_IF_FALSE +25   (to 57)
+     33   LOAD_VAR 6              (current_delay)
+     34   CALL 19                 (<fn baml.math.trunc>)
+     35   STORE_VAR 8             (delay)
+     36   LOAD_VAR 6              (current_delay)
+     37   LOAD_VAR 4              (r)
+     38   LOAD_FIELD 2            
+     39   BIN_OP *                
+     40   STORE_VAR 9             (next)
+     41   LOAD_VAR 9              (next)
+     42   LOAD_VAR 4              (r)
+     43   LOAD_FIELD 3            
+     44   LOAD_CONST 1            (0)
+     45   BIN_OP +                
+     46   CMP_OP >                
+     47   POP_JUMP_IF_FALSE +2    (to 49)
+     48   JUMP +4                 (to 52)
+     49   LOAD_VAR 9              (next)
+     50   STORE_VAR 6             (current_delay)
+     51   JUMP +6                 (to 57)
+     52   LOAD_VAR 4              (r)
+     53   LOAD_FIELD 3            
+     54   LOAD_CONST 1            (0)
+     55   BIN_OP +                
+     56   STORE_VAR 6             (current_delay)
+     57   LOAD_VAR 1              (llm_client)
+     58   LOAD_VAR 2              (planner_state)
+     59   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     60   STORE_VAR 10            (_iter)
+     61   LOAD_VAR 10             (_iter)
+     62   CALL 0                  (<fn baml.Array.length>)
+     63   STORE_VAR 11            (_len)
+     64   LOAD_CONST 2            (0)
+     65   STORE_VAR 12            (_i)
+     66   LOAD_VAR 12             (_i)
+     67   LOAD_VAR 11             (_len)
+     68   CMP_OP <                
+     69   POP_JUMP_IF_FALSE +2    (to 71)
+     70   JUMP +6                 (to 76)
+     71   LOAD_VAR 7              (attempt)
+     72   LOAD_CONST 3            (1)
+     73   BIN_OP +                
+     74   STORE_VAR 7             (attempt)
+     75   JUMP -56                (to 19)
+     76   LOAD_VAR 10             (_iter)
+     77   LOAD_VAR 12             (_i)
+     78   LOAD_ARRAY_ELEMENT      
+     79   STORE_VAR 13            (step)
+     80   LOAD_VAR 12             (_i)
+     81   LOAD_CONST 3            (1)
+     82   BIN_OP +                
+     83   STORE_VAR 12            (_i)
+     84   LOAD_VAR 5              (result)
+     85   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     86   COPY 0                  
+     87   LOAD_VAR 13             (step)
+     88   LOAD_FIELD 0            
+     89   STORE_FIELD 0           
+     90   COPY 0                  
+     91   LOAD_VAR 8              (delay)
+     92   STORE_FIELD 1           
+     93   CALL 1                  (<fn baml.Array.push>)
+     94   POP 1                   
+     95   JUMP -29                (to 66)
+     96   LOAD_VAR 1              (llm_client)
+     97   LOAD_VAR 2              (planner_state)
+     98   CALL 50                 (<fn baml.llm.build_attempt_with_state>)
+     99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 2       
-     1    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     2    LOAD_VAR 1          (function_name)
-     3    CALL 1              
-     4    STORE_VAR 3         (primitive_client)
-     5    LOAD_GLOBAL 52      (<fn baml.llm.render_prompt>)
-     6    LOAD_VAR 1          (function_name)
-     7    LOAD_VAR 2          (args)
-     8    CALL 2              
-     9    STORE_VAR 4         (specialized_prompt)
-     10   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
-     11   LOAD_VAR 3          (primitive_client)
-     12   LOAD_VAR 4          (specialized_prompt)
-     13   DISPATCH_FUTURE 2   
-     14   AWAIT               
-     15   RETURN              
+     0    LOAD_VAR 1          (function_name)
+     1    CALL 53             (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3         (primitive_client)
+     3    LOAD_VAR 1          (function_name)
+     4    LOAD_VAR 2          (args)
+     5    CALL 52             (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4         (specialized_prompt)
+     7    LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.build_request>)
+     8    LOAD_VAR 3          (primitive_client)
+     9    LOAD_VAR 4          (specialized_prompt)
+     10   DISPATCH_FUTURE 2   
+     11   AWAIT               
+     12   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3          
-     1    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1             (function_name)
-     3    DISPATCH_FUTURE 1      
-     4    AWAIT                  
-     5    STORE_VAR 3            (jinja_string)
-     6    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
-     7    LOAD_VAR 1             (function_name)
-     8    DISPATCH_FUTURE 1      
-     9    AWAIT                  
-     10   STORE_VAR 4            (llm_client)
-     11   LOAD_GLOBAL 55         (<fn baml.llm.execute_client>)
-     12   LOAD_VAR 4             (llm_client)
-     13   ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     14   COPY 0                 
-     15   LOAD_VAR 3             (jinja_string)
-     16   STORE_FIELD 0          
-     17   COPY 0                 
-     18   LOAD_VAR 2             (args)
-     19   STORE_FIELD 1          
-     20   COPY 0                 
-     21   LOAD_VAR 1             (function_name)
-     22   STORE_FIELD 2          
-     23   LOAD_CONST 0           (0)
-     24   CALL 3                 
-     25   STORE_VAR 5            (result)
-     26   LOAD_VAR 5             (result)
-     27   LOAD_FIELD 0           
-     28   POP_JUMP_IF_FALSE +2   (to 30)
-     29   JUMP +8                (to 37)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("All orchestration steps failed")
-     32   DISPATCH_FUTURE 1      
-     33   AWAIT                  
-     34   POP 1                  
-     35   LOAD_CONST 2           (null)
-     36   RETURN                 
-     37   LOAD_VAR 5             (result)
-     38   LOAD_FIELD 1           
-     39   RETURN                 
+     0    LOAD_GLOBAL 41         (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1             (function_name)
+     2    DISPATCH_FUTURE 1      
+     3    AWAIT                  
+     4    STORE_VAR 3            (jinja_string)
+     5    LOAD_GLOBAL 43         (<fn baml.llm.get_client>)
+     6    LOAD_VAR 1             (function_name)
+     7    DISPATCH_FUTURE 1      
+     8    AWAIT                  
+     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     10   COPY 0                 
+     11   LOAD_VAR 3             (jinja_string)
+     12   STORE_FIELD 0          
+     13   COPY 0                 
+     14   LOAD_VAR 2             (args)
+     15   STORE_FIELD 1          
+     16   COPY 0                 
+     17   LOAD_VAR 1             (function_name)
+     18   STORE_FIELD 2          
+     19   LOAD_CONST 0           (0)
+     20   CALL 55                (<fn baml.llm.execute_client>)
+     21   STORE_VAR 4            (result)
+     22   LOAD_VAR 4             (result)
+     23   LOAD_FIELD 0           
+     24   POP_JUMP_IF_FALSE +2   (to 26)
+     25   JUMP +8                (to 33)
+     26   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
+     27   LOAD_CONST 1           ("All orchestration steps failed")
+     28   DISPATCH_FUTURE 1      
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           (null)
+     32   RETURN                 
+     33   LOAD_VAR 4             (result)
+     34   LOAD_FIELD 1           
+     35   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
-     0    INIT_LOCALS 7           
-     1    LOAD_VAR 1              (llm_client)
-     2    LOAD_FIELD 3            
-     3    STORE_VAR 4             (_4)
-     4    LOAD_VAR 4              (_4)
-     5    LOAD_CONST 0            (null)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +79                (to 87)
-     9    LOAD_VAR 4              (_4)
-     10   STORE_VAR 5             (r)
-     11   LOAD_VAR 5              (r)
-     12   LOAD_FIELD 1            
-     13   LOAD_CONST 1            (0)
-     14   BIN_OP +                
-     15   STORE_VAR 6             (current_delay)
-     16   LOAD_CONST 2            (0)
-     17   STORE_VAR 7             (attempt)
-     18   LOAD_VAR 7              (attempt)
-     19   LOAD_VAR 5              (r)
-     20   LOAD_FIELD 0            
-     21   CMP_OP <=               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +9                 (to 32)
-     24   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     25   COPY 0                  
-     26   LOAD_CONST 3            (false)
-     27   STORE_FIELD 0           
-     28   COPY 0                  
-     29   LOAD_CONST 0            (null)
-     30   STORE_FIELD 1           
-     31   JUMP +61                (to 92)
-     32   LOAD_VAR 3              (inherited_delay_ms)
-     33   STORE_VAR 8             (attempt_delay)
-     34   LOAD_VAR 7              (attempt)
-     35   LOAD_CONST 2            (0)
-     36   CMP_OP >                
-     37   POP_JUMP_IF_FALSE +26   (to 63)
-     38   LOAD_GLOBAL 19          (<fn baml.math.trunc>)
-     39   LOAD_VAR 6              (current_delay)
-     40   CALL 1                  
-     41   STORE_VAR 8             (attempt_delay)
-     42   LOAD_VAR 6              (current_delay)
-     43   LOAD_VAR 5              (r)
-     44   LOAD_FIELD 2            
-     45   BIN_OP *                
-     46   STORE_VAR 9             (next)
-     47   LOAD_VAR 9              (next)
-     48   LOAD_VAR 5              (r)
-     49   LOAD_FIELD 3            
-     50   LOAD_CONST 1            (0)
-     51   BIN_OP +                
-     52   CMP_OP >                
-     53   POP_JUMP_IF_FALSE +2    (to 55)
-     54   JUMP +4                 (to 58)
-     55   LOAD_VAR 9              (next)
-     56   STORE_VAR 6             (current_delay)
-     57   JUMP +6                 (to 63)
-     58   LOAD_VAR 5              (r)
-     59   LOAD_FIELD 3            
-     60   LOAD_CONST 1            (0)
-     61   BIN_OP +                
-     62   STORE_VAR 6             (current_delay)
-     63   LOAD_VAR 7              (attempt)
-     64   LOAD_VAR 5              (r)
-     65   LOAD_FIELD 0            
-     66   CMP_OP ==               
-     67   POP_JUMP_IF_FALSE +3    (to 70)
-     68   LOAD_VAR 3              (inherited_delay_ms)
-     69   STORE_VAR 8             (attempt_delay)
-     70   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     71   LOAD_VAR 1              (llm_client)
-     72   LOAD_VAR 2              (context)
-     73   LOAD_VAR 8              (attempt_delay)
-     74   CALL 3                  
-     75   STORE_VAR 10            (result)
-     76   LOAD_VAR 10             (result)
-     77   LOAD_FIELD 0            
-     78   POP_JUMP_IF_FALSE +2    (to 80)
-     79   JUMP +6                 (to 85)
-     80   LOAD_VAR 7              (attempt)
-     81   LOAD_CONST 4            (1)
-     82   BIN_OP +                
-     83   STORE_VAR 7             (attempt)
-     84   JUMP -66                (to 18)
-     85   LOAD_VAR 10             (result)
-     86   RETURN                  
-     87   LOAD_GLOBAL 56          (<fn baml.llm.execute_client_once>)
-     88   LOAD_VAR 1              (llm_client)
-     89   LOAD_VAR 2              (context)
-     90   LOAD_VAR 3              (inherited_delay_ms)
-     91   CALL 3                  
-     92   RETURN                  
+     0    LOAD_VAR 1              (llm_client)
+     1    LOAD_FIELD 3            
+     2    STORE_VAR 4             (_4)
+     3    LOAD_VAR 4              (_4)
+     4    LOAD_CONST 0            (null)
+     5    CMP_OP ==               
+     6    POP_JUMP_IF_FALSE +2    (to 8)
+     7    JUMP +77                (to 84)
+     8    LOAD_VAR 4              (_4)
+     9    STORE_VAR 5             (r)
+     10   LOAD_VAR 5              (r)
+     11   LOAD_FIELD 1            
+     12   LOAD_CONST 1            (0)
+     13   BIN_OP +                
+     14   STORE_VAR 6             (current_delay)
+     15   LOAD_CONST 2            (0)
+     16   STORE_VAR 7             (attempt)
+     17   LOAD_VAR 7              (attempt)
+     18   LOAD_VAR 5              (r)
+     19   LOAD_FIELD 0            
+     20   CMP_OP <=               
+     21   POP_JUMP_IF_FALSE +2    (to 23)
+     22   JUMP +9                 (to 31)
+     23   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     24   COPY 0                  
+     25   LOAD_CONST 3            (false)
+     26   STORE_FIELD 0           
+     27   COPY 0                  
+     28   LOAD_CONST 0            (null)
+     29   STORE_FIELD 1           
+     30   JUMP +58                (to 88)
+     31   LOAD_VAR 3              (inherited_delay_ms)
+     32   STORE_VAR 8             (attempt_delay)
+     33   LOAD_VAR 7              (attempt)
+     34   LOAD_CONST 2            (0)
+     35   CMP_OP >                
+     36   POP_JUMP_IF_FALSE +25   (to 61)
+     37   LOAD_VAR 6              (current_delay)
+     38   CALL 19                 (<fn baml.math.trunc>)
+     39   STORE_VAR 8             (attempt_delay)
+     40   LOAD_VAR 6              (current_delay)
+     41   LOAD_VAR 5              (r)
+     42   LOAD_FIELD 2            
+     43   BIN_OP *                
+     44   STORE_VAR 9             (next)
+     45   LOAD_VAR 9              (next)
+     46   LOAD_VAR 5              (r)
+     47   LOAD_FIELD 3            
+     48   LOAD_CONST 1            (0)
+     49   BIN_OP +                
+     50   CMP_OP >                
+     51   POP_JUMP_IF_FALSE +2    (to 53)
+     52   JUMP +4                 (to 56)
+     53   LOAD_VAR 9              (next)
+     54   STORE_VAR 6             (current_delay)
+     55   JUMP +6                 (to 61)
+     56   LOAD_VAR 5              (r)
+     57   LOAD_FIELD 3            
+     58   LOAD_CONST 1            (0)
+     59   BIN_OP +                
+     60   STORE_VAR 6             (current_delay)
+     61   LOAD_VAR 7              (attempt)
+     62   LOAD_VAR 5              (r)
+     63   LOAD_FIELD 0            
+     64   CMP_OP ==               
+     65   POP_JUMP_IF_FALSE +3    (to 68)
+     66   LOAD_VAR 3              (inherited_delay_ms)
+     67   STORE_VAR 8             (attempt_delay)
+     68   LOAD_VAR 1              (llm_client)
+     69   LOAD_VAR 2              (context)
+     70   LOAD_VAR 8              (attempt_delay)
+     71   CALL 56                 (<fn baml.llm.execute_client_once>)
+     72   STORE_VAR 10            (result)
+     73   LOAD_VAR 10             (result)
+     74   LOAD_FIELD 0            
+     75   POP_JUMP_IF_FALSE +2    (to 77)
+     76   JUMP +6                 (to 82)
+     77   LOAD_VAR 7              (attempt)
+     78   LOAD_CONST 4            (1)
+     79   BIN_OP +                
+     80   STORE_VAR 7             (attempt)
+     81   JUMP -64                (to 17)
+     82   LOAD_VAR 10             (result)
+     83   RETURN                  
+     84   LOAD_VAR 1              (llm_client)
+     85   LOAD_VAR 2              (context)
+     86   LOAD_VAR 3              (inherited_delay_ms)
+     87   CALL 56                 (<fn baml.llm.execute_client_once>)
+     88   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
-     0     INIT_LOCALS 15          
-     1     LOAD_VAR 1              (llm_client)
-     2     LOAD_FIELD 1            
-     3     DISCRIMINANT            
-     4     COPY 0                  
-     5     LOAD_CONST 0            (0)
-     6     CMP_OP ==               
-     7     POP_JUMP_IF_FALSE +3    (to 10)
-     8     POP 1                   
-     9     JUMP +74                (to 83)
-     10    COPY 0                  
-     11    LOAD_CONST 1            (1)
-     12    CMP_OP ==               
-     13    POP_JUMP_IF_FALSE +3    (to 16)
-     14    POP 1                   
-     15    JUMP +27                (to 42)
-     16    POP 1                   
-     17    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
-     18    LOAD_VAR 1              (llm_client)
-     19    LOAD_FIELD 0            
-     20    DISPATCH_FUTURE 1       
-     21    AWAIT                   
-     22    STORE_VAR 16            (_92)
-     23    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     24    LOAD_VAR 1              (llm_client)
-     25    LOAD_FIELD 2            
-     26    CALL 1                  
-     27    STORE_VAR 17            (_97)
-     28    LOAD_GLOBAL 2           (<fn baml.Array.at>)
-     29    LOAD_VAR 1              (llm_client)
-     30    LOAD_FIELD 2            
-     31    LOAD_VAR 16             (_92)
-     32    LOAD_VAR 17             (_97)
-     33    BIN_OP %                
-     34    CALL 2                  
-     35    STORE_VAR 18            (_102)
-     36    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     37    LOAD_VAR 18             (_102)
-     38    LOAD_VAR 2              (context)
-     39    LOAD_VAR 3              (active_delay_ms)
-     40    CALL 3                  
-     41    JUMP +97                (to 138)
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_GLOBAL 0           (<fn baml.Array.length>)
-     46    LOAD_VAR 11             (_iter)
-     47    CALL 1                  
-     48    STORE_VAR 12            (_len)
-     49    LOAD_CONST 0            (0)
-     50    STORE_VAR 13            (_i)
-     51    LOAD_VAR 13             (_i)
-     52    LOAD_VAR 12             (_len)
-     53    CMP_OP <                
-     54    POP_JUMP_IF_FALSE +2    (to 56)
-     55    JUMP +9                 (to 64)
-     56    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     57    COPY 0                  
-     58    LOAD_CONST 2            (false)
-     59    STORE_FIELD 0           
-     60    COPY 0                  
-     61    LOAD_CONST 3            (null)
-     62    STORE_FIELD 1           
-     63    JUMP +75                (to 138)
-     64    LOAD_VAR 11             (_iter)
-     65    LOAD_VAR 13             (_i)
-     66    LOAD_ARRAY_ELEMENT      
-     67    STORE_VAR 14            (sub)
-     68    LOAD_VAR 13             (_i)
-     69    LOAD_CONST 1            (1)
-     70    BIN_OP +                
-     71    STORE_VAR 13            (_i)
-     72    LOAD_GLOBAL 55          (<fn baml.llm.execute_client>)
-     73    LOAD_VAR 14             (sub)
-     74    LOAD_VAR 2              (context)
-     75    LOAD_VAR 3              (active_delay_ms)
-     76    CALL 3                  
-     77    STORE_VAR 15            (result)
-     78    LOAD_VAR 15             (result)
-     79    LOAD_FIELD 0            
-     80    POP_JUMP_IF_FALSE -29   (to 51)
-     81    LOAD_VAR 15             (result)
-     82    RETURN                  
-     83    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
-     84    LOAD_VAR 1              (llm_client)
+     0     LOAD_VAR 1              (llm_client)
+     1     LOAD_FIELD 1            
+     2     DISCRIMINANT            
+     3     COPY 0                  
+     4     LOAD_CONST 0            (0)
+     5     CMP_OP ==               
+     6     POP_JUMP_IF_FALSE +3    (to 9)
+     7     POP 1                   
+     8     JUMP +67                (to 75)
+     9     COPY 0                  
+     10    LOAD_CONST 1            (1)
+     11    CMP_OP ==               
+     12    POP_JUMP_IF_FALSE +3    (to 15)
+     13    POP 1                   
+     14    JUMP +22                (to 36)
+     15    POP 1                   
+     16    LOAD_GLOBAL 45          (<fn baml.llm.round_robin_next>)
+     17    LOAD_VAR 1              (llm_client)
+     18    LOAD_FIELD 0            
+     19    DISPATCH_FUTURE 1       
+     20    AWAIT                   
+     21    STORE_VAR 16            (_92)
+     22    LOAD_VAR 1              (llm_client)
+     23    LOAD_FIELD 2            
+     24    CALL 0                  (<fn baml.Array.length>)
+     25    STORE_VAR 17            (_97)
+     26    LOAD_VAR 1              (llm_client)
+     27    LOAD_FIELD 2            
+     28    LOAD_VAR 16             (_92)
+     29    LOAD_VAR 17             (_97)
+     30    BIN_OP %                
+     31    CALL 2                  (<fn baml.Array.at>)
+     32    LOAD_VAR 2              (context)
+     33    LOAD_VAR 3              (active_delay_ms)
+     34    CALL 55                 (<fn baml.llm.execute_client>)
+     35    JUMP +95                (to 130)
+     36    LOAD_VAR 1              (llm_client)
+     37    LOAD_FIELD 2            
+     38    STORE_VAR 11            (_iter)
+     39    LOAD_VAR 11             (_iter)
+     40    CALL 0                  (<fn baml.Array.length>)
+     41    STORE_VAR 12            (_len)
+     42    LOAD_CONST 0            (0)
+     43    STORE_VAR 13            (_i)
+     44    LOAD_VAR 13             (_i)
+     45    LOAD_VAR 12             (_len)
+     46    CMP_OP <                
+     47    POP_JUMP_IF_FALSE +2    (to 49)
+     48    JUMP +9                 (to 57)
+     49    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     50    COPY 0                  
+     51    LOAD_CONST 2            (false)
+     52    STORE_FIELD 0           
+     53    COPY 0                  
+     54    LOAD_CONST 3            (null)
+     55    STORE_FIELD 1           
+     56    JUMP +74                (to 130)
+     57    LOAD_VAR 11             (_iter)
+     58    LOAD_VAR 13             (_i)
+     59    LOAD_ARRAY_ELEMENT      
+     60    STORE_VAR 14            (sub)
+     61    LOAD_VAR 13             (_i)
+     62    LOAD_CONST 1            (1)
+     63    BIN_OP +                
+     64    STORE_VAR 13            (_i)
+     65    LOAD_VAR 14             (sub)
+     66    LOAD_VAR 2              (context)
+     67    LOAD_VAR 3              (active_delay_ms)
+     68    CALL 55                 (<fn baml.llm.execute_client>)
+     69    STORE_VAR 15            (result)
+     70    LOAD_VAR 15             (result)
+     71    LOAD_FIELD 0            
+     72    POP_JUMP_IF_FALSE -28   (to 44)
+     73    LOAD_VAR 15             (result)
+     74    RETURN                  
+     75    LOAD_GLOBAL 44          (<fn baml.llm.resolve_client>)
+     76    LOAD_VAR 1              (llm_client)
+     77    LOAD_FIELD 0            
+     78    DISPATCH_FUTURE 1       
+     79    AWAIT                   
+     80    CALL_INDIRECT           
+     81    STORE_VAR 4             (primitive)
+     82    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
+     83    LOAD_VAR 4              (primitive)
+     84    LOAD_VAR 2              (context)
      85    LOAD_FIELD 0            
-     86    DISPATCH_FUTURE 1       
-     87    AWAIT                   
-     88    CALL 0                  
-     89    STORE_VAR 4             (primitive)
-     90    LOAD_GLOBAL 37          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     91    LOAD_VAR 4              (primitive)
-     92    LOAD_VAR 2              (context)
-     93    LOAD_FIELD 0            
-     94    LOAD_VAR 2              (context)
-     95    LOAD_FIELD 1            
-     96    DISPATCH_FUTURE 3       
-     97    AWAIT                   
-     98    STORE_VAR 5             (prompt)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 5              (prompt)
-     102   DISPATCH_FUTURE 2       
-     103   AWAIT                   
-     104   STORE_VAR 6             (specialized)
-     105   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
-     106   LOAD_VAR 4              (primitive)
-     107   LOAD_VAR 6              (specialized)
-     108   DISPATCH_FUTURE 2       
-     109   AWAIT                   
-     110   STORE_VAR 7             (http_request)
-     111   LOAD_GLOBAL 36          (<fn baml.http.send>)
-     112   LOAD_VAR 7              (http_request)
-     113   DISPATCH_FUTURE 1       
-     114   AWAIT                   
-     115   STORE_VAR 8             (http_response)
-     116   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
-     117   LOAD_VAR 8              (http_response)
-     118   DISPATCH_FUTURE 1       
-     119   AWAIT                   
-     120   POP_JUMP_IF_FALSE +2    (to 122)
-     121   JUMP +18                (to 139)
-     122   LOAD_VAR 3              (active_delay_ms)
-     123   LOAD_CONST 0            (0)
-     124   CMP_OP >                
-     125   POP_JUMP_IF_FALSE +6    (to 131)
-     126   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     127   LOAD_VAR 3              (active_delay_ms)
-     128   DISPATCH_FUTURE 1       
-     129   AWAIT                   
-     130   POP 1                   
-     131   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     132   COPY 0                  
-     133   LOAD_CONST 2            (false)
-     134   STORE_FIELD 0           
-     135   COPY 0                  
-     136   LOAD_CONST 3            (null)
-     137   STORE_FIELD 1           
-     138   RETURN                  
-     139   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
-     140   LOAD_VAR 8              (http_response)
-     141   DISPATCH_FUTURE 1       
-     142   AWAIT                   
-     143   STORE_VAR 9             (body)
-     144   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
-     145   LOAD_VAR 2              (context)
-     146   LOAD_FIELD 2            
-     147   DISPATCH_FUTURE 1       
-     148   AWAIT                   
-     149   STORE_VAR 10            (return_type)
-     150   RETURN                  
+     86    LOAD_VAR 2              (context)
+     87    LOAD_FIELD 1            
+     88    DISPATCH_FUTURE 3       
+     89    AWAIT                   
+     90    STORE_VAR 5             (prompt)
+     91    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     92    LOAD_VAR 4              (primitive)
+     93    LOAD_VAR 5              (prompt)
+     94    DISPATCH_FUTURE 2       
+     95    AWAIT                   
+     96    STORE_VAR 6             (specialized)
+     97    LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.build_request>)
+     98    LOAD_VAR 4              (primitive)
+     99    LOAD_VAR 6              (specialized)
+     100   DISPATCH_FUTURE 2       
+     101   AWAIT                   
+     102   STORE_VAR 7             (http_request)
+     103   LOAD_GLOBAL 36          (<fn baml.http.send>)
+     104   LOAD_VAR 7              (http_request)
+     105   DISPATCH_FUTURE 1       
+     106   AWAIT                   
+     107   STORE_VAR 8             (http_response)
+     108   LOAD_GLOBAL 34          (<fn baml.http.Response.ok>)
+     109   LOAD_VAR 8              (http_response)
+     110   DISPATCH_FUTURE 1       
+     111   AWAIT                   
+     112   POP_JUMP_IF_FALSE +2    (to 114)
+     113   JUMP +18                (to 131)
+     114   LOAD_VAR 3              (active_delay_ms)
+     115   LOAD_CONST 0            (0)
+     116   CMP_OP >                
+     117   POP_JUMP_IF_FALSE +6    (to 123)
+     118   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   DISPATCH_FUTURE 1       
+     121   AWAIT                   
+     122   POP 1                   
+     123   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     124   COPY 0                  
+     125   LOAD_CONST 2            (false)
+     126   STORE_FIELD 0           
+     127   COPY 0                  
+     128   LOAD_CONST 3            (null)
+     129   STORE_FIELD 1           
+     130   RETURN                  
+     131   LOAD_GLOBAL 33          (<fn baml.http.Response.text>)
+     132   LOAD_VAR 8              (http_response)
+     133   DISPATCH_FUTURE 1       
+     134   AWAIT                   
+     135   STORE_VAR 9             (body)
+     136   LOAD_GLOBAL 47          (<fn baml.llm.get_return_type>)
+     137   LOAD_VAR 2              (context)
+     138   LOAD_FIELD 2            
+     139   DISPATCH_FUTURE 1       
+     140   AWAIT                   
+     141   STORE_VAR 10            (return_type)
+     142   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 53      (<fn baml.llm.resolve_primitive>)
-     7    LOAD_VAR 1          (function_name)
-     8    CALL 1              
-     9    STORE_VAR 4         (primitive_client)
-     10   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     11   LOAD_VAR 4          (primitive_client)
-     12   LOAD_VAR 3          (jinja_string)
-     13   LOAD_VAR 2          (args)
-     14   DISPATCH_FUTURE 3   
-     15   AWAIT               
-     16   STORE_VAR 5         (prompt)
-     17   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     18   LOAD_VAR 4          (primitive_client)
-     19   LOAD_VAR 5          (prompt)
-     20   DISPATCH_FUTURE 2   
-     21   AWAIT               
-     22   RETURN              
+     0    LOAD_GLOBAL 41      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 3         (jinja_string)
+     5    LOAD_VAR 1          (function_name)
+     6    CALL 53             (<fn baml.llm.resolve_primitive>)
+     7    STORE_VAR 4         (primitive_client)
+     8    LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     9    LOAD_VAR 4          (primitive_client)
+     10   LOAD_VAR 3          (jinja_string)
+     11   LOAD_VAR 2          (args)
+     12   DISPATCH_FUTURE 3   
+     13   AWAIT               
+     14   STORE_VAR 5         (prompt)
+     15   LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   LOAD_VAR 4          (primitive_client)
+     17   LOAD_VAR 5          (prompt)
+     18   DISPATCH_FUTURE 2   
+     19   AWAIT               
+     20   RETURN              
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
-     2    LOAD_VAR 1          (function_name)
-     3    DISPATCH_FUTURE 1   
-     4    AWAIT               
-     5    STORE_VAR 2         (llm_client)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
-     7    LOAD_VAR 2          (llm_client)
-     8    LOAD_FIELD 0        
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   CALL 0              
-     12   RETURN
+     0    LOAD_GLOBAL 43      (<fn baml.llm.get_client>)
+     1    LOAD_VAR 1          (function_name)
+     2    DISPATCH_FUTURE 1   
+     3    AWAIT               
+     4    STORE_VAR 2         (llm_client)
+     5    LOAD_GLOBAL 44      (<fn baml.llm.resolve_client>)
+     6    LOAD_VAR 2          (llm_client)
+     7    LOAD_FIELD 0        
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL_INDIRECT       
+     11   RETURN

--- a/baml_language/crates/baml_tests/src/bytecode.rs
+++ b/baml_language/crates/baml_tests/src/bytecode.rs
@@ -264,6 +264,8 @@ fn setup_and_exec_program(
 /// Helper struct for testing VM execution with direct bytecode.
 pub struct BytecodeProgram {
     pub arity: usize,
+    /// Number of additional frame-local slots to preallocate.
+    pub real_local_count: usize,
     pub instructions: Vec<bex_vm_types::Instruction>,
     pub constants: Vec<ConstValue>,
     pub expected: VmExecState,
@@ -282,6 +284,7 @@ pub fn assert_vm_executes_bytecode_with_inspection(
     let function = bex_vm_types::Function {
         name: "test_fn".to_string(),
         arity: input.arity,
+        real_local_count: input.real_local_count,
         bytecode: bex_vm_types::Bytecode {
             source_lines: vec![1; input.instructions.len()],
             scopes: vec![0; input.instructions.len()],
@@ -292,7 +295,7 @@ pub fn assert_vm_executes_bytecode_with_inspection(
         },
         kind: bex_vm_types::FunctionKind::Bytecode,
         locals_in_scope: {
-            let mut names = Vec::with_capacity(input.arity + 1);
+            let mut names = Vec::with_capacity(input.arity + input.real_local_count + 1);
             names.push("<fn test_fn>".to_string());
             names.resize_with(names.capacity(), String::new);
             vec![names]

--- a/baml_language/crates/baml_tests/src/codegen.rs
+++ b/baml_language/crates/baml_tests/src/codegen.rs
@@ -131,14 +131,11 @@ fn convert_instruction(
         bex_vm_types::Instruction::Watch(idx) => Instruction::Watch(*idx),
         bex_vm_types::Instruction::Unwatch(idx) => Instruction::Unwatch(*idx),
         bex_vm_types::Instruction::Notify(idx) => Instruction::Notify(*idx),
-        bex_vm_types::Instruction::Call(n) => Instruction::Call(*n),
-
         bex_vm_types::Instruction::Return => Instruction::Return,
         bex_vm_types::Instruction::Assert => Instruction::Assert,
         bex_vm_types::Instruction::NotifyBlock(idx) => Instruction::NotifyBlock(*idx),
         bex_vm_types::Instruction::VizEnter(idx) => Instruction::VizEnter(*idx),
         bex_vm_types::Instruction::VizExit(idx) => Instruction::VizExit(*idx),
-        bex_vm_types::Instruction::InitLocals(n) => Instruction::InitLocals(*n),
         bex_vm_types::Instruction::JumpTable { table_idx, default } => Instruction::JumpTable {
             table_idx: *table_idx,
             default: *default,
@@ -146,6 +143,9 @@ fn convert_instruction(
         bex_vm_types::Instruction::Discriminant => Instruction::Discriminant,
         bex_vm_types::Instruction::TypeTag => Instruction::TypeTag,
         bex_vm_types::Instruction::Unreachable => Instruction::Unreachable,
+        bex_vm_types::Instruction::Call(_) | bex_vm_types::Instruction::CallIndirect => {
+            anyhow::bail!("CALL instructions are handled by the caller")
+        }
     })
 }
 
@@ -266,20 +266,32 @@ pub fn assert_compiles(input: Program) -> anyhow::Result<()> {
         eprintln!();
 
         // Convert runtime instructions to test instructions
+        let globals_by_index: HashMap<usize, &str> = globals
+            .iter()
+            .map(|(name, idx)| (*idx, name.as_str()))
+            .collect();
+
         let actual_instructions: Vec<Instruction> = function
             .bytecode
             .instructions
             .iter()
             .enumerate()
-            .map(|(inst_idx, inst)| {
-                convert_instruction(
+            .map(|(inst_idx, inst)| match inst {
+                bex_vm_types::Instruction::Call(callee) => Ok(Instruction::Call(
+                    globals_by_index
+                        .get(&callee.raw())
+                        .map(|s| (*s).to_string())
+                        .unwrap_or_else(|| format!("global_{callee}")),
+                )),
+                bex_vm_types::Instruction::CallIndirect => Ok(Instruction::CallIndirect),
+                _ => convert_instruction(
                     inst,
                     inst_idx,
                     &function.bytecode.constants,
                     objects,
                     &globals,
                     function,
-                )
+                ),
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 

--- a/baml_language/crates/baml_tests/src/vm.rs
+++ b/baml_language/crates/baml_tests/src/vm.rs
@@ -356,7 +356,9 @@ pub enum Instruction {
     Watch(usize),
     Unwatch(usize),
     Notify(usize),
-    Call(usize),
+    /// Direct call to a statically-known function by name.
+    Call(String),
+    CallIndirect,
 
     Return,
     Assert,
@@ -364,7 +366,10 @@ pub enum Instruction {
     VizEnter(usize),
     VizExit(usize),
     InitLocals(usize),
-    JumpTable { table_idx: usize, default: isize },
+    JumpTable {
+        table_idx: usize,
+        default: isize,
+    },
     Discriminant,
     TypeTag,
     Unreachable,

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -94,6 +94,19 @@ pub fn display_instruction(
                 format!("(global {})", index.raw())
             }
         }
+        Instruction::Call(callee) => {
+            if callee.raw() < globals.len() {
+                format!("({})", display_value(&globals[*callee]))
+            } else if let (Some(ct_globals), Some(objs)) = (compile_time_globals, objects) {
+                if let Some(const_val) = ct_globals.get(callee.raw()) {
+                    format!("({})", display_const_value(const_val, Some(objs)))
+                } else {
+                    format!("(global {})", callee.raw())
+                }
+            } else {
+                format!("(global {})", callee.raw())
+            }
+        }
         Instruction::LoadVar(index)
         | Instruction::StoreVar(index)
         | Instruction::Watch(index)
@@ -175,9 +188,8 @@ pub fn display_instruction(
         | Instruction::StoreMapElement
         | Instruction::DispatchFuture(_)
         | Instruction::Await
-        | Instruction::Call(_)
+        | Instruction::CallIndirect
         | Instruction::Assert
-        | Instruction::InitLocals(_)
         | Instruction::Discriminant
         | Instruction::TypeTag
         | Instruction::Unreachable
@@ -289,7 +301,7 @@ fn instruction_color(instruction: &Instruction) -> Color {
         Instruction::Jump(_) | Instruction::PopJumpIfFalse(_) | Instruction::JumpTable { .. } => {
             Color::Yellow
         }
-        Instruction::Call(_) => Color::Magenta,
+        Instruction::Call(_) | Instruction::CallIndirect => Color::Magenta,
         Instruction::Assert | Instruction::Return | Instruction::Pop(_) | Instruction::Copy(_) => {
             Color::Red
         }
@@ -302,7 +314,6 @@ fn instruction_color(instruction: &Instruction) -> Color {
             Color::BrightRed
         }
         Instruction::VizEnter(_) | Instruction::VizExit(_) => Color::BrightYellow,
-        Instruction::InitLocals(_) => Color::Green,
         Instruction::Discriminant | Instruction::TypeTag => Color::BrightBlue,
         Instruction::Unreachable => Color::BrightRed,
     }

--- a/baml_language/crates/bex_vm/src/native.rs
+++ b/baml_language/crates/bex_vm/src/native.rs
@@ -577,6 +577,7 @@ pub fn attach_builtins(object: Object) -> Result<Object, VmError> {
             Object::Function(Box::new(bex_vm_types::Function {
                 name: function.name,
                 arity: function.arity,
+                real_local_count: function.real_local_count,
                 bytecode: function.bytecode,
                 kind,
                 locals_in_scope: function.locals_in_scope,

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -631,7 +631,6 @@ impl BexVm {
             self.get_object(function)
         );
 
-        self.stack.push(Value::Object(function));
         self.stack.extend(args.iter().copied());
 
         self.frames.push(Frame {
@@ -639,6 +638,11 @@ impl BexVm {
             instruction_ptr: 0,
             locals_offset: StackIndex::from_raw(0),
         });
+
+        // Entry functions need the same frame-local pre-allocation as normal
+        // bytecode calls now that INIT_LOCALS is gone from bytecode.
+        self.allocate_real_locals_for_frame(function)
+            .expect("entry point must be a valid function frame");
     }
 
     /// Restores the VM state and prepares it for the next execution.
@@ -852,7 +856,6 @@ impl BexVm {
         let locals_offset = self.stack.len();
 
         // Params.
-        self.stack.push(Value::Object(function_ptr));
         self.stack.extend(args.iter().copied());
 
         // Push the new frame.
@@ -861,9 +864,156 @@ impl BexVm {
             instruction_ptr: 0,
             locals_offset: StackIndex::from_raw(locals_offset),
         });
+        self.allocate_real_locals_for_frame(function_ptr)?;
 
         // Execute the interrupt code and return the result.
         self.exec()
+    }
+
+    fn allocate_real_locals_for_frame(&mut self, function_ptr: HeapPtr) -> Result<(), VmError> {
+        let Object::Function(function) = self.get_object(function_ptr) else {
+            return Err(RuntimeError::Other("Invalid frame function".to_string()).into());
+        };
+
+        let new_len = self.stack.len() + function.real_local_count;
+        self.stack.resize(new_len, Value::Null);
+        Ok(())
+    }
+
+    #[inline]
+    fn local_slot_stack_index(locals_offset: StackIndex, slot: usize) -> StackIndex {
+        assert!(
+            slot > 0,
+            "local slot 0 is reserved and should never be materialized on stack"
+        );
+        StackIndex::from_raw(locals_offset.raw() + slot - 1)
+    }
+
+    fn resolve_callable_target(&self, callee_value: Value) -> Result<(HeapPtr, usize), VmError> {
+        let expected_type = FunctionType::Callable;
+        let callee_ptr = self.as_object_ptr(&callee_value, expected_type.into())?;
+        let Object::Function(callee_fn) = self.get_object(callee_ptr) else {
+            return Err(InternalError::TypeError {
+                expected: expected_type.into(),
+                got: ObjectType::of(self.get_object(callee_ptr)).into(),
+            }
+            .into());
+        };
+        Ok((callee_ptr, callee_fn.arity))
+    }
+
+    fn execute_call_from_locals_offset(
+        &mut self,
+        callee_ptr: HeapPtr,
+        locals_offset: StackIndex,
+        arg_count: usize,
+        frame_idx: &mut usize,
+        function: &mut &'static Function,
+    ) -> Result<Option<VmExecState>, VmError> {
+        // Can't call a function if it's not a function ¯\_(ツ)_/¯
+        let Object::Function(callee) = self.get_object(callee_ptr) else {
+            return Err(InternalError::TypeError {
+                expected: FunctionType::Callable.into(),
+                got: ObjectType::of(self.get_object(callee_ptr)).into(),
+            }
+            .into());
+        };
+
+        // Compiler should have already checked this so we could
+        // skip it but it's an easy and fast check.
+        if arg_count != callee.arity {
+            return Err(VmError::from(InternalError::InvalidArgumentCount {
+                expected: callee.arity,
+                got: arg_count,
+            }));
+        }
+
+        // Check if we've reached the max call stack size.
+        if self.frames.len() >= MAX_FRAMES {
+            return Err(VmError::RuntimeError(RuntimeError::StackOverflow));
+        }
+
+        let is_traced = callee.trace;
+
+        match callee.kind {
+            FunctionKind::Native(func_ptr) => {
+                // Cast the type-erased pointer back to NativeFunction.
+                //
+                // SAFETY: The pointer was created by casting a NativeFunction to *const ()
+                // in attach_builtins, so it's safe to cast it back. We use transmute
+                // because Rust doesn't allow `as` casts from *const () to fn pointers.
+                // The explicit type parameters document exactly what we're doing.
+                let func = unsafe { std::mem::transmute::<*const (), NativeFunction>(func_ptr) };
+
+                // NOTE: (perf) could use drain(..) instead, or even maintain the arguments
+                // reference in the stack, using `swap` to insert the result.
+                let args = self.stack[locals_offset..].to_owned();
+
+                // Run Rust native function.
+                let result = func(self, &args)?;
+
+                // Drop function call and place result on top.
+                self.stack.drain(locals_offset..);
+                self.stack.push(result);
+            }
+
+            FunctionKind::Bytecode => {
+                // For traced functions, snapshot args before pushing the frame.
+                let trace_data = if is_traced {
+                    let args: Vec<Value> = self.stack[locals_offset..].to_owned();
+                    let callee_name = callee.name.clone();
+                    Some((callee_name, args))
+                } else {
+                    None
+                };
+
+                // Push the new frame.
+                self.frames.push(Frame {
+                    function: callee_ptr,
+                    instruction_ptr: 0,
+                    locals_offset,
+                });
+                self.allocate_real_locals_for_frame(callee_ptr)?;
+
+                // Update frame_idx to point to the new frame.
+                *frame_idx = self.frames.len() - 1;
+
+                // If traced, record the frame and yield a span notification.
+                if let Some((callee_name, args)) = trace_data {
+                    self.traced_frames.push(*frame_idx);
+
+                    return Ok(Some(VmExecState::SpanNotify(
+                        SpanNotification::FunctionEnter {
+                            function_name: callee_name,
+                            frame_depth: *frame_idx,
+                            args,
+                        },
+                    )));
+                }
+
+                // SAFETY: See `load_function` doc comment.
+                *function = unsafe { self.load_function(*frame_idx)? };
+            }
+
+            FunctionKind::SysOp(_) => {
+                return Err(InternalError::TypeError {
+                    expected: FunctionType::Callable.into(),
+                    got: FunctionType::from(&callee.kind).into(),
+                }
+                .into());
+            }
+
+            FunctionKind::NativeUnresolved => {
+                // This should never happen - native functions should be resolved
+                // by attach_builtins() before the VM runs.
+                panic!(
+                    "Unresolved native function '{}' - did you forget to call attach_builtins()?",
+                    callee.name
+                );
+            }
+        }
+
+        Ok(None)
     }
 
     // Runs filters and returns remaining notifications for the watched node.
@@ -1119,19 +1269,17 @@ impl BexVm {
                     self.stack.push(value);
                 }
 
-                Instruction::InitLocals(count) => {
-                    let new_len = self.stack.len() + count;
-                    self.stack.resize(new_len, Value::Null);
-                }
-
                 Instruction::LoadVar(index) => {
-                    let value = self.stack[self.frames[frame_idx].locals_offset + index];
+                    let slot =
+                        Self::local_slot_stack_index(self.frames[frame_idx].locals_offset, index);
+                    let value = self.stack[slot];
                     self.stack.push(value);
                 }
 
                 Instruction::StoreVar(index) => {
                     // Absolute index of the local variable.
-                    let local_var_index = self.frames[frame_idx].locals_offset + index;
+                    let local_var_index =
+                        Self::local_slot_stack_index(self.frames[frame_idx].locals_offset, index);
 
                     // New value.
                     let value = self.stack.ensure_pop()?;
@@ -2066,7 +2214,7 @@ impl BexVm {
                     let channel = self.as_string(&channel_value)?.to_owned();
 
                     let local_var_index =
-                        StackIndex::from_raw(self.frames[frame_idx].locals_offset.raw() + index);
+                        Self::local_slot_stack_index(self.frames[frame_idx].locals_offset, index);
                     let value = self.stack[local_var_index];
 
                     // The variable index should be the same as where the value is stored
@@ -2105,7 +2253,7 @@ impl BexVm {
 
                 Instruction::Unwatch(index) => {
                     let local_var_index =
-                        StackIndex::from_raw(self.frames[frame_idx].locals_offset.raw() + index);
+                        Self::local_slot_stack_index(self.frames[frame_idx].locals_offset, index);
 
                     // Remove from watched_vars tracking
                     if self.watched_vars.remove(&local_var_index).is_some() {
@@ -2127,7 +2275,7 @@ impl BexVm {
 
                 Instruction::Notify(index) => {
                     let local_var_index =
-                        StackIndex::from_raw(self.frames[frame_idx].locals_offset.raw() + index);
+                        Self::local_slot_stack_index(self.frames[frame_idx].locals_offset, index);
                     let var_node = NodeId::LocalVar(local_var_index);
 
                     let notifications = self.watch.copy_roots_reaching(var_node);
@@ -2141,132 +2289,48 @@ impl BexVm {
                     )));
                 }
 
-                Instruction::Call(arg_count) => {
-                    // Function calls are pushed onto the stack like this:
-                    //
-                    // [callee, arg1, arg2, ..., argN]
-                    //
-                    // The callee is a ref to the function object, and after
-                    // that we have all the function arguments. `arg_count` is
-                    // the number of arguments pushed after the callee.
-                    //
-                    // That's how we compute the relative offset of the callee
-                    // and it's local args in the stack.
-                    let locals_offset = self.stack.ensure_slot_from_top(arg_count)?;
+                Instruction::Call(callee) => {
+                    let callee_value = self.globals[callee];
+                    let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
+                    let args_offset = self
+                        .stack
+                        .len()
+                        .checked_sub(arg_count)
+                        .ok_or(InternalError::NotEnoughItemsOnStack(arg_count))?;
+                    let locals_offset = StackIndex::from_raw(args_offset);
 
-                    // Get the function object from the stack.
-                    let local = &self.stack[locals_offset];
-
-                    let function_type = FunctionType::Callable;
-
-                    let index = self.as_object_ptr(local, function_type.into())?;
-
-                    // Can't call a function if it's not a function ¯\_(ツ)_/¯
-                    let Object::Function(callee) = self.get_object(index) else {
-                        return Err(InternalError::TypeError {
-                            expected: function_type.into(),
-                            got: ObjectType::of(self.get_object(index)).into(),
-                        }
-                        .into());
-                    };
-
-                    // Compiler should have already checked this so we could
-                    // skip it but it's an easy and fast check.
-                    if arg_count != callee.arity {
-                        return Err(VmError::from(InternalError::InvalidArgumentCount {
-                            expected: callee.arity,
-                            got: arg_count,
-                        }));
+                    if let Some(state) = self.execute_call_from_locals_offset(
+                        callee_ptr,
+                        locals_offset,
+                        arg_count,
+                        &mut frame_idx,
+                        &mut function,
+                    )? {
+                        return Ok(state);
                     }
+                }
 
-                    // Check if we've reached the max call stack size.
-                    if self.frames.len() >= MAX_FRAMES {
-                        return Err(VmError::RuntimeError(RuntimeError::StackOverflow));
-                    }
+                Instruction::CallIndirect => {
+                    // Stack layout: [arg1, arg2, ..., argN, callee]
+                    let callee_slot = self.stack.ensure_stack_top()?;
+                    let callee_value = self.stack[callee_slot];
+                    let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
+                    let args_offset = self
+                        .stack
+                        .len()
+                        .checked_sub(arg_count + 1)
+                        .ok_or(InternalError::NotEnoughItemsOnStack(arg_count + 1))?;
+                    let _popped_callee = self.stack.ensure_pop()?;
+                    let locals_offset = StackIndex::from_raw(args_offset);
 
-                    let is_traced = callee.trace;
-
-                    match callee.kind {
-                        FunctionKind::Native(func_ptr) => {
-                            // Cast the type-erased pointer back to NativeFunction.
-                            //
-                            // SAFETY: The pointer was created by casting a NativeFunction to *const ()
-                            // in attach_builtins, so it's safe to cast it back. We use transmute
-                            // because Rust doesn't allow `as` casts from *const () to fn pointers.
-                            // The explicit type parameters document exactly what we're doing.
-                            let func = unsafe {
-                                std::mem::transmute::<*const (), NativeFunction>(func_ptr)
-                            };
-
-                            // NOTE: (perf) could use drain(..) instead, or even maintain the arguments
-                            // reference in the stack, using `swap` to insert the result.
-                            let args = self.stack
-                                [StackIndex::from_raw(locals_offset.into_raw() + 1)..]
-                                .to_owned();
-
-                            // Run Rust native function.
-                            let result = func(self, &args)?;
-
-                            // Drop function call and place result on top.
-                            self.stack.drain(locals_offset..);
-                            self.stack.push(result);
-                        }
-
-                        FunctionKind::Bytecode => {
-                            // For traced functions, snapshot args before pushing the frame.
-                            let trace_data = if is_traced {
-                                let args_start = locals_offset.into_raw() + 1;
-                                let args: Vec<Value> =
-                                    self.stack[StackIndex::from_raw(args_start)..].to_owned();
-                                let callee_name = callee.name.clone();
-                                Some((callee_name, args))
-                            } else {
-                                None
-                            };
-
-                            // Push the new frame.
-                            self.frames.push(Frame {
-                                function: index,
-                                instruction_ptr: 0,
-                                locals_offset,
-                            });
-
-                            // Update frame_idx to point to the new frame.
-                            frame_idx = self.frames.len() - 1;
-
-                            // If traced, record the frame and yield a span notification.
-                            if let Some((callee_name, args)) = trace_data {
-                                self.traced_frames.push(frame_idx);
-
-                                return Ok(VmExecState::SpanNotify(
-                                    SpanNotification::FunctionEnter {
-                                        function_name: callee_name,
-                                        frame_depth: frame_idx,
-                                        args,
-                                    },
-                                ));
-                            }
-
-                            // SAFETY: See `load_function` doc comment.
-                            function = unsafe { self.load_function(frame_idx)? };
-                        }
-
-                        FunctionKind::SysOp(_) => {
-                            return Err(InternalError::TypeError {
-                                expected: FunctionType::Callable.into(),
-                                got: FunctionType::from(&callee.kind).into(),
-                            }
-                            .into());
-                        }
-
-                        FunctionKind::NativeUnresolved => {
-                            // This should never happen - native functions should be resolved
-                            // by attach_builtins() before the VM runs.
-                            panic!(
-                                "Unresolved native function '{}' - did you forget to call attach_builtins()?",
-                                callee.name
-                            );
-                        }
+                    if let Some(state) = self.execute_call_from_locals_offset(
+                        callee_ptr,
+                        locals_offset,
+                        arg_count,
+                        &mut frame_idx,
+                        &mut function,
+                    )? {
+                        return Ok(state);
                     }
                 }
 

--- a/baml_language/crates/bex_vm/tests/functions.rs
+++ b/baml_language/crates/bex_vm/tests/functions.rs
@@ -1,6 +1,10 @@
 //! VM tests for function calls, parameters, and return statements.
 
-use baml_tests::bytecode::{ExecState, Program, Value, assert_vm_executes};
+use baml_tests::bytecode::{
+    BytecodeProgram, ExecState, Program, Value, assert_vm_executes, assert_vm_executes_bytecode,
+};
+use bex_vm::VmExecState;
+use bex_vm_types::{ConstValue, Instruction, Value as VmValue};
 
 #[test]
 fn return_function_call() -> anyhow::Result<()> {
@@ -157,5 +161,43 @@ fn recursive() -> anyhow::Result<()> {
         "#,
         function: "main",
         expected: ExecState::Complete(Value::Int(2)),
+    })
+}
+
+#[test]
+fn indirect_call_with_function_value() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            function add(a: int, b: int) -> int {
+                a + b
+            }
+
+            function call_twice(f: (int, int) -> int, x: int, y: int) -> int {
+                f(x, y) + f(x, y)
+            }
+
+            function main() -> int {
+                let f = add;
+                call_twice(f, 20, 1)
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::Int(42)),
+    })
+}
+
+#[test]
+fn bytecode_respects_real_local_count() -> anyhow::Result<()> {
+    assert_vm_executes_bytecode(BytecodeProgram {
+        arity: 0,
+        real_local_count: 1,
+        instructions: vec![
+            Instruction::LoadConst(0),
+            Instruction::StoreVar(1),
+            Instruction::LoadVar(1),
+            Instruction::Return,
+        ],
+        constants: vec![ConstValue::Int(42)],
+        expected: VmExecState::Complete(VmValue::Int(42)),
     })
 }

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -262,14 +262,22 @@ pub enum Instruction {
     /// Manually triggers notifications for a watched variable.
     Notify(usize),
 
-    /// Call a function.
+    /// Call a statically-known global function.
     ///
-    /// Format: `CALL n` where `n` is the number of arguments passed to the
-    /// function.
+    /// Format: `CALL g` where `g` is the global index of the callee function.
     ///
-    /// Arguments are pushed onto the eval stack and the name of the function
-    /// is right below them.
-    Call(usize),
+    /// Arguments are pushed onto the eval stack. The callee is read from
+    /// `Vm::globals[g]`, and arity is read from function metadata.
+    Call(GlobalIndex),
+
+    /// Call a function value from the eval stack.
+    ///
+    /// Format: `CALL_INDIRECT`.
+    ///
+    /// Stack layout: `[arg1, ..., argN, callee]`.
+    ///
+    /// Arity is read from the runtime callee function object.
+    CallIndirect,
 
     /// Return from a function.
     ///
@@ -336,17 +344,6 @@ pub enum Instruction {
     /// - Primitives: `int=0`, `string=1`, `bool=2`, `null=3`, `float=4`
     /// - Classes: assigned unique IDs starting at 100
     TypeTag,
-
-    /// Initialize local variable slots by pushing `n` null values onto the stack.
-    ///
-    /// Format: `INIT_LOCALS n` where `n` is the number of local variable slots
-    /// to allocate. Each slot is initialized to null.
-    ///
-    /// This is emitted once at the start of a function's bytecode to reserve
-    /// stack space for all "Real" local variables (i.e., those that aren't
-    /// virtual, phi-like, or dead). Parameters are not included since they
-    /// are already on the stack after [`Instruction::Call`].
-    InitLocals(usize),
 
     /// Halt execution with an unreachable code error.
     ///
@@ -535,7 +532,8 @@ impl std::fmt::Display for Instruction {
             Instruction::AllocVariant(i) => write!(f, "ALLOC_VARIANT {i}"),
             Instruction::DispatchFuture(i) => write!(f, "DISPATCH_FUTURE {i}"),
             Instruction::Await => f.write_str("AWAIT"),
-            Instruction::Call(n) => write!(f, "CALL {n}"),
+            Instruction::Call(callee) => write!(f, "CALL {callee}"),
+            Instruction::CallIndirect => f.write_str("CALL_INDIRECT"),
 
             Instruction::Return => f.write_str("RETURN"),
             Instruction::Assert => f.write_str("ASSERT"),
@@ -553,7 +551,6 @@ impl std::fmt::Display for Instruction {
             }
             Instruction::Discriminant => f.write_str("DISCRIMINANT"),
             Instruction::TypeTag => f.write_str("TYPE_TAG"),
-            Instruction::InitLocals(n) => write!(f, "INIT_LOCALS {n}"),
             Instruction::Unreachable => f.write_str("UNREACHABLE"),
         }
     }

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -231,6 +231,12 @@ pub struct Function {
     /// Number of arguments the function accepts.
     pub arity: usize,
 
+    /// Number of additional local slots (beyond callee + params) needed by the frame.
+    ///
+    /// The VM allocates these slots when creating a bytecode frame, instead of
+    /// relying on a dedicated bytecode instruction.
+    pub real_local_count: usize,
+
     /// Bytecode to execute.
     ///
     /// Only relevant if [`Self::kind`] is [`FunctionKind::Bytecode`].


### PR DESCRIPTION
## Summary
- change VM call ABI to split direct and indirect calls: CALL with global callee index for statically-known callees, and CALL_INDIRECT for runtime function values
- remove InitLocals instruction and move local-slot setup into frame metadata via Function.real_local_count
- update emitter, pull semantics, and stack-carry simulation to match the new call stack layouts and keep analysis/emission behavior aligned
- update test-friendly codegen representation for direct calls by name and refresh compiler snapshots
- fix debug formatting so CALL metadata resolves compile-time globals to readable function names

## Tests
- cargo test -p bex_vm --test functions
- cargo test -p baml_tests test_06_codegen
- cargo test -p baml_compiler_emit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized bytecode generation for improved local variable initialization and function call efficiency
  * Updated compiler internals to emit cleaner, more direct function calls
  * Streamlined stack-handling logic for better code generation

* **Tests**
  * Updated test expectations to reflect compiler optimizations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->