### PR TITLE
Formatter in LSP

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -17,5 +17,5 @@ package = "bridge_wasm"
 target = "wasm32-unknown-unknown"
 no_default_features = true
 wasm = true
-policy.max_gzip_bytes = 1_820_000
+policy.max_gzip_bytes = 1_920_000
 policy.max_delta_pct = 10.0

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -8,6 +8,6 @@ stripped_bytes = 7390520
 gzip_bytes = 3282547
 
 [artifacts.bridge_cffi-stripped]
-file_bytes = 4328384
-stripped_bytes = 4328408
-gzip_bytes = 1716155
+file_bytes = 4927136
+stripped_bytes = 4927176
+gzip_bytes = 1959257

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -3,5 +3,5 @@ recorded_at = "2026-02-19T10:05:10Z"
 git_sha = "6aaeec0b2"
 
 [artifacts.bridge_wasm]
-file_bytes = 6755539
-gzip_bytes = 1811650
+file_bytes = 7067598
+gzip_bytes = 1898753

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -8,6 +8,6 @@ stripped_bytes = 7363584
 gzip_bytes = 3250605
 
 [artifacts.bridge_cffi-stripped]
-file_bytes = 4432384
-stripped_bytes = 4432384
-gzip_bytes = 1763092
+file_bytes = 5085696
+stripped_bytes = 5085696
+gzip_bytes = 2022449

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -8,6 +8,6 @@ stripped_bytes = 10551424
 gzip_bytes = 3984950
 
 [artifacts.bridge_cffi-stripped]
-file_bytes = 5951896
-stripped_bytes = 5951888
-gzip_bytes = 2147649
+file_bytes = 6781976
+stripped_bytes = 6781968
+gzip_bytes = 2447882

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -817,6 +817,7 @@ dependencies = [
  "baml_compiler_diagnostics",
  "baml_compiler_emit",
  "baml_db",
+ "baml_fmt",
  "baml_lsp_actions",
  "baml_project",
  "baml_workspace",

--- a/baml_language/crates/bex_project/Cargo.toml
+++ b/baml_language/crates/bex_project/Cargo.toml
@@ -23,6 +23,7 @@ baml_builtins = { workspace = true }
 baml_compiler_diagnostics = { workspace = true }
 baml_compiler_emit = { workspace = true }
 baml_db = { workspace = true }
+baml_fmt = { workspace = true }
 baml_lsp_actions = { workspace = true }
 baml_project = { workspace = true }
 baml_workspace = { workspace = true }

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -34,6 +34,7 @@ pub(super) fn server_capabilities() -> ServerCapabilities {
             commands: vec![commands::OpenBamlPanel::COMMAND_ID.to_string()],
             work_done_progress_options: lsp_types::WorkDoneProgressOptions::default(),
         }),
+        document_formatting_provider: Some(lsp_types::OneOf::Left(true)),
         definition_provider: Some(lsp_types::OneOf::Left(true)),
         references_provider: Some(lsp_types::OneOf::Left(true)),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
@@ -687,6 +688,68 @@ impl BexLspRequest for BexMulitProject {
         } else {
             Ok(Some(lsp_types::DocumentSymbolResponse::Nested(symbols)))
         }
+    }
+
+    fn on_request_text_document_formatting(
+        &self,
+        params: lsp_request_params!("textDocument/formatting"),
+    ) -> Result<lsp_request_result!("textDocument/formatting"), LspError> {
+        let path = self.get_path_from_uri(&params.text_document.uri)?;
+        let root_path = Self::get_baml_project_root(&path)?;
+        let project_handle = self.get_or_create_project(root_path)?;
+        // Get current file text from the project database.
+        let text = {
+            let db = project_handle.project.try_lock_db()?;
+            let Some(source_file) = db.get_file(std::path::Path::new(path.as_str())) else {
+                return Err(LspError::FileNotFound(path));
+            };
+            source_file.text(&*db).clone()
+        };
+
+        // Map LSP FormattingOptions → baml_fmt FormatOptions.
+        let options = baml_fmt::FormatOptions::default();
+
+        // Run the formatter. On parse errors, return no edits (silently skip).
+        let formatted = match baml_fmt::format(&text, &options) {
+            Ok(f) => f,
+            Err(baml_fmt::FormatterError::ParseErrors { .. }) => return Ok(None),
+            Err(baml_fmt::FormatterError::StrongAstError(e)) => {
+                return Err(crate::RuntimeError::Other(format!(
+                    "Failed to build strong AST: {}",
+                    e.print_with_file_context(path.as_str(), &text)
+                ))
+                .into());
+            }
+        };
+
+        // No change → no edits.
+        if formatted == text {
+            return Ok(None);
+        }
+
+        // Compute end position of the original text for the replacement range.
+        let line_count = u32::try_from(text.lines().count()).unwrap_or(u32::MAX);
+        let last_line_len =
+            u32::try_from(text.lines().last().map_or(0, str::len)).unwrap_or(u32::MAX);
+        let (end_line, end_char) = if text.ends_with('\n') {
+            (line_count, 0)
+        } else {
+            (line_count.saturating_sub(1), last_line_len)
+        };
+
+        Ok(Some(vec![lsp_types::TextEdit {
+            range: lsp_types::Range {
+                start: lsp_types::Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: lsp_types::Position {
+                    line: end_line,
+                    character: end_char,
+                },
+            },
+            new_text: formatted,
+        }]))
     }
 }
 


### PR DESCRIPTION
Adds document formatting action to the LSP, using `baml_fmt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language server now supports document formatting.

* **Chores**
  * Build artifact size metadata updated across platforms (reported size increases).
  * Added project formatter dependency to the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->