### PR TITLE
feat(debugger): add BAML DAP, Cursor integration, and stepping/hover fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,15 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "BAML: Debug smoke main()",
+      "type": "baml",
+      "request": "launch",
+      "projectPath": "${workspaceFolder}/debugger_smoke",
+      "functionName": "main",
+      "args": {},
+      "stopOnEntry": false
+    },
+    {
       "name": "Launch VS Code extension (v2)",
       "type": "extensionHost",
       "request": "launch",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,6 +45,7 @@
   "[baml]": {
     "editor.defaultFormatter": "Boundary.baml-extension"
   },
+  "baml.cliPath": "/media/tony/WesternDigitalNvmeSsd/Code/baml/baml_language/target/debug/baml-cli",
   "[typescript]": {
     "editor.defaultFormatter": "vscode.typescript-language-features",
     "editor.insertSpaces": true,

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -358,9 +358,16 @@ dependencies = [
  "anyhow",
  "baml_fmt",
  "baml_lsp_server",
+ "baml_project",
+ "bex_vm",
+ "bex_vm_types",
  "clap",
  "clap-cargo",
  "ctrlc",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "walkdir",
 ]
 
 [[package]]

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -19,10 +19,17 @@ workspace = true
 [dependencies]
 baml_fmt = { workspace = true }
 baml_lsp_server = { workspace = true }
+baml_project = { workspace = true }
+bex_vm = { workspace = true }
+bex_vm_types = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = [ "color", "env" ] }
 clap-cargo = { workspace = true }
 ctrlc = { workspace = true }
+indexmap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+walkdir = { workspace = true }
 
 [features]
 default = [ "native-tls" ]
@@ -49,4 +56,3 @@ path = "src/main.rs"
 
 [package.metadata.ci]
 wasm_support = false
-

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -58,6 +58,12 @@ pub(crate) enum Commands {
     // DumpBytecode(baml_runtime::cli::dump_intermediate::DumpIntermediateArgs),
     #[command(about = "Starts a language server", name = "lsp")]
     LanguageServer(crate::lsp::LanguageServerArgs),
+    #[command(
+        about = "Starts the BAML Debug Adapter Protocol server",
+        name = "dap",
+        hide = true
+    )]
+    DebugAdapter(crate::dap::DebugAdapterArgs),
     // #[command(about = "Start an interactive REPL for BAML expressions", hide = true)]
     // Repl(baml_runtime::cli::repl::ReplArgs),
 
