### PR TITLE
baml_language: route vm function execution to `BexEngine`

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "baml_project",
  "baml_type",
  "baml_workspace",
+ "bex_heap",
  "bex_vm",
  "bex_vm_types",
  "codspeed-divan-compat",
@@ -4865,6 +4866,7 @@ dependencies = [
  "baml_project",
  "baml_type",
  "baml_workspace",
+ "bex_engine",
  "bex_vm",
  "bex_vm_types",
  "clap",
@@ -4875,6 +4877,8 @@ dependencies = [
  "rowan 0.16.1",
  "salsa",
  "similar",
+ "sys_types",
+ "tokio",
 ]
 
 [[package]]

--- a/baml_language/crates/baml_tests/Cargo.toml
+++ b/baml_language/crates/baml_tests/Cargo.toml
@@ -22,6 +22,7 @@ baml_fmt = { workspace = true }
 baml_project = { workspace = true }
 baml_type = { workspace = true }
 baml_workspace = { workspace = true }
+bex_heap = { workspace = true }
 bex_vm = { workspace = true }
 bex_vm_types = { workspace = true }
 anyhow = { workspace = true }

--- a/baml_language/crates/baml_tests/src/bytecode.rs
+++ b/baml_language/crates/baml_tests/src/bytecode.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 
 pub use baml_project::ProjectDatabase;
 use bex_vm::{BexVm, VmExecState};
-use bex_vm_types::{ConstValue, ObjectIndex, Program as VmProgram};
+use bex_vm_types::{ConstValue, GlobalPool, ObjectIndex, Program as VmProgram};
 
 // Re-export test types from crate::vm
 pub use crate::vm::{
@@ -37,6 +37,26 @@ pub use crate::vm::{
 
 /// Backwards-compatible alias for code that still references `TestDatabase`.
 pub type TestDatabase = ProjectDatabase;
+
+/// Create a [`BexVm`] from a compiled program for direct VM testing.
+///
+/// Bypasses `BexEngine` — these tests exercise raw bytecode execution,
+/// exec-state sequencing, and watch/emit behaviour the engine does not expose.
+/// Production callers must use `BexEngine`.
+pub fn make_vm(program: VmProgram) -> Result<BexVm, bex_vm::errors::VmError> {
+    let bytecode = bex_vm::convert_program(program)?;
+
+    let objects: Vec<_> = bytecode.objects.into_iter().collect();
+    let heap = bex_heap::BexHeap::new(objects);
+
+    let globals: Vec<_> = bytecode
+        .globals
+        .into_iter()
+        .map(|cv| cv.to_value(|idx| heap.compile_time_ptr(idx.into_raw())))
+        .collect();
+
+    Ok(BexVm::new(heap, GlobalPool::from_vec(globals)))
+}
 
 //
 // ────────────────────────────────────────────────────────── COMPILATION ─────
@@ -176,7 +196,7 @@ pub fn collect_vm_exec_states(
         .function_index(function)
         .ok_or_else(|| anyhow::anyhow!("function '{function}' not found"))?;
 
-    let mut vm = BexVm::from_program(program)?;
+    let mut vm = make_vm(program)?;
     let function_ptr = vm.heap.compile_time_ptr(function_index);
     vm.set_entry_point(function_ptr, &[]);
 
@@ -244,7 +264,7 @@ fn setup_and_exec_program(
         .function_index(function)
         .ok_or_else(|| anyhow::anyhow!("function '{function}' not found"))?;
 
-    let mut vm = BexVm::from_program(program)?;
+    let mut vm = make_vm(program)?;
     let function_ptr = vm.heap.compile_time_ptr(function_index);
     vm.set_entry_point(function_ptr, &[]);
 
@@ -336,7 +356,7 @@ pub fn assert_vm_executes_bytecode_with_inspection(
         .function_indices
         .insert("test_fn".to_string(), fn_idx);
 
-    let mut vm = BexVm::from_program(program)?;
+    let mut vm = make_vm(program)?;
     // Get HeapPtr for function from the heap
     let function_ptr = vm.heap.compile_time_ptr(fn_idx);
     vm.set_entry_point(function_ptr, &[]);

--- a/baml_language/crates/baml_tests/src/bytecode.rs
+++ b/baml_language/crates/baml_tests/src/bytecode.rs
@@ -81,7 +81,9 @@ pub fn setup_test_db(source: &str) -> ProjectDatabase {
 pub fn assert_no_diagnostic_errors(db: &ProjectDatabase) {
     use baml_compiler_diagnostics::Severity;
 
-    let project = db.get_project().expect("project must be set");
+    let Some(project) = db.get_project() else {
+        panic!("project must be set");
+    };
     let all_files = db.get_source_files();
     let diagnostics = baml_project::collect_diagnostics(db, project, &all_files);
     let errors: Vec<_> = diagnostics
@@ -104,13 +106,21 @@ pub fn compile_source(source: &str) -> VmProgram {
     let db = setup_test_db(source);
     assert_no_diagnostic_errors(&db);
 
-    let project = db.get_project().unwrap();
-    let all_files = project.files(&db).clone();
+    let Some(project) = db.get_project() else {
+        panic!("project must be set");
+    };
     let options = baml_compiler_emit::CompileOptions {
         emit_test_cases: false,
     };
-    baml_compiler_emit::compile_files(&db, &all_files, baml_compiler_emit::OptLevel::One, &options)
-        .expect("compile_files should succeed for valid test source")
+    match baml_compiler_emit::compile_files(
+        &db,
+        project.files(&db),
+        baml_compiler_emit::OptLevel::One,
+        &options,
+    ) {
+        Ok(program) => program,
+        Err(err) => panic!("compile_files should succeed for valid test source: {err}"),
+    }
 }
 
 //
@@ -235,19 +245,36 @@ pub fn assert_vm_emits_with_inspection(
 ) -> anyhow::Result<()> {
     let (vm, states) = collect_vm_exec_states(input.source, input.function)?;
 
-    let emit_states: Vec<Vec<Notification>> = states
-        .iter()
-        .filter_map(|state| match state {
-            ExecState::Emit(roots) => Some(roots.clone()),
-            _ => None,
-        })
-        .collect();
+    let mut expected_iter = input.expected.iter();
+    let mut emit_index = 0;
 
-    assert_eq!(
-        emit_states, input.expected,
-        "VM emit states mismatch for function '{}'",
-        input.function
-    );
+    for state in &states {
+        let ExecState::Emit(roots) = state else {
+            continue;
+        };
+
+        let Some(expected) = expected_iter.next() else {
+            panic!(
+                "VM emit states mismatch for function '{}': unexpected extra emit at index {}",
+                input.function, emit_index
+            );
+        };
+
+        assert_eq!(
+            roots, expected,
+            "VM emit states mismatch for function '{}': emit index {}",
+            input.function, emit_index
+        );
+
+        emit_index += 1;
+    }
+
+    if expected_iter.next().is_some() {
+        panic!(
+            "VM emit states mismatch for function '{}': missing emit at index {}",
+            input.function, emit_index
+        );
+    }
 
     inspect(&vm, &states)?;
 

--- a/baml_language/crates/bex_vm/benches/fib.rs
+++ b/baml_language/crates/bex_vm/benches/fib.rs
@@ -2,7 +2,7 @@
 //!
 //! Do not measure compilation here, only VM execution time.
 
-use baml_tests::bytecode::compile_source;
+use baml_tests::bytecode::{compile_source, make_vm};
 use bex_vm::BexVm;
 use bex_vm_types::Value;
 
@@ -19,7 +19,7 @@ fn bootstrap_vm(input: &Program) -> BexVm {
         .function_index(input.function)
         .expect("function not found");
 
-    let mut vm = BexVm::from_program(program).expect("All native functions should be attached");
+    let mut vm = make_vm(program).expect("native function attachment must succeed");
     let function_ptr = vm.heap.compile_time_ptr(function_index);
     vm.set_entry_point(function_ptr, &input.args);
     vm

--- a/baml_language/crates/bex_vm/benches/fib.rs
+++ b/baml_language/crates/bex_vm/benches/fib.rs
@@ -21,7 +21,7 @@ fn bootstrap_vm(input: &Program) -> BexVm {
 
     let mut vm = match make_vm(program) {
         Ok(vm) => vm,
-        Err(err) => panic!("native function attachment must succeed: {err}"),
+        Err(err) => panic!("failed to construct VM from compiled program: {err}"),
     };
     let function_ptr = vm.heap.compile_time_ptr(function_index);
     vm.set_entry_point(function_ptr, &input.args);

--- a/baml_language/crates/bex_vm/benches/fib.rs
+++ b/baml_language/crates/bex_vm/benches/fib.rs
@@ -15,11 +15,14 @@ struct Program {
 fn bootstrap_vm(input: &Program) -> BexVm {
     let program = compile_source(input.source);
 
-    let function_index = program
-        .function_index(input.function)
-        .expect("function not found");
+    let Some(function_index) = program.function_index(input.function) else {
+        panic!("function not found");
+    };
 
-    let mut vm = make_vm(program).expect("native function attachment must succeed");
+    let mut vm = match make_vm(program) {
+        Ok(vm) => vm,
+        Err(err) => panic!("native function attachment must succeed: {err}"),
+    };
     let function_ptr = vm.heap.compile_time_ptr(function_index);
     vm.set_entry_point(function_ptr, &input.args);
     vm
@@ -43,7 +46,10 @@ pub fn recursive_fib<const N: i64>(bencher: divan::Bencher) {
                 args: vec![Value::Int(N)],
             })
         })
-        .bench_refs(|vm| vm.exec().unwrap());
+        .bench_refs(|vm| match vm.exec() {
+            Ok(result) => result,
+            Err(err) => panic!("vm exec failed: {err}"),
+        });
 }
 
 #[divan::bench(consts = [1000, 2000, 3000])]
@@ -74,7 +80,10 @@ pub fn iterative_fib<const N: i64>(bencher: divan::Bencher) {
                 args: vec![Value::Int(N)],
             })
         })
-        .bench_refs(|vm| vm.exec().unwrap());
+        .bench_refs(|vm| match vm.exec() {
+            Ok(result) => result,
+            Err(err) => panic!("vm exec failed: {err}"),
+        });
 }
 
 fn main() {

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -601,31 +601,6 @@ impl BexVm {
         Err(InternalError::InvalidObjectRef(ptr.as_ptr() as usize))
     }
 
-    /// TODO: We should remove this API in favor of using `bex_engine` only (vbv)
-    /// Creates a VM from a compiled [`bex_vm_types::Program`].
-    ///
-    /// This is primarily for testing. In production, use `BexEngine` which
-    /// manages the heap across multiple VM instances.
-    pub fn from_program(program: bex_vm_types::Program) -> Result<Self, VmError> {
-        let bytecode = convert_program(program)?;
-
-        // Extract compile-time objects for the heap
-        let compile_time_objects: Vec<Object> = bytecode.objects.into_iter().collect();
-
-        // Create heap with compile-time objects
-        let heap = BexHeap::new(compile_time_objects);
-
-        // Convert compile-time globals (ConstValue) to runtime globals (Value)
-        let globals_vec: Vec<Value> = bytecode
-            .globals
-            .into_iter()
-            .map(|cv| cv.to_value(|idx| heap.compile_time_ptr(idx.into_raw())))
-            .collect();
-        let globals = GlobalPool::from_vec(globals_vec);
-
-        Ok(Self::new(heap, globals))
-    }
-
     /// Bootstraps the VM preparing the given function to run.
     pub fn set_entry_point(&mut self, function: HeapPtr, args: &[Value]) {
         debug_assert!(

--- a/baml_language/crates/tools_onionskin/Cargo.toml
+++ b/baml_language/crates/tools_onionskin/Cargo.toml
@@ -29,8 +29,11 @@ baml_fmt = { workspace = true }
 baml_project = { workspace = true }
 baml_type = { workspace = true }
 baml_workspace = { workspace = true }
+bex_engine = { workspace = true }
 bex_vm = { workspace = true }
 bex_vm_types = { workspace = true }
+sys_types = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
 anyhow = { workspace = true }
 arboard = { workspace = true }
 clap = { workspace = true, features = [ "derive" ] }

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -1523,24 +1523,27 @@ impl CompilerRunner {
             .insert(CompilerPhase::Diagnostics, output_annotated);
     }
 
-    fn run_codegen(&mut self) {
-        // Include both user files and builtin files so codegen can compile
-        // builtin functions (e.g., baml.llm.render_prompt) that compiler-generated
-        // functions call.
+    /// Compile the current project including builtin files.
+    fn compile_program_with_builtins(
+        &self,
+    ) -> std::result::Result<baml_compiler_emit::Program, baml_compiler_emit::LoweringError> {
         let mut files: Vec<_> = self.source_files.values().copied().collect();
         files.extend(&self.builtin_files);
-
-        let mut output = String::new();
-        let mut output_annotated = Vec::new();
-
-        let program = match baml_compiler_emit::compile_files(
+        baml_compiler_emit::compile_files(
             &self.db,
             &files,
             baml_compiler_emit::OptLevel::One,
             &baml_compiler_emit::CompileOptions {
                 emit_test_cases: false,
             },
-        ) {
+        )
+    }
+
+    fn run_codegen(&mut self) {
+        let mut output = String::new();
+        let mut output_annotated = Vec::new();
+
+        let program = match self.compile_program_with_builtins() {
             Ok(p) => p,
             Err(err) => {
                 writeln!(output, "=== NO CODEGEN DUE TO ERRORS ===").ok();
@@ -1640,16 +1643,7 @@ impl CompilerRunner {
         let mut output_annotated = Vec::new();
 
         // Compile the program (include builtins so codegen can resolve builtin functions)
-        let mut files: Vec<_> = self.source_files.values().copied().collect();
-        files.extend(&self.builtin_files);
-        let program = match baml_compiler_emit::compile_files(
-            &self.db,
-            &files,
-            baml_compiler_emit::OptLevel::One,
-            &baml_compiler_emit::CompileOptions {
-                emit_test_cases: false,
-            },
-        ) {
+        let program = match self.compile_program_with_builtins() {
             Ok(p) => p,
             Err(err) => {
                 writeln!(output, "=== VM RUNNER ===").ok();
@@ -1808,15 +1802,7 @@ impl CompilerRunner {
         use bex_engine::{BexEngine, FunctionCallContextBuilder};
         use sys_types::{CallId, SysOps};
 
-        let files: Vec<_> = self.source_files.values().copied().collect();
-        let program = match baml_compiler_emit::compile_files(
-            &self.db,
-            &files,
-            baml_compiler_emit::OptLevel::One,
-            &baml_compiler_emit::CompileOptions {
-                emit_test_cases: false,
-            },
-        ) {
+        let program = match self.compile_program_with_builtins() {
             Ok(p) => p,
             Err(err) => return VmExecutionResult::Error(format!("Codegen failed: {err}")),
         };
@@ -2701,5 +2687,43 @@ fn format_external_value(value: &bex_engine::BexExternalValue) -> String {
         // Remaining variants (Resource, Handle, FunctionRef, Adt) are not
         // expected from pure-compute functions; fall back to the type name.
         other => format!("<{}>", other.type_name()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_external_value;
+    use bex_engine::{BexExternalValue, Ty, UnionMetadata};
+
+    #[test]
+    fn formats_scalars_and_variant() {
+        assert_eq!(format_external_value(&BexExternalValue::Null), "null");
+        assert_eq!(format_external_value(&BexExternalValue::Int(42)), "42");
+        assert_eq!(
+            format_external_value(&BexExternalValue::String("hi".to_string())),
+            "\"hi\""
+        );
+        assert_eq!(
+            format_external_value(&BexExternalValue::Variant {
+                enum_name: "Status".to_string(),
+                variant_name: "Ok".to_string(),
+            }),
+            "Status::Ok"
+        );
+    }
+
+    #[test]
+    fn formats_array_and_union_unwrap() {
+        let array = BexExternalValue::Array {
+            element_type: Ty::Union(vec![Ty::Int, Ty::Bool]),
+            items: vec![BexExternalValue::Int(1), BexExternalValue::Bool(true)],
+        };
+        assert_eq!(format_external_value(&array), "[1, true]");
+
+        let union = BexExternalValue::Union {
+            value: Box::new(BexExternalValue::Int(7)),
+            metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::Int),
+        };
+        assert_eq!(format_external_value(&union), "7");
     }
 }

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -1791,10 +1791,22 @@ impl CompilerRunner {
             .insert(CompilerPhase::VmRunner, output_annotated);
     }
 
-    /// Execute the selected function in the VM
+    /// Execute the selected function via the engine.
+    ///
+    /// Uses `BexEngine` with `SysOps::all_unsupported()` — this tool only runs
+    /// pure-compute functions. Any LLM or IO operation will surface as an engine
+    /// error rather than silently hanging.
     pub(crate) fn execute_selected_function(&mut self) {
-        use bex_vm::{BexVm, VmExecState};
-        use bex_vm_types::Object;
+        let result = self.try_execute_selected_function();
+        self.vm_runner_state.execution_result = Some(result);
+        self.run_vm_runner();
+    }
+
+    fn try_execute_selected_function(&mut self) -> VmExecutionResult {
+        use std::sync::Arc;
+
+        use bex_engine::{BexEngine, FunctionCallContextBuilder};
+        use sys_types::{CallId, SysOps};
 
         let files: Vec<_> = self.source_files.values().copied().collect();
         let program = match baml_compiler_emit::compile_files(
@@ -1806,13 +1818,7 @@ impl CompilerRunner {
             },
         ) {
             Ok(p) => p,
-            Err(err) => {
-                self.vm_runner_state.execution_result = Some(VmExecutionResult::Error(format!(
-                    "Codegen failed: {:?}",
-                    err
-                )));
-                return;
-            }
+            Err(err) => return VmExecutionResult::Error(format!("Codegen failed: {err}")),
         };
 
         let Some(func_name) = self
@@ -1820,73 +1826,43 @@ impl CompilerRunner {
             .available_functions
             .get(self.vm_runner_state.selected_function)
         else {
-            self.vm_runner_state.execution_result =
-                Some(VmExecutionResult::Error("No function selected".to_string()));
-            return;
+            return VmExecutionResult::Error("No function selected".to_string());
         };
 
-        let Some(func_index) = program.function_index(func_name) else {
-            self.vm_runner_state.execution_result = Some(VmExecutionResult::Error(format!(
-                "Function '{}' not found",
-                func_name
-            )));
-            return;
+        // All sys-ops (LLM, HTTP, etc.) return Unsupported — correct for a
+        // pure-compute dev tool. No event sink needed.
+        //
+        // TODO(vbv): When the VM Runner gains support for async/LLM functions,
+        // inject a real SysOps and an event sink here instead.
+        let engine = match BexEngine::new(program, Arc::new(SysOps::all_unsupported()), None) {
+            Ok(e) => e,
+            Err(err) => return VmExecutionResult::Error(format!("Engine init failed: {err}")),
         };
 
-        // Check function arity
-        if let Some(Object::Function(func)) = program.objects.get(func_index)
-            && func.arity > 0
-        {
-            self.vm_runner_state.execution_result =
-                Some(VmExecutionResult::RequiresArgs { arity: func.arity });
-            return;
+        // Use the engine API for arity — avoids accessing raw heap objects.
+        match engine.function_params(func_name) {
+            Err(err) => return VmExecutionResult::Error(format!("{err}")),
+            Ok(params) if !params.is_empty() => {
+                return VmExecutionResult::RequiresArgs {
+                    arity: params.len(),
+                };
+            }
+            Ok(_) => {}
         }
 
-        // Create VM and run
-        let mut vm = match BexVm::from_program(program) {
-            Ok(vm) => vm,
-            Err(err) => {
-                self.vm_runner_state.execution_result =
-                    Some(VmExecutionResult::Error(format!("{:?}", err)));
-                return;
-            }
+        // Build a minimal per-call context: no host span, no collectors.
+        let ctx = FunctionCallContextBuilder::new(CallId::next()).build();
+
+        // Drive the async engine from this synchronous TUI context.
+        let rt = match tokio::runtime::Builder::new_current_thread().build() {
+            Ok(rt) => rt,
+            Err(err) => return VmExecutionResult::Error(format!("Runtime error: {err}")),
         };
-        // Convert compile-time index to runtime HeapPtr
-        let func_ptr = vm.heap.compile_time_ptr(func_index);
-        vm.set_entry_point(func_ptr, &[]);
 
-        match vm.exec() {
-            Ok(VmExecState::Complete(value)) => {
-                let result_str = format_vm_value(&value, &vm);
-                self.vm_runner_state.execution_result =
-                    Some(VmExecutionResult::Success(result_str));
-            }
-            Ok(VmExecState::Await(_)) => {
-                self.vm_runner_state.execution_result = Some(VmExecutionResult::Error(
-                    "Function awaits a future (not supported in VM Runner)".to_string(),
-                ));
-            }
-            Ok(VmExecState::ScheduleFuture(_)) => {
-                self.vm_runner_state.execution_result = Some(VmExecutionResult::Error(
-                    "Function schedules a future (not supported in VM Runner)".to_string(),
-                ));
-            }
-            Ok(VmExecState::Notify(_)) => {
-                self.vm_runner_state.execution_result = Some(VmExecutionResult::Error(
-                    "Function sent a watch notification (not supported in VM Runner)".to_string(),
-                ));
-            }
-            Ok(VmExecState::SpanNotify(_)) => {
-                // Span notifications are ignored in the VM Runner — just continue.
-            }
-            Err(e) => {
-                self.vm_runner_state.execution_result =
-                    Some(VmExecutionResult::Error(format!("{:?}", e)));
-            }
+        match rt.block_on(engine.call_function(func_name, vec![], ctx)) {
+            Ok(value) => VmExecutionResult::Success(format_external_value(&value)),
+            Err(err) => VmExecutionResult::Error(format!("{err}")),
         }
-
-        // Regenerate output to show the result
-        self.run_vm_runner();
     }
 
     /// Get mutable VM runner state for UI
@@ -2685,68 +2661,45 @@ pub(crate) fn normalize_files_to_virtual_root(
         .collect()
 }
 
-/// Format a VM value for display
-fn format_vm_value(value: &bex_vm_types::Value, vm: &bex_vm::BexVm) -> String {
-    use bex_vm_types::{Object, Value};
+/// Format a `BexExternalValue` for display in the VM Runner panel.
+///
+/// `BexExternalValue` is fully self-describing (class names, variant names, and
+/// field names are embedded), so no heap access is required.
+fn format_external_value(value: &bex_engine::BexExternalValue) -> String {
+    use bex_engine::BexExternalValue as V;
 
     match value {
-        Value::Null => "null".to_string(),
-        Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Object(idx) => {
-            let obj = vm.get_object(*idx);
-            match obj {
-                Object::String(s) => format!("\"{}\"", s),
-                Object::Array(arr) => {
-                    let items: Vec<String> = arr.iter().map(|v| format_vm_value(v, vm)).collect();
-                    format!("[{}]", items.join(", "))
-                }
-                Object::Map(map) => {
-                    let items: Vec<String> = map
-                        .iter()
-                        .map(|(k, v)| format!("\"{}\": {}", k, format_vm_value(v, vm)))
-                        .collect();
-                    format!("{{{}}}", items.join(", "))
-                }
-                Object::Instance(inst) => {
-                    let class_obj = vm.get_object(inst.class);
-                    if let Object::Class(class) = class_obj {
-                        let fields: Vec<String> = class
-                            .fields
-                            .iter()
-                            .zip(inst.fields.iter())
-                            .map(|(f, val)| format!("{}: {}", f.name, format_vm_value(val, vm)))
-                            .collect();
-                        format!("{}{{ {} }}", class.name, fields.join(", "))
-                    } else {
-                        "<instance>".to_string()
-                    }
-                }
-                Object::Variant(var) => {
-                    let enum_obj = vm.get_object(var.enm);
-                    if let Object::Enum(enm) = enum_obj {
-                        if let Some(v) = enm.variants.get(var.index) {
-                            format!("{}::{}", enm.name, v.name)
-                        } else {
-                            format!("{}::variant_{}", enm.name, var.index)
-                        }
-                    } else {
-                        "<variant>".to_string()
-                    }
-                }
-                Object::Function(f) => format!("<fn {}>", f.name),
-                Object::Class(c) => format!("<class {}>", c.name),
-                Object::Media(m) => format!("<type {}>", m.kind),
-                Object::Enum(e) => format!("<enum {}>", e.name),
-                Object::Future(_) => "<future>".to_string(),
-                Object::Resource(r) => format!("<resource: {}>", r),
-                Object::PromptAst(_) => "<prompt_ast>".to_string(),
-                Object::Collector(_) => "<collector>".to_string(),
-                Object::Type(ty) => format!("<type: {ty}>"),
-                #[cfg(feature = "heap_debug")]
-                Object::Sentinel(_) => "<sentinel>".to_string(),
-            }
+        V::Null => "null".to_string(),
+        V::Int(i) => i.to_string(),
+        V::Float(f) => f.to_string(),
+        V::Bool(b) => b.to_string(),
+        V::String(s) => format!("\"{s}\""),
+        V::Array { items, .. } => {
+            let parts: Vec<String> = items.iter().map(format_external_value).collect();
+            format!("[{}]", parts.join(", "))
         }
+        V::Map { entries, .. } => {
+            let parts: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| format!("\"{k}\": {}", format_external_value(v)))
+                .collect();
+            format!("{{{}}}", parts.join(", "))
+        }
+        V::Instance { class_name, fields } => {
+            let parts: Vec<String> = fields
+                .iter()
+                .map(|(k, v)| format!("{k}: {}", format_external_value(v)))
+                .collect();
+            format!("{class_name}{{ {} }}", parts.join(", "))
+        }
+        V::Variant {
+            enum_name,
+            variant_name,
+        } => format!("{enum_name}::{variant_name}"),
+        // Unwrap the union wrapper — the display value is the inner value.
+        V::Union { value, .. } => format_external_value(value),
+        // Remaining variants (Resource, Handle, FunctionRef, Adt) are not
+        // expected from pure-compute functions; fall back to the type name.
+        other => format!("<{}>", other.type_name()),
     }
 }


### PR DESCRIPTION
### Why this change

`BexVm::from_program` let callers run the VM without the engine, but the engine is where execution correctness lives (event loop, notify/span-notify handling, GC, and consistent result/error propagation). In practice, bypassing it meant re-implementing that logic, and getting edge cases wrong.

`tools_onionskin` was the only real non-test user, and its custom loop had a user-visible bug: `SpanNotify` could be dropped, leaving the final result unset (blank Runner panel). It also treated `Notify` as an error instead of a normal mid-execution event.

### What this PR does

* Removes `from_program` to prevent bypassing the engine.
* Switches `tools_onionskin` to run via `BexEngine` using `SysOps::all_unsupported()` (safe no-op SysOps), so all intermediate events are handled correctly and results are always set.
* Adds `make_vm()` in `baml_tests` for VM-level tests/benchmarks that need direct VM control; everywhere else should use `BexEngine`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched the tool’s execution backend from a VM-based runner to an engine-driven runner for more reliable execution and UI sync.
  * Updated value formatting to reflect engine results, improving display for arrays, variants and union cases.
  * Improved runtime error and arity reporting when running functions.

* **Chores**
  * Updated crate dependencies to support the new execution path (including async runtime).

* **Tests**
  * Added formatter tests for scalar, string, array and variant representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->