### PR TITLE
Align DispatchFuture with direct-call ABI

### DIFF
--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -799,8 +799,21 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 future,
                 resume,
             } => {
-                unwrap_infallible(pull_semantics::walk_invoke_operands(self, callee, args));
-                self.emit(Instruction::DispatchFuture(args.len()));
+                let global_callee = pull_semantics::resolve_constant_function_name(
+                    callee,
+                    &self.analysis.classifications,
+                    &self.analysis.def_use,
+                )
+                .and_then(|name| self.globals.get(&name).copied())
+                .map(GlobalIndex::from_raw)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "dispatch_future callee must resolve to a statically-known global function: {callee:?}"
+                    )
+                });
+
+                unwrap_infallible(pull_semantics::walk_call_direct_args(self, args));
+                self.emit(Instruction::DispatchFuture(global_callee));
                 self.emit_store_place(future);
                 self.emit_jump_unless_fallthrough(*resume);
             }

--- a/baml_language/crates/baml_compiler_emit/src/pull_semantics.rs
+++ b/baml_language/crates/baml_compiler_emit/src/pull_semantics.rs
@@ -174,21 +174,6 @@ pub(crate) fn walk_assert_statement<S: StackEffectSink>(
     sink.assert_top()
 }
 
-/// Shared pull order for call-like terminators that consume `[callee, args...]`.
-///
-/// This remains the order used by `DispatchFuture`.
-pub(crate) fn walk_invoke_operands<S: PullSink>(
-    sink: &mut S,
-    callee: &Operand,
-    args: &[Operand],
-) -> Result<(), S::Error> {
-    walk_operand_pull(sink, callee)?;
-    for arg in args {
-        walk_operand_pull(sink, arg)?;
-    }
-    Ok(())
-}
-
 /// Shared pull order for direct calls: each arg only.
 pub(crate) fn walk_call_direct_args<S: PullSink>(
     sink: &mut S,

--- a/baml_language/crates/baml_compiler_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler_emit/src/stack_carry.rs
@@ -474,17 +474,23 @@ fn simulate_terminator_stack(
             future,
             ..
         } => {
+            if pull_semantics::resolve_constant_function_name(callee, classifications, def_use)
+                .is_none()
+            {
+                return false;
+            }
+
             let mut sink = StackCarryPullSink {
                 sim,
                 carried_local,
                 classifications,
                 def_use,
             };
-            if pull_semantics::walk_invoke_operands(&mut sink, callee, args).is_err() {
+            if pull_semantics::walk_call_direct_args(&mut sink, args).is_err() {
                 return false;
             }
 
-            if !sim.pop_n(args.len() + 1) {
+            if !sim.pop_n(args.len()) {
                 return false;
             }
             sim.push();

--- a/baml_language/crates/baml_compiler_emit/tests/builtins.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/builtins.rs
@@ -50,10 +50,9 @@ fn fetch_as() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::LoadGlobal(Value::function("baml.fetch_as")),
                 Instruction::LoadConst(Value::string("https://dummyjson.com/todos/1")),
                 Instruction::LoadConst(Value::class("DummyJsonTodo")),
-                Instruction::DispatchFuture(2),
+                Instruction::DispatchFuture("baml.fetch_as".to_string()),
                 Instruction::Await,
                 Instruction::Return,
             ],
@@ -88,7 +87,6 @@ fn fetch_as_with_request_param() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::LoadGlobal(Value::function("baml.fetch_as")),
                 Instruction::AllocInstance(Value::class("baml.HttpRequest")),
                 Instruction::Copy(0),
                 Instruction::LoadConst(Value::Int(1)), // Enum variant index for Post
@@ -108,7 +106,7 @@ fn fetch_as_with_request_param() -> anyhow::Result<()> {
                 Instruction::AllocMap(3),
                 Instruction::StoreField(4),
                 Instruction::LoadConst(Value::class("DummyJsonTodo")),
-                Instruction::DispatchFuture(2),
+                Instruction::DispatchFuture("baml.fetch_as".to_string()),
                 Instruction::Await,
                 Instruction::Return,
             ],

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
@@ -44,24 +44,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -114,9 +113,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -133,7 +132,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -168,22 +167,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -297,66 +295,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -366,7 +358,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -389,71 +381,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -464,193 +455,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -70,24 +70,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -140,9 +139,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -159,7 +158,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -194,22 +193,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -323,66 +321,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -392,7 +384,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -415,71 +407,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -490,193 +481,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/big_t_type_annotation/baml_tests__big_t_type_annotation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/big_t_type_annotation/baml_tests__big_t_type_annotation__06_codegen.snap
@@ -44,24 +44,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -114,9 +113,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -133,7 +132,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -168,22 +167,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -297,66 +295,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -366,7 +358,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -389,71 +381,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -464,202 +455,179 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN              
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN               
 
 Function test_big_t_type (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48      (<fn baml.llm.get_return_type>)
-     1   LOAD_VAR 1          (function_name)
-     2   DISPATCH_FUTURE 1   
-     3   AWAIT               
-     4   STORE_VAR 2         (t)
-     5   LOAD_CONST 0        ("ok")
-     6   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 48   (<fn baml.llm.get_return_type>)
+     2   AWAIT                
+     3   STORE_VAR 2          (t)
+     4   LOAD_CONST 0         ("ok")
+     5   RETURN

--- a/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
@@ -8,174 +8,140 @@ Objects: 104
 Globals: 74
 
 Function ChainCommands (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 27      (<fn baml.sys.shell>)
-     1    LOAD_CONST 0        ("pwd")
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 1         (result1)
-     5    LOAD_GLOBAL 27      (<fn baml.sys.shell>)
-     6    LOAD_CONST 1        ("whoami")
-     7    DISPATCH_FUTURE 1   
-     8    AWAIT               
-     9    STORE_VAR 2         (result2)
-     10   LOAD_VAR 1          (result1)
-     11   LOAD_CONST 2        (" - ")
-     12   BIN_OP +            
-     13   LOAD_VAR 2          (result2)
-     14   BIN_OP +            
-     15   RETURN              
+     0    LOAD_CONST 0         ("pwd")
+     1    DISPATCH_FUTURE 27   (<fn baml.sys.shell>)
+     2    AWAIT                
+     3    STORE_VAR 1          (result1)
+     4    LOAD_CONST 1         ("whoami")
+     5    DISPATCH_FUTURE 27   (<fn baml.sys.shell>)
+     6    AWAIT                
+     7    STORE_VAR 2          (result2)
+     8    LOAD_VAR 1           (result1)
+     9    LOAD_CONST 2         (" - ")
+     10   BIN_OP +             
+     11   LOAD_VAR 2           (result2)
+     12   BIN_OP +             
+     13   RETURN               
 
 Function ConnectAndRead (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 33      (<fn baml.net.connect>)
-     1   LOAD_CONST 0        ("127.0.0.1:8080")
-     2   DISPATCH_FUTURE 1   
-     3   AWAIT               
-     4   STORE_VAR 1         (sock)
-     5   LOAD_GLOBAL 31      (<fn baml.net.Socket.read>)
-     6   LOAD_VAR 1          (sock)
-     7   DISPATCH_FUTURE 1   
-     8   AWAIT               
-     9   RETURN              
+     0   LOAD_CONST 0         ("127.0.0.1:8080")
+     1   DISPATCH_FUTURE 33   (<fn baml.net.connect>)
+     2   AWAIT                
+     3   DISPATCH_FUTURE 31   (<fn baml.net.Socket.read>)
+     4   AWAIT                
+     5   RETURN               
 
 Function ConnectAndReadInline (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 33      (<fn baml.net.connect>)
-     1   LOAD_CONST 0        ("localhost:3000")
-     2   DISPATCH_FUTURE 1   
-     3   AWAIT               
-     4   STORE_VAR 1         (_1)
-     5   LOAD_GLOBAL 31      (<fn baml.net.Socket.read>)
-     6   LOAD_VAR 1          (_1)
-     7   DISPATCH_FUTURE 1   
-     8   AWAIT               
-     9   RETURN              
+     0   LOAD_CONST 0         ("localhost:3000")
+     1   DISPATCH_FUTURE 33   (<fn baml.net.connect>)
+     2   AWAIT                
+     3   DISPATCH_FUTURE 31   (<fn baml.net.Socket.read>)
+     4   AWAIT                
+     5   RETURN               
 
 Function ConnectReadAndClose (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 33      (<fn baml.net.connect>)
-     1    LOAD_CONST 0        ("127.0.0.1:8080")
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 1         (sock)
-     5    LOAD_GLOBAL 31      (<fn baml.net.Socket.read>)
-     6    LOAD_VAR 1          (sock)
-     7    DISPATCH_FUTURE 1   
-     8    AWAIT               
-     9    STORE_VAR 2         (data)
-     10   LOAD_GLOBAL 32      (<fn baml.net.Socket.close>)
-     11   LOAD_VAR 1          (sock)
-     12   DISPATCH_FUTURE 1   
-     13   AWAIT               
-     14   POP 1               
-     15   LOAD_VAR 2          (data)
-     16   RETURN              
+     0    LOAD_CONST 0         ("127.0.0.1:8080")
+     1    DISPATCH_FUTURE 33   (<fn baml.net.connect>)
+     2    AWAIT                
+     3    STORE_VAR 1          (sock)
+     4    LOAD_VAR 1           (sock)
+     5    DISPATCH_FUTURE 31   (<fn baml.net.Socket.read>)
+     6    AWAIT                
+     7    STORE_VAR 2          (data)
+     8    LOAD_VAR 1           (sock)
+     9    DISPATCH_FUTURE 32   (<fn baml.net.Socket.close>)
+     10   AWAIT                
+     11   POP 1                
+     12   LOAD_VAR 2           (data)
+     13   RETURN               
 
 Function MultipleConnections (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 33      (<fn baml.net.connect>)
-     1    LOAD_CONST 0        ("server1:80")
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 1         (s1)
-     5    LOAD_GLOBAL 33      (<fn baml.net.connect>)
-     6    LOAD_CONST 1        ("server2:80")
-     7    DISPATCH_FUTURE 1   
-     8    AWAIT               
-     9    STORE_VAR 2         (s2)
-     10   LOAD_GLOBAL 31      (<fn baml.net.Socket.read>)
-     11   LOAD_VAR 1          (s1)
-     12   DISPATCH_FUTURE 1   
-     13   AWAIT               
-     14   STORE_VAR 3         (data1)
-     15   LOAD_GLOBAL 31      (<fn baml.net.Socket.read>)
-     16   LOAD_VAR 2          (s2)
-     17   DISPATCH_FUTURE 1   
-     18   AWAIT               
-     19   STORE_VAR 4         (data2)
-     20   LOAD_VAR 3          (data1)
-     21   LOAD_VAR 4          (data2)
-     22   BIN_OP +            
-     23   RETURN              
+     0    LOAD_CONST 0         ("server1:80")
+     1    DISPATCH_FUTURE 33   (<fn baml.net.connect>)
+     2    AWAIT                
+     3    STORE_VAR 1          (s1)
+     4    LOAD_CONST 1         ("server2:80")
+     5    DISPATCH_FUTURE 33   (<fn baml.net.connect>)
+     6    AWAIT                
+     7    STORE_VAR 2          (s2)
+     8    LOAD_VAR 1           (s1)
+     9    DISPATCH_FUTURE 31   (<fn baml.net.Socket.read>)
+     10   AWAIT                
+     11   STORE_VAR 3          (data1)
+     12   LOAD_VAR 2           (s2)
+     13   DISPATCH_FUTURE 31   (<fn baml.net.Socket.read>)
+     14   AWAIT                
+     15   STORE_VAR 4          (data2)
+     16   LOAD_VAR 3           (data1)
+     17   LOAD_VAR 4           (data2)
+     18   BIN_OP +             
+     19   RETURN               
 
 Function ReadAndClose (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     1    LOAD_CONST 0        ("example.txt")
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 1         (f)
-     5    LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     6    LOAD_VAR 1          (f)
-     7    DISPATCH_FUTURE 1   
-     8    AWAIT               
-     9    STORE_VAR 2         (content)
-     10   LOAD_GLOBAL 25      (<fn baml.fs.File.close>)
-     11   LOAD_VAR 1          (f)
-     12   DISPATCH_FUTURE 1   
-     13   AWAIT               
-     14   POP 1               
-     15   LOAD_VAR 2          (content)
-     16   RETURN              
+     0    LOAD_CONST 0         ("example.txt")
+     1    DISPATCH_FUTURE 26   (<fn baml.fs.open>)
+     2    AWAIT                
+     3    STORE_VAR 1          (f)
+     4    LOAD_VAR 1           (f)
+     5    DISPATCH_FUTURE 24   (<fn baml.fs.File.read>)
+     6    AWAIT                
+     7    STORE_VAR 2          (content)
+     8    LOAD_VAR 1           (f)
+     9    DISPATCH_FUTURE 25   (<fn baml.fs.File.close>)
+     10   AWAIT                
+     11   POP 1                
+     12   LOAD_VAR 2           (content)
+     13   RETURN               
 
 Function ReadFile (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     1   LOAD_CONST 0        ("example.txt")
-     2   DISPATCH_FUTURE 1   
-     3   AWAIT               
-     4   STORE_VAR 1         (f)
-     5   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     6   LOAD_VAR 1          (f)
-     7   DISPATCH_FUTURE 1   
-     8   AWAIT               
-     9   RETURN              
+     0   LOAD_CONST 0         ("example.txt")
+     1   DISPATCH_FUTURE 26   (<fn baml.fs.open>)
+     2   AWAIT                
+     3   DISPATCH_FUTURE 24   (<fn baml.fs.File.read>)
+     4   AWAIT                
+     5   RETURN               
 
 Function ReadFileInline (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     1   LOAD_CONST 0        ("data.json")
-     2   DISPATCH_FUTURE 1   
-     3   AWAIT               
-     4   STORE_VAR 1         (_1)
-     5   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     6   LOAD_VAR 1          (_1)
-     7   DISPATCH_FUTURE 1   
-     8   AWAIT               
-     9   RETURN              
+     0   LOAD_CONST 0         ("data.json")
+     1   DISPATCH_FUTURE 26   (<fn baml.fs.open>)
+     2   AWAIT                
+     3   DISPATCH_FUTURE 24   (<fn baml.fs.File.read>)
+     4   AWAIT                
+     5   RETURN               
 
 Function ReadMultipleFiles (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     1    LOAD_CONST 0        ("file1.txt")
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 1         (f1)
-     5    LOAD_GLOBAL 26      (<fn baml.fs.open>)
-     6    LOAD_CONST 1        ("file2.txt")
-     7    DISPATCH_FUTURE 1   
-     8    AWAIT               
-     9    STORE_VAR 2         (f2)
-     10   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     11   LOAD_VAR 1          (f1)
-     12   DISPATCH_FUTURE 1   
-     13   AWAIT               
-     14   STORE_VAR 3         (content1)
-     15   LOAD_GLOBAL 24      (<fn baml.fs.File.read>)
-     16   LOAD_VAR 2          (f2)
-     17   DISPATCH_FUTURE 1   
-     18   AWAIT               
-     19   STORE_VAR 4         (content2)
-     20   LOAD_VAR 3          (content1)
-     21   LOAD_VAR 4          (content2)
-     22   BIN_OP +            
-     23   RETURN              
+     0    LOAD_CONST 0         ("file1.txt")
+     1    DISPATCH_FUTURE 26   (<fn baml.fs.open>)
+     2    AWAIT                
+     3    STORE_VAR 1          (f1)
+     4    LOAD_CONST 1         ("file2.txt")
+     5    DISPATCH_FUTURE 26   (<fn baml.fs.open>)
+     6    AWAIT                
+     7    STORE_VAR 2          (f2)
+     8    LOAD_VAR 1           (f1)
+     9    DISPATCH_FUTURE 24   (<fn baml.fs.File.read>)
+     10   AWAIT                
+     11   STORE_VAR 3          (content1)
+     12   LOAD_VAR 2           (f2)
+     13   DISPATCH_FUTURE 24   (<fn baml.fs.File.read>)
+     14   AWAIT                
+     15   STORE_VAR 4          (content2)
+     16   LOAD_VAR 3           (content1)
+     17   LOAD_VAR 4           (content2)
+     18   BIN_OP +             
+     19   RETURN               
 
 Function RunCommand (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 27      (<fn baml.sys.shell>)
-     1   LOAD_CONST 0        ("echo hello")
-     2   DISPATCH_FUTURE 1   
-     3   AWAIT               
-     4   RETURN              
+     0   LOAD_CONST 0         ("echo hello")
+     1   DISPATCH_FUTURE 27   (<fn baml.sys.shell>)
+     2   AWAIT                
+     3   RETURN               
 
 Function RunCommandWithVar (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 27      (<fn baml.sys.shell>)
-     1   LOAD_CONST 0        ("ls -la")
-     2   DISPATCH_FUTURE 1   
-     3   AWAIT               
-     4   RETURN              
+     0   LOAD_CONST 0         ("ls -la")
+     1   DISPATCH_FUTURE 27   (<fn baml.sys.shell>)
+     2   AWAIT                
+     3   RETURN               
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0            (0)
@@ -214,24 +180,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -284,9 +249,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -303,7 +268,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -338,22 +303,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -467,66 +431,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -536,7 +494,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -559,71 +517,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -634,193 +591,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
@@ -8,33 +8,31 @@ Objects: 93
 Globals: 64
 
 Function OpenRouterMistralSmall3_1_24b.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 50      (<fn env.get_or_panic>)
-     1    LOAD_CONST 0        ("OPENROUTER_API_KEY")
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 1         (_13)
-     5    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
-     6    LOAD_CONST 1        ("OpenRouterMistralSmall3_1_24b")
-     7    LOAD_CONST 2        ("unknown")
-     8    LOAD_CONST 3        ("user")
-     9    LOAD_CONST 4        ("user")
-     10   LOAD_CONST 5        ("assistant")
-     11   LOAD_CONST 6        ("system")
-     12   ALLOC_ARRAY 3       
-     13   LOAD_CONST 7        ("https://openrouter.ai/api/v1")
-     14   LOAD_VAR 1          (_13)
-     15   LOAD_CONST 8        ("mistralai/mistral-small-3.1-24b-instruct")
-     16   LOAD_CONST 9        (0.1)
-     17   ALLOC_MAP 0         
-     18   LOAD_CONST 10       ("base_url")
-     19   LOAD_CONST 11       ("api_key")
-     20   LOAD_CONST 12       ("model")
-     21   LOAD_CONST 13       ("temperature")
-     22   LOAD_CONST 14       ("headers")
-     23   ALLOC_MAP 5         
-     24   DISPATCH_FUTURE 5   
-     25   AWAIT               
-     26   RETURN              
+     0    LOAD_CONST 0         ("OPENROUTER_API_KEY")
+     1    DISPATCH_FUTURE 50   (<fn env.get_or_panic>)
+     2    AWAIT                
+     3    STORE_VAR 1          (_13)
+     4    LOAD_CONST 1         ("OpenRouterMistralSmall3_1_24b")
+     5    LOAD_CONST 2         ("unknown")
+     6    LOAD_CONST 3         ("user")
+     7    LOAD_CONST 4         ("user")
+     8    LOAD_CONST 5         ("assistant")
+     9    LOAD_CONST 6         ("system")
+     10   ALLOC_ARRAY 3        
+     11   LOAD_CONST 7         ("https://openrouter.ai/api/v1")
+     12   LOAD_VAR 1           (_13)
+     13   LOAD_CONST 8         ("mistralai/mistral-small-3.1-24b-instruct")
+     14   LOAD_CONST 9         (0.1)
+     15   ALLOC_MAP 0          
+     16   LOAD_CONST 10        ("base_url")
+     17   LOAD_CONST 11        ("api_key")
+     18   LOAD_CONST 12        ("model")
+     19   LOAD_CONST 13        ("temperature")
+     20   LOAD_CONST 14        ("headers")
+     21   ALLOC_MAP 5          
+     22   DISPATCH_FUTURE 43   (<fn baml.llm.build_primitive_client>)
+     23   AWAIT                
+     24   RETURN               
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0            (0)
@@ -73,24 +71,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -143,9 +140,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -162,7 +159,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -197,22 +194,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -326,66 +322,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -395,7 +385,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -418,71 +408,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -493,193 +482,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -24,18 +24,17 @@ Function FunctionWithComments (arity: 2, kind: Bytecode):
      7   RETURN         
 
 Function TestClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
-     1    LOAD_CONST 0        ("TestClient")
-     2    LOAD_CONST 1        ("baml-openai-chat")
-     3    LOAD_CONST 2        ("user")
-     4    LOAD_CONST 3        ("user")
-     5    LOAD_CONST 4        ("assistant")
-     6    LOAD_CONST 5        ("system")
-     7    ALLOC_ARRAY 3       
-     8    ALLOC_MAP 0         
-     9    DISPATCH_FUTURE 5   
-     10   AWAIT               
-     11   RETURN              
+     0    LOAD_CONST 0         ("TestClient")
+     1    LOAD_CONST 1         ("baml-openai-chat")
+     2    LOAD_CONST 2         ("user")
+     3    LOAD_CONST 3         ("user")
+     4    LOAD_CONST 4         ("assistant")
+     5    LOAD_CONST 5         ("system")
+     6    ALLOC_ARRAY 3        
+     7    ALLOC_MAP 0          
+     8    DISPATCH_FUTURE 43   (<fn baml.llm.build_primitive_client>)
+     9    AWAIT                
+     10   RETURN               
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0            (0)
@@ -74,24 +73,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -144,9 +142,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -163,7 +161,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -198,22 +196,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -327,66 +324,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -396,7 +387,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -419,71 +410,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -494,193 +484,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
@@ -8,90 +8,89 @@ Objects: 136
 Globals: 64
 
 Function MyClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
-     1    LOAD_CONST 0        ("MyClient")
-     2    LOAD_CONST 1        ("baml-openai-chat")
-     3    LOAD_CONST 2        ("user")
-     4    LOAD_CONST 3        ("user")
-     5    LOAD_CONST 4        ("assistant")
-     6    LOAD_CONST 5        ("system")
-     7    ALLOC_ARRAY 3       
-     8    LOAD_CONST 6        (100)
-     9    LOAD_CONST 7        ("abc")
-     10   LOAD_CONST 8        ("abc")
-     11   LOAD_CONST 9        ("ccc")
-     12   ALLOC_ARRAY 3       
-     13   LOAD_CONST 10       ("some random value")
-     14   LOAD_CONST 11       ("world")
-     15   LOAD_CONST 12       ("hello")
-     16   LOAD_CONST 13       ("hello there my frien
+     0    LOAD_CONST 0         ("MyClient")
+     1    LOAD_CONST 1         ("baml-openai-chat")
+     2    LOAD_CONST 2         ("user")
+     3    LOAD_CONST 3         ("user")
+     4    LOAD_CONST 4         ("assistant")
+     5    LOAD_CONST 5         ("system")
+     6    ALLOC_ARRAY 3        
+     7    LOAD_CONST 6         (100)
+     8    LOAD_CONST 7         ("abc")
+     9    LOAD_CONST 8         ("abc")
+     10   LOAD_CONST 9         ("ccc")
+     11   ALLOC_ARRAY 3        
+     12   LOAD_CONST 10        ("some random value")
+     13   LOAD_CONST 11        ("world")
+     14   LOAD_CONST 12        ("hello")
+     15   LOAD_CONST 13        ("hello there my frien
                   d")
-     17   LOAD_CONST 14       ("inline "raw" string,,")
-     18   LOAD_CONST 15       (true)
-     19   LOAD_CONST 16       ("true")
-     20   LOAD_CONST 17       ("one")
-     21   LOAD_CONST 18       ("two")
-     22   ALLOC_ARRAY 2       
-     23   LOAD_CONST 19       ("one")
-     24   LOAD_CONST 20       ("two")
-     25   ALLOC_ARRAY 2       
-     26   LOAD_CONST 21       (1)
-     27   LOAD_CONST 22       (2)
-     28   LOAD_CONST 23       (3)
-     29   ALLOC_ARRAY 3       
-     30   LOAD_CONST 24       ("value")
-     31   LOAD_CONST 25       ("value2")
-     32   LOAD_CONST 26       ("yes")
-     33   LOAD_CONST 27       ("queen")
-     34   ALLOC_ARRAY 2       
-     35   LOAD_CONST 28       (10)
-     36   LOAD_CONST 29       ("key")
-     37   LOAD_CONST 30       ("key2")
-     38   LOAD_CONST 31       ("nestedArray")
-     39   LOAD_CONST 32       ("number")
-     40   ALLOC_MAP 4         
-     41   LOAD_CONST 33       ("value")
-     42   LOAD_CONST 6        (100)
-     43   LOAD_CONST 34       ("parallel_web_search")
-     44   LOAD_CONST 35       ("https://example.com")
-     45   LOAD_CONST 36       ("Bearer token")
-     46   LOAD_CONST 37       ("authorization")
-     47   ALLOC_MAP 1         
-     48   LOAD_CONST 38       ("mcp")
-     49   LOAD_CONST 39       ("server_label")
-     50   LOAD_CONST 40       ("server_url")
-     51   LOAD_CONST 41       ("headers")
-     52   LOAD_CONST 42       ("type")
-     53   ALLOC_MAP 4         
-     54   LOAD_CONST 43       ("value")
-     55   LOAD_CONST 44       ("another_tool")
-     56   ALLOC_MAP 1         
-     57   ALLOC_ARRAY 2       
-     58   LOAD_CONST 45       ("
+     16   LOAD_CONST 14        ("inline "raw" string,,")
+     17   LOAD_CONST 15        (true)
+     18   LOAD_CONST 16        ("true")
+     19   LOAD_CONST 17        ("one")
+     20   LOAD_CONST 18        ("two")
+     21   ALLOC_ARRAY 2        
+     22   LOAD_CONST 19        ("one")
+     23   LOAD_CONST 20        ("two")
+     24   ALLOC_ARRAY 2        
+     25   LOAD_CONST 21        (1)
+     26   LOAD_CONST 22        (2)
+     27   LOAD_CONST 23        (3)
+     28   ALLOC_ARRAY 3        
+     29   LOAD_CONST 24        ("value")
+     30   LOAD_CONST 25        ("value2")
+     31   LOAD_CONST 26        ("yes")
+     32   LOAD_CONST 27        ("queen")
+     33   ALLOC_ARRAY 2        
+     34   LOAD_CONST 28        (10)
+     35   LOAD_CONST 29        ("key")
+     36   LOAD_CONST 30        ("key2")
+     37   LOAD_CONST 31        ("nestedArray")
+     38   LOAD_CONST 32        ("number")
+     39   ALLOC_MAP 4          
+     40   LOAD_CONST 33        ("value")
+     41   LOAD_CONST 6         (100)
+     42   LOAD_CONST 34        ("parallel_web_search")
+     43   LOAD_CONST 35        ("https://example.com")
+     44   LOAD_CONST 36        ("Bearer token")
+     45   LOAD_CONST 37        ("authorization")
+     46   ALLOC_MAP 1          
+     47   LOAD_CONST 38        ("mcp")
+     48   LOAD_CONST 39        ("server_label")
+     49   LOAD_CONST 40        ("server_url")
+     50   LOAD_CONST 41        ("headers")
+     51   LOAD_CONST 42        ("type")
+     52   ALLOC_MAP 4          
+     53   LOAD_CONST 43        ("value")
+     54   LOAD_CONST 44        ("another_tool")
+     55   ALLOC_MAP 1          
+     56   ALLOC_ARRAY 2        
+     57   LOAD_CONST 45        ("
         hello there my friend
         {# a comment in a prompt #}
       ")
-     59   LOAD_CONST 46       ("max_tokens")
-     60   LOAD_CONST 47       ("array_key_with_quoted_unquoted")
-     61   LOAD_CONST 48       ("key2")
-     62   LOAD_CONST 49       ("hello")
-     63   LOAD_CONST 50       ("thing")
-     64   LOAD_CONST 51       ("block_string")
-     65   LOAD_CONST 52       ("inline_raw_string")
-     66   LOAD_CONST 53       ("booleanValue")
-     67   LOAD_CONST 54       ("stringKey")
-     68   LOAD_CONST 55       ("array1")
-     69   LOAD_CONST 56       ("array2")
-     70   LOAD_CONST 57       ("array3Numbers")
-     71   LOAD_CONST 58       ("nestedKey")
-     72   LOAD_CONST 59       ("oneMoreValueToTestBrokenness")
-     73   LOAD_CONST 60       ("myInteger")
-     74   LOAD_CONST 61       ("tools")
-     75   LOAD_CONST 62       ("block_string")
-     76   ALLOC_MAP 17        
-     77   DISPATCH_FUTURE 5   
-     78   AWAIT               
-     79   RETURN              
+     58   LOAD_CONST 46        ("max_tokens")
+     59   LOAD_CONST 47        ("array_key_with_quoted_unquoted")
+     60   LOAD_CONST 48        ("key2")
+     61   LOAD_CONST 49        ("hello")
+     62   LOAD_CONST 50        ("thing")
+     63   LOAD_CONST 51        ("block_string")
+     64   LOAD_CONST 52        ("inline_raw_string")
+     65   LOAD_CONST 53        ("booleanValue")
+     66   LOAD_CONST 54        ("stringKey")
+     67   LOAD_CONST 55        ("array1")
+     68   LOAD_CONST 56        ("array2")
+     69   LOAD_CONST 57        ("array3Numbers")
+     70   LOAD_CONST 58        ("nestedKey")
+     71   LOAD_CONST 59        ("oneMoreValueToTestBrokenness")
+     72   LOAD_CONST 60        ("myInteger")
+     73   LOAD_CONST 61        ("tools")
+     74   LOAD_CONST 62        ("block_string")
+     75   ALLOC_MAP 17         
+     76   DISPATCH_FUTURE 43   (<fn baml.llm.build_primitive_client>)
+     77   AWAIT                
+     78   RETURN               
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0            (0)
@@ -130,24 +129,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -200,9 +198,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -219,7 +217,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -254,22 +252,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -383,66 +380,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -452,7 +443,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -475,71 +466,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -550,193 +540,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
@@ -44,24 +44,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -114,9 +113,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -133,7 +132,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -168,22 +167,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -297,66 +295,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -366,7 +358,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -389,71 +381,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -464,193 +455,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
@@ -80,24 +80,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -150,9 +149,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -169,7 +168,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -204,22 +203,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -333,66 +331,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -402,7 +394,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -425,71 +417,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -500,196 +491,174 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN              
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN               
 
 Function param_in_if_statement (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1             (b)

--- a/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
@@ -48,24 +48,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -118,9 +117,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -137,7 +136,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -172,22 +171,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -301,66 +299,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -370,7 +362,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -393,71 +385,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -468,193 +459,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -50,24 +50,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -120,9 +119,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -139,7 +138,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -174,22 +173,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -303,66 +301,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -372,7 +364,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -395,71 +387,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -470,193 +461,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -16,20 +16,19 @@ Function FetchDatax (arity: 1, kind: Bytecode):
      5   RETURN         
 
 Function VertexGCP.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
-     1    LOAD_CONST 0        ("VertexGCP")
-     2    LOAD_CONST 1        ("vertex-ai")
-     3    LOAD_CONST 2        ("user")
-     4    LOAD_CONST 3        ("user")
-     5    LOAD_CONST 4        ("assistant")
-     6    LOAD_CONST 5        ("system")
-     7    ALLOC_ARRAY 3       
-     8    LOAD_CONST 6        ("gemini-2")
-     9    LOAD_CONST 7        ("model")
-     10   ALLOC_MAP 1         
-     11   DISPATCH_FUTURE 5   
-     12   AWAIT               
-     13   RETURN              
+     0    LOAD_CONST 0         ("VertexGCP")
+     1    LOAD_CONST 1         ("vertex-ai")
+     2    LOAD_CONST 2         ("user")
+     3    LOAD_CONST 3         ("user")
+     4    LOAD_CONST 4         ("assistant")
+     5    LOAD_CONST 5         ("system")
+     6    ALLOC_ARRAY 3        
+     7    LOAD_CONST 6         ("gemini-2")
+     8    LOAD_CONST 7         ("model")
+     9    ALLOC_MAP 1          
+     10   DISPATCH_FUTURE 43   (<fn baml.llm.build_primitive_client>)
+     11   AWAIT                
+     12   RETURN               
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0            (0)
@@ -68,24 +67,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -138,9 +136,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -157,7 +155,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -192,22 +190,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -321,66 +318,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -390,7 +381,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -413,71 +404,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -488,193 +478,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
@@ -185,24 +185,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -255,9 +254,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -274,7 +273,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -309,22 +308,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -438,66 +436,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -507,7 +499,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -530,71 +522,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -605,193 +596,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1544,24 +1544,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -1614,9 +1613,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -1633,7 +1632,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -1668,22 +1667,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -1797,66 +1795,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -1866,7 +1858,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -1889,71 +1881,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -1964,193 +1955,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
@@ -44,24 +44,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -114,9 +113,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -133,7 +132,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -168,22 +167,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -297,66 +295,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -366,7 +358,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -389,71 +381,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -464,193 +455,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
@@ -44,24 +44,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -114,9 +113,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -133,7 +132,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -168,22 +167,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -297,66 +295,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -366,7 +358,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -389,71 +381,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -464,196 +455,174 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN              
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN               
 
 Function boolArray (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0    (true)

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -12,18 +12,17 @@ Function Foo (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function GPT4.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
-     1    LOAD_CONST 0        ("GPT4")
-     2    LOAD_CONST 1        ("unknown")
-     3    LOAD_CONST 2        ("user")
-     4    LOAD_CONST 3        ("user")
-     5    LOAD_CONST 4        ("assistant")
-     6    LOAD_CONST 5        ("system")
-     7    ALLOC_ARRAY 3       
-     8    ALLOC_MAP 0         
-     9    DISPATCH_FUTURE 5   
-     10   AWAIT               
-     11   RETURN              
+     0    LOAD_CONST 0         ("GPT4")
+     1    LOAD_CONST 1         ("unknown")
+     2    LOAD_CONST 2         ("user")
+     3    LOAD_CONST 3         ("user")
+     4    LOAD_CONST 4         ("assistant")
+     5    LOAD_CONST 5         ("system")
+     6    ALLOC_ARRAY 3        
+     7    ALLOC_MAP 0          
+     8    DISPATCH_FUTURE 43   (<fn baml.llm.build_primitive_client>)
+     9    AWAIT                
+     10   RETURN               
 
 Function Incomplete (arity: 1, kind: Bytecode):
   (no bytecode)
@@ -69,24 +68,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -139,9 +137,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -158,7 +156,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -193,22 +191,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -322,66 +319,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -391,7 +382,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -414,71 +405,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -489,193 +479,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
@@ -139,24 +139,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -209,9 +208,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -228,7 +227,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -263,22 +262,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -392,66 +390,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -461,7 +453,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -484,71 +476,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -559,193 +550,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -147,24 +147,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -217,9 +216,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -236,7 +235,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -271,22 +270,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -400,66 +398,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -469,7 +461,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -492,71 +484,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -567,193 +558,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
@@ -94,24 +94,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -164,9 +163,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -183,7 +182,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -218,22 +217,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -347,66 +345,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -416,7 +408,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -439,71 +431,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -514,196 +505,174 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN              
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN               
 
 Function block_with_tail (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -888,24 +888,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -958,9 +957,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -977,7 +976,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -1012,22 +1011,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -1141,66 +1139,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -1210,7 +1202,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -1233,71 +1225,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -1308,193 +1299,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -16,18 +16,17 @@ Function FormatMessage (arity: 1, kind: Bytecode):
      5   RETURN         
 
 Function GPT4.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
-     1    LOAD_CONST 0        ("GPT4")
-     2    LOAD_CONST 1        ("unknown")
-     3    LOAD_CONST 2        ("user")
-     4    LOAD_CONST 3        ("user")
-     5    LOAD_CONST 4        ("assistant")
-     6    LOAD_CONST 5        ("system")
-     7    ALLOC_ARRAY 3       
-     8    ALLOC_MAP 0         
-     9    DISPATCH_FUTURE 5   
-     10   AWAIT               
-     11   RETURN              
+     0    LOAD_CONST 0         ("GPT4")
+     1    LOAD_CONST 1         ("unknown")
+     2    LOAD_CONST 2         ("user")
+     3    LOAD_CONST 3         ("user")
+     4    LOAD_CONST 4         ("assistant")
+     5    LOAD_CONST 5         ("system")
+     6    ALLOC_ARRAY 3        
+     7    ALLOC_MAP 0          
+     8    DISPATCH_FUTURE 43   (<fn baml.llm.build_primitive_client>)
+     9    AWAIT                
+     10   RETURN               
 
 Function GetRole (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   ("user")
@@ -78,24 +77,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -148,9 +146,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -167,7 +165,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -202,22 +200,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -331,66 +328,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -400,7 +391,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -423,71 +414,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -498,193 +488,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -58,24 +58,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -128,9 +127,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -147,7 +146,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -182,22 +181,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -311,66 +309,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -380,7 +372,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -403,71 +395,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -478,193 +469,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
@@ -8,20 +8,19 @@ Objects: 87
 Globals: 64
 
 Function MyClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
-     1    LOAD_CONST 0        ("MyClient")
-     2    LOAD_CONST 1        ("openai")
-     3    LOAD_CONST 2        ("user")
-     4    LOAD_CONST 3        ("user")
-     5    LOAD_CONST 4        ("assistant")
-     6    LOAD_CONST 5        ("system")
-     7    ALLOC_ARRAY 3       
-     8    LOAD_CONST 6        ("gpt-4")
-     9    LOAD_CONST 7        ("model")
-     10   ALLOC_MAP 1         
-     11   DISPATCH_FUTURE 5   
-     12   AWAIT               
-     13   RETURN              
+     0    LOAD_CONST 0         ("MyClient")
+     1    LOAD_CONST 1         ("openai")
+     2    LOAD_CONST 2         ("user")
+     3    LOAD_CONST 3         ("user")
+     4    LOAD_CONST 4         ("assistant")
+     5    LOAD_CONST 5         ("system")
+     6    ALLOC_ARRAY 3        
+     7    LOAD_CONST 6         ("gpt-4")
+     8    LOAD_CONST 7         ("model")
+     9    ALLOC_MAP 1          
+     10   DISPATCH_FUTURE 43   (<fn baml.llm.build_primitive_client>)
+     11   AWAIT                
+     12   RETURN               
 
 Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0            (0)
@@ -60,24 +59,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -130,9 +128,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -149,7 +147,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -184,22 +182,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -313,66 +310,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -382,7 +373,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -405,71 +396,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -480,193 +470,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -52,24 +52,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -122,9 +121,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -141,7 +140,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -176,22 +175,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -305,66 +303,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -374,7 +366,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -397,71 +389,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -472,193 +463,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
@@ -50,24 +50,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -120,9 +119,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -139,7 +138,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -174,22 +173,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -303,66 +301,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -372,7 +364,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -395,71 +387,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -470,193 +461,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
@@ -48,24 +48,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -118,9 +117,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -137,7 +136,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -172,22 +171,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -301,66 +299,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -370,7 +362,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -393,71 +385,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -468,193 +459,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
@@ -44,24 +44,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -114,9 +113,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -133,7 +132,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -168,22 +167,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -297,66 +295,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -366,7 +358,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -389,71 +381,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -464,193 +455,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
@@ -68,24 +68,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -138,9 +137,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -157,7 +156,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -192,22 +191,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -321,66 +319,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -390,7 +382,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -413,71 +405,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -488,193 +479,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -52,24 +52,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -122,9 +121,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -141,7 +140,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -176,22 +175,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -305,66 +303,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -374,7 +366,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -397,71 +389,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -472,193 +463,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -50,24 +50,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -120,9 +119,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -139,7 +138,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -174,22 +173,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -303,66 +301,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -372,7 +364,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -395,71 +387,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -470,193 +461,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
@@ -56,24 +56,23 @@ Function baml.llm.PlannerState.rr_local_offset (arity: 2, kind: Bytecode):
      33   JUMP -23                (to 10)
 
 Function baml.llm.PlannerState.rr_pick_index (arity: 3, kind: Bytecode):
-     0    LOAD_VAR 1          (self)
-     1    LOAD_VAR 2          (client_name)
-     2    CALL 61             (<fn baml.llm.PlannerState.rr_local_offset>)
-     3    STORE_VAR 4         (local_offset)
-     4    LOAD_VAR 1          (self)
-     5    LOAD_FIELD 0        
-     6    LOAD_VAR 2          (client_name)
-     7    CALL 1              (<fn baml.Array.push>)
-     8    POP 1               
-     9    LOAD_GLOBAL 47      (<fn baml.llm.round_robin_peek>)
-     10   LOAD_VAR 2          (client_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   LOAD_VAR 4          (local_offset)
-     14   BIN_OP +            
-     15   LOAD_VAR 3          (sub_client_count)
-     16   BIN_OP %            
-     17   RETURN              
+     0    LOAD_VAR 1           (self)
+     1    LOAD_VAR 2           (client_name)
+     2    CALL 61              (<fn baml.llm.PlannerState.rr_local_offset>)
+     3    STORE_VAR 4          (local_offset)
+     4    LOAD_VAR 1           (self)
+     5    LOAD_FIELD 0         
+     6    LOAD_VAR 2           (client_name)
+     7    CALL 1               (<fn baml.Array.push>)
+     8    POP 1                
+     9    LOAD_VAR 2           (client_name)
+     10   DISPATCH_FUTURE 47   (<fn baml.llm.round_robin_peek>)
+     11   AWAIT                
+     12   LOAD_VAR 4           (local_offset)
+     13   BIN_OP +             
+     14   LOAD_VAR 3           (sub_client_count)
+     15   BIN_OP %             
+     16   RETURN               
 
 Function baml.llm.build_attempt (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -126,9 +125,9 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      38    CALL 2                  (<fn baml.Array.at>)
      39    LOAD_VAR 2              (planner_state)
      40    CALL 52                 (<fn baml.llm.build_plan_with_state>)
-     41    JUMP +69                (to 110)
+     41    JUMP +68                (to 109)
      42    ALLOC_ARRAY 0           
-     43    JUMP +67                (to 110)
+     43    JUMP +66                (to 109)
      44    ALLOC_ARRAY 0           
      45    STORE_VAR 4             (steps)
      46    LOAD_VAR 1              (llm_client)
@@ -145,7 +144,7 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      57    POP_JUMP_IF_FALSE +2    (to 59)
      58    JUMP +3                 (to 61)
      59    LOAD_VAR 4              (steps)
-     60    JUMP +50                (to 110)
+     60    JUMP +49                (to 109)
      61    LOAD_VAR 5              (_iter)
      62    LOAD_VAR 7              (_i)
      63    LOAD_ARRAY_ELEMENT      
@@ -180,22 +179,21 @@ Function baml.llm.build_attempt_with_state (arity: 2, kind: Bytecode):
      92    CALL 1                  (<fn baml.Array.push>)
      93    POP 1                   
      94    JUMP -16                (to 78)
-     95    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     96    LOAD_VAR 1              (llm_client)
-     97    LOAD_FIELD 0            
-     98    DISPATCH_FUTURE 1       
-     99    AWAIT                   
-     100   CALL_INDIRECT           
-     101   STORE_VAR 3             (primitive)
-     102   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
-     103   COPY 0                  
-     104   LOAD_VAR 3              (primitive)
-     105   STORE_FIELD 0           
-     106   COPY 0                  
-     107   LOAD_CONST 0            (0)
-     108   STORE_FIELD 1           
-     109   ALLOC_ARRAY 1           
-     110   RETURN                  
+     95    LOAD_VAR 1              (llm_client)
+     96    LOAD_FIELD 0            
+     97    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     98    AWAIT                   
+     99    CALL_INDIRECT           
+     100   STORE_VAR 3             (primitive)
+     101   ALLOC_INSTANCE 11       (<class baml.llm.OrchestrationStep>)
+     102   COPY 0                  
+     103   LOAD_VAR 3              (primitive)
+     104   STORE_FIELD 0           
+     105   COPY 0                  
+     106   LOAD_CONST 0            (0)
+     107   STORE_FIELD 1           
+     108   ALLOC_ARRAY 1           
+     109   RETURN                  
 
 Function baml.llm.build_plan (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1          (llm_client)
@@ -309,66 +307,60 @@ Function baml.llm.build_plan_with_state (arity: 2, kind: Bytecode):
      99   RETURN                  
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_VAR 1          (function_name)
-     1    CALL 54             (<fn baml.llm.resolve_primitive>)
-     2    STORE_VAR 3         (primitive_client)
-     3    LOAD_VAR 1          (function_name)
-     4    LOAD_VAR 2          (args)
-     5    CALL 53             (<fn baml.llm.render_prompt>)
-     6    STORE_VAR 4         (specialized_prompt)
-     7    LOAD_GLOBAL 40      (<fn baml.llm.PrimitiveClient.build_request>)
-     8    LOAD_VAR 3          (primitive_client)
-     9    LOAD_VAR 4          (specialized_prompt)
-     10   DISPATCH_FUTURE 2   
-     11   AWAIT               
-     12   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    CALL 54              (<fn baml.llm.resolve_primitive>)
+     2    STORE_VAR 3          (primitive_client)
+     3    LOAD_VAR 1           (function_name)
+     4    LOAD_VAR 2           (args)
+     5    CALL 53              (<fn baml.llm.render_prompt>)
+     6    STORE_VAR 4          (specialized_prompt)
+     7    LOAD_VAR 3           (primitive_client)
+     8    LOAD_VAR 4           (specialized_prompt)
+     9    DISPATCH_FUTURE 40   (<fn baml.llm.PrimitiveClient.build_request>)
+     10   AWAIT                
+     11   RETURN               
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42         (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1             (function_name)
-     2    DISPATCH_FUTURE 1      
-     3    AWAIT                  
-     4    STORE_VAR 3            (jinja_string)
-     5    LOAD_GLOBAL 44         (<fn baml.llm.get_client>)
-     6    LOAD_VAR 1             (function_name)
-     7    DISPATCH_FUTURE 1      
-     8    AWAIT                  
-     9    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
-     10   COPY 0                 
-     11   LOAD_VAR 3             (jinja_string)
-     12   STORE_FIELD 0          
-     13   COPY 0                 
-     14   LOAD_VAR 2             (args)
-     15   STORE_FIELD 1          
-     16   COPY 0                 
-     17   LOAD_VAR 1             (function_name)
-     18   STORE_FIELD 2          
-     19   LOAD_CONST 0           (0)
-     20   CALL 56                (<fn baml.llm.execute_client>)
-     21   STORE_VAR 4            (result)
-     22   LOAD_VAR 4             (result)
-     23   LOAD_FIELD 0           
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +17               (to 42)
-     26   LOAD_GLOBAL 30         (<fn baml.sys.cancellation_requested>)
-     27   DISPATCH_FUTURE 0      
-     28   AWAIT                  
-     29   POP_JUMP_IF_FALSE +6   (to 35)
-     30   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     31   LOAD_CONST 1           ("Operation cancelled")
-     32   DISPATCH_FUTURE 1      
+     0    LOAD_VAR 1             (function_name)
+     1    DISPATCH_FUTURE 42     (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                  
+     3    STORE_VAR 3            (jinja_string)
+     4    LOAD_VAR 1             (function_name)
+     5    DISPATCH_FUTURE 44     (<fn baml.llm.get_client>)
+     6    AWAIT                  
+     7    ALLOC_INSTANCE 9       (<class baml.llm.ExecutionContext>)
+     8    COPY 0                 
+     9    LOAD_VAR 3             (jinja_string)
+     10   STORE_FIELD 0          
+     11   COPY 0                 
+     12   LOAD_VAR 2             (args)
+     13   STORE_FIELD 1          
+     14   COPY 0                 
+     15   LOAD_VAR 1             (function_name)
+     16   STORE_FIELD 2          
+     17   LOAD_CONST 0           (0)
+     18   CALL 56                (<fn baml.llm.execute_client>)
+     19   STORE_VAR 4            (result)
+     20   LOAD_VAR 4             (result)
+     21   LOAD_FIELD 0           
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +14               (to 37)
+     24   DISPATCH_FUTURE 30     (<fn baml.sys.cancellation_requested>)
+     25   AWAIT                  
+     26   POP_JUMP_IF_FALSE +5   (to 31)
+     27   LOAD_CONST 1           ("Operation cancelled")
+     28   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
+     29   AWAIT                  
+     30   POP 1                  
+     31   LOAD_CONST 2           ("All orchestration steps failed")
+     32   DISPATCH_FUTURE 29     (<fn baml.sys.panic>)
      33   AWAIT                  
      34   POP 1                  
-     35   LOAD_GLOBAL 29         (<fn baml.sys.panic>)
-     36   LOAD_CONST 2           ("All orchestration steps failed")
-     37   DISPATCH_FUTURE 1      
-     38   AWAIT                  
-     39   POP 1                  
-     40   LOAD_CONST 3           (null)
-     41   RETURN                 
-     42   LOAD_VAR 4             (result)
-     43   LOAD_FIELD 1           
-     44   RETURN                 
+     35   LOAD_CONST 3           (null)
+     36   RETURN                 
+     37   LOAD_VAR 4             (result)
+     38   LOAD_FIELD 1           
+     39   RETURN                 
 
 Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      0    LOAD_VAR 1              (llm_client)
@@ -378,7 +370,7 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      4    LOAD_CONST 0            (null)
      5    CMP_OP ==               
      6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +83                (to 90)
+     7    JUMP +82                (to 89)
      8    LOAD_VAR 4              (_4)
      9    STORE_VAR 5             (r)
      10   LOAD_VAR 5              (r)
@@ -401,71 +393,70 @@ Function baml.llm.execute_client (arity: 3, kind: Bytecode):
      27   COPY 0                  
      28   LOAD_CONST 0            (null)
      29   STORE_FIELD 1           
-     30   JUMP +64                (to 94)
-     31   LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     32   DISPATCH_FUTURE 0       
-     33   AWAIT                   
-     34   POP_JUMP_IF_FALSE +2    (to 36)
-     35   JUMP +54                (to 89)
-     36   LOAD_VAR 3              (inherited_delay_ms)
-     37   STORE_VAR 8             (attempt_delay)
-     38   LOAD_VAR 7              (attempt)
-     39   LOAD_CONST 2            (0)
-     40   CMP_OP >                
-     41   POP_JUMP_IF_FALSE +25   (to 66)
-     42   LOAD_VAR 6              (current_delay)
-     43   CALL 19                 (<fn baml.math.trunc>)
-     44   STORE_VAR 8             (attempt_delay)
-     45   LOAD_VAR 6              (current_delay)
-     46   LOAD_VAR 5              (r)
-     47   LOAD_FIELD 2            
-     48   BIN_OP *                
-     49   STORE_VAR 9             (next)
-     50   LOAD_VAR 9              (next)
-     51   LOAD_VAR 5              (r)
-     52   LOAD_FIELD 3            
-     53   LOAD_CONST 1            (0)
-     54   BIN_OP +                
-     55   CMP_OP >                
-     56   POP_JUMP_IF_FALSE +2    (to 58)
-     57   JUMP +4                 (to 61)
-     58   LOAD_VAR 9              (next)
-     59   STORE_VAR 6             (current_delay)
-     60   JUMP +6                 (to 66)
-     61   LOAD_VAR 5              (r)
-     62   LOAD_FIELD 3            
-     63   LOAD_CONST 1            (0)
-     64   BIN_OP +                
-     65   STORE_VAR 6             (current_delay)
-     66   LOAD_VAR 7              (attempt)
-     67   LOAD_VAR 5              (r)
-     68   LOAD_FIELD 0            
-     69   CMP_OP ==               
-     70   POP_JUMP_IF_FALSE +3    (to 73)
-     71   LOAD_VAR 3              (inherited_delay_ms)
-     72   STORE_VAR 8             (attempt_delay)
-     73   LOAD_VAR 1              (llm_client)
-     74   LOAD_VAR 2              (context)
-     75   LOAD_VAR 8              (attempt_delay)
-     76   CALL 57                 (<fn baml.llm.execute_client_once>)
-     77   STORE_VAR 10            (result)
-     78   LOAD_VAR 10             (result)
-     79   LOAD_FIELD 0            
-     80   POP_JUMP_IF_FALSE +2    (to 82)
-     81   JUMP +6                 (to 87)
-     82   LOAD_VAR 7              (attempt)
-     83   LOAD_CONST 4            (1)
-     84   BIN_OP +                
-     85   STORE_VAR 7             (attempt)
-     86   JUMP -69                (to 17)
-     87   LOAD_VAR 10             (result)
+     30   JUMP +63                (to 93)
+     31   DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     32   AWAIT                   
+     33   POP_JUMP_IF_FALSE +2    (to 35)
+     34   JUMP +54                (to 88)
+     35   LOAD_VAR 3              (inherited_delay_ms)
+     36   STORE_VAR 8             (attempt_delay)
+     37   LOAD_VAR 7              (attempt)
+     38   LOAD_CONST 2            (0)
+     39   CMP_OP >                
+     40   POP_JUMP_IF_FALSE +25   (to 65)
+     41   LOAD_VAR 6              (current_delay)
+     42   CALL 19                 (<fn baml.math.trunc>)
+     43   STORE_VAR 8             (attempt_delay)
+     44   LOAD_VAR 6              (current_delay)
+     45   LOAD_VAR 5              (r)
+     46   LOAD_FIELD 2            
+     47   BIN_OP *                
+     48   STORE_VAR 9             (next)
+     49   LOAD_VAR 9              (next)
+     50   LOAD_VAR 5              (r)
+     51   LOAD_FIELD 3            
+     52   LOAD_CONST 1            (0)
+     53   BIN_OP +                
+     54   CMP_OP >                
+     55   POP_JUMP_IF_FALSE +2    (to 57)
+     56   JUMP +4                 (to 60)
+     57   LOAD_VAR 9              (next)
+     58   STORE_VAR 6             (current_delay)
+     59   JUMP +6                 (to 65)
+     60   LOAD_VAR 5              (r)
+     61   LOAD_FIELD 3            
+     62   LOAD_CONST 1            (0)
+     63   BIN_OP +                
+     64   STORE_VAR 6             (current_delay)
+     65   LOAD_VAR 7              (attempt)
+     66   LOAD_VAR 5              (r)
+     67   LOAD_FIELD 0            
+     68   CMP_OP ==               
+     69   POP_JUMP_IF_FALSE +3    (to 72)
+     70   LOAD_VAR 3              (inherited_delay_ms)
+     71   STORE_VAR 8             (attempt_delay)
+     72   LOAD_VAR 1              (llm_client)
+     73   LOAD_VAR 2              (context)
+     74   LOAD_VAR 8              (attempt_delay)
+     75   CALL 57                 (<fn baml.llm.execute_client_once>)
+     76   STORE_VAR 10            (result)
+     77   LOAD_VAR 10             (result)
+     78   LOAD_FIELD 0            
+     79   POP_JUMP_IF_FALSE +2    (to 81)
+     80   JUMP +6                 (to 86)
+     81   LOAD_VAR 7              (attempt)
+     82   LOAD_CONST 4            (1)
+     83   BIN_OP +                
+     84   STORE_VAR 7             (attempt)
+     85   JUMP -68                (to 17)
+     86   LOAD_VAR 10             (result)
+     87   RETURN                  
      88   RETURN                  
-     89   RETURN                  
-     90   LOAD_VAR 1              (llm_client)
-     91   LOAD_VAR 2              (context)
-     92   LOAD_VAR 3              (inherited_delay_ms)
-     93   CALL 57                 (<fn baml.llm.execute_client_once>)
-     94   RETURN                  
+     89   LOAD_VAR 1              (llm_client)
+     90   LOAD_VAR 2              (context)
+     91   LOAD_VAR 3              (inherited_delay_ms)
+     92   CALL 57                 (<fn baml.llm.execute_client_once>)
+     93   RETURN                  
 
 Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      0     LOAD_VAR 1              (llm_client)
@@ -476,193 +467,171 @@ Function baml.llm.execute_client_once (arity: 3, kind: Bytecode):
      5     CMP_OP ==               
      6     POP_JUMP_IF_FALSE +3    (to 9)
      7     POP 1                   
-     8     JUMP +79                (to 87)
+     8     JUMP +76                (to 84)
      9     COPY 0                  
      10    LOAD_CONST 1            (1)
      11    CMP_OP ==               
      12    POP_JUMP_IF_FALSE +3    (to 15)
      13    POP 1                   
-     14    JUMP +28                (to 42)
+     14    JUMP +26                (to 40)
      15    POP 1                   
-     16    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     17    DISPATCH_FUTURE 0       
-     18    AWAIT                   
-     19    POP_JUMP_IF_FALSE +2    (to 21)
-     20    JUMP +21                (to 41)
-     21    LOAD_GLOBAL 46          (<fn baml.llm.round_robin_next>)
-     22    LOAD_VAR 1              (llm_client)
-     23    LOAD_FIELD 0            
-     24    DISPATCH_FUTURE 1       
-     25    AWAIT                   
-     26    STORE_VAR 16            (_107)
-     27    LOAD_VAR 1              (llm_client)
-     28    LOAD_FIELD 2            
-     29    CALL 0                  (<fn baml.Array.length>)
-     30    STORE_VAR 17            (_112)
-     31    LOAD_VAR 1              (llm_client)
-     32    LOAD_FIELD 2            
-     33    LOAD_VAR 16             (_107)
-     34    LOAD_VAR 17             (_112)
-     35    BIN_OP %                
-     36    CALL 2                  (<fn baml.Array.at>)
-     37    LOAD_VAR 2              (context)
-     38    LOAD_VAR 3              (active_delay_ms)
-     39    CALL 56                 (<fn baml.llm.execute_client>)
-     40    JUMP +107               (to 147)
-     41    RETURN                  
-     42    LOAD_VAR 1              (llm_client)
-     43    LOAD_FIELD 2            
-     44    STORE_VAR 11            (_iter)
-     45    LOAD_VAR 11             (_iter)
-     46    CALL 0                  (<fn baml.Array.length>)
-     47    STORE_VAR 12            (_len)
-     48    LOAD_CONST 0            (0)
-     49    STORE_VAR 13            (_i)
-     50    LOAD_VAR 13             (_i)
-     51    LOAD_VAR 12             (_len)
-     52    CMP_OP <                
-     53    POP_JUMP_IF_FALSE +2    (to 55)
-     54    JUMP +9                 (to 63)
-     55    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     56    COPY 0                  
-     57    LOAD_CONST 2            (false)
-     58    STORE_FIELD 0           
-     59    COPY 0                  
-     60    LOAD_CONST 3            (null)
-     61    STORE_FIELD 1           
-     62    JUMP +85                (to 147)
-     63    LOAD_VAR 11             (_iter)
-     64    LOAD_VAR 13             (_i)
-     65    LOAD_ARRAY_ELEMENT      
-     66    STORE_VAR 14            (sub)
-     67    LOAD_VAR 13             (_i)
-     68    LOAD_CONST 1            (1)
-     69    BIN_OP +                
-     70    STORE_VAR 13            (_i)
-     71    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     72    DISPATCH_FUTURE 0       
-     73    AWAIT                   
-     74    POP_JUMP_IF_FALSE +2    (to 76)
-     75    JUMP +11                (to 86)
-     76    LOAD_VAR 14             (sub)
-     77    LOAD_VAR 2              (context)
-     78    LOAD_VAR 3              (active_delay_ms)
-     79    CALL 56                 (<fn baml.llm.execute_client>)
-     80    STORE_VAR 15            (result)
-     81    LOAD_VAR 15             (result)
-     82    LOAD_FIELD 0            
-     83    POP_JUMP_IF_FALSE -33   (to 50)
-     84    LOAD_VAR 15             (result)
-     85    RETURN                  
-     86    RETURN                  
-     87    LOAD_GLOBAL 30          (<fn baml.sys.cancellation_requested>)
-     88    DISPATCH_FUTURE 0       
-     89    AWAIT                   
-     90    POP_JUMP_IF_FALSE +2    (to 92)
-     91    JUMP +69                (to 160)
-     92    LOAD_GLOBAL 45          (<fn baml.llm.resolve_client>)
-     93    LOAD_VAR 1              (llm_client)
-     94    LOAD_FIELD 0            
-     95    DISPATCH_FUTURE 1       
-     96    AWAIT                   
-     97    CALL_INDIRECT           
-     98    STORE_VAR 4             (primitive)
-     99    LOAD_GLOBAL 38          (<fn baml.llm.PrimitiveClient.render_prompt>)
-     100   LOAD_VAR 4              (primitive)
-     101   LOAD_VAR 2              (context)
-     102   LOAD_FIELD 0            
-     103   LOAD_VAR 2              (context)
-     104   LOAD_FIELD 1            
-     105   DISPATCH_FUTURE 3       
-     106   AWAIT                   
-     107   STORE_VAR 5             (prompt)
-     108   LOAD_GLOBAL 39          (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     109   LOAD_VAR 4              (primitive)
-     110   LOAD_VAR 5              (prompt)
-     111   DISPATCH_FUTURE 2       
+     16    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     17    AWAIT                   
+     18    POP_JUMP_IF_FALSE +2    (to 20)
+     19    JUMP +20                (to 39)
+     20    LOAD_VAR 1              (llm_client)
+     21    LOAD_FIELD 0            
+     22    DISPATCH_FUTURE 46      (<fn baml.llm.round_robin_next>)
+     23    AWAIT                   
+     24    STORE_VAR 15            (_107)
+     25    LOAD_VAR 1              (llm_client)
+     26    LOAD_FIELD 2            
+     27    CALL 0                  (<fn baml.Array.length>)
+     28    STORE_VAR 16            (_112)
+     29    LOAD_VAR 1              (llm_client)
+     30    LOAD_FIELD 2            
+     31    LOAD_VAR 15             (_107)
+     32    LOAD_VAR 16             (_112)
+     33    BIN_OP %                
+     34    CALL 2                  (<fn baml.Array.at>)
+     35    LOAD_VAR 2              (context)
+     36    LOAD_VAR 3              (active_delay_ms)
+     37    CALL 56                 (<fn baml.llm.execute_client>)
+     38    JUMP +96                (to 134)
+     39    RETURN                  
+     40    LOAD_VAR 1              (llm_client)
+     41    LOAD_FIELD 2            
+     42    STORE_VAR 10            (_iter)
+     43    LOAD_VAR 10             (_iter)
+     44    CALL 0                  (<fn baml.Array.length>)
+     45    STORE_VAR 11            (_len)
+     46    LOAD_CONST 0            (0)
+     47    STORE_VAR 12            (_i)
+     48    LOAD_VAR 12             (_i)
+     49    LOAD_VAR 11             (_len)
+     50    CMP_OP <                
+     51    POP_JUMP_IF_FALSE +2    (to 53)
+     52    JUMP +9                 (to 61)
+     53    ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     54    COPY 0                  
+     55    LOAD_CONST 2            (false)
+     56    STORE_FIELD 0           
+     57    COPY 0                  
+     58    LOAD_CONST 3            (null)
+     59    STORE_FIELD 1           
+     60    JUMP +74                (to 134)
+     61    LOAD_VAR 10             (_iter)
+     62    LOAD_VAR 12             (_i)
+     63    LOAD_ARRAY_ELEMENT      
+     64    STORE_VAR 13            (sub)
+     65    LOAD_VAR 12             (_i)
+     66    LOAD_CONST 1            (1)
+     67    BIN_OP +                
+     68    STORE_VAR 12            (_i)
+     69    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     70    AWAIT                   
+     71    POP_JUMP_IF_FALSE +2    (to 73)
+     72    JUMP +11                (to 83)
+     73    LOAD_VAR 13             (sub)
+     74    LOAD_VAR 2              (context)
+     75    LOAD_VAR 3              (active_delay_ms)
+     76    CALL 56                 (<fn baml.llm.execute_client>)
+     77    STORE_VAR 14            (result)
+     78    LOAD_VAR 14             (result)
+     79    LOAD_FIELD 0            
+     80    POP_JUMP_IF_FALSE -32   (to 48)
+     81    LOAD_VAR 14             (result)
+     82    RETURN                  
+     83    RETURN                  
+     84    DISPATCH_FUTURE 30      (<fn baml.sys.cancellation_requested>)
+     85    AWAIT                   
+     86    POP_JUMP_IF_FALSE +2    (to 88)
+     87    JUMP +58                (to 145)
+     88    LOAD_VAR 1              (llm_client)
+     89    LOAD_FIELD 0            
+     90    DISPATCH_FUTURE 45      (<fn baml.llm.resolve_client>)
+     91    AWAIT                   
+     92    CALL_INDIRECT           
+     93    STORE_VAR 4             (primitive)
+     94    LOAD_VAR 4              (primitive)
+     95    LOAD_VAR 2              (context)
+     96    LOAD_FIELD 0            
+     97    LOAD_VAR 2              (context)
+     98    LOAD_FIELD 1            
+     99    DISPATCH_FUTURE 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     100   AWAIT                   
+     101   STORE_VAR 5             (prompt)
+     102   LOAD_VAR 4              (primitive)
+     103   LOAD_VAR 5              (prompt)
+     104   DISPATCH_FUTURE 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     105   AWAIT                   
+     106   STORE_VAR 6             (specialized)
+     107   LOAD_VAR 4              (primitive)
+     108   LOAD_VAR 6              (specialized)
+     109   DISPATCH_FUTURE 40      (<fn baml.llm.PrimitiveClient.build_request>)
+     110   AWAIT                   
+     111   DISPATCH_FUTURE 37      (<fn baml.http.send>)
      112   AWAIT                   
-     113   STORE_VAR 6             (specialized)
-     114   LOAD_GLOBAL 40          (<fn baml.llm.PrimitiveClient.build_request>)
-     115   LOAD_VAR 4              (primitive)
-     116   LOAD_VAR 6              (specialized)
-     117   DISPATCH_FUTURE 2       
-     118   AWAIT                   
-     119   STORE_VAR 7             (http_request)
-     120   LOAD_GLOBAL 37          (<fn baml.http.send>)
-     121   LOAD_VAR 7              (http_request)
-     122   DISPATCH_FUTURE 1       
-     123   AWAIT                   
-     124   STORE_VAR 8             (http_response)
-     125   LOAD_GLOBAL 35          (<fn baml.http.Response.ok>)
-     126   LOAD_VAR 8              (http_response)
-     127   DISPATCH_FUTURE 1       
-     128   AWAIT                   
-     129   POP_JUMP_IF_FALSE +2    (to 131)
-     130   JUMP +18                (to 148)
-     131   LOAD_VAR 3              (active_delay_ms)
-     132   LOAD_CONST 0            (0)
-     133   CMP_OP >                
-     134   POP_JUMP_IF_FALSE +6    (to 140)
-     135   LOAD_GLOBAL 28          (<fn baml.sys.sleep>)
-     136   LOAD_VAR 3              (active_delay_ms)
-     137   DISPATCH_FUTURE 1       
-     138   AWAIT                   
-     139   POP 1                   
-     140   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
-     141   COPY 0                  
-     142   LOAD_CONST 2            (false)
-     143   STORE_FIELD 0           
-     144   COPY 0                  
-     145   LOAD_CONST 3            (null)
-     146   STORE_FIELD 1           
-     147   RETURN                  
-     148   LOAD_GLOBAL 34          (<fn baml.http.Response.text>)
-     149   LOAD_VAR 8              (http_response)
-     150   DISPATCH_FUTURE 1       
-     151   AWAIT                   
-     152   STORE_VAR 9             (body)
-     153   LOAD_GLOBAL 48          (<fn baml.llm.get_return_type>)
-     154   LOAD_VAR 2              (context)
-     155   LOAD_FIELD 2            
-     156   DISPATCH_FUTURE 1       
-     157   AWAIT                   
-     158   STORE_VAR 10            (return_type)
-     159   RETURN                  
-     160   RETURN                  
+     113   STORE_VAR 7             (http_response)
+     114   LOAD_VAR 7              (http_response)
+     115   DISPATCH_FUTURE 35      (<fn baml.http.Response.ok>)
+     116   AWAIT                   
+     117   POP_JUMP_IF_FALSE +2    (to 119)
+     118   JUMP +17                (to 135)
+     119   LOAD_VAR 3              (active_delay_ms)
+     120   LOAD_CONST 0            (0)
+     121   CMP_OP >                
+     122   POP_JUMP_IF_FALSE +5    (to 127)
+     123   LOAD_VAR 3              (active_delay_ms)
+     124   DISPATCH_FUTURE 28      (<fn baml.sys.sleep>)
+     125   AWAIT                   
+     126   POP 1                   
+     127   ALLOC_INSTANCE 8        (<class baml.llm.ExecutionResult>)
+     128   COPY 0                  
+     129   LOAD_CONST 2            (false)
+     130   STORE_FIELD 0           
+     131   COPY 0                  
+     132   LOAD_CONST 3            (null)
+     133   STORE_FIELD 1           
+     134   RETURN                  
+     135   LOAD_VAR 7              (http_response)
+     136   DISPATCH_FUTURE 34      (<fn baml.http.Response.text>)
+     137   AWAIT                   
+     138   STORE_VAR 8             (body)
+     139   LOAD_VAR 2              (context)
+     140   LOAD_FIELD 2            
+     141   DISPATCH_FUTURE 48      (<fn baml.llm.get_return_type>)
+     142   AWAIT                   
+     143   STORE_VAR 9             (return_type)
+     144   RETURN                  
+     145   RETURN                  
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 3         (jinja_string)
-     5    LOAD_VAR 1          (function_name)
-     6    CALL 54             (<fn baml.llm.resolve_primitive>)
-     7    STORE_VAR 4         (primitive_client)
-     8    LOAD_GLOBAL 38      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     9    LOAD_VAR 4          (primitive_client)
-     10   LOAD_VAR 3          (jinja_string)
-     11   LOAD_VAR 2          (args)
-     12   DISPATCH_FUTURE 3   
-     13   AWAIT               
-     14   STORE_VAR 5         (prompt)
-     15   LOAD_GLOBAL 39      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 5          (prompt)
-     18   DISPATCH_FUTURE 2   
-     19   AWAIT               
-     20   RETURN              
+     0    LOAD_VAR 1           (function_name)
+     1    DISPATCH_FUTURE 42   (<fn baml.llm.get_jinja_template>)
+     2    AWAIT                
+     3    STORE_VAR 3          (jinja_string)
+     4    LOAD_VAR 1           (function_name)
+     5    CALL 54              (<fn baml.llm.resolve_primitive>)
+     6    STORE_VAR 4          (primitive_client)
+     7    LOAD_VAR 4           (primitive_client)
+     8    LOAD_VAR 3           (jinja_string)
+     9    LOAD_VAR 2           (args)
+     10   DISPATCH_FUTURE 38   (<fn baml.llm.PrimitiveClient.render_prompt>)
+     11   AWAIT                
+     12   STORE_VAR 5          (prompt)
+     13   LOAD_VAR 4           (primitive_client)
+     14   LOAD_VAR 5           (prompt)
+     15   DISPATCH_FUTURE 39   (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     16   AWAIT                
+     17   RETURN               
 
 Function baml.llm.resolve_primitive (arity: 1, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.get_client>)
-     1    LOAD_VAR 1          (function_name)
-     2    DISPATCH_FUTURE 1   
-     3    AWAIT               
-     4    STORE_VAR 2         (llm_client)
-     5    LOAD_GLOBAL 45      (<fn baml.llm.resolve_client>)
-     6    LOAD_VAR 2          (llm_client)
-     7    LOAD_FIELD 0        
-     8    DISPATCH_FUTURE 1   
-     9    AWAIT               
-     10   CALL_INDIRECT       
-     11   RETURN
+     0   LOAD_VAR 1           (function_name)
+     1   DISPATCH_FUTURE 44   (<fn baml.llm.get_client>)
+     2   AWAIT                
+     3   LOAD_FIELD 0         
+     4   DISPATCH_FUTURE 45   (<fn baml.llm.resolve_client>)
+     5   AWAIT                
+     6   CALL_INDIRECT        
+     7   RETURN

--- a/baml_language/crates/baml_tests/src/codegen.rs
+++ b/baml_language/crates/baml_tests/src/codegen.rs
@@ -126,7 +126,6 @@ fn convert_instruction(
                 _ => anyhow::bail!("Expected Enum object for AllocVariant, got {obj:?}"),
             }
         }
-        bex_vm_types::Instruction::DispatchFuture(n) => Instruction::DispatchFuture(*n),
         bex_vm_types::Instruction::Await => Instruction::Await,
         bex_vm_types::Instruction::Watch(idx) => Instruction::Watch(*idx),
         bex_vm_types::Instruction::Unwatch(idx) => Instruction::Unwatch(*idx),
@@ -143,8 +142,10 @@ fn convert_instruction(
         bex_vm_types::Instruction::Discriminant => Instruction::Discriminant,
         bex_vm_types::Instruction::TypeTag => Instruction::TypeTag,
         bex_vm_types::Instruction::Unreachable => Instruction::Unreachable,
-        bex_vm_types::Instruction::Call(_) | bex_vm_types::Instruction::CallIndirect => {
-            anyhow::bail!("CALL instructions are handled by the caller")
+        bex_vm_types::Instruction::Call(_)
+        | bex_vm_types::Instruction::CallIndirect
+        | bex_vm_types::Instruction::DispatchFuture(_) => {
+            anyhow::bail!("Call-like instructions are handled by the caller")
         }
     })
 }
@@ -284,6 +285,14 @@ pub fn assert_compiles(input: Program) -> anyhow::Result<()> {
                         .unwrap_or_else(|| format!("global_{callee}")),
                 )),
                 bex_vm_types::Instruction::CallIndirect => Ok(Instruction::CallIndirect),
+                bex_vm_types::Instruction::DispatchFuture(callee) => {
+                    Ok(Instruction::DispatchFuture(
+                        globals_by_index
+                            .get(&callee.raw())
+                            .map(|s| (*s).to_string())
+                            .unwrap_or_else(|| format!("global_{callee}")),
+                    ))
+                }
                 _ => convert_instruction(
                     inst,
                     inst_idx,

--- a/baml_language/crates/baml_tests/src/vm.rs
+++ b/baml_language/crates/baml_tests/src/vm.rs
@@ -351,7 +351,8 @@ pub enum Instruction {
     StoreMapElement,
     AllocInstance(Value),
     AllocVariant(Value),
-    DispatchFuture(usize),
+    /// Direct dispatch to a statically-known sys_op by name.
+    DispatchFuture(String),
     Await,
     Watch(usize),
     Unwatch(usize),

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -94,7 +94,7 @@ pub fn display_instruction(
                 format!("(global {})", index.raw())
             }
         }
-        Instruction::Call(callee) => {
+        Instruction::Call(callee) | Instruction::DispatchFuture(callee) => {
             if callee.raw() < globals.len() {
                 format!("({})", display_value(&globals[*callee]))
             } else if let (Some(ct_globals), Some(objs)) = (compile_time_globals, objects) {
@@ -186,7 +186,6 @@ pub fn display_instruction(
         | Instruction::LoadMapElement
         | Instruction::StoreArrayElement
         | Instruction::StoreMapElement
-        | Instruction::DispatchFuture(_)
         | Instruction::Await
         | Instruction::CallIndirect
         | Instruction::Assert

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2100,31 +2100,19 @@ impl BexVm {
                     self.stack.push(Value::Object(variant_ptr));
                 }
 
-                Instruction::DispatchFuture(arg_count) => {
-                    let args_offset = self.stack.ensure_slot_from_top(arg_count)?;
-
+                Instruction::DispatchFuture(callee) => {
+                    let callee_value = self.globals[callee];
                     let expected_type = FunctionType::SysOp;
+                    let callee_ptr = self.as_object_ptr(&callee_value, expected_type.into())?;
 
-                    let index =
-                        self.as_object_ptr(&self.stack[args_offset], expected_type.into())?;
-
-                    // Can't call a function if it's not a function ¯\_(ツ)_/¯
-                    let Object::Function(callable_future) = self.get_object(index) else {
+                    // Can't dispatch if it's not a function ¯\_(ツ)_/¯
+                    let Object::Function(callable_future) = self.get_object(callee_ptr) else {
                         return Err(InternalError::TypeError {
                             expected: expected_type.into(),
-                            got: ObjectType::of(self.get_object(index)).into(),
+                            got: ObjectType::of(self.get_object(callee_ptr)).into(),
                         }
                         .into());
                     };
-
-                    // Compiler should have already checked this so we could
-                    // skip it but it's an easy and fast check.
-                    if arg_count != callable_future.arity {
-                        return Err(VmError::from(InternalError::InvalidArgumentCount {
-                            expected: callable_future.arity,
-                            got: arg_count,
-                        }));
-                    }
 
                     // Must be a sys_op - extract the SysOp.
                     let FunctionKind::SysOp(sys_op) = callable_future.kind else {
@@ -2134,8 +2122,15 @@ impl BexVm {
                         }));
                     };
 
-                    // Collect the function call args and cleanup the call.
-                    let future_args: Vec<Value> = self.stack.drain(args_offset..).skip(1).collect();
+                    let args_offset = self
+                        .stack
+                        .len()
+                        .checked_sub(callable_future.arity)
+                        .ok_or(InternalError::NotEnoughItemsOnStack(callable_future.arity))?;
+                    let args_offset = StackIndex::from_raw(args_offset);
+
+                    // Collect function call args and cleanup consumed stack.
+                    let future_args: Vec<Value> = self.stack.drain(args_offset..).collect();
 
                     // Create the pending future with the SysOp enum.
                     let pending_future = PendingFuture {

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -226,19 +226,14 @@ pub enum Instruction {
     /// `Vm::objects` array.
     AllocVariant(ObjectIndex),
 
-    /// Creates a pending future, pushes it on the stack and notifies embedder.
+    /// Dispatch a statically-known global `sys_op` and create a pending future.
     ///
-    /// Format: `DISPATCH_FUTURE n` where `n` is the number of arguments passed
-    /// to the _callable_ future.
+    /// Format: `DISPATCH_FUTURE g` where `g` is the global index of the
+    /// `sys_op` function.
     ///
-    /// [`Instruction::DispatchFuture`] behaves like a function call
-    /// ([`Instruction::Call`]). That is due to the fact that as of right now
-    /// the only "futures" we can really run are LLM calls, and the VM doesn't
-    /// even run those, that's up to the embedder. So, just like a function
-    /// call, the stack should contain the future followed by the arguments, and
-    /// this instruction takes care of emmiting a notification to the embedder
-    /// so that it can schedule the future.
-    DispatchFuture(usize),
+    /// Arguments are pushed onto the eval stack. The callee is read from
+    /// `Vm::globals[g]`, and arity is read from function metadata.
+    DispatchFuture(GlobalIndex),
 
     /// Awaits the future on top of the stack.
     ///
@@ -530,7 +525,7 @@ impl std::fmt::Display for Instruction {
             Instruction::StoreMapElement => f.write_str("STORE_MAP_ELEMENT"),
             Instruction::AllocInstance(i) => write!(f, "ALLOC_INSTANCE {i}"),
             Instruction::AllocVariant(i) => write!(f, "ALLOC_VARIANT {i}"),
-            Instruction::DispatchFuture(i) => write!(f, "DISPATCH_FUTURE {i}"),
+            Instruction::DispatchFuture(callee) => write!(f, "DISPATCH_FUTURE {callee}"),
             Instruction::Await => f.write_str("AWAIT"),
             Instruction::Call(callee) => write!(f, "CALL {callee}"),
             Instruction::CallIndirect => f.write_str("CALL_INDIRECT"),


### PR DESCRIPTION
## Summary
- change `Instruction::DispatchFuture` to use a statically-known global callee index (matching direct `CALL`) instead of reading a callee value from the eval stack
- update emitter and stack-carry simulation to emit/consume `DispatchFuture` as args-only, with compile-time callee resolution and no `LOAD_GLOBAL` prelude
- update VM execution to resolve sys_op callee/arity from globals + function metadata, and update debug display/snapshots so `DISPATCH_FUTURE` shows callee metadata like `CALL`

## Testing
- cargo test -p baml_compiler_emit
- cargo test -p bex_vm --test functions
- INSTA_UPDATE=always cargo test -p baml_tests test_06_codegen
- cargo test -p baml_tests test_06_codegen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated function dispatch mechanism to use direct function name references instead of index-based lookup.
  * Enhanced function call resolution validation with earlier error detection.
  * Streamlined direct-call handling in the compiler pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->