### PR TITLE
Fix diagnostic span rendering in Promptfiddle

### DIFF
--- a/typescript/packages/playground-common/src/components/ErrorWarningDialog.tsx
+++ b/typescript/packages/playground-common/src/components/ErrorWarningDialog.tsx
@@ -11,14 +11,32 @@ import {
 } from '@baml/ui/dialog';
 import { AlertTriangle, XCircle, Info } from 'lucide-react';
 import { useAtomValue } from 'jotai';
-import { diagnosticsAtom } from '../sdk/atoms/core.atoms';
+import { diagnosticsAtom, filesAtom, type DiagnosticError } from '../sdk/atoms/core.atoms';
+
+function locationOf(d: DiagnosticError, files: Record<string, string>): string | null {
+  if (!d.filePath) return null;
+  const content = files[d.filePath];
+  if (!content) return d.filePath;
+  let line = 1;
+  let col = 1;
+  for (let i = 0; i < d.start_ch && i < content.length; i++) {
+    if (content[i] === '\n') {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+  return `${d.filePath}:${line}:${col}`;
+}
 
 export const ErrorWarningDialog: React.FC<{
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   trigger?: React.ReactNode;
 }> = ({ open, onOpenChange, trigger }) => {
-  const diagnostics = useAtomValue(diagnosticsAtom) as Array<any>;
+  const diagnostics = useAtomValue(diagnosticsAtom);
+  const files = useAtomValue(filesAtom);
   const errors = diagnostics.filter((d) => d.type === 'error');
   const warnings = diagnostics.filter((d) => d.type === 'warning');
 
@@ -45,19 +63,11 @@ export const ErrorWarningDialog: React.FC<{
                 {errors.map((err, i) => (
                   <li key={i} className="bg-accent border border-l-chart-5 rounded p-2 text-sm">
                     <div className="font-medium">{err.message}</div>
-                    <div className="text-xs text-muted-foreground mt-1">
-                      {err.file_path && (
-                        <span>
-                          <span className="font-mono">{err.file_path}</span>
-                          {typeof err.start_line === 'number' && (
-                            <span>
-                              :{err.start_line + 1}
-                              {typeof err.start_column === 'number' ? `:${err.start_column + 1}` : ''}
-                            </span>
-                          )}
-                        </span>
-                      )}
-                    </div>
+                    {locationOf(err, files) && (
+                      <div className="text-xs text-muted-foreground mt-1">
+                        <span className="font-mono">{locationOf(err, files)}</span>
+                      </div>
+                    )}
                   </li>
                 ))}
               </ul>
@@ -72,19 +82,11 @@ export const ErrorWarningDialog: React.FC<{
                 {warnings.map((warn, i) => (
                   <li key={i} className="bg-accent border border-l-chart-4 rounded p-2 text-sm">
                     <div className="font-medium">{warn.message}</div>
-                    <div className="text-xs text-muted-foreground mt-1">
-                      {warn.file_path && (
-                        <span>
-                          <span className="font-mono">{warn.file_path}</span>
-                          {typeof warn.start_line === 'number' && (
-                            <span>
-                              :{warn.start_line + 1}
-                              {typeof warn.start_column === 'number' ? `:${warn.start_column + 1}` : ''}
-                            </span>
-                          )}
-                        </span>
-                      )}
-                    </div>
+                    {locationOf(warn, files) && (
+                      <div className="text-xs text-muted-foreground mt-1">
+                        <span className="font-mono">{locationOf(warn, files)}</span>
+                      </div>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/typescript/packages/playground-common/src/sdk/atoms/core.atoms.ts
+++ b/typescript/packages/playground-common/src/sdk/atoms/core.atoms.ts
@@ -638,11 +638,8 @@ export interface DiagnosticError {
   type: 'error' | 'warning';
   message: string;
   filePath?: string;
-  line?: number;
-  column?: number;
-  // For compatibility with old code (CodeMirror needs these)
-  start_ch?: number;
-  end_ch?: number;
+  start_ch: number;
+  end_ch: number;
 }
 
 /**

--- a/typescript/packages/playground-common/src/sdk/runtime/BamlRuntime.ts
+++ b/typescript/packages/playground-common/src/sdk/runtime/BamlRuntime.ts
@@ -25,20 +25,16 @@ import {
   type WasmFunctionResponse,
   type WasmControlFlowGraph,
   type WasmControlFlowNode,
-} from '@gloo-ai/baml-schema-wasm-web/baml_schema_build';
+} from "@gloo-ai/baml-schema-wasm-web/baml_schema_build";
 import type {
   BamlRuntimeInterface,
   CursorPosition,
   CursorNavigationResult,
   ExecutionOptions,
-} from './BamlRuntimeInterface';
-import type {
-  TestCaseInput,
-  BAMLFile,
-  BAMLTest,
-} from '../types';
-import type { DiagnosticError, GeneratedFile } from '../atoms/core.atoms';
-import { vscode } from '../../shared/baml-project-panel/vscode';
+} from "./BamlRuntimeInterface";
+import type { TestCaseInput, BAMLFile, BAMLTest } from "../types";
+import type { DiagnosticError, GeneratedFile } from "../atoms/core.atoms";
+import { vscode } from "../../shared/baml-project-panel/vscode";
 
 // Import unified types and adapter from interface layer
 import {
@@ -53,14 +49,11 @@ import {
   type PromptInfo,
   type RichExecutionEvent,
   type TestExecutionContext,
-} from '../interface';
-
-
-
-
+} from "../interface";
 
 // Type for the WASM module that contains all exports
-type BamlWasmModule = typeof import('@gloo-ai/baml-schema-wasm-web/baml_schema_build');
+type BamlWasmModule =
+  typeof import("@gloo-ai/baml-schema-wasm-web/baml_schema_build");
 
 // // Type for WASM diagnostic error objects
 // type WasmDiagnosticErrorObject = {
@@ -84,7 +77,11 @@ type RichWasmFunction = WasmFunction & { function_type: WasmFunctionKind };
 
 // Type for test execution callbacks
 type WasmPartialResponse = WasmFunctionResponse | WasmTestResponse; // Can be either partial or complete response
-type WasmStateUpdate = { node_id: number; log_filter_key: string; new_state: 'not_running' | 'running' | 'completed' };
+type WasmStateUpdate = {
+  node_id: number;
+  log_filter_key: string;
+  new_state: "not_running" | "running" | "completed";
+};
 type WasmNotification = {
   variable_name?: string;
   channel_name?: string;
@@ -119,17 +116,21 @@ let wasmModuleCache: BamlWasmModule | null = null;
  */
 async function getWasmModule(): Promise<BamlWasmModule> {
   if (!wasmModuleCache) {
-    console.log('[BamlRuntime] Loading WASM module for the first time...');
-    wasmModuleCache = await import('@gloo-ai/baml-schema-wasm-web/baml_schema_build');
+    console.log("[BamlRuntime] Loading WASM module for the first time...");
+    wasmModuleCache =
+      await import("@gloo-ai/baml-schema-wasm-web/baml_schema_build");
 
     // CRITICAL: Initialize callback bridge ONCE when module is loaded
     // This enables AWS/GCP credential loading
-    console.log('[BamlRuntime] Initializing WASM callback bridge');
-    wasmModuleCache.init_js_callback_bridge(vscode.loadAwsCreds, vscode.loadGcpCreds);
+    console.log("[BamlRuntime] Initializing WASM callback bridge");
+    wasmModuleCache.init_js_callback_bridge(
+      vscode.loadAwsCreds,
+      vscode.loadGcpCreds,
+    );
 
-    console.log('[BamlRuntime] WASM module loaded and cached ✓');
+    console.log("[BamlRuntime] WASM module loaded and cached ✓");
   } else {
-    console.log('loaded wasm from cache');
+    console.log("loaded wasm from cache");
   }
 
   return wasmModuleCache;
@@ -140,30 +141,30 @@ type ControlFlowArtifacts = {
   callGraphDepth: number;
   nodes: GraphNode[];
   edges: GraphEdge[];
-  rootType: FunctionMetadata['type'];
+  rootType: FunctionMetadata["type"];
 };
 
 export type ControlFlowOptions = {
   rootName: string;
-  rootType: FunctionMetadata['type'];
+  rootType: FunctionMetadata["type"];
   llmClient?: string;
   timestamp: number;
 };
 
 export function createFallbackControlFlowArtifacts(
   metadata: FunctionMetadata,
-  timestamp: number
+  timestamp: number,
 ): ControlFlowArtifacts {
-  const nodeType: GraphNode['type'] =
-    metadata.type === 'llm_function'
-      ? 'llm_function'
-      : metadata.type === 'workflow'
-        ? 'group'
-        : 'function';
-  const callGraphType: CallGraphNode['type'] = (() => {
-    if (metadata.type === 'llm_function') return 'llm_function';
-    if (metadata.type === 'workflow') return 'block';
-    return 'function';
+  const nodeType: GraphNode["type"] =
+    metadata.type === "llm_function"
+      ? "llm_function"
+      : metadata.type === "workflow"
+        ? "group"
+        : "function";
+  const callGraphType: CallGraphNode["type"] = (() => {
+    if (metadata.type === "llm_function") return "llm_function";
+    if (metadata.type === "workflow") return "block";
+    return "function";
   })();
   const callGraph: CallGraphNode = {
     id: metadata.name,
@@ -177,7 +178,7 @@ export function createFallbackControlFlowArtifacts(
     type: nodeType,
     label: metadata.name,
     functionName: metadata.name,
-    codeHash: '',
+    codeHash: "",
     lastModified: timestamp,
     llmClient: metadata.clientName,
   };
@@ -194,7 +195,7 @@ export function createFallbackControlFlowArtifacts(
 export function buildControlFlowArtifacts(
   graph: WasmControlFlowGraph,
   adapter: WasmTypeAdapter,
-  options: ControlFlowOptions
+  options: ControlFlowOptions,
 ): ControlFlowArtifacts | null {
   const nodes = graph.nodes ?? [];
   if (nodes.length === 0) {
@@ -202,10 +203,10 @@ export function buildControlFlowArtifacts(
   }
 
   const hasStructure = nodes.some(
-    (node) => node.node_type !== WasmControlFlowNodeType.FunctionRoot
+    (node) => node.node_type !== WasmControlFlowNodeType.FunctionRoot,
   );
-  const normalizedRootType: FunctionMetadata['type'] = hasStructure
-    ? 'workflow'
+  const normalizedRootType: FunctionMetadata["type"] = hasStructure
+    ? "workflow"
     : options.rootType;
 
   const nodeById = new Map<string, WasmControlFlowNode>();
@@ -229,7 +230,9 @@ export function buildControlFlowArtifacts(
 
   const toCallGraphNode = (node: WasmControlFlowNode): CallGraphNode => {
     const nodeIdStr = node.id.toString();
-    const children = (childrenByParent.get(nodeIdStr) ?? []).map((child) => toCallGraphNode(child));
+    const children = (childrenByParent.get(nodeIdStr) ?? []).map((child) =>
+      toCallGraphNode(child),
+    );
     return {
       id: nodeIdStr,
       type: mapNodeTypeToCallGraphType(node.node_type, normalizedRootType),
@@ -251,13 +254,16 @@ export function buildControlFlowArtifacts(
       label: node.label || nodeIdStr,
       functionName: options.rootName,
       parent: node.parent_id?.toString(),
-      codeHash: '',
+      codeHash: "",
       lastModified: options.timestamp,
-      llmClient: node.node_type === WasmControlFlowNodeType.FunctionRoot ? options.llmClient : undefined,
+      llmClient:
+        node.node_type === WasmControlFlowNodeType.FunctionRoot
+          ? options.llmClient
+          : undefined,
       metadata: {
         wasmNodeId: node.id,
         logFilterKey: node.log_filter_key,
-        controlFlowType: WasmControlFlowNodeType[node.node_type] ?? 'Unknown',
+        controlFlowType: WasmControlFlowNodeType[node.node_type] ?? "Unknown",
       },
     };
   });
@@ -304,49 +310,51 @@ export function buildControlFlowArtifacts(
 
 function mapNodeTypeToCallGraphType(
   nodeType: WasmControlFlowNodeType,
-  rootType: FunctionMetadata['type']
-): CallGraphNode['type'] {
+  rootType: FunctionMetadata["type"],
+): CallGraphNode["type"] {
   if (nodeType === WasmControlFlowNodeType.FunctionRoot) {
-    if (rootType === 'llm_function') return 'llm_function';
-    if (rootType === 'workflow') return 'block';
-    return 'function';
+    if (rootType === "llm_function") return "llm_function";
+    if (rootType === "workflow") return "block";
+    return "function";
   }
-  return 'block';
+  return "block";
 }
 
 function mapNodeTypeToGraphNodeType(
   nodeType: WasmControlFlowNodeType,
-  rootType: FunctionMetadata['type']
-): GraphNode['type'] {
+  rootType: FunctionMetadata["type"],
+): GraphNode["type"] {
   if (nodeType === WasmControlFlowNodeType.FunctionRoot) {
-    if (rootType === 'llm_function') return 'llm_function';
+    if (rootType === "llm_function") return "llm_function";
     // Workflow roots are still functions - they have inputs and can be run
-    if (rootType === 'workflow') return 'function';
-    return 'function';
+    if (rootType === "workflow") return "function";
+    return "function";
   }
   switch (nodeType) {
     case WasmControlFlowNodeType.Loop:
-      return 'loop';
+      return "loop";
     case WasmControlFlowNodeType.BranchGroup:
-      return 'conditional';
+      return "conditional";
     case WasmControlFlowNodeType.BranchArm:
     case WasmControlFlowNodeType.HeaderContextEnter:
     case WasmControlFlowNodeType.OtherScope:
     default:
-      return 'group';
+      return "group";
   }
 }
 
-function mapNodeTypeToBlockType(nodeType: WasmControlFlowNodeType): BlockType | undefined {
+function mapNodeTypeToBlockType(
+  nodeType: WasmControlFlowNodeType,
+): BlockType | undefined {
   switch (nodeType) {
     case WasmControlFlowNodeType.BranchGroup:
-      return 'if';
+      return "if";
     case WasmControlFlowNodeType.Loop:
-      return 'loop';
+      return "loop";
     case WasmControlFlowNodeType.BranchArm:
     case WasmControlFlowNodeType.HeaderContextEnter:
     case WasmControlFlowNodeType.OtherScope:
-      return 'expression';
+      return "expression";
     default:
       return undefined;
   }
@@ -359,7 +367,9 @@ function computeCallGraphDepth(node: CallGraphNode | undefined): number {
   if (!node.children || node.children.length === 0) {
     return 1;
   }
-  const childDepths = node.children.map((child) => computeCallGraphDepth(child));
+  const childDepths = node.children.map((child) =>
+    computeCallGraphDepth(child),
+  );
   return 1 + Math.max(...childDepths);
 }
 
@@ -382,7 +392,7 @@ export class BamlRuntime implements BamlRuntimeInterface {
     wasm: BamlWasmModule,
     wasmProject: WasmProject,
     wasmRuntime: WasmRuntime | undefined,
-    diagnostics: DiagnosticError[]
+    diagnostics: DiagnosticError[],
   ) {
     this.wasm = wasm;
     this.wasmProject = wasmProject;
@@ -401,27 +411,46 @@ export class BamlRuntime implements BamlRuntimeInterface {
   static async create(
     files: Record<string, string>,
     envVars: Record<string, string> = {},
-    featureFlags: string[] = []
-  ): Promise<{ wasm: typeof import('@gloo-ai/baml-schema-wasm-web/baml_schema_build'), runtime: BamlRuntime }> {
-    console.log('[BamlRuntime] Creating runtime with', Object.keys(files).length, 'files');
+    featureFlags: string[] = [],
+  ): Promise<{
+    wasm: typeof import("@gloo-ai/baml-schema-wasm-web/baml_schema_build");
+    runtime: BamlRuntime;
+  }> {
+    console.log(
+      "[BamlRuntime] Creating runtime with",
+      Object.keys(files).length,
+      "files",
+    );
 
     // Get cached WASM module (loads once, then reuses)
     const wasm = await getWasmModule();
 
     // Filter to .baml files only
-    const bamlFiles = Object.entries(files).filter(([path]) => path.endsWith('.baml'));
-    console.log('[BamlRuntime] Filtered to', bamlFiles.length, 'BAML files');
+    const bamlFiles = Object.entries(files).filter(([path]) =>
+      path.endsWith(".baml"),
+    );
+    console.log("[BamlRuntime] Filtered to", bamlFiles.length, "BAML files");
 
     // Create WasmProject (matches wasmAtom pattern)
-    const wasmProject = wasm.WasmProject.new('./', bamlFiles);
+    const wasmProject = wasm.WasmProject.new("./", bamlFiles);
 
     // Try to create runtime and collect diagnostics
     let wasmRuntime: WasmRuntime | undefined;
     let diagnostics: DiagnosticError[] = [];
 
     try {
-      console.log('[BamlRuntime] Creating runtime with env vars and feature flags', { envVars, featureFlags, files: Object.entries(files).map(([path, content]) => ({ path, content })) });
-      // Create runtime with env vars and feature 
+      console.log(
+        "[BamlRuntime] Creating runtime with env vars and feature flags",
+        {
+          envVars,
+          featureFlags,
+          files: Object.entries(files).map(([path, content]) => ({
+            path,
+            content,
+          })),
+        },
+      );
+      // Create runtime with env vars and feature
       // flags
       wasmRuntime = wasmProject.runtime(envVars, featureFlags);
 
@@ -430,44 +459,63 @@ export class BamlRuntime implements BamlRuntimeInterface {
       if (diags) {
         diagnostics = diags.errors().map((e: WasmError, index: number) => ({
           id: `diag_${index}`,
-          type: e.type as 'error' | 'warning',
+          type: e.type as "error" | "warning",
           message: e.message || String(e),
           filePath: e.file_path,
           line: e.start_line,
           column: e.start_column,
+          start_ch: e.start_ch,
+          end_ch: e.end_ch,
         }));
       }
 
-      console.log('[BamlRuntime] Runtime created successfully with', diagnostics.length, 'diagnostics');
+      console.log(
+        "[BamlRuntime] Runtime created successfully with",
+        diagnostics.length,
+        "diagnostics",
+      );
     } catch (e) {
-      console.error('[BamlRuntime] Error creating runtime:', e);
+      console.error("[BamlRuntime] Error creating runtime:", e);
 
       // Check if it's a WasmDiagnosticError
       if (wasm.WasmDiagnosticError && e instanceof wasm.WasmDiagnosticError) {
         const wasmDiagError = e as WasmDiagnosticError;
-        diagnostics = wasmDiagError.errors().map((err: WasmError, index: number) => ({
-          id: `diag_${index}`,
-          type: err.type as 'error' | 'warning',
-          message: err.message || String(err),
-          filePath: err.file_path,
-          line: err.start_line,
-          column: err.start_column,
-        }));
-        console.log('[BamlRuntime] Captured', diagnostics.length, 'diagnostics from error');
+        diagnostics = wasmDiagError
+          .errors()
+          .map((err: WasmError, index: number) => ({
+            id: `diag_${index}`,
+            type: err.type as "error" | "warning",
+            message: err.message || String(err),
+            filePath: err.file_path,
+            line: err.start_line,
+            column: err.start_column,
+            start_ch: err.start_ch,
+            end_ch: err.end_ch,
+          }));
+        console.log(
+          "[BamlRuntime] Captured",
+          diagnostics.length,
+          "diagnostics from error",
+        );
       } else {
         // Unknown error - create a generic diagnostic
-        diagnostics = [{
-          id: 'diag_unknown',
-          type: 'error',
-          message: e instanceof Error ? e.message : String(e),
-        }];
+        diagnostics = [
+          {
+            id: "diag_unknown",
+            type: "error",
+            message: e instanceof Error ? e.message : String(e),
+          },
+        ];
       }
 
       // Runtime is undefined if there was an error
       wasmRuntime = undefined;
     }
 
-    return { wasm, runtime: new BamlRuntime(wasm, wasmProject, wasmRuntime, diagnostics) };
+    return {
+      wasm,
+      runtime: new BamlRuntime(wasm, wasmProject, wasmRuntime, diagnostics),
+    };
   }
 
   // ============================================================================
@@ -489,17 +537,21 @@ export class BamlRuntime implements BamlRuntimeInterface {
     // TODO: Filter by isRoot: true when we properly analyze call relationships
     const workflows = this.getFunctions();
     const endTime = performance.now();
-    console.log(`[BamlRuntime] getWorkflows() took ${(endTime - startTime).toFixed(2)}ms`);
+    console.log(
+      `[BamlRuntime] getWorkflows() took ${(endTime - startTime).toFixed(2)}ms`,
+    );
     return workflows;
   }
 
   getCallGraph(functionName: string): CallGraphNode | undefined {
     const startTime = performance.now();
     const functions = this.getFunctions();
-    const func = functions.find(f => f.name === functionName);
+    const func = functions.find((f) => f.name === functionName);
     const callGraph = func?.callGraph;
     const endTime = performance.now();
-    console.log(`[BamlRuntime] getCallGraph('${functionName}') took ${(endTime - startTime).toFixed(2)}ms`);
+    console.log(
+      `[BamlRuntime] getCallGraph('${functionName}') took ${(endTime - startTime).toFixed(2)}ms`,
+    );
     return callGraph;
   }
 
@@ -511,7 +563,7 @@ export class BamlRuntime implements BamlRuntimeInterface {
 
     const startTime = performance.now();
     if (!this.wasmRuntime) {
-      console.log('[BamlRuntime] Cannot get functions - runtime is invalid');
+      console.log("[BamlRuntime] Cannot get functions - runtime is invalid");
       return [];
     }
 
@@ -537,20 +589,22 @@ export class BamlRuntime implements BamlRuntimeInterface {
       }
 
       const endTime = performance.now();
-      console.log(`[BamlRuntime] getFunctions() took ${(endTime - startTime).toFixed(2)}ms (cached for future calls)`);
+      console.log(
+        `[BamlRuntime] getFunctions() took ${(endTime - startTime).toFixed(2)}ms (cached for future calls)`,
+      );
 
       // Cache the result
       this.functionsCache = combined;
       return combined;
     } catch (e) {
-      console.error('[BamlRuntime] Error getting functions:', e);
+      console.error("[BamlRuntime] Error getting functions:", e);
       return [];
     }
   }
 
   private buildFunctionRecord(
     fn: RichWasmFunction,
-    metadata: FunctionMetadata
+    metadata: FunctionMetadata,
   ): FunctionWithCallGraph {
     const timestamp = Date.now();
     let controlFlow = createFallbackControlFlowArtifacts(metadata, timestamp);
@@ -567,7 +621,7 @@ export class BamlRuntime implements BamlRuntimeInterface {
           llmClient: metadata.clientName,
           timestamp,
         });
-        console.log('[BamlRuntime] converted:', converted);
+        console.log("[BamlRuntime] converted:", converted);
         if (converted && converted.nodes.length > 0) {
           controlFlow = converted;
         }
@@ -575,7 +629,7 @@ export class BamlRuntime implements BamlRuntimeInterface {
       } catch (graphErr) {
         console.warn(
           `[BamlRuntime] Failed to build control flow graph for ${fn.name}`,
-          graphErr
+          graphErr,
         );
       }
     }
@@ -587,9 +641,8 @@ export class BamlRuntime implements BamlRuntimeInterface {
       throw new Error(`[BamlRuntime] Missing span information for ${fn.name}`);
     })();
 
-    let finalType: FunctionMetadata['type'] = controlFlow.rootType === 'workflow'
-      ? 'workflow'
-      : metadata.type;
+    let finalType: FunctionMetadata["type"] =
+      controlFlow.rootType === "workflow" ? "workflow" : metadata.type;
 
     // if (finalType === 'workflow' && controlFlow.nodes.length <= 1) {
     //   // HACK: Treat single-node “workflows” (pure LLM calls) as llm_functions until
@@ -609,7 +662,8 @@ export class BamlRuntime implements BamlRuntimeInterface {
       type: finalType,
       span: resolvedSpan,
       callGraph: controlFlow.callGraph,
-      isRoot: finalType === 'workflow' ? true : controlFlow.callGraphDepth === 1,
+      isRoot:
+        finalType === "workflow" ? true : controlFlow.callGraphDepth === 1,
       callGraphDepth: controlFlow.callGraphDepth,
 
       // Backward compatibility fields
@@ -622,17 +676,17 @@ export class BamlRuntime implements BamlRuntimeInterface {
       edges: controlFlow.edges,
       entryPoint: fn.name,
       parameters: [],
-      returnType: '',
+      returnType: "",
       childFunctions: [],
       lastModified: timestamp,
-      codeHash: '',
+      codeHash: "",
     };
   }
 
   getTestCases(functionName?: string): TestCaseMetadata[] {
     // Need valid runtime to get test cases
     if (!this.wasmRuntime) {
-      console.log('[BamlRuntime] Cannot get test cases - runtime is invalid');
+      console.log("[BamlRuntime] Cannot get test cases - runtime is invalid");
       return [];
     }
 
@@ -642,11 +696,15 @@ export class BamlRuntime implements BamlRuntimeInterface {
       try {
         // Get all test cases from WASM runtime and cache them
         const allTestCases: WasmTestCase[] = this.wasmRuntime.list_testcases();
-        this.testCasesCache = allTestCases.map((tc) => this.adapter.convertTestCase(tc));
+        this.testCasesCache = allTestCases.map((tc) =>
+          this.adapter.convertTestCase(tc),
+        );
         const endTime = performance.now();
-        console.log(`[BamlRuntime] getTestCases() took ${(endTime - startTime).toFixed(2)}ms (cached for future calls)`);
+        console.log(
+          `[BamlRuntime] getTestCases() took ${(endTime - startTime).toFixed(2)}ms (cached for future calls)`,
+        );
       } catch (e) {
-        console.error('[BamlRuntime] Error getting test cases:', e);
+        console.error("[BamlRuntime] Error getting test cases:", e);
         return [];
       }
     }
@@ -665,7 +723,7 @@ export class BamlRuntime implements BamlRuntimeInterface {
     }
 
     if (!this.wasmRuntime) {
-      console.log('[BamlRuntime] Cannot get BAML files - runtime is invalid');
+      console.log("[BamlRuntime] Cannot get BAML files - runtime is invalid");
       return [];
     }
 
@@ -675,14 +733,22 @@ export class BamlRuntime implements BamlRuntimeInterface {
       const functions: FunctionWithCallGraph[] = this.getFunctions();
       const testCases: TestCaseMetadata[] = this.getTestCases();
 
-      const fileMap = new Map<string, { functions: FunctionWithCallGraph[], tests: BAMLTest[] }>();
-      const functionTypeByName = new Map(functions.map(fn => [fn.name, fn.type]));
+      const fileMap = new Map<
+        string,
+        { functions: FunctionWithCallGraph[]; tests: BAMLTest[] }
+      >();
+      const functionTypeByName = new Map(
+        functions.map((fn) => [fn.name, fn.type]),
+      );
 
       for (const fn of functions) {
         if (!fn.span) {
-          console.warn('[BamlRuntime] Missing span for function while grouping files:', fn.name);
+          console.warn(
+            "[BamlRuntime] Missing span for function while grouping files:",
+            fn.name,
+          );
         }
-        const filePath = fn.span?.filePath || 'unknown.baml';
+        const filePath = fn.span?.filePath || "unknown.baml";
         if (!fileMap.has(filePath)) {
           fileMap.set(filePath, { functions: [], tests: [] });
         }
@@ -690,13 +756,14 @@ export class BamlRuntime implements BamlRuntimeInterface {
       }
 
       for (const tc of testCases) {
-        const filePath = tc.span?.filePath || 'unknown.baml';
+        const filePath = tc.span?.filePath || "unknown.baml";
         if (!fileMap.has(filePath)) {
           fileMap.set(filePath, { functions: [], tests: [] });
         }
-        const parentName = tc.functionId || 'unknown';
-        const parentType = functionTypeByName.get(parentName) ?? 'function';
-        const nodeType: 'llm_function' | 'function' = parentType === 'llm_function' ? 'llm_function' : 'function';
+        const parentName = tc.functionId || "unknown";
+        const parentType = functionTypeByName.get(parentName) ?? "function";
+        const nodeType: "llm_function" | "function" =
+          parentType === "llm_function" ? "llm_function" : "function";
 
         const bamlTest: BAMLTest = {
           name: tc.name,
@@ -709,18 +776,22 @@ export class BamlRuntime implements BamlRuntimeInterface {
       }
 
       // Convert map to array of BAMLFile objects and cache
-      this.bamlFilesCache = Array.from(fileMap.entries()).map(([path, data]) => ({
-        path,
-        functions: data.functions,
-        tests: data.tests,
-      }));
+      this.bamlFilesCache = Array.from(fileMap.entries()).map(
+        ([path, data]) => ({
+          path,
+          functions: data.functions,
+          tests: data.tests,
+        }),
+      );
 
       const endTime = performance.now();
-      console.log(`[BamlRuntime] getBAMLFiles() took ${(endTime - startTime).toFixed(2)}ms (cached for future calls)`);
+      console.log(
+        `[BamlRuntime] getBAMLFiles() took ${(endTime - startTime).toFixed(2)}ms (cached for future calls)`,
+      );
 
       return this.bamlFilesCache;
     } catch (e) {
-      console.error('[BamlRuntime] Error getting BAML files:', e);
+      console.error("[BamlRuntime] Error getting BAML files:", e);
       return [];
     }
   }
@@ -732,24 +803,25 @@ export class BamlRuntime implements BamlRuntimeInterface {
   getGeneratedFiles(): GeneratedFile[] {
     // Only return generated files if runtime is valid
     if (!this.wasmRuntime) {
-      console.log('[BamlRuntime] Cannot generate files - runtime is invalid');
+      console.log("[BamlRuntime] Cannot generate files - runtime is invalid");
       return [];
     }
 
     try {
-      const generators: WasmGeneratorOutput[] = this.wasmProject.run_generators();
+      const generators: WasmGeneratorOutput[] =
+        this.wasmProject.run_generators();
       const files = generators.flatMap((gen) =>
         gen.files.map((f) => ({
           path: f.path_in_output_dir,
           content: f.contents,
           outputDir: gen.output_dir,
-        }))
+        })),
       );
 
-      console.log('[BamlRuntime] Generated', files.length, 'files');
+      console.log("[BamlRuntime] Generated", files.length, "files");
       return files;
     } catch (e) {
-      console.error('[BamlRuntime] Error generating files:', e);
+      console.error("[BamlRuntime] Error generating files:", e);
       return [];
     }
   }
@@ -757,20 +829,19 @@ export class BamlRuntime implements BamlRuntimeInterface {
   async *executeWorkflow(
     workflowId: string,
     inputs: Record<string, any>,
-    options?: ExecutionOptions
+    options?: ExecutionOptions,
   ): AsyncGenerator<RichExecutionEvent> {
     // TODO: Implement workflow execution
-    console.warn('[BamlRuntime] executeWorkflow() not yet implemented');
-    throw new Error('Workflow execution not yet implemented for BamlRuntime');
+    console.warn("[BamlRuntime] executeWorkflow() not yet implemented");
+    throw new Error("Workflow execution not yet implemented for BamlRuntime");
   }
-
 
   async executeTests(
     tests: Array<{ functionName: string; testName: string }>,
-    context: TestExecutionContext
+    context: TestExecutionContext,
   ): Promise<void> {
     if (!this.wasmRuntime) {
-      throw new Error('Cannot execute tests - runtime is invalid');
+      throw new Error("Cannot execute tests - runtime is invalid");
     }
 
     // Prepare test cases for run_tests
@@ -813,14 +884,26 @@ export class BamlRuntime implements BamlRuntimeInterface {
     const results = await this.wasmRuntime.run_tests(
       testCases,
       // on_partial_response callback
-      (partial: WasmPartialResponse & { func_test_pair: () => { function_name: string; test_name: string } }) => {
+      (
+        partial: WasmPartialResponse & {
+          func_test_pair: () => { function_name: string; test_name: string };
+        },
+      ) => {
         // console.log('[BamlRuntime] on_partial_response:', partial);
         const pair = partial.func_test_pair();
         const convertedPartial = this.adapter.convertResponseToData(partial);
 
         if (context.onPartialResponse) {
-          console.log('[BamlRuntime] calling context.onPartialResponse for', pair.function_name, pair.test_name);
-          context.onPartialResponse(pair.function_name, pair.test_name, convertedPartial);
+          console.log(
+            "[BamlRuntime] calling context.onPartialResponse for",
+            pair.function_name,
+            pair.test_name,
+          );
+          context.onPartialResponse(
+            pair.function_name,
+            pair.test_name,
+            convertedPartial,
+          );
         }
       },
       // get_baml_src_cb - load media files
@@ -830,30 +913,40 @@ export class BamlRuntime implements BamlRuntimeInterface {
       // abort_signal
       context.abortSignal || null,
       // watch_handler - for watch notifications
-      (notification: WasmNotification & { function_name?: string; test_name?: string }) => {
-        const rawStateUpdates = (notification as any).state_updates ?? (notification as any).stateUpdates;
+      (
+        notification: WasmNotification & {
+          function_name?: string;
+          test_name?: string;
+        },
+      ) => {
+        const rawStateUpdates =
+          (notification as any).state_updates ??
+          (notification as any).stateUpdates;
         const vizUpdates = Array.isArray(rawStateUpdates)
           ? rawStateUpdates
-              .filter((u) => u?.kind === 'viz_state_update')
+              .filter((u) => u?.kind === "viz_state_update")
               .map((u) => ({
                 nodeId: u.node_id,
                 logFilterKey: u.log_filter_key,
-                newState: u.new_state as 'not_running' | 'running' | 'completed',
+                newState: u.new_state as
+                  | "not_running"
+                  | "running"
+                  | "completed",
               }))
           : undefined;
 
         // Derive a display value from the reduced events, falling back to an empty string
         let derivedValue: string | undefined;
         if (Array.isArray(rawStateUpdates)) {
-          const valueEvent = rawStateUpdates.find((u) => u?.kind === 'value');
-          if (valueEvent && typeof valueEvent.value === 'string') {
+          const valueEvent = rawStateUpdates.find((u) => u?.kind === "value");
+          if (valueEvent && typeof valueEvent.value === "string") {
             derivedValue = valueEvent.value;
           }
         }
 
-        const value = derivedValue ?? notification.value ?? '';
+        const value = derivedValue ?? notification.value ?? "";
 
-        console.info('[BamlRuntime] watch notification', {
+        console.info("[BamlRuntime] watch notification", {
           functionName: notification.function_name,
           testName: notification.test_name,
           value,
@@ -870,7 +963,15 @@ export class BamlRuntime implements BamlRuntimeInterface {
           isStream: notification.is_stream,
           value,
         };
-        const notifications: Array<typeof baseNotification & { stateUpdate?: { nodeId: number; logFilterKey?: string; newState: 'not_running' | 'running' | 'completed' } }> = [];
+        const notifications: Array<
+          typeof baseNotification & {
+            stateUpdate?: {
+              nodeId: number;
+              logFilterKey?: string;
+              newState: "not_running" | "running" | "completed";
+            };
+          }
+        > = [];
         if (vizUpdates && vizUpdates.length > 0) {
           for (const update of vizUpdates) {
             notifications.push({ ...baseNotification, stateUpdate: update });
@@ -885,7 +986,7 @@ export class BamlRuntime implements BamlRuntimeInterface {
         }
       },
       // parallel - whether to run tests in parallel (default: false, optional in WASM)
-      context.parallel ?? false
+      context.parallel ?? false,
     );
 
     // Process final results and call onTestComplete for each test
@@ -896,42 +997,55 @@ export class BamlRuntime implements BamlRuntimeInterface {
       const testKey = `${pair.function_name}:${pair.test_name}`;
       const latencyMs = Date.now() - (startTimes[testKey] || Date.now());
 
-      const statusMap: Record<number, 'passed' | 'llm_failed' | 'parse_failed' | 'constraints_failed' | 'assert_failed' | 'error'> = {
-        [this.wasm.TestStatus.Passed]: 'passed',
-        [this.wasm.TestStatus.LLMFailure]: 'llm_failed',
-        [this.wasm.TestStatus.ParseFailure]: 'parse_failed',
-        [this.wasm.TestStatus.ConstraintsFailed]: 'constraints_failed',
-        [this.wasm.TestStatus.AssertFailed]: 'assert_failed',
-        [this.wasm.TestStatus.UnableToRun]: 'error',
-        [this.wasm.TestStatus.FinishReasonFailed]: 'error',
+      const statusMap: Record<
+        number,
+        | "passed"
+        | "llm_failed"
+        | "parse_failed"
+        | "constraints_failed"
+        | "assert_failed"
+        | "error"
+      > = {
+        [this.wasm.TestStatus.Passed]: "passed",
+        [this.wasm.TestStatus.LLMFailure]: "llm_failed",
+        [this.wasm.TestStatus.ParseFailure]: "parse_failed",
+        [this.wasm.TestStatus.ConstraintsFailed]: "constraints_failed",
+        [this.wasm.TestStatus.AssertFailed]: "assert_failed",
+        [this.wasm.TestStatus.UnableToRun]: "error",
+        [this.wasm.TestStatus.FinishReasonFailed]: "error",
       };
 
-      const testStatus = statusMap[status] || 'error';
+      const testStatus = statusMap[status] || "error";
       const responseData = this.adapter.convertResponseToData(response);
 
       if (context.onTestComplete) {
-        context.onTestComplete(pair.function_name, pair.test_name, responseData, testStatus, latencyMs);
+        context.onTestComplete(
+          pair.function_name,
+          pair.test_name,
+          responseData,
+          testStatus,
+          latencyMs,
+        );
       }
     }
   }
 
   async cancelExecution(executionId: string): Promise<void> {
     // TODO: Implement execution cancellation
-    console.warn('[BamlRuntime] cancelExecution() not yet implemented');
+    console.warn("[BamlRuntime] cancelExecution() not yet implemented");
   }
 
   async renderPromptForTest(
     functionName: string,
     testName: string,
-    context: TestExecutionContext
+    context: TestExecutionContext,
   ): Promise<PromptInfo> {
     if (!this.wasmRuntime) {
-      throw new Error('Runtime not initialized');
+      throw new Error("Runtime not initialized");
     }
     try {
-
       const wasmFunctions = this.wasmRuntime.list_functions();
-      const wasmFn = wasmFunctions.find(f => f.name === functionName);
+      const wasmFn = wasmFunctions.find((f) => f.name === functionName);
       if (!wasmFn) {
         throw new Error(`Function ${functionName} not found`);
       }
@@ -944,14 +1058,14 @@ export class BamlRuntime implements BamlRuntimeInterface {
         this.wasmRuntime,
         testName,
         wasmCallContext,
-        context.loadMediaFile || (() => Promise.resolve('')),
-        context.apiKeys || {}
+        context.loadMediaFile || (() => Promise.resolve("")),
+        context.apiKeys || {},
       );
 
       // Convert WASM prompt to unified type
       return this.adapter.convertPrompt(wasmPrompt);
     } catch (error) {
-      console.error('[BamlRuntime] Error rendering prompt for test:', error);
+      console.error("[BamlRuntime] Error rendering prompt for test:", error);
       throw error;
     }
   }
@@ -964,15 +1078,15 @@ export class BamlRuntime implements BamlRuntimeInterface {
       expandImages: boolean;
       exposeSecrets: boolean;
     },
-    context: TestExecutionContext
+    context: TestExecutionContext,
   ): Promise<string> {
     try {
       if (!this.wasmRuntime) {
-        throw new Error('Runtime not initialized');
+        throw new Error("Runtime not initialized");
       }
 
       const wasmFunctions = this.wasmRuntime.list_functions();
-      const wasmFn = wasmFunctions.find(f => f.name === functionName);
+      const wasmFn = wasmFunctions.find((f) => f.name === functionName);
       if (!wasmFn) {
         throw new Error(`Function ${functionName} not found`);
       }
@@ -987,12 +1101,12 @@ export class BamlRuntime implements BamlRuntimeInterface {
         wasmCallContext,
         options.stream || false,
         options.expandImages || false,
-        context.loadMediaFile || (() => Promise.resolve('')),
+        context.loadMediaFile || (() => Promise.resolve("")),
         context.apiKeys || {},
-        options.exposeSecrets || false
+        options.exposeSecrets || false,
       );
     } catch (error) {
-      console.error('[BamlRuntime] Error rendering curl for test:', error);
+      console.error("[BamlRuntime] Error rendering curl for test:", error);
       throw error;
     }
   }
@@ -1000,21 +1114,21 @@ export class BamlRuntime implements BamlRuntimeInterface {
   updateCursor(
     cursor: CursorPosition,
     fileContents: Record<string, string>,
-    _currentSelection: string | null
+    _currentSelection: string | null,
   ): CursorNavigationResult {
     if (!this.wasmRuntime) {
-      console.log('no wasm runtime');
+      console.log("no wasm runtime");
       return { functionName: null, testCaseName: null, nodeId: null };
     }
     try {
       const fileContent = fileContents[cursor.fileName];
       if (!fileContent) {
-        console.log('no file content');
+        console.log("no file content");
         return { functionName: null, testCaseName: null, nodeId: null };
       }
 
       // Convert line/column to character index
-      const lines = fileContent.split('\n');
+      const lines = fileContent.split("\n");
       let cursorIdx = 0;
       for (let i = 0; i < cursor.line; i++) {
         cursorIdx += (lines[i]?.length ?? 0) + 1; // +1 for newline
@@ -1024,15 +1138,17 @@ export class BamlRuntime implements BamlRuntimeInterface {
       // get_entity_at_position now handles functions, nodes, AND test cases
       const entity = this.wasmRuntime.get_entity_at_position(
         cursor.fileName,
-        cursorIdx
+        cursorIdx,
       );
 
       if (!entity) {
-        console.warn('clicked on something that is not a function, node, or test case');
+        console.warn(
+          "clicked on something that is not a function, node, or test case",
+        );
         return { functionName: null, testCaseName: null, nodeId: null };
       }
 
-      console.log('[BamlRuntime] Entity at cursor:', {
+      console.log("[BamlRuntime] Entity at cursor:", {
         entity_type: entity.entity_type,
         entity_name: entity.entity_name,
         function_name: entity.function_name,
@@ -1048,7 +1164,7 @@ export class BamlRuntime implements BamlRuntimeInterface {
         nodeId: entity.node_id ?? null,
       };
     } catch (error) {
-      console.error('[BamlRuntime] Error updating cursor:', error);
+      console.error("[BamlRuntime] Error updating cursor:", error);
       throw error;
     }
   }

--- a/typescript/packages/playground-common/src/sdk/runtime/BamlRuntime.ts
+++ b/typescript/packages/playground-common/src/sdk/runtime/BamlRuntime.ts
@@ -462,8 +462,6 @@ export class BamlRuntime implements BamlRuntimeInterface {
           type: e.type as "error" | "warning",
           message: e.message || String(e),
           filePath: e.file_path,
-          line: e.start_line,
-          column: e.start_column,
           start_ch: e.start_ch,
           end_ch: e.end_ch,
         }));
@@ -487,8 +485,6 @@ export class BamlRuntime implements BamlRuntimeInterface {
             type: err.type as "error" | "warning",
             message: err.message || String(err),
             filePath: err.file_path,
-            line: err.start_line,
-            column: err.start_column,
             start_ch: err.start_ch,
             end_ch: err.end_ch,
           }));
@@ -504,6 +500,8 @@ export class BamlRuntime implements BamlRuntimeInterface {
             id: "diag_unknown",
             type: "error",
             message: e instanceof Error ? e.message : String(e),
+            start_ch: 0,
+            end_ch: 0,
           },
         ];
       }

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/codemirror-panel/atoms.ts
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/codemirror-panel/atoms.ts
@@ -5,11 +5,9 @@ import { diagnosticsAtom } from '../atoms';
 export const CodeMirrorDiagnosticsAtom = atom((get) => {
   const diags = get(diagnosticsAtom);
   return diags.map((d): Diagnostic => {
-    const start = d.start_ch ?? 0;
-    const end = d.end_ch ?? 0;
     return {
-      from: start,
-      to: start === end ? end + 1 : end,
+      from: d.start_ch,
+      to: d.start_ch === d.end_ch ? d.end_ch + 1 : d.end_ch,
       message: d.message,
       severity: d.type === 'warning' ? 'warning' : 'error',
       source: 'baml',


### PR DESCRIPTION
During a migration to the SDK abstraction in our typescript code, span start and end location got moved to a different field in the WASM diagnostic types, and those fields didn't get copied in to the components that render error spans in CodeMirror.

This PR ties the knot on that refactor by wiring span locations the rest of the way through, and also removes the prior span location fields.

### Before:

<img width="633" height="483" alt="Screenshot 2026-02-20 at 11 31 15 AM" src="https://github.com/user-attachments/assets/8efec629-a653-4f68-8bf5-ade43266f960" />

<img width="584" height="315" alt="Screenshot 2026-02-20 at 11 31 27 AM" src="https://github.com/user-attachments/assets/36234426-e962-405f-9f64-cf0efbead528" />

(note: the span is appearing at row1 col1, not the true error location. And the Errors dialog has no span info)


### After:
<img width="470" height="155" alt="Screenshot 2026-02-20 at 11 30 38 AM" src="https://github.com/user-attachments/assets/8ce2c0c0-e4cb-4e1f-b28b-fc468cadce36" />

<img width="576" height="341" alt="Screenshot 2026-02-20 at 11 30 20 AM" src="https://github.com/user-attachments/assets/d4ede75a-9cd2-42de-af63-e2f022a0adf5" />

(span appears at the intended spot, Errors dialog shows full span info)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error and warning locations now display as a single human-readable location (file:line:column) instead of separate fragments.

* **Refactor**
  * Diagnostic data now always includes character-position fields to improve location accuracy.
  * Normalized code formatting and string-style consistency across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->