### PR TITLE
Global request body limit

### DIFF
--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -177,6 +177,7 @@ aws-sdk-bedrockruntime = { version = "=1.106.0", default-features = false, featu
 ] }
 axum = "0.7.5"
 axum-extra = { version = "0.9.3", features = ["erased-json", "typed-header"] }
+tower-http = { version = "0.5", features = ["limit"] }
 criterion = "0.5.1"
 # depends on ring
 gcp_auth = "0.12.3"

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc, task::Poll};
 use anyhow::{Context, Result};
 use arg_validation::BamlServeValidate;
 use axum::{
-    extract::{self, DefaultBodyLimit},
+    extract::{self},
     http::{HeaderName, HeaderValue, StatusCode},
     middleware::Next,
     response::{
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::{net::TcpListener, sync::RwLock};
 use tokio_stream::StreamExt;
+use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::{
     cli::dotenv::DotenvArgs, client_registry::ClientRegistry, errors::ExposedError,
@@ -296,10 +297,9 @@ impl Server {
             get(move || s.clone().openapi_json_handler()),
         );
 
-        // Set request body size limit to 100 MiB. This is chosen to be larger than
-        // providers like Gemini which accept files up to 50 MiB. The default Axum
-        // limit is only 2 MiB which is too restrictive for PDF uploads and similar use cases.
-        let app = app.layer(DefaultBodyLimit::max(100 * 1024 * 1024));
+        // Set request body size limit to 50 MB globally. This provides sufficient capacity
+        // for large payloads like PDF uploads while maintaining reasonable resource limits.
+        let app = app.layer(RequestBodyLimitLayer::new(50 * 1024 * 1024));
 
         let service = axum::serve(
             tcp_listener,


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

This PR implements a global request body limit for the BAML runtime server.
- Replaced `axum::extract::DefaultBodyLimit` with `tower_http::limit::RequestBodyLimitLayer` to apply a global limit.
- Set the global request body limit to 50 MB (50 * 1024 * 1024 bytes) for all routes.
- Added `tower-http` dependency with the `limit` feature to `engine/baml-runtime/Cargo.toml`.
- Updated imports in `engine/baml-runtime/src/cli/serve/mod.rs` to reflect these changes.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [X] Manual testing performed
    - Ran `cargo test -p baml-runtime --lib` which resulted in all 147 tests passing.
    - Applied `cargo fmt` for code formatting.
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [ ] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project (via `cargo fmt`)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

This change addresses the need for a global request body limit, replacing a more specific or default limit with a consistent approach across the server.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1771872248502569?thread_ts=1771872248.502569&cid=C09F3QMJE9G)

<p><a href="https://cursor.com/agents/bc-fefd2951-64f4-5e47-985c-2c745bf85d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fefd2951-64f4-5e47-985c-2c745bf85d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

