### PR TITLE
Remove duplicate prek entry from mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -30,7 +30,6 @@ java = "temurin-23"
 # Node tools
 "npm:pnpm" = "10.14.0"
 "npm:@infisical/cli" = "latest"
-prek = "latest"
 
 [tasks]
 "bep:readme" = "./beps/scripts/update_bep_readme.py"


### PR DESCRIPTION
## Summary
- Removed bare `prek = "latest"` entry that caused `mise install` to fail with "repository not found"
- The tool is already correctly listed as `cargo:prek = "latest"`, so the bare entry was a duplicate that mise tried to resolve as an asdf plugin

## Test plan
- [x] Verified `mise install` completes successfully after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "prek" tool alias from configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->