### PR TITLE
fix(beps): improve Unicode code block alignment for diagrams

### DIFF
--- a/typescript/apps/beps/README.md
+++ b/typescript/apps/beps/README.md
@@ -682,6 +682,19 @@ Set your Anthropic API key in the Convex dashboard:
 
 Colors and dark mode are defined in `src/app/globals.css` with semantic tokens. See [docs/THEMING.md](docs/THEMING.md) for usage and extension guidelines.
 
+### Markdown Code Block Tips
+
+- Unlabeled fenced code blocks default to TypeScript highlighting (useful for BAML snippets).
+- For ASCII/Unicode diagrams, use `text` or `plaintext` fences to preserve spacing/alignment:
+
+  ````md
+  ```text
+  ┌───────┐
+  │ Box   │
+  └───────┘
+  ```
+  ````
+
 ### Available Scripts
 
 ```bash

--- a/typescript/apps/beps/src/app/globals.css
+++ b/typescript/apps/beps/src/app/globals.css
@@ -112,6 +112,26 @@ body {
   text-decoration: var(--shiki-dark-text-decoration) !important;
 }
 
+/* Code blocks: improve Unicode diagram alignment with robust mono fallbacks */
+.bep-shiki-code pre,
+.bep-shiki-code code {
+  font-family:
+    var(--font-geist-mono),
+    "DejaVu Sans Mono",
+    "Noto Sans Mono",
+    "Liberation Mono",
+    Menlo,
+    Consolas,
+    Monaco,
+    monospace;
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0, "calt" 0;
+}
+
+.bep-shiki-code .line {
+  white-space: pre;
+}
+
 /* MDX Editor: ensure content area uses semantic colors in dark mode */
 .dark .mdxeditor-root-contenteditable,
 .dark .mdxeditor-root-contenteditable [contenteditable="true"] {

--- a/typescript/apps/beps/src/components/ui/shiki-code-block.tsx
+++ b/typescript/apps/beps/src/components/ui/shiki-code-block.tsx
@@ -117,7 +117,7 @@ export function ShikiCodeBlock({
   if (isLoading) {
     const lines = code.split("\n");
     return (
-      <div className="not-prose my-5 rounded-xl border border-code-border overflow-hidden">
+      <div className="bep-shiki-code not-prose my-5 rounded-xl border border-code-border overflow-hidden">
         {showLanguageBar && (
           <div className="bg-muted border-b border-code-border px-4 py-2 text-xs font-medium text-muted-foreground">
             {getDisplayName(normalizedLang)}
@@ -144,7 +144,7 @@ export function ShikiCodeBlock({
   }
 
   return (
-    <div className="not-prose my-5 rounded-xl border border-code-border overflow-hidden">
+    <div className="bep-shiki-code not-prose my-5 rounded-xl border border-code-border overflow-hidden">
       {showLanguageBar && (
         <div className="bg-muted border-b border-code-border px-4 py-2 text-xs font-medium text-muted-foreground">
           {getDisplayName(normalizedLang)}
@@ -175,4 +175,3 @@ export function ShikiCodeBlock({
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Add a dedicated `bep-shiki-code` wrapper around rendered Shiki blocks so BEPs can target code-block-specific typography safely.
- Apply a Unicode-friendly monospace fallback stack, disable ligatures, and preserve line whitespace to keep box-drawing diagrams aligned.
- Document markdown authoring guidance to use `text`/`plaintext` fences for ASCII/Unicode diagrams while keeping unlabeled fences defaulting to TypeScript for BAML snippets.

## Testing
- Start the BEPs app locally and verify BEP-009 (`/beps/9`) renders the dual-loop diagram with correct alignment.

## Comparison

### Before

<img width="774" height="574" alt="image" src="https://github.com/user-attachments/assets/a2d315ee-acc2-422b-a8a0-7efe6ddc7e78" />


### After

<img width="774" height="574" alt="screenshot2" src="https://github.com/user-attachments/assets/972f37cf-4f19-4d6f-a31b-6ee64665bec1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on code block syntax and best practices for formatting ASCII and Unicode diagrams.

* **Style**
  * Improved code block rendering with enhanced font handling, spacing, and character alignment for better diagram display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->