### PR TITLE
feat(jinja): add format() support

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -2806,10 +2806,19 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.11.0"
-source = "git+https://github.com/boundaryml/minijinja.git?branch=main#ee25c021c8bb78d7ca11fa99972918eea4585330"
+version = "2.16.0"
+source = "git+https://github.com/boundaryml/minijinja.git?branch=value-cmp#8cfc770a5dffeda2de5b910d2b9f870d7edeff7c"
 dependencies = [
  "indexmap",
+ "serde",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.16.0"
+source = "git+https://github.com/boundaryml/minijinja.git?branch=value-cmp#8cfc770a5dffeda2de5b910d2b9f870d7edeff7c"
+dependencies = [
+ "minijinja",
  "serde",
 ]
 
@@ -4392,6 +4401,7 @@ dependencies = [
  "bex_vm_types",
  "indexmap",
  "minijinja",
+ "minijinja-contrib",
  "regex",
  "serde",
  "serde_json",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -58,15 +58,15 @@ bex_resource_types = { path = "crates/bex_resource_types" }
 bex_factory = { path = "crates/bex_factory" }
 
 # External dependency for sys_llm jinja module
-minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "main", default-features = false, features = [
+minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "value-cmp", default-features = false, features = [
   "macros",
   "builtins",
   "debug",
   "preserve_order",
   "serde",
   "unstable_machinery",
-  "unstable_machinery_serde",
 ] }
+minijinja-contrib = { git = "https://github.com/boundaryml/minijinja.git", branch = "value-cmp", features = [ "pycompat" ] }
 baml_workspace = { path = "crates/baml_workspace" }
 
 #  External dependencies

--- a/baml_language/crates/sys_llm/Cargo.toml
+++ b/baml_language/crates/sys_llm/Cargo.toml
@@ -15,6 +15,7 @@ bex_heap = { workspace = true }
 bex_vm_types = { workspace = true }
 indexmap = { workspace = true }
 minijinja = { workspace = true }
+minijinja-contrib = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/baml_language/crates/sys_llm/src/jinja/render.rs
+++ b/baml_language/crates/sys_llm/src/jinja/render.rs
@@ -92,6 +92,9 @@ fn create_environment() -> Environment<'static> {
     env.add_filter("regex_match", filters::regex_match);
     env.add_filter("sum", filters::sum);
 
+    // Enable Python-compatible methods on primitives (e.g. str.format())
+    env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
+
     // Custom formatter: replace 'none' with 'null'
     env.set_formatter(|out, _state, value| {
         if value.is_none() || value.is_undefined() {
@@ -497,6 +500,24 @@ mod tests {
         let result = render_prompt(template, &args, &ctx).unwrap();
 
         assert_eq!(result, "Please respond with: int".to_string().into());
+    }
+
+    #[test]
+    fn test_format_number_with_commas() {
+        let template = r#"{{ "{:,}".format(1234567) }}"#;
+        let args = IndexMap::new();
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+        assert_eq!(result, "1,234,567".to_string().into());
+
+        // float formatting
+        let template = r#"{{ "{:.2f}".format(3.14159) }}"#;
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+        assert_eq!(result, "3.14".to_string().into());
+
+        // negative integers
+        let template = r#"{{ "{:,}".format(-1234567) }}"#;
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+        assert_eq!(result, "-1,234,567".to_string().into());
     }
 
     #[test]

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2603,7 +2603,7 @@ dependencies = [
  "filetime",
  "indexmap 2.9.0",
  "internal-baml-core",
- "pathdiff 0.1.0",
+ "pathdiff 0.2.3",
  "serde_json",
  "sugar_path",
  "walkdir",
@@ -4128,6 +4128,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "minijinja",
+ "minijinja-contrib",
  "once_cell",
  "rayon",
  "regex",
@@ -4790,8 +4791,8 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.11.0"
-source = "git+https://github.com/boundaryml/minijinja.git?branch=main#ee25c021c8bb78d7ca11fa99972918eea4585330"
+version = "2.16.0"
+source = "git+https://github.com/boundaryml/minijinja.git?branch=value-cmp#8cfc770a5dffeda2de5b910d2b9f870d7edeff7c"
 dependencies = [
  "aho-corasick",
  "indexmap 2.9.0",
@@ -4799,6 +4800,15 @@ dependencies = [
  "serde_json",
  "unicase",
  "unicode-ident",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.16.0"
+source = "git+https://github.com/boundaryml/minijinja.git?branch=value-cmp#8cfc770a5dffeda2de5b910d2b9f870d7edeff7c"
+dependencies = [
+ "minijinja",
+ "serde",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -96,8 +96,7 @@ itertools = "0.14.0"
 jsonish = { path = "baml-lib/jsonish" }
 log = "0.4.20"
 # TODO: disable imports, etc
-# minijinja = { path = "../third_party/minijinja/minijinja", default-features = false, features = [
-minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "main", default-features = false, features = [
+minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "value-cmp", default-features = false, features = [
   "macros",
   "builtins",
   "debug",
@@ -106,9 +105,7 @@ minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "mai
   "unicode",
   "json",
   "unstable_machinery",
-  "unstable_machinery_serde",
   "custom_syntax",
-  "internal_debug",
   "deserialization",
   "serde",
   # We don't want to use these features:
@@ -116,6 +113,7 @@ minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "mai
   # loader
   #
 ] }
+minijinja-contrib = { git = "https://github.com/boundaryml/minijinja.git", branch = "value-cmp", features = ["pycompat"] }
 once_cell = "1"
 pathdiff = "0.2.2"
 pest = "2.8.1"

--- a/engine/baml-lib/baml-core/Cargo.toml
+++ b/engine/baml-lib/baml-core/Cargo.toml
@@ -36,6 +36,7 @@ internal-baml-parser-database = { path = "../parser-database" }
 internal-baml-prompt-parser = { path = "../prompt-parser" }
 baml-rpc.workspace = true
 minijinja.workspace = true
+minijinja-contrib.workspace = true
 rayon = "1.8.0"
 regex.workspace = true
 semver.workspace = true

--- a/engine/baml-lib/baml-core/src/ir/jinja_helpers.rs
+++ b/engine/baml-lib/baml-core/src/ir/jinja_helpers.rs
@@ -31,6 +31,7 @@ pub fn get_env<'a>() -> minijinja::Environment<'a> {
     env.set_lstrip_blocks(true);
     env.add_filter("regex_match", regex_match);
     env.add_filter("sum", sum_filter);
+    env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
     env
 }
 
@@ -169,6 +170,37 @@ mod tests {
             .unwrap(),
             "true"
         )
+    }
+
+    #[test]
+    fn test_format_number_with_commas() {
+        let ctx = vec![].into_iter().collect();
+        assert_eq!(
+            render_expression(
+                &JinjaExpression(r#""{:,}".format(1234567)"#.to_string()),
+                &ctx
+            )
+            .unwrap(),
+            "1,234,567"
+        );
+        // float formatting
+        assert_eq!(
+            render_expression(
+                &JinjaExpression(r#""{:.2f}".format(3.14159)"#.to_string()),
+                &ctx
+            )
+            .unwrap(),
+            "3.14"
+        );
+        // negative integers
+        assert_eq!(
+            render_expression(
+                &JinjaExpression(r#""{:,}".format(-1234567)"#.to_string()),
+                &ctx
+            )
+            .unwrap(),
+            "-1,234,567"
+        );
     }
 
     #[test]

--- a/engine/baml-lib/jinja-runtime/src/lib.rs
+++ b/engine/baml-lib/jinja-runtime/src/lib.rs
@@ -4493,4 +4493,47 @@ Enum value is not equal to the "ALIAS_B" string, as expected
 
         Ok(())
     }
+
+    #[test]
+    fn test_string_format_method() -> anyhow::Result<()> {
+        setup_logging();
+
+        let args = BamlValue::Map(BamlMap::new());
+
+        let ir = make_test_ir(
+            "
+            class C {
+            }
+            ",
+        )?;
+
+        let rendered = render_prompt(
+            r#"{{ "{}, {}!".format("Hello", "World") }}"#,
+            &args,
+            RenderContext {
+                client: RenderContext_Client {
+                    name: "gpt4".to_string(),
+                    provider: "openai".to_string(),
+                    default_role: "system".to_string(),
+                    allowed_roles: vec!["system".to_string()],
+                    remap_role: HashMap::new(),
+                    options: IndexMap::new(),
+                },
+                output_format: OutputFormatContent::new_string(),
+                tags: HashMap::new(),
+            },
+            &[],
+            &ir,
+            &HashMap::new(),
+        )?;
+
+        match rendered {
+            RenderedPrompt::Completion(content) => {
+                assert_eq!(content, "Hello, World!");
+            }
+            _ => panic!("Expected Completion prompt"),
+        }
+
+        Ok(())
+    }
 }

--- a/fern/03-reference/baml/prompt-syntax/jinja-filters.mdx
+++ b/fern/03-reference/baml/prompt-syntax/jinja-filters.mdx
@@ -17,6 +17,12 @@ Jinja filters allow you to transform and format values within your BAML prompts.
 
 Serializes values into structured text while preserving all BAML-specific aliases. Use the required `type` argument to choose the output representation.
 
+<Note>
+This is BAML's serialization filter, not Python's `%`-style string formatting. The `|format` filter in BAML always requires a `type` keyword argument.
+
+For string formatting, use Python's `.format()` method syntax instead: `"{}, {}!".format("Hello", "World")`. See the [String Formatting](/ref/prompt-syntax/what-is-jinja#string-formatting) cookbook for examples.
+</Note>
+
 **Signature**: `value|format(type="yaml" | "json" | "toon", **kwargs)`
 
 **Required arguments**:

--- a/fern/03-reference/baml/prompt-syntax/what-is-jinja.mdx
+++ b/fern/03-reference/baml/prompt-syntax/what-is-jinja.mdx
@@ -79,5 +79,34 @@ function MyFunc(arg1: string, user: User) -> string {
 }
 ```
 
+### String Formatting
+
+BAML supports Python's new-style string formatting via the `.format()` method on strings. This uses `{}` placeholders (not `%s`-style).
+
+```jinja
+{# Basic substitution #}
+{{ "{}, {}!".format("Hello", "World") }}
+{# Output: Hello, World! #}
+
+{# Number formatting with commas #}
+{{ "{:,}".format(1234567) }}
+{# Output: 1,234,567 #}
+
+{# Fixed decimal places #}
+{{ "{:.2f}".format(3.14159) }}
+{# Output: 3.14 #}
+
+{# Padding and alignment #}
+{{ "{:<10}".format("left") }}
+{{ "{:>10}".format("right") }}
+{{ "{:^10}".format("center") }}
+```
+
+<Note>
+Only new-style `{}` formatting is supported. Old-style `%s` formatting via the `|format` filter is **not** available because BAML uses the `|format` filter for [serializing objects](/ref/prompt-syntax/jinja-filters#format) (e.g. `value|format(type="yaml")`).
+</Note>
+
+For a full reference of what's possible with Python's format specification, see [pyformat.info](https://pyformat.info/).
+
 ### Built-in filters
 See [jinja docs](https://jinja.palletsprojects.com/en/3.1.x/templates/#list-of-builtin-filters)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated templating dependency and added a community-contrib package to the workspace.

* **New Features**
  * Python-compatible template attribute/method access enabled for better Python-style interop.
  * Number formatting with thousands separators supported in templates.
  * Added support for Python-style string .format() usage in templates.

* **Documentation**
  * Clarified string-formatting guidance and examples in the template reference.

* **Tests**
  * Added unit tests for number and string-format behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->