### PR TITLE
baml-language: make '_' discard handling consistent in match lowering

### DIFF
--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -1419,16 +1419,19 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                     self.locals.insert(name.clone(), local);
                 }
                 Pattern::TypedBinding { name, ty } => {
-                    // Typed binding - bind the variable with its specific type
-                    let pattern_ty = ty.clone();
-                    let local =
-                        self.builder
-                            .declare_local(Some(name.clone()), pattern_ty, None, false);
-                    self.builder.assign(
-                        Place::local(local),
-                        Rvalue::Use(Operand::copy_local(scrutinee_local)),
-                    );
-                    self.locals.insert(name.clone(), local);
+                    // Typed binding - bind the variable with its specific type.
+                    // `_` is a discard binding and must not be materialized.
+                    if name.as_str() != "_" {
+                        let pattern_ty = ty.clone();
+                        let local =
+                            self.builder
+                                .declare_local(Some(name.clone()), pattern_ty, None, false);
+                        self.builder.assign(
+                            Place::local(local),
+                            Rvalue::Use(Operand::copy_local(scrutinee_local)),
+                        );
+                        self.locals.insert(name.clone(), local);
+                    }
                 }
                 _ => {
                     // No binding needed (e.g., literal patterns, enum variants, wildcards)
@@ -1457,18 +1460,21 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
         let pat = body.pattern(pat_id);
         match pat {
             Pattern::Binding(name) => {
-                // Binding always matches - bind the variable and go to success
-                let local = self.builder.declare_local(
-                    Some(name.clone()),
-                    scrutinee_ty.clone(),
-                    None,
-                    false,
-                );
-                self.builder.assign(
-                    Place::local(local),
-                    Rvalue::Use(Operand::copy_local(scrutinee_local)),
-                );
-                self.locals.insert(name.clone(), local);
+                // Binding always matches. `_` is a discard binding and must not
+                // be materialized as a usable local.
+                if name.as_str() != "_" {
+                    let local = self.builder.declare_local(
+                        Some(name.clone()),
+                        scrutinee_ty.clone(),
+                        None,
+                        false,
+                    );
+                    self.builder.assign(
+                        Place::local(local),
+                        Rvalue::Use(Operand::copy_local(scrutinee_local)),
+                    );
+                    self.locals.insert(name.clone(), local);
+                }
                 self.builder.goto(success_block);
             }
             Pattern::TypedBinding { name, ty } => {
@@ -1493,16 +1499,19 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                 self.builder
                     .branch(Operand::copy_local(check_local), bind_block, fail_block);
 
-                // In bind block: bind the variable and go to success
+                // In bind block: bind the variable and go to success.
+                // `_` is a discard binding and must not be materialized.
                 self.builder.set_current_block(bind_block);
-                let local = self
-                    .builder
-                    .declare_local(Some(name.clone()), pattern_ty, None, false);
-                self.builder.assign(
-                    Place::local(local),
-                    Rvalue::Use(Operand::copy_local(scrutinee_local)),
-                );
-                self.locals.insert(name.clone(), local);
+                if name.as_str() != "_" {
+                    let local =
+                        self.builder
+                            .declare_local(Some(name.clone()), pattern_ty, None, false);
+                    self.builder.assign(
+                        Place::local(local),
+                        Rvalue::Use(Operand::copy_local(scrutinee_local)),
+                    );
+                    self.locals.insert(name.clone(), local);
+                }
                 self.builder.goto(success_block);
             }
             Pattern::Literal(lit) => {

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -2577,9 +2577,12 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         let (binding_name, narrowed_ty) =
                             extract_pattern_binding(ctx, pattern, arm.pattern, &scrutinee_ty, body);
 
-                        // Bind the pattern variable with the narrowed type
+                        // Bind the pattern variable with the narrowed type.
+                        // `_` is a discard binding
                         if let Some(name) = binding_name {
-                            ctx.define(name, narrowed_ty);
+                            if name.as_str() != "_" {
+                                ctx.define(name, narrowed_ty);
+                            }
                         }
 
                         // Type-check the guard (if present)

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-5f3cea2866046cb1/out/generated_tests.rs
+source: target/debug/build/baml_tests-1a45e748177ce512/out/generated_tests.rs
 expression: output
 ---
 === MIR ===
@@ -191,14 +191,12 @@ fn UnreachableMultiple(x: int) -> string {
     // Locals:
     let _0: string // return
     let _1: int // x // param
-    let _2: int // _
-    let _3: bool
-    let _4: int // n
-    let _5: bool
-    let _6: int // m
+    let _2: bool
+    let _3: int // n
+    let _4: bool
+    let _5: int // m
 
     bb0: {
-        _2 = copy _1;
         goto -> bb4;
     }
 
@@ -220,8 +218,8 @@ fn UnreachableMultiple(x: int) -> string {
     }
 
     bb5: {
-        _3 = is_type(copy _1, Int);
-        branch copy _3 -> [bb8, bb7];
+        _2 = is_type(copy _1, Int);
+        branch copy _2 -> [bb8, bb7];
     }
 
     bb6: {
@@ -230,12 +228,12 @@ fn UnreachableMultiple(x: int) -> string {
     }
 
     bb7: {
-        _5 = is_type(copy _1, Int);
-        branch copy _5 -> [bb10, bb3];
+        _4 = is_type(copy _1, Int);
+        branch copy _4 -> [bb10, bb3];
     }
 
     bb8: {
-        _4 = copy _1;
+        _3 = copy _1;
         goto -> bb6;
     }
 
@@ -245,7 +243,7 @@ fn UnreachableMultiple(x: int) -> string {
     }
 
     bb10: {
-        _6 = copy _1;
+        _5 = copy _1;
         goto -> bb9;
     }
 
@@ -721,7 +719,6 @@ fn ExhaustiveTypeAliasWithCatchAll(r: Success | Failure) -> string {
     let _2: bool
     let _3: Success // s
     let _4: Success
-    let _5: Success | Failure // _
 
     bb0: {
         _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
@@ -747,7 +744,6 @@ fn ExhaustiveTypeAliasWithCatchAll(r: Success | Failure) -> string {
     }
 
     bb5: {
-        _5 = copy _1;
         goto -> bb7;
     }
 
@@ -1266,7 +1262,6 @@ fn BoolWithCatchAll(b: bool) -> string {
     let _0: string // return
     let _1: bool // b // param
     let _2: bool
-    let _3: bool // _
 
     bb0: {
         _2 = copy _1 == const true;
@@ -1291,7 +1286,6 @@ fn BoolWithCatchAll(b: bool) -> string {
     }
 
     bb5: {
-        _3 = copy _1;
         goto -> bb6;
     }
 
@@ -1720,7 +1714,6 @@ fn PartialUnionPlusCatchAll(r: Success | Failure | Pending) -> string {
     let _2: bool
     let _3: Success | Failure // x
     let _4: bool
-    let _5: Pending // _
 
     bb0: {
         _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
@@ -1760,7 +1753,6 @@ fn PartialUnionPlusCatchAll(r: Success | Failure | Pending) -> string {
     }
 
     bb8: {
-        _5 = copy _1;
         goto -> bb7;
     }
 
@@ -2319,7 +2311,6 @@ fn GuardedWithFallback(x: int) -> int {
     let _6: 0
     let _7: int
     let _8: 2
-    let _9: int // _
 
     bb0: {
         _2 = is_type(copy _1, Int);
@@ -2346,7 +2337,6 @@ fn GuardedWithFallback(x: int) -> int {
     }
 
     bb5: {
-        _9 = copy _1;
         goto -> bb8;
     }
 
@@ -2982,12 +2972,10 @@ fn UnreachableAfterCatchAll(x: int) -> string {
     // Locals:
     let _0: string // return
     let _1: int // x // param
-    let _2: int // _
-    let _3: bool
-    let _4: int // n
+    let _2: bool
+    let _3: int // n
 
     bb0: {
-        _2 = copy _1;
         goto -> bb4;
     }
 
@@ -3009,8 +2997,8 @@ fn UnreachableAfterCatchAll(x: int) -> string {
     }
 
     bb5: {
-        _3 = is_type(copy _1, Int);
-        branch copy _3 -> [bb7, bb3];
+        _2 = is_type(copy _1, Int);
+        branch copy _2 -> [bb7, bb3];
     }
 
     bb6: {
@@ -3019,7 +3007,7 @@ fn UnreachableAfterCatchAll(x: int) -> string {
     }
 
     bb7: {
-        _4 = copy _1;
+        _3 = copy _1;
         goto -> bb6;
     }
 
@@ -3030,7 +3018,6 @@ fn OptionalWithCatchAll(x: int?) -> string {
     let _0: string // return
     let _1: int? // x // param
     let _2: bool
-    let _3: int? // _
 
     bb0: {
         _2 = copy _1 == const null;
@@ -3055,7 +3042,6 @@ fn OptionalWithCatchAll(x: int?) -> string {
     }
 
     bb5: {
-        _3 = copy _1;
         goto -> bb6;
     }
 
@@ -3123,9 +3109,7 @@ fn OverlappingTypedPatterns(r: Success | Failure) -> string {
     let _0: string // return
     let _1: Success | Failure // r // param
     let _2: bool
-    let _3: Success // _
-    let _4: bool
-    let _5: Success | Failure // _
+    let _3: bool
 
     bb0: {
         _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
@@ -3150,12 +3134,11 @@ fn OverlappingTypedPatterns(r: Success | Failure) -> string {
     }
 
     bb5: {
-        _4 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
-        branch copy _4 -> [bb8, bb3];
+        _3 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
+        branch copy _3 -> [bb8, bb3];
     }
 
     bb6: {
-        _3 = copy _1;
         goto -> bb4;
     }
 
@@ -3165,7 +3148,6 @@ fn OverlappingTypedPatterns(r: Success | Failure) -> string {
     }
 
     bb8: {
-        _5 = copy _1;
         goto -> bb7;
     }
 
@@ -3447,7 +3429,6 @@ fn StringLiteralWithCatchAll(role: "user" | "assistant" | "system") -> string {
     let _1: "user" | "assistant" | "system" // role // param
     let _2: bool
     let _3: bool
-    let _4: "user" | "assistant" | "system" // _
 
     bb0: {
         _2 = copy _1 == const "user";
@@ -3482,7 +3463,6 @@ fn StringLiteralWithCatchAll(role: "user" | "assistant" | "system") -> string {
     }
 
     bb7: {
-        _4 = copy _1;
         goto -> bb8;
     }
 
@@ -3534,7 +3514,6 @@ fn MixedPatterns(x: int) -> string {
     let _6: bool
     let _7: int
     let _8: 0
-    let _9: int // _
 
     bb0: {
         _2 = copy _1 == const 0_i64;
@@ -3581,7 +3560,6 @@ fn MixedPatterns(x: int) -> string {
     }
 
     bb9: {
-        _9 = copy _1;
         goto -> bb12;
     }
 

--- a/baml_language/crates/bex_vm/tests/match_expr.rs
+++ b/baml_language/crates/bex_vm/tests/match_expr.rs
@@ -195,6 +195,28 @@ fn match_typed_pattern_with_field_access() -> anyhow::Result<()> {
     })
 }
 
+#[test]
+fn match_typed_discard_patterns_typetag_switch_path() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            function classify(x int | string | bool | float) -> int {
+                match (x) {
+                    _: int => 1,
+                    _: string => 2,
+                    _: bool => 3,
+                    _: float => 4,
+                }
+            }
+
+            function main() -> int {
+                classify(true)
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::Int(3)),
+    })
+}
+
 // ============================================================================
 // Guard Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- Stop materializing `_` as a local match binding in TIR and MIR so discard behavior is consistent across switch and if-else lowering paths.
- Extend switch-path typed binding handling so typed discard patterns like `_: Type` also skip local insertion.
- Add a VM regression test for typed discard patterns on the type-tag switch path.

## Validation
- cargo test -p baml_compiler_tir
- cargo test -p baml_compiler_emit --test match_expr
- cargo test -p bex_vm --test match_expr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed discard patterns (underscore `_`) in pattern matching to no longer allocate unnecessary resources during compilation and type inference.

* **Tests**
  * Added test coverage for typed discard patterns in match expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->