@@ -109,6 +115,16 @@ impl RuntimeCli {
     pub fn run(&self) -> Result<crate::ExitCode> {
         match &self.command {
             Commands::LanguageServer(args) => match args.run() {
+                Ok(()) => Ok(crate::ExitCode::Success),
+                Err(e) => {
+                    #[allow(clippy::print_stderr)]
+                    {
+                        eprintln!("Error: {e}");
+                    }
+                    Ok(crate::ExitCode::Other)
+                }
+            },
+            Commands::DebugAdapter(args) => match args.run() {
                 Ok(()) => Ok(crate::ExitCode::Success),
                 Err(e) => {
                     #[allow(clippy::print_stderr)]

--- a/baml_language/crates/baml_cli/src/dap.rs
+++ b/baml_language/crates/baml_cli/src/dap.rs
@@ -1,0 +1,1105 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    io::{self, BufRead, BufReader, BufWriter, Write},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use baml_project::ProjectDatabase;
+use bex_vm::{BexVm, DebugBreakpoint, DebugStop, DebugStopReason, VmExecState, types::ObjectTrait};
+use bex_vm_types::{Object, Program, Value};
+use clap::Args;
+use serde::Deserialize;
+use serde_json::{Value as JsonValue, json};
+use walkdir::WalkDir;
+
+const THREAD_ID: i64 = 1;
+const BUILTIN_PATH_PREFIX: &str = "<builtin>/";
+
+#[derive(Args, Debug, Default)]
+pub struct DebugAdapterArgs {}
+
+impl DebugAdapterArgs {
+    pub fn run(&self) -> Result<()> {
+        run()
+    }
+}
+
+pub fn run() -> Result<()> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut reader = BufReader::new(stdin.lock());
+    let writer = BufWriter::new(stdout.lock());
+    let mut server = DapServer::new(writer);
+
+    while let Some(message) = read_dap_message(&mut reader)? {
+        let value: JsonValue =
+            serde_json::from_str(&message).context("failed to parse incoming DAP message")?;
+
+        if value.get("type").and_then(JsonValue::as_str) != Some("request") {
+            continue;
+        }
+
+        let keep_running = server.handle_request(&value)?;
+        if !keep_running {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn read_dap_message(reader: &mut impl BufRead) -> Result<Option<String>> {
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let mut line = String::new();
+        let read = reader.read_line(&mut line)?;
+        if read == 0 {
+            return Ok(None);
+        }
+
+        let header = line.trim_end_matches(['\r', '\n']);
+        if header.is_empty() {
+            break;
+        }
+
+        if let Some(length) = header.strip_prefix("Content-Length:") {
+            let parsed = length.trim().parse::<usize>()?;
+            content_length = Some(parsed);
+        }
+    }
+
+    let content_length =
+        content_length.ok_or_else(|| anyhow!("missing Content-Length header in DAP message"))?;
+
+    let mut body = vec![0u8; content_length];
+    reader.read_exact(&mut body)?;
+    let payload = String::from_utf8(body).context("DAP payload is not valid UTF-8")?;
+    Ok(Some(payload))
+}
+
+struct DapServer<W: Write> {
+    writer: W,
+    next_seq: i64,
+    pending_breakpoints: HashMap<PathBuf, Vec<usize>>,
+    session: Option<DebugSession>,
+}
+
+fn build_sequence_points_by_file(program: &Program) -> HashMap<u32, Vec<usize>> {
+    let mut by_file: HashMap<u32, Vec<usize>> = HashMap::new();
+
+    for object in &program.objects {
+        let Object::Function(function) = object else {
+            continue;
+        };
+
+        for entry in &function.bytecode.line_table {
+            if !entry.sequence_point {
+                continue;
+            }
+            by_file
+                .entry(entry.span.file_id.as_u32())
+                .or_default()
+                .push(entry.line);
+        }
+    }
+
+    for lines in by_file.values_mut() {
+        lines.sort_unstable();
+        lines.dedup();
+    }
+
+    by_file
+}
+
+impl<W: Write> DapServer<W> {
+    fn new(writer: W) -> Self {
+        Self {
+            writer,
+            next_seq: 1,
+            pending_breakpoints: HashMap::new(),
+            session: None,
+        }
+    }
+
+    fn handle_request(&mut self, request: &JsonValue) -> Result<bool> {
+        let request_seq = request.get("seq").and_then(JsonValue::as_i64).unwrap_or(0);
+        let command = request
+            .get("command")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("");
+        let args = request.get("arguments").cloned().unwrap_or(JsonValue::Null);
+
+        let result = match command {
+            "initialize" => self.handle_initialize(request_seq, command),
+            "launch" => self.handle_launch(request_seq, command, args),
+            "setBreakpoints" => self.handle_set_breakpoints(request_seq, command, args),
+            "configurationDone" => self.handle_configuration_done(request_seq, command),
+            "threads" => self.handle_threads(request_seq, command),
+            "stackTrace" => self.handle_stack_trace(request_seq, command, args),
+            "scopes" => self.handle_scopes(request_seq, command, args),
+            "variables" => self.handle_variables(request_seq, command, args),
+            "continue" => self.handle_resume_command(request_seq, command, ResumeAction::Continue),
+            "next" => self.handle_resume_command(request_seq, command, ResumeAction::StepOver),
+            "stepIn" => self.handle_resume_command(request_seq, command, ResumeAction::StepIn),
+            "stepOut" => self.handle_resume_command(request_seq, command, ResumeAction::StepOut),
+            "pause" => self.handle_resume_command(request_seq, command, ResumeAction::Pause),
+            "disconnect" => {
+                self.respond_success(request_seq, command, Some(json!({})))?;
+                self.send_terminated_event()?;
+                self.session = None;
+                return Ok(false);
+            }
+            _ => self.respond_error(
+                request_seq,
+                command,
+                format!("unsupported DAP request: {command}"),
+            ),
+        };
+
+        if let Err(error) = result {
+            self.respond_error(request_seq, command, error.to_string())?;
+        }
+
+        Ok(true)
+    }
+
+    fn handle_initialize(&mut self, request_seq: i64, command: &str) -> Result<()> {
+        let body = json!({
+            "supportsConfigurationDoneRequest": true,
+            "supportsRestartRequest": false,
+            "supportsStepBack": false,
+            "supportsTerminateRequest": true,
+            "supportsEvaluateForHovers": false,
+        });
+        self.respond_success(request_seq, command, Some(body))?;
+        self.send_event("initialized", json!({}))
+    }
+
+    fn handle_launch(&mut self, request_seq: i64, command: &str, args: JsonValue) -> Result<()> {
+        let launch = serde_json::from_value::<LaunchArgs>(args)
+            .context("invalid launch arguments for baml debugger")?;
+        let project_path = launch
+            .project_path
+            .ok_or_else(|| anyhow!("launch.projectPath is required"))?;
+        let function_name = launch
+            .function_name
+            .ok_or_else(|| anyhow!("launch.functionName is required"))?;
+        let root = canonicalize_path(&project_path);
+
+        if !root.is_dir() {
+            bail!("projectPath is not a directory: {}", root.display());
+        }
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(&root);
+        load_project_files(&mut db, &root)?;
+
+        let bytecode = db
+            .get_debug_bytecode()
+            .map_err(|error| anyhow!("{error}"))?;
+        let function_index = bytecode
+            .function_index(&function_name)
+            .ok_or_else(|| anyhow!("function not found: {function_name}"))?;
+
+        let sequence_points_by_file = build_sequence_points_by_file(&bytecode);
+        let mut vm = BexVm::from_program(bytecode)?;
+        let function_ptr = vm.heap.compile_time_ptr(function_index);
+        let args = parse_launch_args(&mut vm, function_ptr, launch.args)?;
+        vm.set_entry_point(function_ptr, &args);
+
+        let mut session = DebugSession::new(
+            db,
+            vm,
+            launch.stop_on_entry.unwrap_or(false),
+            sequence_points_by_file,
+        );
+
+        let pending = self.pending_breakpoints.clone();
+        for (path, lines) in &pending {
+            if let Some(file_id) = session.path_to_file_id.get(path).copied() {
+                session.set_breakpoints(file_id, lines);
+            }
+        }
+
+        self.session = Some(session);
+        self.respond_success(request_seq, command, Some(json!({})))
+    }
+
+    fn handle_set_breakpoints(
+        &mut self,
+        request_seq: i64,
+        command: &str,
+        args: JsonValue,
+    ) -> Result<()> {
+        let args = serde_json::from_value::<SetBreakpointsArgs>(args)
+            .context("invalid setBreakpoints arguments")?;
+        let source = args
+            .source
+            .and_then(|source| source.path)
+            .ok_or_else(|| anyhow!("setBreakpoints.source.path is required"))?;
+        let requested_lines = if !args.breakpoints.is_empty() {
+            args.breakpoints
+                .iter()
+                .filter_map(|bp| usize::try_from(bp.line).ok())
+                .collect::<Vec<_>>()
+        } else {
+            args.lines
+                .iter()
+                .filter_map(|line| usize::try_from(*line).ok())
+                .collect::<Vec<_>>()
+        };
+
+        let canonical_path = canonicalize_path(&source);
+        self.pending_breakpoints
+            .insert(canonical_path.clone(), requested_lines.clone());
+
+        let mut resolved_lines = vec![None; requested_lines.len()];
+
+        if !source.starts_with(BUILTIN_PATH_PREFIX)
+            && let Some(session) = self.session.as_mut()
+            && let Some(file_id) = session.path_to_file_id.get(&canonical_path).copied()
+        {
+            resolved_lines = session.set_breakpoints(file_id, &requested_lines);
+        }
+
+        let breakpoints = requested_lines
+            .into_iter()
+            .zip(resolved_lines)
+            .map(|(requested_line, resolved_line)| {
+                let resolved = resolved_line.unwrap_or(requested_line);
+                json!({
+                    "verified": resolved_line.is_some(),
+                    "line": resolved,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        self.respond_success(
+            request_seq,
+            command,
+            Some(json!({ "breakpoints": breakpoints })),
+        )
+    }
+
+    fn handle_configuration_done(&mut self, request_seq: i64, command: &str) -> Result<()> {
+        let stop_on_entry = self
+            .session
+            .as_ref()
+            .ok_or_else(|| anyhow!("launch must be called before configurationDone"))?
+            .stop_on_entry;
+        self.respond_success(request_seq, command, Some(json!({})))?;
+        let action = if stop_on_entry {
+            ResumeAction::StepIn
+        } else {
+            ResumeAction::Continue
+        };
+        self.run_and_emit_or_terminate(action)
+    }
+
+    fn handle_threads(&mut self, request_seq: i64, command: &str) -> Result<()> {
+        self.respond_success(
+            request_seq,
+            command,
+            Some(json!({
+                "threads": [{
+                    "id": THREAD_ID,
+                    "name": "main",
+                }]
+            })),
+        )
+    }
+
+    fn handle_stack_trace(
+        &mut self,
+        request_seq: i64,
+        command: &str,
+        args: JsonValue,
+    ) -> Result<()> {
+        let args = serde_json::from_value::<StackTraceArgs>(args).unwrap_or_default();
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| anyhow!("no active debug session"))?;
+
+        let frames = session.vm.debug_stack_frames();
+        let total_frames = frames.len();
+        let start = args.start_frame.unwrap_or(0);
+        let levels = args.levels.unwrap_or(total_frames.saturating_sub(start));
+
+        let stack_frames = frames
+            .into_iter()
+            .skip(start)
+            .take(levels)
+            .map(|frame| {
+                let (line, source) = match frame.line_entry {
+                    Some(entry) => {
+                        let source = session
+                            .file_id_to_path
+                            .get(&entry.span.file_id.as_u32())
+                            .map(|path| {
+                                json!({
+                                    "name": path.file_name().and_then(|name| name.to_str()).unwrap_or(""),
+                                    "path": path.to_string_lossy().to_string(),
+                                })
+                            });
+                        (entry.line, source)
+                    }
+                    None => (1, None),
+                };
+
+                json!({
+                    "id": i64::try_from(frame.frame_depth).unwrap_or_default(),
+                    "name": frame.function_name,
+                    "line": line,
+                    "column": 1,
+                    "source": source.unwrap_or(json!(null)),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        self.respond_success(
+            request_seq,
+            command,
+            Some(json!({
+                "stackFrames": stack_frames,
+                "totalFrames": total_frames,
+            })),
+        )
+    }
+
+    fn handle_scopes(&mut self, request_seq: i64, command: &str, args: JsonValue) -> Result<()> {
+        let args =
+            serde_json::from_value::<ScopesArgs>(args).context("invalid scopes arguments")?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| anyhow!("no active debug session"))?;
+        let frame_depth = usize::try_from(args.frame_id).context("invalid frameId")?;
+
+        let variables_reference = session.new_handle(HandleValue::Locals { frame_depth });
+        self.respond_success(
+            request_seq,
+            command,
+            Some(json!({
+                "scopes": [{
+                    "name": "Locals",
+                    "presentationHint": "locals",
+                    "variablesReference": variables_reference,
+                    "expensive": false,
+                }]
+            })),
+        )
+    }
+
+    fn handle_variables(&mut self, request_seq: i64, command: &str, args: JsonValue) -> Result<()> {
+        let args =
+            serde_json::from_value::<VariablesArgs>(args).context("invalid variables arguments")?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| anyhow!("no active debug session"))?;
+        let variables = session.variables_for_reference(args.variables_reference)?;
+
+        self.respond_success(
+            request_seq,
+            command,
+            Some(json!({
+                "variables": variables,
+            })),
+        )
+    }
+
+    fn handle_resume_command(
+        &mut self,
+        request_seq: i64,
+        command: &str,
+        action: ResumeAction,
+    ) -> Result<()> {
+        if self.session.is_none() {
+            bail!("no active debug session");
+        }
+
+        let body = if command == "continue" {
+            Some(json!({ "allThreadsContinued": true }))
+        } else {
+            Some(json!({}))
+        };
+        self.respond_success(request_seq, command, body)?;
+        self.send_event(
+            "continued",
+            json!({
+                "threadId": THREAD_ID,
+                "allThreadsContinued": true,
+            }),
+        )?;
+        self.run_and_emit_or_terminate(action)
+    }
+
+    fn run_and_emit_or_terminate(&mut self, action: ResumeAction) -> Result<()> {
+        if let Err(error) = self.run_and_emit(action) {
+            self.send_event(
+                "output",
+                json!({
+                    "category": "stderr",
+                    "output": format!("{}\n", error),
+                }),
+            )?;
+            self.send_terminated_event()?;
+            self.session = None;
+        }
+        Ok(())
+    }
+
+    fn run_and_emit(&mut self, action: ResumeAction) -> Result<()> {
+        let outcome = {
+            let session = self
+                .session
+                .as_mut()
+                .ok_or_else(|| anyhow!("no active debug session"))?;
+            session.run(action)?
+        };
+
+        match outcome {
+            RunOutcome::Stopped(stop) => self.send_stopped_event(stop.reason),
+            RunOutcome::Complete => self.send_terminated_event(),
+        }
+    }
+
+    fn send_stopped_event(&mut self, reason: DebugStopReason) -> Result<()> {
+        let reason = match reason {
+            DebugStopReason::Breakpoint => "breakpoint",
+            DebugStopReason::Step => "step",
+            DebugStopReason::Pause => "pause",
+        };
+
+        self.send_event(
+            "stopped",
+            json!({
+                "reason": reason,
+                "threadId": THREAD_ID,
+                "allThreadsStopped": true,
+            }),
+        )
+    }
+
+    fn send_terminated_event(&mut self) -> Result<()> {
+        self.send_event("terminated", json!({}))
+    }
+
+    fn respond_success(
+        &mut self,
+        request_seq: i64,
+        command: &str,
+        body: Option<JsonValue>,
+    ) -> Result<()> {
+        let mut response = json!({
+            "seq": self.next_outgoing_seq(),
+            "type": "response",
+            "request_seq": request_seq,
+            "success": true,
+            "command": command,
+        });
+        if let Some(body) = body {
+            response["body"] = body;
+        }
+        self.write_message(&response)
+    }
+
+    fn respond_error(&mut self, request_seq: i64, command: &str, message: String) -> Result<()> {
+        let response = json!({
+            "seq": self.next_outgoing_seq(),
+            "type": "response",
+            "request_seq": request_seq,
+            "success": false,
+            "command": command,
+            "message": message,
+        });
+        self.write_message(&response)
+    }
+
+    fn send_event(&mut self, event: &str, body: JsonValue) -> Result<()> {
+        let message = json!({
+            "seq": self.next_outgoing_seq(),
+            "type": "event",
+            "event": event,
+            "body": body,
+        });
+        self.write_message(&message)
+    }
+
+    fn write_message(&mut self, payload: &JsonValue) -> Result<()> {
+        let serialized = serde_json::to_vec(payload)?;
+        let header = format!("Content-Length: {}\r\n\r\n", serialized.len());
+        self.writer.write_all(header.as_bytes())?;
+        self.writer.write_all(&serialized)?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    fn next_outgoing_seq(&mut self) -> i64 {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        seq
+    }
+}
+
+#[derive(Clone, Copy)]
+enum HandleValue {
+    Locals { frame_depth: usize },
+    Value(Value),
+}
+
+#[derive(Clone, Copy)]
+enum ResumeAction {
+    Continue,
+    StepIn,
+    StepOver,
+    StepOut,
+    Pause,
+}
+
+enum RunOutcome {
+    Stopped(DebugStop),
+    Complete,
+}
+
+#[derive(Clone, Copy)]
+struct SourceStopSite {
+    frame_depth: usize,
+    file_id: u32,
+    line: usize,
+    pc: usize,
+}
+
+struct DebugSession {
+    db: ProjectDatabase,
+    vm: BexVm,
+    stop_on_entry: bool,
+    file_id_to_path: HashMap<u32, PathBuf>,
+    path_to_file_id: HashMap<PathBuf, u32>,
+    sequence_points_by_file: HashMap<u32, Vec<usize>>,
+    breakpoints_by_file: HashMap<u32, HashSet<usize>>,
+    handles: HashMap<i64, HandleValue>,
+    next_handle: i64,
+}
+
+impl DebugSession {
+    fn new(
+        db: ProjectDatabase,
+        vm: BexVm,
+        stop_on_entry: bool,
+        sequence_points_by_file: HashMap<u32, Vec<usize>>,
+    ) -> Self {
+        let mut session = Self {
+            db,
+            vm,
+            stop_on_entry,
+            file_id_to_path: HashMap::new(),
+            path_to_file_id: HashMap::new(),
+            sequence_points_by_file,
+            breakpoints_by_file: HashMap::new(),
+            handles: HashMap::new(),
+            next_handle: 1,
+        };
+        session.rebuild_file_maps();
+        session
+    }
+
+    fn rebuild_file_maps(&mut self) {
+        self.file_id_to_path.clear();
+        self.path_to_file_id.clear();
+
+        for path in self.db.non_builtin_file_paths() {
+            if let Some(file_id) = self.db.path_to_file_id(&path) {
+                let id = file_id.as_u32();
+                self.path_to_file_id.insert(path.clone(), id);
+                self.file_id_to_path.insert(id, path);
+            }
+        }
+    }
+
+    fn set_breakpoints(&mut self, file_id: u32, requested_lines: &[usize]) -> Vec<Option<usize>> {
+        let mut verified_lines = HashSet::new();
+        let mut resolved_lines = Vec::with_capacity(requested_lines.len());
+
+        for &line in requested_lines {
+            let resolved = self.resolve_breakpoint_line(file_id, line);
+            if let Some(resolved_line) = resolved {
+                verified_lines.insert(resolved_line);
+            }
+            resolved_lines.push(resolved);
+        }
+
+        if verified_lines.is_empty() {
+            self.breakpoints_by_file.remove(&file_id);
+        } else {
+            self.breakpoints_by_file
+                .insert(file_id, verified_lines.clone());
+        }
+        self.sync_breakpoints_to_vm();
+
+        resolved_lines
+    }
+
+    fn resolve_breakpoint_line(&self, file_id: u32, requested_line: usize) -> Option<usize> {
+        let lines = self.sequence_points_by_file.get(&file_id)?;
+        if lines.is_empty() {
+            return None;
+        }
+
+        // Snap to the first executable line at/after the requested line.
+        // If the request is past the last executable line, snap to the last one.
+        let idx = lines.partition_point(|line| *line < requested_line);
+        if idx < lines.len() {
+            Some(lines[idx])
+        } else {
+            lines.last().copied()
+        }
+    }
+
+    fn sync_breakpoints_to_vm(&mut self) {
+        let breakpoints = self
+            .breakpoints_by_file
+            .iter()
+            .flat_map(|(file_id, lines)| {
+                lines.iter().map(move |line| DebugBreakpoint {
+                    file_id: *file_id,
+                    line: *line,
+                })
+            })
+            .collect::<Vec<_>>();
+        self.vm.debug_set_breakpoints(breakpoints);
+    }
+
+    fn apply_resume_action(&mut self, action: ResumeAction) {
+        match action {
+            ResumeAction::Continue => self.vm.debug_continue(),
+            ResumeAction::StepIn => self.vm.debug_step_in(),
+            ResumeAction::StepOver => self.vm.debug_step_over(),
+            ResumeAction::StepOut => self.vm.debug_step_out(),
+            ResumeAction::Pause => self.vm.debug_pause(),
+        }
+    }
+
+    fn current_source_stop_site(&self) -> Option<SourceStopSite> {
+        let frame = self.vm.debug_stack_frames().into_iter().next()?;
+        let line_entry = frame.line_entry?;
+        Some(SourceStopSite {
+            frame_depth: frame.frame_depth,
+            file_id: line_entry.span.file_id.as_u32(),
+            line: line_entry.line,
+            pc: frame.pc,
+        })
+    }
+
+    fn run(&mut self, action: ResumeAction) -> Result<RunOutcome> {
+        self.clear_handles();
+
+        let step_origin = match action {
+            ResumeAction::StepIn | ResumeAction::StepOver => self.current_source_stop_site(),
+            ResumeAction::Continue | ResumeAction::StepOut | ResumeAction::Pause => None,
+        };
+        let mut forward_same_line_cursor = step_origin.map(|origin| origin.pc);
+        let mut skipped_same_site_breakpoints = 0usize;
+
+        self.apply_resume_action(action);
+
+        loop {
+            match self.vm.exec()? {
+                VmExecState::Complete(_) => return Ok(RunOutcome::Complete),
+                VmExecState::DebugStop(stop) => {
+                    if let Some(origin) = step_origin {
+                        let same_source_site = stop.frame_depth == origin.frame_depth
+                            && stop.line_entry.span.file_id.as_u32() == origin.file_id
+                            && stop.line_entry.line == origin.line;
+                        // While stepping, don't get stuck on a breakpoint bound to the
+                        // current source site. Continue until execution reaches a
+                        // different site (or completion).
+                        if same_source_site
+                            && stop.reason == DebugStopReason::Breakpoint
+                            && skipped_same_site_breakpoints < 32
+                        {
+                            skipped_same_site_breakpoints += 1;
+                            self.apply_resume_action(action);
+                            continue;
+                        }
+                        // Skip only forward same-line stops (multiple sequence points on one
+                        // source line). Keep same-line stops when control flow loops back.
+                        if same_source_site
+                            && stop.pc > forward_same_line_cursor.unwrap_or(origin.pc)
+                        {
+                            forward_same_line_cursor = Some(stop.pc);
+                            self.apply_resume_action(action);
+                            continue;
+                        }
+                    }
+                    return Ok(RunOutcome::Stopped(stop));
+                }
+                VmExecState::Notify(_) | VmExecState::SpanNotify(_) => continue,
+                VmExecState::ScheduleFuture(_) | VmExecState::Await(_) => {
+                    bail!("debugger does not support async/sys-op execution yet")
+                }
+            }
+        }
+    }
+
+    fn new_handle(&mut self, value: HandleValue) -> i64 {
+        let id = self.next_handle;
+        self.next_handle += 1;
+        self.handles.insert(id, value);
+        id
+    }
+
+    fn clear_handles(&mut self) {
+        self.handles.clear();
+        self.next_handle = 1;
+    }
+
+    fn variables_for_reference(&mut self, reference: i64) -> Result<Vec<JsonValue>> {
+        let handle = self
+            .handles
+            .get(&reference)
+            .copied()
+            .ok_or_else(|| anyhow!("invalid variablesReference: {reference}"))?;
+
+        let entries = match handle {
+            HandleValue::Locals { frame_depth } => self
+                .vm
+                .debug_frame_locals(frame_depth)
+                .into_iter()
+                .map(|local| (local.name, local.value))
+                .collect::<Vec<_>>(),
+            HandleValue::Value(value) => self.child_entries_for_value(value),
+        };
+
+        Ok(entries
+            .into_iter()
+            .map(|(name, value)| self.variable_json(name, value))
+            .collect())
+    }
+
+    fn child_entries_for_value(&self, value: Value) -> Vec<(String, Value)> {
+        let Value::Object(ptr) = value else {
+            return Vec::new();
+        };
+
+        match self.vm.get_object(ptr) {
+            Object::Array(items) => items
+                .iter()
+                .enumerate()
+                .map(|(index, value)| (format!("[{index}]"), *value))
+                .collect(),
+            Object::Map(map) => map
+                .iter()
+                .map(|(key, value)| (key.to_string(), *value))
+                .collect(),
+            Object::Instance(instance) => {
+                let field_names = match self.vm.get_object(instance.class) {
+                    Object::Class(class) => class
+                        .fields
+                        .iter()
+                        .map(|field| field.name.clone())
+                        .collect::<Vec<_>>(),
+                    _ => Vec::new(),
+                };
+
+                instance
+                    .fields
+                    .iter()
+                    .enumerate()
+                    .map(|(index, field_value)| {
+                        let name = field_names
+                            .get(index)
+                            .cloned()
+                            .unwrap_or_else(|| format!("field_{index}"));
+                        (name, *field_value)
+                    })
+                    .collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn variable_json(&mut self, name: String, value: Value) -> JsonValue {
+        let (display, type_name, expandable) = self.describe_value(value);
+        let variables_reference = if expandable {
+            self.new_handle(HandleValue::Value(value))
+        } else {
+            0
+        };
+
+        json!({
+            "name": name,
+            "value": display,
+            "type": type_name,
+            "variablesReference": variables_reference,
+        })
+    }
+
+    fn describe_value(&self, value: Value) -> (String, String, bool) {
+        match value {
+            Value::Null => ("null".to_string(), "null".to_string(), false),
+            Value::Int(value) => (value.to_string(), "int".to_string(), false),
+            Value::Float(value) => (value.to_string(), "float".to_string(), false),
+            Value::Bool(value) => (value.to_string(), "bool".to_string(), false),
+            Value::Object(ptr) =>
+            {
+                #[allow(unreachable_patterns)]
+                match self.vm.get_object(ptr) {
+                    Object::String(value) => (format!("{value:?}"), "string".to_string(), false),
+                    Object::Array(values) => (
+                        format!("Array({})", values.len()),
+                        "array".to_string(),
+                        true,
+                    ),
+                    Object::Map(values) => {
+                        (format!("Map({})", values.len()), "map".to_string(), true)
+                    }
+                    Object::Instance(instance) => {
+                        let class_name = match self.vm.get_object(instance.class) {
+                            Object::Class(class) => class.name.clone(),
+                            _ => "instance".to_string(),
+                        };
+                        (format!("{class_name} {{...}}"), class_name, true)
+                    }
+                    Object::Variant(variant) => {
+                        let variant_name = match self.vm.get_object(variant.enm) {
+                            Object::Enum(enm) => enm
+                                .variants
+                                .get(variant.index)
+                                .map(|entry| format!("{}::{}", enm.name, entry.name))
+                                .unwrap_or_else(|| format!("{}::<{}>", enm.name, variant.index)),
+                            _ => format!("<variant {}>", variant.index),
+                        };
+                        (variant_name, "variant".to_string(), false)
+                    }
+                    Object::Function(function) => (
+                        format!("<fn {}>", function.name),
+                        "function".to_string(),
+                        false,
+                    ),
+                    Object::Class(class) => (
+                        format!("<class {}>", class.name),
+                        "class".to_string(),
+                        false,
+                    ),
+                    Object::Enum(enm) => {
+                        (format!("<enum {}>", enm.name), "enum".to_string(), false)
+                    }
+                    Object::Future(_) => ("<future>".to_string(), "future".to_string(), false),
+                    Object::Resource(resource) => (
+                        format!("<resource {resource:?}>"),
+                        "resource".to_string(),
+                        false,
+                    ),
+                    Object::Media(media) => (
+                        format!("<media {:?}>", media.kind),
+                        "media".to_string(),
+                        false,
+                    ),
+                    Object::PromptAst(_) => {
+                        ("<prompt_ast>".to_string(), "prompt_ast".to_string(), false)
+                    }
+                    Object::Collector(_) => {
+                        ("<collector>".to_string(), "collector".to_string(), false)
+                    }
+                    Object::Type(ty) => (ty.to_string(), "type".to_string(), false),
+                    _ => ("<object>".to_string(), "object".to_string(), false),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LaunchArgs {
+    project_path: Option<String>,
+    function_name: Option<String>,
+    args: Option<JsonValue>,
+    stop_on_entry: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetBreakpointsArgs {
+    source: Option<DapSource>,
+    #[serde(default)]
+    breakpoints: Vec<SourceBreakpoint>,
+    #[serde(default)]
+    lines: Vec<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceBreakpoint {
+    line: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct DapSource {
+    path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StackTraceArgs {
+    start_frame: Option<usize>,
+    levels: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScopesArgs {
+    frame_id: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VariablesArgs {
+    variables_reference: i64,
+}
+
+fn canonicalize_path(path: impl AsRef<Path>) -> PathBuf {
+    path.as_ref()
+        .canonicalize()
+        .unwrap_or_else(|_| path.as_ref().to_path_buf())
+}
+
+fn load_project_files(db: &mut ProjectDatabase, root: &Path) -> Result<()> {
+    for entry in WalkDir::new(root)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.into_path();
+        let is_baml = path.extension().and_then(|ext| ext.to_str()) == Some("baml");
+        let is_baml_jinja = path
+            .to_string_lossy()
+            .to_ascii_lowercase()
+            .ends_with(".baml.jinja");
+        if !is_baml && !is_baml_jinja {
+            continue;
+        }
+
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read source file {}", path.display()))?;
+        db.add_or_update_file(&path, &content);
+    }
+
+    Ok(())
+}
+
+fn parse_launch_args(
+    vm: &mut BexVm,
+    function_ptr: bex_vm_types::HeapPtr,
+    raw_args: Option<JsonValue>,
+) -> Result<Vec<Value>> {
+    let function = vm
+        .get_object(function_ptr)
+        .as_function()
+        .context("launch target is not a function")?
+        .clone();
+
+    let raw_args = raw_args.unwrap_or(JsonValue::Null);
+    let arity = function.arity;
+
+    if raw_args.is_null() {
+        if arity == 0 {
+            return Ok(Vec::new());
+        }
+        bail!(
+            "function '{}' requires {} argument(s)",
+            function.name,
+            arity
+        );
+    }
+
+    if let Some(values) = raw_args.as_array() {
+        if values.len() != arity {
+            bail!(
+                "function '{}' expects {} argument(s), got {}",
+                function.name,
+                arity,
+                values.len()
+            );
+        }
+
+        return values
+            .iter()
+            .map(|value| json_to_vm_value(vm, value))
+            .collect();
+    }
+
+    if let Some(map) = raw_args.as_object() {
+        let mut ordered = Vec::with_capacity(arity);
+        for param in &function.param_names {
+            let value = map
+                .get(param)
+                .ok_or_else(|| anyhow!("missing argument '{param}'"))?;
+            ordered.push(json_to_vm_value(vm, value)?);
+        }
+
+        let extras = map
+            .keys()
+            .filter(|key| !function.param_names.iter().any(|param| param == *key))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !extras.is_empty() {
+            bail!("unexpected argument(s): {}", extras.join(", "));
+        }
+
+        return Ok(ordered);
+    }
+
+    if arity == 1 {
+        return Ok(vec![json_to_vm_value(vm, &raw_args)?]);
+    }
+
+    bail!(
+        "function '{}' expects {} argument(s), launch.args must be an object or array",
+        function.name,
+        arity
+    )
+}
+
+fn json_to_vm_value(vm: &mut BexVm, value: &JsonValue) -> Result<Value> {
+    match value {
+        JsonValue::Null => Ok(Value::Null),
+        JsonValue::Bool(value) => Ok(Value::Bool(*value)),
+        JsonValue::Number(number) => {
+            if let Some(value) = number.as_i64() {
+                return Ok(Value::Int(value));
+            }
+            if let Some(value) = number.as_u64() {
+                let value = i64::try_from(value).context("integer is too large for i64")?;
+                return Ok(Value::Int(value));
+            }
+            if let Some(value) = number.as_f64() {
+                return Ok(Value::Float(value));
+            }
+            bail!("unsupported JSON number representation")
+        }
+        JsonValue::String(value) => Ok(vm.alloc_string(value.clone())),
+        JsonValue::Array(values) => {
+            let values = values
+                .iter()
+                .map(|value| json_to_vm_value(vm, value))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(vm.alloc_array(values))
+        }
+        JsonValue::Object(values) => {
+            let mut map = indexmap::IndexMap::new();
+            for (key, value) in values {
+                map.insert(key.clone(), json_to_vm_value(vm, value)?);
+            }
+            Ok(vm.alloc_map(map))
+        }
+    }
+}

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -10,6 +10,7 @@
 )]
 
 pub(crate) mod commands;
+pub(crate) mod dap;
 pub(crate) mod format;
 pub(crate) mod lsp;
 

--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -530,6 +530,12 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
 
     /// Set the current debug span used for subsequent emitted instructions.
     fn set_debug_span(&mut self, span: Option<Span>, sequence_point: bool) {
+        // Preserve a pending statement/terminator boundary until the next emitted
+        // instruction consumes it. This avoids losing sequence points when helper
+        // routines temporarily retag spans for operand attribution.
+        if self.pending_sequence_point && !sequence_point {
+            return;
+        }
         self.current_debug_span = span;
         self.pending_sequence_point = sequence_point;
     }

--- a/baml_language/crates/baml_compiler_emit/tests/while_loops.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/while_loops.rs
@@ -1,6 +1,7 @@
 //! Compiler tests for while loops, break, and continue.
 
 use baml_tests::{
+    bytecode::{assert_no_diagnostic_errors, setup_test_db},
     codegen::{Program, assert_compiles},
     vm::{Instruction, Value},
 };
@@ -356,6 +357,59 @@ fn break_nested() -> anyhow::Result<()> {
             ],
         )],
     })
+}
+
+#[test]
+fn while_loop_unoptimized_keeps_condition_and_body_sequence_points() {
+    let source = r#"function sum_to(n: int) -> int {
+    let total = 0;
+    let i = 1;
+
+    while (i <= n) {
+        total = total + i;
+        i = i + 1;
+    }
+
+    total
+}"#;
+
+    let db = setup_test_db(source);
+    assert_no_diagnostic_errors(&db);
+
+    let project = db.get_project().expect("project must be set");
+    let files = project.files(&db).clone();
+    let program =
+        baml_compiler_emit::compile_files(&db, &files, baml_compiler_emit::OptLevel::Zero)
+            .expect("compile_files should succeed for valid while-loop source");
+    let sum_to_idx = program
+        .function_index("sum_to")
+        .expect("sum_to should be present in compiled program");
+    let Some(bex_vm_types::Object::Function(sum_to)) = program.objects.get(sum_to_idx) else {
+        panic!("sum_to object index did not resolve to a function");
+    };
+
+    let mut seq_lines: Vec<usize> = sum_to
+        .bytecode
+        .line_table
+        .iter()
+        .filter(|entry| entry.sequence_point)
+        .map(|entry| entry.line)
+        .collect();
+    seq_lines.sort_unstable();
+    seq_lines.dedup();
+
+    assert!(
+        seq_lines.contains(&5),
+        "expected sequence points to include while condition line 5; got {seq_lines:?}"
+    );
+    assert!(
+        seq_lines.contains(&6),
+        "expected sequence points to include loop body line 6; got {seq_lines:?}"
+    );
+    assert!(
+        seq_lines.contains(&7),
+        "expected sequence points to include loop body line 7; got {seq_lines:?}"
+    );
 }
 
 /// Test break with variable conditions to verify bytecode generation.

--- a/baml_language/crates/baml_lsp_server/src/lib.rs
+++ b/baml_language/crates/baml_lsp_server/src/lib.rs
@@ -84,7 +84,7 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
         .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("debug")),
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .with_ansi(false)
         .init();
@@ -122,6 +122,9 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
         Arc::new(native_lsp_sender::NativeLspSender::new(&writer_tx));
 
     // Pick the playground port early so we can pass it to the sender.
+    let playground_enabled = std::env::var("BAML_PLAYGROUND_DEV_PORT").is_ok()
+        || std::env::var("BAML_PLAYGROUND_DIR").is_ok();
+
     let (playground_listener, playground_port): (Option<TcpListener>, u16) =
         match tokio_runtime.block_on(playground_server::pick_port(3700, 100)) {
             Ok((listener, port)) => (Some(listener), port),
@@ -137,6 +140,7 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
         lsp_sender.clone(),
         playground_port,
         playground_via_browser,
+        playground_enabled,
     ));
 
     // Start the native event sink if BAML_TRACE_FILE is set.
@@ -162,7 +166,14 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
         let es = env_state.clone();
         tokio_runtime.spawn(async move {
             if let Err(e) = playground_server::run(listener, bex_for_playground, btx, es).await {
-                tracing::error!("Playground server exited: {e}");
+                let message = e.to_string();
+                if message.contains("BAML_PLAYGROUND_DEV_PORT")
+                    || message.contains("BAML_PLAYGROUND_DIR")
+                {
+                    tracing::info!("Playground server disabled: {message}");
+                } else {
+                    tracing::error!("Playground server exited: {e}");
+                }
             }
         });
     }

--- a/baml_language/crates/baml_lsp_server/src/playground_env.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_env.rs
@@ -48,6 +48,18 @@ impl PlaygroundEnvState {
 /// `SysOpEnv` implementation that asks the webview for every env var.
 pub struct PlaygroundEnv(pub Arc<PlaygroundEnvState>);
 
+impl PlaygroundEnv {
+    fn local_env_get(key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+
+    fn local_env_get_or_err(key: &str) -> Result<String, sys_types::OpErrorKind> {
+        std::env::var(key).map_err(|_| {
+            sys_types::OpErrorKind::Other(format!("Environment variable '{}' not found", key))
+        })
+    }
+}
+
 impl sys_types::SysOpEnv for PlaygroundEnv {
     fn env_get(
         &self,
@@ -56,17 +68,32 @@ impl sys_types::SysOpEnv for PlaygroundEnv {
     ) -> sys_types::SysOpOutput<Option<String>> {
         let state = self.0.clone();
         sys_types::SysOpOutput::async_op(async move {
+            // Avoid blocking LSP requests when no playground/webview client is connected.
+            if state.broadcast_tx.receiver_count() == 0 {
+                return Ok(Self::local_env_get(&key));
+            }
+
             let (tx, rx) = oneshot::channel();
             let id = state.next_id.fetch_add(1, Ordering::Relaxed);
             state.pending.lock().unwrap().insert(id, tx);
-            let _ = state
+
+            if state
                 .broadcast_tx
-                .send(WsOutMessage::EnvVarRequest { id, variable: key });
+                .send(WsOutMessage::EnvVarRequest {
+                    id,
+                    variable: key.clone(),
+                })
+                .is_err()
+            {
+                state.pending.lock().unwrap().remove(&id);
+                return Ok(Self::local_env_get(&key));
+            }
+
             match tokio::time::timeout(ENV_REQUEST_TIMEOUT, rx).await {
                 Ok(Ok(value)) => Ok(value),
                 Ok(Err(_)) | Err(_) => {
                     state.pending.lock().unwrap().remove(&id);
-                    Ok(None)
+                    Ok(Self::local_env_get(&key))
                 }
             }
         })
@@ -80,34 +107,37 @@ impl sys_types::SysOpEnv for PlaygroundEnv {
         let state = self.0.clone();
         let key_for_err = key.clone();
         sys_types::SysOpOutput::async_op(async move {
+            // Avoid blocking LSP requests when no playground/webview client is connected.
+            if state.broadcast_tx.receiver_count() == 0 {
+                return Self::local_env_get_or_err(&key_for_err);
+            }
+
             let (tx, rx) = oneshot::channel();
             let id = state.next_id.fetch_add(1, Ordering::Relaxed);
             state.pending.lock().unwrap().insert(id, tx);
-            let _ = state
+
+            if state
                 .broadcast_tx
-                .send(WsOutMessage::EnvVarRequest { id, variable: key });
+                .send(WsOutMessage::EnvVarRequest {
+                    id,
+                    variable: key.clone(),
+                })
+                .is_err()
+            {
+                state.pending.lock().unwrap().remove(&id);
+                return Self::local_env_get_or_err(&key_for_err);
+            }
+
             match tokio::time::timeout(ENV_REQUEST_TIMEOUT, rx).await {
                 Ok(Ok(Some(val))) => Ok(val),
-                Ok(Ok(None)) => Err(sys_types::OpErrorKind::Other(format!(
-                    "Environment variable '{}' not found",
-                    key_for_err
-                ))),
+                Ok(Ok(None)) => Self::local_env_get_or_err(&key_for_err),
                 Ok(Err(_)) => {
                     state.pending.lock().unwrap().remove(&id);
-                    Err(sys_types::OpErrorKind::Other(format!(
-                        "Environment variable '{}' request cancelled",
-                        key_for_err
-                    )))
+                    Self::local_env_get_or_err(&key_for_err)
                 }
                 Err(_) => {
                     state.pending.lock().unwrap().remove(&id);
-                    Err(sys_types::OpErrorKind::Timeout {
-                        message: format!(
-                            "Environment variable '{}' request timed out",
-                            key_for_err
-                        ),
-                        duration: ENV_REQUEST_TIMEOUT,
-                    })
+                    Self::local_env_get_or_err(&key_for_err)
                 }
             }
         })

--- a/baml_language/crates/baml_lsp_server/src/playground_sender.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_sender.rs
@@ -18,6 +18,7 @@ pub struct NativePlaygroundSender {
     lsp_sender: Arc<dyn bex_project::LspClientSenderTrait + Send + Sync>,
     playground_port: u16,
     playground_via_browser: bool,
+    playground_enabled: bool,
 }
 
 impl NativePlaygroundSender {
@@ -26,12 +27,14 @@ impl NativePlaygroundSender {
         lsp_sender: Arc<dyn bex_project::LspClientSenderTrait + Send + Sync>,
         playground_port: u16,
         playground_via_browser: bool,
+        playground_enabled: bool,
     ) -> Self {
         Self {
             broadcast_tx,
             lsp_sender,
             playground_port,
             playground_via_browser,
+            playground_enabled,
         }
     }
 }
@@ -43,6 +46,18 @@ impl bex_project::PlaygroundSender for NativePlaygroundSender {
             ref function_name,
         } = notification
         {
+            if !self.playground_enabled || self.playground_port == 0 {
+                let params = serde_json::json!({
+                    "type": 2,
+                    "message": "BAML Playground is not configured in this build. Set BAML_PLAYGROUND_DIR or BAML_PLAYGROUND_DEV_PORT to enable it.",
+                });
+                let notif = lsp_server::Notification::new("window/showMessage".to_string(), params);
+                if let Err(e) = self.lsp_sender.send_notification(notif) {
+                    tracing::error!("Failed to send playground unavailable message: {}", e);
+                }
+                return;
+            }
+
             if self.playground_via_browser {
                 let url = format!("http://localhost:{}", self.playground_port);
                 if let Err(e) = webbrowser::open(&url) {

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -345,8 +345,11 @@ impl ProjectDatabase {
             .and_then(|path| self.file_map.get(path).copied())
     }
 
-    /// Get the compiled bytecode for the project.
-    pub fn get_bytecode(&self) -> Result<bex_vm_types::Program, baml_compiler_emit::LoweringError> {
+    /// Get the compiled bytecode for the project using the requested optimization level.
+    pub fn get_bytecode_with_opt(
+        &self,
+        opt: baml_compiler_emit::OptLevel,
+    ) -> Result<bex_vm_types::Program, baml_compiler_emit::LoweringError> {
         // First ensure no diagnostics errors are present
         let diagnostics = self.check();
         if diagnostics
@@ -356,7 +359,26 @@ impl ProjectDatabase {
         {
             return Err(baml_compiler_emit::LoweringError::HasDiagnosticsErrors);
         }
-        baml_compiler_emit::generate_project_bytecode(self)
+
+        let project = self
+            .get_project()
+            .expect("project must be set before requesting bytecode");
+        let files = project.files(self).clone();
+        baml_compiler_emit::compile_files(self, &files, opt)
+    }
+
+    /// Get the compiled bytecode for the project.
+    pub fn get_bytecode(&self) -> Result<bex_vm_types::Program, baml_compiler_emit::LoweringError> {
+        self.get_bytecode_with_opt(baml_compiler_emit::OptLevel::One)
+    }
+
+    /// Get debugger-oriented bytecode for the project.
+    ///
+    /// This uses `OptLevel::Zero` to preserve source-level stepping fidelity.
+    pub fn get_debug_bytecode(
+        &self,
+    ) -> Result<bex_vm_types::Program, baml_compiler_emit::LoweringError> {
+        self.get_bytecode_with_opt(baml_compiler_emit::OptLevel::Zero)
     }
 }
 

--- a/baml_language/crates/baml_tests/src/vm.rs
+++ b/baml_language/crates/baml_tests/src/vm.rs
@@ -299,6 +299,10 @@ impl ExecState {
                 // The test runner will call exec() again to continue.
                 Ok(ExecState::Emit(vec![]))
             }
+            VmExecState::DebugStop(_) => {
+                // Debugger stops are ignored by legacy VM tests.
+                Ok(ExecState::Emit(vec![]))
+            }
             VmExecState::Notify(notification) => match notification {
                 VmWatchNotification::Variables(nodes) => {
                     let notifications = nodes

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -1366,6 +1366,12 @@ impl BexEngine {
                         }
                     }
                 }
+
+                VmExecState::DebugStop(_stop) => {
+                    return Err(EngineError::TypeMismatch {
+                        message: "unexpected VM debug stop during non-debug execution".to_string(),
+                    });
+                }
             }
         }
     }

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/notification.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/notification.rs
@@ -1,35 +1,15 @@
 use super::{BexMulitProject, LspError, ProjectRefreshMode};
 use crate::bex_lsp::notification::BexLspNotification;
 
-impl BexLspNotification for BexMulitProject {
-    fn notification_sender(
-        &self,
-    ) -> Box<dyn Fn(lsp_server::Notification) -> Result<(), LspError> + '_> {
-        let sender = self.sender.clone();
-        Box::new(move |notif| sender.send_notification(notif))
-    }
-
-    fn on_notification_exit(
-        &self,
-        _params: lsp_notification_params!("exit"),
-    ) -> Result<(), LspError> {
-        tracing::info!("LSP exit received");
-        let mut projects = self.projects.lock().unwrap();
-        projects.clear();
-        Ok(())
-    }
-
-    fn on_notification_initialized(
-        &self,
-        _params: lsp_notification_params!("initialized"),
-    ) -> Result<(), LspError> {
+impl BexMulitProject {
+    fn discover_workspace_projects(&self) {
         let workspace_roots = self.workspace_roots.lock().unwrap().clone();
 
         if workspace_roots.is_empty() {
             tracing::warn!(
                 "No workspace roots provided during initialize — skipping project discovery"
             );
-            return Ok(());
+            return;
         }
 
         let mut project_roots = Vec::new();
@@ -55,6 +35,43 @@ impl BexLspNotification for BexMulitProject {
                 continue;
             };
             self.refresh_project(&project_root, ProjectRefreshMode::Full);
+        }
+    }
+}
+
+impl BexLspNotification for BexMulitProject {
+    fn notification_sender(
+        &self,
+    ) -> Box<dyn Fn(lsp_server::Notification) -> Result<(), LspError> + '_> {
+        let sender = self.sender.clone();
+        Box::new(move |notif| sender.send_notification(notif))
+    }
+
+    fn on_notification_exit(
+        &self,
+        _params: lsp_notification_params!("exit"),
+    ) -> Result<(), LspError> {
+        tracing::info!("LSP exit received");
+        let mut projects = self.projects.lock().unwrap();
+        projects.clear();
+        Ok(())
+    }
+
+    fn on_notification_initialized(
+        &self,
+        _params: lsp_notification_params!("initialized"),
+    ) -> Result<(), LspError> {
+        let this = self.clone();
+        let thread_name = "baml-lsp-project-discovery".to_string();
+        let spawn_result = std::thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || this.discover_workspace_projects());
+
+        if let Err(err) = spawn_result {
+            tracing::warn!(
+                "Failed to spawn project discovery thread; running inline instead: {err}"
+            );
+            self.discover_workspace_projects();
         }
 
         Ok(())

--- a/baml_language/crates/bex_vm/src/debugger.rs
+++ b/baml_language/crates/bex_vm/src/debugger.rs
@@ -1,0 +1,62 @@
+//! VM debugger data structures.
+
+use bex_vm_types::{StackIndex, Value, bytecode::LineTableEntry};
+
+/// User breakpoint expressed in source coordinates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DebugBreakpoint {
+    /// Numeric file identifier (`Span.file_id.as_u32()`).
+    pub file_id: u32,
+    /// 1-indexed source line.
+    pub line: usize,
+}
+
+/// Current debugger stepping mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DebugStepMode {
+    /// Run freely unless a breakpoint or pause request hits.
+    #[default]
+    Continue,
+    /// Stop at the next sequence point in any frame.
+    StepIn,
+    /// Stop at the next sequence point in the current frame (or after unwinding).
+    StepOver { start_depth: usize },
+    /// Stop at the next sequence point after unwinding at least one frame.
+    StepOut { start_depth: usize },
+}
+
+/// Why the VM yielded a debug stop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DebugStopReason {
+    Breakpoint,
+    Step,
+    Pause,
+}
+
+/// VM stop snapshot for debugger consumers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebugStop {
+    pub reason: DebugStopReason,
+    pub frame_depth: usize,
+    pub function_name: String,
+    pub pc: usize,
+    pub line_entry: LineTableEntry,
+}
+
+/// Frame view for debugger stack traces.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebugStackFrame {
+    pub frame_depth: usize,
+    pub function_name: String,
+    pub pc: usize,
+    pub line_entry: Option<LineTableEntry>,
+}
+
+/// In-scope local bound to a concrete stack slot/value.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DebugScopedLocal {
+    pub name: String,
+    pub slot: usize,
+    pub stack_index: StackIndex,
+    pub value: Value,
+}

--- a/baml_language/crates/bex_vm/src/lib.rs
+++ b/baml_language/crates/bex_vm/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod builtins;
 pub mod debug;
+pub mod debugger;
 pub mod errors;
 pub mod indexable;
 pub mod native;
@@ -19,6 +20,9 @@ pub mod types;
 pub mod vm;
 pub mod watch;
 
+pub use debugger::{
+    DebugBreakpoint, DebugScopedLocal, DebugStackFrame, DebugStepMode, DebugStop, DebugStopReason,
+};
 pub use errors::{InternalError, RuntimeError, StackTrace};
 pub use indexable::EvalStack;
 pub use native::NativeFunction;

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -14,7 +14,10 @@
 
 #![allow(unsafe_code)]
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use bex_heap::{BexHeap, Tlab};
 use bex_resource_types::ResourceHandle;
@@ -28,6 +31,10 @@ use indexmap::IndexMap;
 
 use crate::{
     StackTrace,
+    debugger::{
+        DebugBreakpoint, DebugScopedLocal, DebugStackFrame, DebugStepMode, DebugStop,
+        DebugStopReason,
+    },
     errors::{ErrorLocation, InternalError, RuntimeError, VmError},
     indexable::{EvalStack, EvalStackTrait},
     native::NativeFunction,
@@ -57,6 +64,13 @@ pub(crate) struct Frame {
 
     /// Local variables offset in the eval stack.
     pub(crate) locals_offset: StackIndex,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct DebugStopKey {
+    frame_depth: usize,
+    function_ptr: HeapPtr,
+    pc: usize,
 }
 
 /// The beast.
@@ -201,6 +215,18 @@ pub struct BexVm {
     /// Frame depths for traced function calls. Always sorted ascending (LIFO).
     /// Checked on `Return` to yield `FunctionExit` notifications.
     traced_frames: Vec<usize>,
+
+    /// Active source-level breakpoints.
+    debug_breakpoints: HashSet<DebugBreakpoint>,
+
+    /// Request a stop at the next sequence point.
+    debug_pause_requested: bool,
+
+    /// Current stepping mode.
+    debug_step_mode: DebugStepMode,
+
+    /// Suppress exactly one duplicate stop after a resume.
+    debug_resume_skip: Option<DebugStopKey>,
 }
 
 /// VM execution state.
@@ -233,6 +259,9 @@ pub enum VmExecState {
 
     /// Notify about span lifecycle (from traced `Call` / `Return`).
     SpanNotify(SpanNotification),
+
+    /// VM paused for debugger control.
+    DebugStop(DebugStop),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -412,6 +441,10 @@ impl BexVm {
             watched_vars: HashMap::new(),
             interrupt_frame: None,
             traced_frames: Vec::new(),
+            debug_breakpoints: HashSet::new(),
+            debug_pause_requested: false,
+            debug_step_mode: DebugStepMode::Continue,
+            debug_resume_skip: None,
         }
     }
 
@@ -655,6 +688,125 @@ impl BexVm {
         self.frames.clear();
     }
 
+    /// Replace active breakpoints.
+    pub fn debug_set_breakpoints(
+        &mut self,
+        breakpoints: impl IntoIterator<Item = DebugBreakpoint>,
+    ) {
+        self.debug_breakpoints = breakpoints.into_iter().collect();
+    }
+
+    /// Continue execution until a breakpoint, pause, or completion.
+    pub fn debug_continue(&mut self) {
+        self.debug_step_mode = DebugStepMode::Continue;
+        self.debug_pause_requested = false;
+    }
+
+    /// Stop on the next sequence point.
+    pub fn debug_step_in(&mut self) {
+        self.debug_step_mode = DebugStepMode::StepIn;
+        self.debug_pause_requested = false;
+    }
+
+    /// Step to the next sequence point in the current frame.
+    pub fn debug_step_over(&mut self) {
+        self.debug_step_mode = DebugStepMode::StepOver {
+            start_depth: self.frames.len().saturating_sub(1),
+        };
+        self.debug_pause_requested = false;
+    }
+
+    /// Continue until returning to the caller frame.
+    pub fn debug_step_out(&mut self) {
+        self.debug_step_mode = DebugStepMode::StepOut {
+            start_depth: self.frames.len().saturating_sub(1),
+        };
+        self.debug_pause_requested = false;
+    }
+
+    /// Request a pause at the next sequence point.
+    pub fn debug_pause(&mut self) {
+        self.debug_pause_requested = true;
+    }
+
+    /// Current stack trace snapshot (top frame first).
+    pub fn debug_stack_frames(&self) -> Vec<DebugStackFrame> {
+        self.frames
+            .iter()
+            .enumerate()
+            .rev()
+            .filter_map(|(frame_depth, frame)| {
+                let Ok(function) = self.get_object(frame.function).as_function() else {
+                    return None;
+                };
+
+                let pc = frame.instruction_ptr;
+                let line_entry = function.bytecode.line_entry_for_pc(pc).cloned();
+
+                Some(DebugStackFrame {
+                    frame_depth,
+                    function_name: function.name.clone(),
+                    pc,
+                    line_entry,
+                })
+            })
+            .collect()
+    }
+
+    /// In-scope locals for a frame at its current instruction pointer.
+    pub fn debug_frame_locals(&self, frame_depth: usize) -> Vec<DebugScopedLocal> {
+        let Some(frame) = self.frames.get(frame_depth) else {
+            return Vec::new();
+        };
+        let Ok(function) = self.get_object(frame.function).as_function() else {
+            return Vec::new();
+        };
+
+        let mut locals = Vec::new();
+        let mut seen_slots = std::collections::HashSet::new();
+
+        for local in function.debug_locals_in_scope(frame.instruction_ptr) {
+            if local.slot == 0 {
+                continue;
+            }
+
+            let stack_index = Self::local_slot_stack_index(frame.locals_offset, local.slot);
+            let Some(value) = self.stack.get(stack_index.raw()).copied() else {
+                continue;
+            };
+
+            seen_slots.insert(local.slot);
+            locals.push(DebugScopedLocal {
+                name: local.name.clone(),
+                slot: local.slot,
+                stack_index,
+                value,
+            });
+        }
+
+        // Fallback for cases where lexical debug scopes are incomplete:
+        // include all named local slots so debugger locals remain useful.
+        for (slot, name) in function.local_names.iter().enumerate().skip(1) {
+            if seen_slots.contains(&slot) || name.is_empty() {
+                continue;
+            }
+
+            let stack_index = Self::local_slot_stack_index(frame.locals_offset, slot);
+            let Some(value) = self.stack.get(stack_index.raw()).copied() else {
+                continue;
+            };
+
+            locals.push(DebugScopedLocal {
+                name: name.clone(),
+                slot,
+                stack_index,
+                value,
+            });
+        }
+
+        locals
+    }
+
     /// Returns a reference to the pending future.
     ///
     /// Returns [`InternalError::TypeError`] if the future is not pending, or not a future.
@@ -889,6 +1041,67 @@ impl BexVm {
             "local slot 0 is reserved and should never be materialized on stack"
         );
         StackIndex::from_raw(locals_offset.raw() + slot - 1)
+    }
+
+    fn debug_step_matches(&self, frame_depth: usize) -> bool {
+        match self.debug_step_mode {
+            DebugStepMode::Continue => false,
+            DebugStepMode::StepIn => true,
+            DebugStepMode::StepOver { start_depth } => frame_depth <= start_depth,
+            DebugStepMode::StepOut { start_depth } => frame_depth < start_depth,
+        }
+    }
+
+    fn debug_try_stop(
+        &mut self,
+        frame_depth: usize,
+        function_ptr: HeapPtr,
+        function: &Function,
+        pc: usize,
+    ) -> Option<DebugStop> {
+        let line_entry = function.bytecode.line_entry_for_pc(pc)?;
+        if !line_entry.sequence_point {
+            return None;
+        }
+
+        let key = DebugStopKey {
+            frame_depth,
+            function_ptr,
+            pc,
+        };
+        if self.debug_resume_skip == Some(key) {
+            self.debug_resume_skip = None;
+            return None;
+        }
+
+        let pause_hit = self.debug_pause_requested;
+        let breakpoint_hit = self.debug_breakpoints.contains(&DebugBreakpoint {
+            file_id: line_entry.span.file_id.as_u32(),
+            line: line_entry.line,
+        });
+        let step_hit = self.debug_step_matches(frame_depth);
+
+        let reason = if pause_hit {
+            Some(DebugStopReason::Pause)
+        } else if breakpoint_hit {
+            Some(DebugStopReason::Breakpoint)
+        } else if step_hit {
+            Some(DebugStopReason::Step)
+        } else {
+            None
+        }?;
+
+        self.debug_pause_requested = false;
+        self.debug_step_mode = DebugStepMode::Continue;
+        self.debug_resume_skip = Some(key);
+
+        Some(DebugStop {
+            reason,
+            frame_depth,
+            function_name: function.name.clone(),
+            pc,
+            line_entry: line_entry.clone(),
+        })
     }
 
     fn resolve_callable_target(&self, callee_value: Value) -> Result<(HeapPtr, usize), VmError> {
@@ -1189,6 +1402,13 @@ impl BexVm {
         loop {
             // Current instruction pointer (read from frame).
             let instruction_ptr = self.frames[frame_idx].instruction_ptr;
+            let function_ptr = self.frames[frame_idx].function;
+
+            if let Some(stop) =
+                self.debug_try_stop(frame_idx, function_ptr, function, instruction_ptr)
+            {
+                return Ok(VmExecState::DebugStop(stop));
+            }
 
             // Move the frame's IP to the next instruction. We'll deal with
             // jump offsets later.

--- a/baml_language/crates/bex_vm/tests/debugger.rs
+++ b/baml_language/crates/bex_vm/tests/debugger.rs
@@ -1,0 +1,214 @@
+//! VM debugger behavior tests with explicit sequence points.
+
+use bex_vm::{BexVm, DebugBreakpoint, DebugStopReason, VmExecState};
+use bex_vm_types::{
+    Bytecode, ConstValue, Function, FunctionKind, GlobalIndex, Instruction, Object, ObjectIndex,
+    Program as VmProgram, Value,
+    bytecode::{InstructionMeta, LineTableEntry},
+};
+
+const FILE_ID: u32 = u32::MAX;
+const MAIN_CALL_LINE: usize = 10;
+const MAIN_AFTER_CALL_LINE: usize = 11;
+const CALLEE_LINE: usize = 20;
+
+fn line(pc: usize, line: usize, discriminator: u32) -> LineTableEntry {
+    let span = baml_type::Span::fake();
+    LineTableEntry {
+        pc,
+        span,
+        line,
+        sequence_point: true,
+        discriminator,
+    }
+}
+
+fn make_function(
+    name: &str,
+    instructions: Vec<Instruction>,
+    constants: Vec<ConstValue>,
+    line_table: Vec<LineTableEntry>,
+) -> Function {
+    let meta = vec![InstructionMeta { operand: None }; instructions.len()];
+    Function {
+        name: name.to_string(),
+        arity: 0,
+        real_local_count: 0,
+        bytecode: Bytecode {
+            instructions,
+            constants,
+            resolved_constants: Vec::new(),
+            jump_tables: Vec::new(),
+            line_table,
+            meta,
+        },
+        kind: FunctionKind::Bytecode,
+        local_names: Vec::new(),
+        debug_locals: Vec::new(),
+        span: baml_type::Span::fake(),
+        block_notifications: Vec::new(),
+        viz_nodes: Vec::new(),
+        return_type: baml_type::Ty::Int,
+        param_names: Vec::new(),
+        param_types: Vec::new(),
+        body_meta: None,
+        trace: false,
+    }
+}
+
+fn setup_vm() -> anyhow::Result<BexVm> {
+    let callee = make_function(
+        "callee",
+        vec![Instruction::LoadConst(0), Instruction::Return],
+        vec![ConstValue::Int(7)],
+        vec![line(0, CALLEE_LINE, 0), line(1, CALLEE_LINE + 1, 0)],
+    );
+
+    let main = make_function(
+        "main",
+        vec![
+            Instruction::Call(GlobalIndex::from_raw(0)),
+            Instruction::Return,
+        ],
+        vec![],
+        vec![line(0, MAIN_CALL_LINE, 0), line(1, MAIN_AFTER_CALL_LINE, 0)],
+    );
+
+    let mut program = VmProgram::new();
+    let callee_idx = program.add_object(Object::Function(Box::new(callee)));
+    let main_idx = program.add_object(Object::Function(Box::new(main)));
+    program.add_global(ConstValue::Object(ObjectIndex::from_raw(callee_idx)));
+    program.add_global(ConstValue::Object(ObjectIndex::from_raw(main_idx)));
+    program
+        .function_indices
+        .insert("callee".to_string(), callee_idx);
+    program
+        .function_indices
+        .insert("main".to_string(), main_idx);
+    program
+        .function_global_indices
+        .insert("callee".to_string(), 0);
+    program
+        .function_global_indices
+        .insert("main".to_string(), 1);
+
+    let mut vm = BexVm::from_program(program)?;
+    let main_ptr = vm.heap.compile_time_ptr(main_idx);
+    vm.set_entry_point(main_ptr, &[]);
+    Ok(vm)
+}
+
+fn exec_until_stop_or_complete(vm: &mut BexVm) -> anyhow::Result<VmExecState> {
+    loop {
+        let state = vm.exec()?;
+        if matches!(state, VmExecState::SpanNotify(_)) {
+            continue;
+        }
+        return Ok(state);
+    }
+}
+
+#[test]
+fn hits_line_breakpoint() -> anyhow::Result<()> {
+    let mut vm = setup_vm()?;
+    vm.debug_set_breakpoints([DebugBreakpoint {
+        file_id: FILE_ID,
+        line: MAIN_CALL_LINE,
+    }]);
+
+    let state = exec_until_stop_or_complete(&mut vm)?;
+    let VmExecState::DebugStop(stop) = state else {
+        anyhow::bail!("expected DebugStop");
+    };
+    assert_eq!(stop.reason, DebugStopReason::Breakpoint);
+    assert_eq!(stop.line_entry.line, MAIN_CALL_LINE);
+    Ok(())
+}
+
+#[test]
+fn step_over_stays_in_current_frame() -> anyhow::Result<()> {
+    let mut vm = setup_vm()?;
+    vm.debug_set_breakpoints([DebugBreakpoint {
+        file_id: FILE_ID,
+        line: MAIN_CALL_LINE,
+    }]);
+
+    let first = exec_until_stop_or_complete(&mut vm)?;
+    let VmExecState::DebugStop(first_stop) = first else {
+        anyhow::bail!("expected initial DebugStop");
+    };
+    assert_eq!(first_stop.function_name, "main");
+    assert_eq!(first_stop.frame_depth, 0);
+
+    vm.debug_step_over();
+    let second = exec_until_stop_or_complete(&mut vm)?;
+    let VmExecState::DebugStop(second_stop) = second else {
+        anyhow::bail!("expected step DebugStop");
+    };
+    assert_eq!(second_stop.reason, DebugStopReason::Step);
+    assert_eq!(second_stop.function_name, "main");
+    assert_eq!(second_stop.frame_depth, 0);
+    assert_eq!(second_stop.line_entry.line, MAIN_AFTER_CALL_LINE);
+    Ok(())
+}
+
+#[test]
+fn step_out_unwinds_to_caller() -> anyhow::Result<()> {
+    let mut vm = setup_vm()?;
+    vm.debug_set_breakpoints([DebugBreakpoint {
+        file_id: FILE_ID,
+        line: CALLEE_LINE,
+    }]);
+
+    let first = exec_until_stop_or_complete(&mut vm)?;
+    let VmExecState::DebugStop(first_stop) = first else {
+        anyhow::bail!("expected initial DebugStop");
+    };
+    assert_eq!(first_stop.function_name, "callee");
+    assert_eq!(first_stop.frame_depth, 1);
+
+    vm.debug_step_out();
+    let second = exec_until_stop_or_complete(&mut vm)?;
+    let VmExecState::DebugStop(second_stop) = second else {
+        anyhow::bail!("expected step-out DebugStop");
+    };
+    assert_eq!(second_stop.reason, DebugStopReason::Step);
+    assert_eq!(second_stop.function_name, "main");
+    assert_eq!(second_stop.frame_depth, 0);
+    assert_eq!(second_stop.line_entry.line, MAIN_AFTER_CALL_LINE);
+    Ok(())
+}
+
+#[test]
+fn pause_stops_on_next_sequence_point() -> anyhow::Result<()> {
+    let mut vm = setup_vm()?;
+    vm.debug_pause();
+
+    let state = exec_until_stop_or_complete(&mut vm)?;
+    let VmExecState::DebugStop(stop) = state else {
+        anyhow::bail!("expected DebugStop");
+    };
+    assert_eq!(stop.reason, DebugStopReason::Pause);
+    assert_eq!(stop.line_entry.line, MAIN_CALL_LINE);
+    Ok(())
+}
+
+#[test]
+fn resume_does_not_repeat_same_stop() -> anyhow::Result<()> {
+    let mut vm = setup_vm()?;
+    vm.debug_set_breakpoints([DebugBreakpoint {
+        file_id: FILE_ID,
+        line: MAIN_CALL_LINE,
+    }]);
+
+    let first = exec_until_stop_or_complete(&mut vm)?;
+    let VmExecState::DebugStop(first_stop) = first else {
+        anyhow::bail!("expected initial stop");
+    };
+    assert_eq!(first_stop.line_entry.line, MAIN_CALL_LINE);
+
+    vm.debug_continue();
+    let second = exec_until_stop_or_complete(&mut vm)?;
+    assert_eq!(second, VmExecState::Complete(Value::Int(7)));
+    Ok(())
+}

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -1702,6 +1702,11 @@ impl CompilerRunner {
             Ok(VmExecState::SpanNotify(_)) => {
                 // Span notifications are ignored in the VM Runner — just continue.
             }
+            Ok(VmExecState::DebugStop(_)) => {
+                self.vm_runner_state.execution_result = Some(VmExecutionResult::Error(
+                    "Function hit a debugger stop (not supported in VM Runner)".to_string(),
+                ));
+            }
             Err(e) => {
                 self.vm_runner_state.execution_result =
                     Some(VmExecutionResult::Error(format!("{:?}", e)));

--- a/baml_language/stow.toml
+++ b/baml_language/stow.toml
@@ -80,13 +80,13 @@ reason = "Use baml_db or baml_project to access compiler interfaces."
 [[namespaces.dependency_rules]]
 pattern.select = "bex_*"
 pattern.exclude = ["bex_vm_types"]
-allowed_crates = ["bridge_cffi"]
-reason = "baml_* crates should not depend on bex_* crates."
+allowed_crates = ["bridge_cffi", "baml_cli"]
+reason = "baml_* crates should not depend on bex_* crates (except baml_cli for DAP runtime integration)."
 
 [[namespaces.dependency_rules]]
 pattern.select = "bex_vm_types"
-allowed_crates = ["baml_compiler_emit", "baml_project"]
-reason = "Only compiler_emit and baml_project crates should depend on bex_vm_types (pure data layer)."
+allowed_crates = ["baml_compiler_emit", "baml_project", "baml_cli"]
+reason = "Only compiler_emit, baml_project, and baml_cli (DAP) should depend on bex_vm_types (pure data layer)."
 
 
 # tools namespace configuration

--- a/debugger_smoke/baml_src/main.baml
+++ b/debugger_smoke/baml_src/main.baml
@@ -1,0 +1,17 @@
+function sum_to(n: int) -> int {
+  let total = 0;
+  let i = 1;
+
+  while (i <= n) {
+    total = total + i;
+    i = i + 1;
+  }
+
+  total
+}
+
+function main() -> int {
+  let seed = 8;
+  let triangle = sum_to(seed);
+  triangle
+}

--- a/typescript2/app-vscode-ext/package.json
+++ b/typescript2/app-vscode-ext/package.json
@@ -14,7 +14,8 @@
   ],
   "main": "./dist/extension.js",
   "activationEvents": [
-    "onLanguage:baml"
+    "onLanguage:baml",
+    "onDebug"
   ],
   "contributes": {
     "languages": [
@@ -44,6 +45,54 @@
         "language": "baml-jinja",
         "scopeName": "source.baml-jinja",
         "path": "./syntaxes/jinja.tmLanguage.json"
+      }
+    ],
+    "breakpoints": [
+      {
+        "language": "baml"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "baml",
+        "label": "BAML",
+        "languages": ["baml"],
+        "configurationAttributes": {
+          "launch": {
+            "required": ["projectPath", "functionName"],
+            "properties": {
+              "projectPath": {
+                "type": "string",
+                "description": "Absolute path to the BAML project root directory."
+              },
+              "functionName": {
+                "type": "string",
+                "description": "BAML function to execute in the debugger."
+              },
+              "args": {
+                "type": ["array", "object", "null"],
+                "default": {},
+                "description": "Function arguments. Use an object for named parameters or an array for positional parameters."
+              },
+              "stopOnEntry": {
+                "type": "boolean",
+                "default": false,
+                "description": "Pause on the first debugger sequence point after launch."
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "name": "BAML Debug Function",
+            "type": "baml",
+            "request": "launch",
+            "projectPath": "${workspaceFolder}",
+            "functionName": "main",
+            "args": {},
+            "stopOnEntry": false
+          }
+        ]
       }
     ],
     "commands": [

--- a/typescript2/app-vscode-ext/src/__tests__/debugger.test.ts
+++ b/typescript2/app-vscode-ext/src/__tests__/debugger.test.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  DebugAdapterExecutable: class DebugAdapterExecutable {
+    constructor(
+      public readonly command: string,
+      public readonly args: string[] = [],
+    ) {}
+  },
+}));
+
+import { buildBamlDebugAdapterCommand } from '../debugger';
+
+describe('buildBamlDebugAdapterCommand', () => {
+  it('launches baml-cli in dap mode', () => {
+    expect(buildBamlDebugAdapterCommand('/custom/bin/baml-cli')).toEqual({
+      command: '/custom/bin/baml-cli',
+      args: ['dap'],
+    });
+  });
+});
+
+describe('package debugger contribution', () => {
+  it('declares the baml debugger contribution', () => {
+    const packageJsonPath = path.resolve(__dirname, '../../package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    const debuggerContribution = packageJson?.contributes?.debuggers?.find(
+      (entry: { type?: string }) => entry?.type === 'baml',
+    );
+
+    expect(debuggerContribution).toBeDefined();
+    expect(debuggerContribution.languages).toContain('baml');
+    expect(debuggerContribution.initialConfigurations?.[0]?.type).toBe('baml');
+    expect(
+      packageJson?.contributes?.breakpoints?.some(
+        (entry: { language?: string }) => entry?.language === 'baml',
+      ),
+    ).toBe(true);
+  });
+});

--- a/typescript2/app-vscode-ext/src/debugger.ts
+++ b/typescript2/app-vscode-ext/src/debugger.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+
+export type DebugAdapterCommand = {
+  command: string;
+  args: string[];
+};
+
+export function buildBamlDebugAdapterCommand(cliPath: string): DebugAdapterCommand {
+  return {
+    command: cliPath,
+    args: ['dap'],
+  };
+}
+
+export class BamlDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
+  constructor(private readonly cliPath: string) {}
+
+  createDebugAdapterDescriptor(
+    _session: vscode.DebugSession,
+    _executable: vscode.DebugAdapterExecutable | undefined,
+  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    const command = buildBamlDebugAdapterCommand(this.cliPath);
+    return new vscode.DebugAdapterExecutable(command.command, command.args);
+  }
+}

--- a/typescript2/app-vscode-ext/src/extension.ts
+++ b/typescript2/app-vscode-ext/src/extension.ts
@@ -5,6 +5,7 @@ import {
   type ServerOptions,
   State,
 } from 'vscode-languageclient/node';
+import { BamlDebugAdapterFactory } from './debugger';
 import { WebviewPanel } from './panels/WebviewPanel';
 
 let client: LanguageClient | undefined;
@@ -93,6 +94,11 @@ export async function activate(context: vscode.ExtensionContext) {
     command: cliPath,
     args: ['lsp'],
   };
+
+  const debugAdapterFactory = new BamlDebugAdapterFactory(cliPath);
+  context.subscriptions.push(
+    vscode.debug.registerDebugAdapterDescriptorFactory('baml', debugAdapterFactory),
+  );
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ language: 'baml', scheme: 'file' }],

--- a/typescript2/app-vscode-ext/tsup.config.ts
+++ b/typescript2/app-vscode-ext/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   target: 'node18',
   format: ['cjs'],
   external: ['vscode'],
+  noExternal: [/^vscode-languageclient/],
   bundle: true,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
## Summary
- add a native BAML Debug Adapter Protocol server to baml-cli (baml-cli dap) with launch, breakpoints, stack trace, scopes, variables, continue/pause/step commands
- add VM debugger primitives and tests (bex_vm::debugger, breakpoint/step/step-out/pause coverage)
- wire Cursor extension debug adapter factory and breakpoint contribution updates
- add debugger_smoke/baml_src/main.baml + VSCode launch entry for quick manual smoke testing
- improve DAP stepping behavior to avoid same-site breakpoint stickiness and collapse forward same-line sequence-point noise
- ensure debugger bytecode uses OptLevel::Zero via ProjectDatabase::get_debug_bytecode()
- fix sequence-point emission so pending statement/terminator sequence points are not clobbered during operand attribution
- LSP quality-of-life fixes: reduced default log noise, non-blocking project discovery, safer playground behavior when playground env is missing
- update stow policy to allow baml_cli to depend on bex_vm / bex_vm_types for DAP runtime integration
-- 

## Notes

Add this to `.vscode/settings.json`:

```
"baml.cliPath": "/media/tony/WesternDigitalNvmeSsd/Code/baml/baml_language/target/debug/baml-cli"
```

## Validation
- cargo test -p bex_vm --test debugger
- cargo test -p baml_compiler_emit while_loop_unoptimized_keeps_condition_and_body_sequence_points
- cargo build -p baml_cli
- pnpm --filter ./app-vscode-ext test:run
- manual DAP smoke against debugger_smoke/baml_src/main.baml confirms loop stepping sequence (7 -> 5 -> 6 -> 7 ...) and verified breakpoints

## Notes
- local machine-specific .vscode/settings.json (baml.cliPath) was intentionally left out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * VS Code: full BAML debug integration (adapter, launch config, breakpoints, stepping, pause, variable & stack inspection).
  * CLI: built-in Debug Adapter support to run/debug BAML programs.
  * VM: runtime debugger API enabling breakpoints and step controls.
  * Project: compile with selectable optimization levels and a debug build mode.

* **Bug Fixes / Improvements**
  * Playground env falls back to local env on timeouts/errors.

* **Tests**
  * Added debugger integration tests and a debugger smoke project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->