### PR TITLE
Fix ARM (aarch64) FFI portability: use c_char instead of i8

### DIFF
--- a/languages/rust/baml-sys/src/lib.rs
+++ b/languages/rust/baml-sys/src/lib.rs
@@ -71,7 +71,7 @@ pub fn version() -> Result<String> {
 
     let result = if !buf.ptr.is_null() && buf.len > 0 {
         #[allow(unsafe_code)]
-        let bytes = unsafe { std::slice::from_raw_parts(buf.ptr as *const u8, buf.len) };
+        let bytes = unsafe { std::slice::from_raw_parts(buf.ptr.cast::<u8>(), buf.len) };
         String::from_utf8_lossy(bytes).into_owned()
     } else {
         "unknown".to_string()

--- a/languages/rust/baml-sys/src/symbols.rs
+++ b/languages/rust/baml-sys/src/symbols.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Callback function type for results.
 pub type CallbackFn =
-    extern "C" fn(call_id: u32, is_done: c_int, content: *const i8, length: size_t);
+    extern "C" fn(call_id: u32, is_done: c_int, content: *const c_char, length: size_t);
 
 /// Callback function type for streaming ticks.
 pub type OnTickCallbackFn = extern "C" fn(call_id: u32);
@@ -21,7 +21,7 @@ pub type OnTickCallbackFn = extern "C" fn(call_id: u32);
 #[allow(missing_docs)] // FFI struct fields are self-explanatory
 pub struct Buffer {
     /// Pointer to the buffer data.
-    pub ptr: *const i8,
+    pub ptr: *const c_char,
     /// Length of the buffer.
     pub len: size_t,
 }
@@ -82,7 +82,7 @@ fn load_symbols(lib: &'static LoadedLibrary) -> Result<Symbols> {
         // Verify version matches - version() now returns Buffer
         let version_buf = version();
         let lib_version = if !version_buf.ptr.is_null() && version_buf.len > 0 {
-            let bytes = std::slice::from_raw_parts(version_buf.ptr as *const u8, version_buf.len);
+            let bytes = std::slice::from_raw_parts(version_buf.ptr.cast::<u8>(), version_buf.len);
             String::from_utf8_lossy(bytes).into_owned()
         } else {
             "unknown".to_string()

--- a/languages/rust/baml/src/ffi/callbacks.rs
+++ b/languages/rust/baml/src/ffi/callbacks.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    ffi::c_int,
+    ffi::{c_char, c_int},
     sync::{mpsc, Mutex, OnceLock},
 };
 
@@ -127,7 +127,7 @@ pub fn remove_callback(id: u32) {
 }
 
 /// Result callback invoked by FFI
-extern "C" fn result_callback(call_id: u32, is_done: c_int, content: *const i8, length: usize) {
+extern "C" fn result_callback(call_id: u32, is_done: c_int, content: *const c_char, length: usize) {
     let data = if !content.is_null() && length > 0 {
         #[allow(unsafe_code)]
         let slice = unsafe { std::slice::from_raw_parts(content.cast::<u8>(), length) };
@@ -164,7 +164,7 @@ extern "C" fn result_callback(call_id: u32, is_done: c_int, content: *const i8, 
 }
 
 /// Error callback invoked by FFI
-extern "C" fn error_callback(call_id: u32, _is_done: c_int, content: *const i8, length: usize) {
+extern "C" fn error_callback(call_id: u32, _is_done: c_int, content: *const c_char, length: usize) {
     let error_msg = if !content.is_null() && length > 0 {
         #[allow(unsafe_code)]
         let slice = unsafe { std::slice::from_raw_parts(content.cast::<u8>(), length) };

--- a/languages/rust/baml/src/ffi/mod.rs
+++ b/languages/rust/baml/src/ffi/mod.rs
@@ -1,10 +1,11 @@
 mod bindings;
 pub mod callbacks;
 
-use crate::proto::baml_cffi_v1::{invocation_response::Response, InvocationResponse};
 use baml_sys::Buffer;
 pub(crate) use bindings::*;
 use prost::Message;
+
+use crate::proto::baml_cffi_v1::{invocation_response::Response, InvocationResponse};
 
 /// RAII guard that frees Buffer on drop
 pub(crate) struct BufferGuard(pub Buffer);
@@ -35,7 +36,7 @@ pub(crate) fn decode_async_response(buf: Buffer) -> Result<(), String> {
 
     // Safety: Buffer pointer and length are valid as returned from FFI
     #[allow(unsafe_code)]
-    let bytes = unsafe { std::slice::from_raw_parts(_guard.0.ptr as *const u8, _guard.0.len) };
+    let bytes = unsafe { std::slice::from_raw_parts(_guard.0.ptr.cast::<u8>(), _guard.0.len) };
 
     let response =
         InvocationResponse::decode(bytes).map_err(|e| format!("failed to decode response: {e}"))?;

--- a/languages/rust/baml/src/raw_objects/mod.rs
+++ b/languages/rust/baml/src/raw_objects/mod.rs
@@ -7,6 +7,7 @@
 #![allow(unsafe_code)]
 
 use std::{
+    ffi::c_char,
     fs::OpenOptions,
     io::Write,
     sync::{Mutex, OnceLock},
@@ -119,7 +120,7 @@ use std::{ffi::c_void, sync::Arc};
 pub use collector::{Collector, FunctionLog, LogType, StreamTiming, Timing, Usage};
 pub use http::{HTTPBody, HTTPRequest, HTTPResponse, SSEResponse};
 pub use llm_call::{LLMCall, LLMCallKind, LLMStreamCall};
-pub use media::{Audio, Image, Pdf, Video, BamlMediaRepr, BamlMediaReprContent};
+pub use media::{Audio, BamlMediaRepr, BamlMediaReprContent, Image, Pdf, Video};
 use prost::Message;
 pub use type_builder::{
     ClassBuilder, ClassPropertyBuilder, EnumBuilder, EnumValueBuilder, TypeBuilder, TypeDef,
@@ -214,7 +215,7 @@ impl RawObject {
 
         // Call FFI
         let response_buf = unsafe {
-            ffi::call_object_constructor(buf.as_ptr().cast::<i8>(), buf.len())
+            ffi::call_object_constructor(buf.as_ptr().cast::<c_char>(), buf.len())
                 .map_err(|e| BamlError::internal(format!("Failed to load BAML library: {e}")))?
         };
 
@@ -465,7 +466,7 @@ impl RawObject {
             .map_err(|e| BamlError::internal(format!("failed to encode method call: {e}")))?;
 
         let response_buf = unsafe {
-            ffi::call_object_method(self.inner.runtime, buf.as_ptr().cast::<i8>(), buf.len())
+            ffi::call_object_method(self.inner.runtime, buf.as_ptr().cast::<c_char>(), buf.len())
                 .map_err(|e| BamlError::internal(format!("Failed to load BAML library: {e}")))?
         };
 

--- a/languages/rust/baml/src/runtime.rs
+++ b/languages/rust/baml/src/runtime.rs
@@ -1,7 +1,7 @@
 #![allow(unsafe_code)]
 use std::{
     collections::HashMap,
-    ffi::{c_void, CString},
+    ffi::{c_char, c_void, CString},
 };
 
 use prost::Message;
@@ -91,7 +91,7 @@ impl BamlRuntime {
             ffi::call_function_from_c(
                 self.ptr,
                 name_cstr.as_ptr(),
-                encoded.as_ptr().cast::<i8>(),
+                encoded.as_ptr().cast::<c_char>(),
                 encoded.len(),
                 id,
             )
@@ -155,7 +155,7 @@ impl BamlRuntime {
             ffi::call_function_stream_from_c(
                 self.ptr,
                 name_cstr.as_ptr(),
-                encoded.as_ptr().cast::<i8>(),
+                encoded.as_ptr().cast::<c_char>(),
                 encoded.len(),
                 id,
             )
@@ -201,7 +201,7 @@ impl BamlRuntime {
             ffi::call_function_from_c(
                 self.ptr,
                 name_cstr.as_ptr(),
-                encoded.as_ptr().cast::<i8>(),
+                encoded.as_ptr().cast::<c_char>(),
                 encoded.len(),
                 id,
             )
@@ -264,7 +264,7 @@ impl BamlRuntime {
             ffi::call_function_stream_from_c(
                 self.ptr,
                 name_cstr.as_ptr(),
-                encoded.as_ptr().cast::<i8>(),
+                encoded.as_ptr().cast::<c_char>(),
                 encoded.len(),
                 id,
             )
@@ -332,7 +332,7 @@ impl BamlRuntime {
             ffi::call_function_parse_from_c(
                 self.ptr,
                 name_cstr.as_ptr(),
-                encoded.as_ptr().cast::<i8>(),
+                encoded.as_ptr().cast::<c_char>(),
                 encoded.len(),
                 id,
             )
@@ -432,7 +432,7 @@ impl BamlRuntime {
             ffi::build_request_from_c(
                 self.ptr,
                 name_cstr.as_ptr(),
-                encoded.as_ptr().cast::<i8>(),
+                encoded.as_ptr().cast::<c_char>(),
                 encoded.len(),
                 id,
             )
@@ -478,7 +478,7 @@ impl BamlRuntime {
             ffi::build_request_from_c(
                 self.ptr,
                 name_cstr.as_ptr(),
-                encoded.as_ptr().cast::<i8>(),
+                encoded.as_ptr().cast::<c_char>(),
                 encoded.len(),
                 id,
             )


### PR DESCRIPTION
## Summary
Fixes [#3145](https://github.com/BoundaryML/baml/issues/3145): Rust build failure when cross-compiling for `aarch64-unknown-linux-gnu` due to `*const i8` vs `*const u8` type mismatch (on ARM, `c_char` is `u8`; on x86_64 it is `i8`).

## Changes
- **baml-sys**: `Buffer.ptr` and `CallbackFn` `content` use `*const c_char`; when building byte slices from these pointers, use `.cast::<u8>()`.
- **baml**: In `runtime.rs` and `raw_objects/mod.rs`, cast encoded buffers to `c_char` instead of `i8` when passing to FFI; in `ffi/callbacks.rs`, callback `content` parameter is `*const c_char`; in `ffi/mod.rs`, cast `Buffer.ptr` to `u8` when decoding.

## Verification
- `cargo build --release -p baml-sys -p baml` succeeds.
- `cargo test --lib -p baml-sys -p baml` (12 tests) pass.
- Cross-compilation: `cargo zigbuild --target aarch64-unknown-linux-gnu --release` should succeed on this branch.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated FFI pointer type handling in Rust bindings to use more idiomatic casting syntax for improved code consistency and type correctness.
  * Reorganized module exports for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->