### PR TITLE
Revert "baml-language: implement never type (#3181)"

### DIFF
--- a/baml_language/crates/baml_compiler_hir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_hir/src/pretty.rs
@@ -470,7 +470,6 @@ fn type_ref_to_str_impl(ty: &TypeRef, wrap_union: bool) -> String {
         TypeRef::String => "string".to_string(),
         TypeRef::Bool => "bool".to_string(),
         TypeRef::Null => "null".to_string(),
-        TypeRef::Never => "never".to_string(),
         TypeRef::Media(kind) => kind.to_string(),
         TypeRef::Optional(inner) => format!("{}?", type_ref_to_str_impl(inner, true)),
         TypeRef::List(inner) => format!("{}[]", type_ref_to_str_impl(inner, true)),

--- a/baml_language/crates/baml_compiler_hir/src/type_ref.rs
+++ b/baml_language/crates/baml_compiler_hir/src/type_ref.rs
@@ -50,8 +50,6 @@ pub enum TypeRef {
     String,
     Bool,
     Null,
-    /// The bottom type — uninhabited. No value has this type.
-    Never,
 
     Media(baml_base::MediaKind),
 
@@ -399,7 +397,6 @@ impl TypeRef {
             "string" => TypeRef::String,
             "bool" => TypeRef::Bool,
             "null" => TypeRef::Null,
-            "never" => TypeRef::Never,
             "unknown" => TypeRef::BuiltinUnknown,
             "type" => TypeRef::Type,
             "image" => TypeRef::Media(baml_base::MediaKind::Image),

--- a/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
+++ b/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
@@ -401,8 +401,8 @@ impl<'a> ExhaustivenessChecker<'a> {
             // When they are, this should include key/value types: map<{key}, {value}>
             Ty::Map { .. } => vec![ValueSet::OfType(Name::new("<map>"))],
 
-            // Special types (uninhabited/void/error produce no required values)
-            Ty::Unknown | Ty::Error | Ty::Void | Ty::Never | Ty::BuiltinUnknown => Vec::new(),
+            // Special types
+            Ty::Unknown | Ty::Error | Ty::Void | Ty::BuiltinUnknown => Vec::new(),
             Ty::Function { .. } => vec![ValueSet::OfType(Name::new("<function>"))],
             Ty::WatchAccessor(_) => vec![ValueSet::OfType(Name::new("<$watch>"))],
         }

--- a/baml_language/crates/baml_compiler_tir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lower.rs
@@ -118,7 +118,6 @@ fn lower_type_ref_resolved_with_ctx(
         TypeRef::String => Ty::String,
         TypeRef::Bool => Ty::Bool,
         TypeRef::Null => Ty::Null,
-        TypeRef::Never => Ty::Never,
 
         // Media types
         TypeRef::Media(kind) => Ty::Media(*kind),
@@ -305,19 +304,16 @@ fn is_simple_type_name(name: &str) -> bool {
     !name.contains(['<', '>', '[', ']', '|', '?', ','])
 }
 
-/// Normalize a union type by flattening nested unions, removing duplicates,
-/// and filtering out `Never` variants (`T | never → T`).
+/// Normalize a union type by flattening nested unions and removing duplicates.
 fn normalize_union(types: Vec<Ty>) -> Ty {
     let mut normalized = Vec::new();
 
     for ty in types {
         match ty {
-            // Never is the identity element for unions: T | never → T
-            Ty::Never => { /* skip */ }
             // Flatten nested unions
             Ty::Union(inner) => {
                 for inner_ty in inner {
-                    if inner_ty != Ty::Never && !normalized.contains(&inner_ty) {
+                    if !normalized.contains(&inner_ty) {
                         normalized.push(inner_ty);
                     }
                 }
@@ -333,7 +329,7 @@ fn normalize_union(types: Vec<Ty>) -> Ty {
 
     // Simplify
     match normalized.len() {
-        0 => Ty::Never, // Empty union is uninhabited (bottom type)
+        0 => Ty::Unknown, // Empty union becomes Unknown (could be Never in a more complete type system)
         1 => normalized.pop().unwrap(),
         _ => Ty::Union(normalized),
     }
@@ -346,7 +342,7 @@ mod tests {
     #[test]
     fn test_normalize_union_empty() {
         let result = normalize_union(vec![]);
-        assert_eq!(result, Ty::Never);
+        assert_eq!(result, Ty::Unknown);
     }
 
     #[test]
@@ -366,24 +362,5 @@ mod tests {
         let inner = Ty::Union(vec![Ty::Int, Ty::Float]);
         let result = normalize_union(vec![inner, Ty::String]);
         assert_eq!(result, Ty::Union(vec![Ty::Int, Ty::Float, Ty::String]));
-    }
-
-    #[test]
-    fn test_normalize_union_filters_never() {
-        let result = normalize_union(vec![Ty::Int, Ty::Never]);
-        assert_eq!(result, Ty::Int);
-    }
-
-    #[test]
-    fn test_normalize_union_all_never() {
-        let result = normalize_union(vec![Ty::Never, Ty::Never]);
-        assert_eq!(result, Ty::Never);
-    }
-
-    #[test]
-    fn test_normalize_union_never_in_nested() {
-        let inner = Ty::Union(vec![Ty::Never, Ty::String]);
-        let result = normalize_union(vec![inner, Ty::Never]);
-        assert_eq!(result, Ty::String);
     }
 }

--- a/baml_language/crates/baml_compiler_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler_tir/src/normalize.rs
@@ -64,7 +64,6 @@ enum StructuralTy {
     Unknown,
     Error,
     Void,
-    Never,
     Resource,
     /// Internal-only type for builtins - any type is assignable to it.
     BuiltinUnknown,
@@ -94,11 +93,6 @@ impl StructuralTy {
         if matches!(self, StructuralTy::Unknown | StructuralTy::Error)
             || matches!(other, StructuralTy::Unknown | StructuralTy::Error)
         {
-            return true;
-        }
-
-        // Never <: T  (bottom type is subtype of everything)
-        if matches!(self, StructuralTy::Never) {
             return true;
         }
 
@@ -295,7 +289,6 @@ fn is_valid_map_key_type(ty: &Ty, aliases: &HashMap<Name, Ty>) -> bool {
             StructuralTy::TyVar(_) => false,
             StructuralTy::Unknown => false,
             StructuralTy::Void => false,
-            StructuralTy::Never => false,
             StructuralTy::Resource => false,
             StructuralTy::BuiltinUnknown => false,
             StructuralTy::WatchAccessor(_) => false,
@@ -373,7 +366,6 @@ fn normalize_impl(
         Ty::Unknown => StructuralTy::Unknown,
         Ty::Error => StructuralTy::Error,
         Ty::Void => StructuralTy::Void,
-        Ty::Never => StructuralTy::Never,
         Ty::Resource => StructuralTy::Resource,
         Ty::BuiltinUnknown => StructuralTy::BuiltinUnknown,
         Ty::Type => StructuralTy::Type,
@@ -745,57 +737,6 @@ mod tests {
 
         // null <: ((int) -> string) | null
         assert!(is_subtype_of(&Ty::Null, &union, &aliases));
-    }
-
-    // ═══════════════════════════════════════════════════════════════════════
-    // NEVER SUBTYPING TESTS
-    // ═══════════════════════════════════════════════════════════════════════
-
-    #[test]
-    fn test_never_subtype_of_everything() {
-        let aliases = HashMap::new();
-
-        // Never <: T for all T
-        assert!(is_subtype_of(&Ty::Never, &Ty::Int, &aliases));
-        assert!(is_subtype_of(&Ty::Never, &Ty::String, &aliases));
-        assert!(is_subtype_of(&Ty::Never, &Ty::Bool, &aliases));
-        assert!(is_subtype_of(&Ty::Never, &Ty::Float, &aliases));
-        assert!(is_subtype_of(&Ty::Never, &Ty::Null, &aliases));
-        assert!(is_subtype_of(
-            &Ty::Never,
-            &Ty::List(Box::new(Ty::Int)),
-            &aliases
-        ));
-        assert!(is_subtype_of(
-            &Ty::Never,
-            &Ty::Optional(Box::new(Ty::String)),
-            &aliases
-        ));
-    }
-
-    #[test]
-    fn test_never_subtype_of_never() {
-        let aliases = HashMap::new();
-        // Reflexive
-        assert!(is_subtype_of(&Ty::Never, &Ty::Never, &aliases));
-    }
-
-    #[test]
-    fn test_inhabited_not_subtype_of_never() {
-        let aliases = HashMap::new();
-        // T </: Never for inhabited T
-        assert!(!is_subtype_of(&Ty::Int, &Ty::Never, &aliases));
-        assert!(!is_subtype_of(&Ty::String, &Ty::Never, &aliases));
-        assert!(!is_subtype_of(&Ty::Null, &Ty::Never, &aliases));
-    }
-
-    #[test]
-    fn test_never_in_union() {
-        let aliases = HashMap::new();
-        let union = Ty::Union(vec![Ty::Int, Ty::String]);
-
-        // Never <: int | string
-        assert!(is_subtype_of(&Ty::Never, &union, &aliases));
     }
 
     #[test]

--- a/baml_language/crates/baml_compiler_tir/src/types.rs
+++ b/baml_language/crates/baml_compiler_tir/src/types.rs
@@ -93,10 +93,6 @@ pub enum Ty {
     Error,
     /// The void/unit type for functions that return nothing.
     Void,
-    /// The bottom type — uninhabited, subtype of everything.
-    /// Used in streaming type expansion (e.g., `@stream.starts_as(never)`).
-    /// `T | never` simplifies to `T`.
-    Never,
 
     /// Opaque resource handle (file, socket, HTTP response body).
     Resource,
@@ -177,8 +173,6 @@ impl Ty {
         match self {
             // Error recovery: don't emit additional errors when type inference failed
             Ty::Unknown | Ty::Error => true,
-            // Bottom type is uninhabited by definition
-            Ty::Never => true,
             // Empty union has no members, therefore no possible values
             Ty::Union(types) => types.is_empty(),
             // All other types are inhabited
@@ -278,7 +272,6 @@ impl fmt::Display for Ty {
             Ty::Unknown => write!(f, "unknown"),
             Ty::Error => write!(f, "error"),
             Ty::Void => write!(f, "void"),
-            Ty::Never => write!(f, "never"),
             Ty::Resource => write!(f, "resource"),
             Ty::BuiltinUnknown => write!(f, "unknown"),
             Ty::WatchAccessor(inner) => write!(f, "{inner}.$watch"),

--- a/baml_language/crates/baml_type/src/convert.rs
+++ b/baml_language/crates/baml_type/src/convert.rs
@@ -142,7 +142,6 @@ pub fn convert_tir_ty(
         // baml_type, these just mean "no meaningful type" → map to Null.
         baml_compiler_tir::Ty::Unknown => Ok(Ty::Null),
         baml_compiler_tir::Ty::Error => Ok(Ty::Null),
-        baml_compiler_tir::Ty::Never => Ok(Ty::Never),
         baml_compiler_tir::Ty::Void => Ok(Ty::Void),
         baml_compiler_tir::Ty::Resource => Ok(Ty::resource()),
         // BuiltinUnknown is preserved for VIR type checking at call sites.
@@ -163,9 +162,8 @@ pub fn convert_tir_ty(
 pub fn sanitize_for_runtime(ty: Ty) -> Result<Ty, String> {
     match ty {
         // Compiler-only → Null (preserves backwards compatibility)
-        // Note: Unknown/Error don't exist in baml_type::Ty — they were
-        // already mapped to Null during convert_tir_ty.
-        // Never passes through (it's a valid runtime type for streaming).
+        // Note: Unknown/Error/Never don't exist in baml_type::Ty — they were
+        // already mapped to Null/Void during convert_tir_ty.
         Ty::Void => Ok(Ty::Null),
         Ty::BuiltinUnknown => Ok(Ty::BuiltinUnknown),
         Ty::Function { params, ret } => Ok(Ty::Function {

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -82,10 +82,6 @@ pub enum Ty {
     String,
     Bool,
     Null,
-    /// The bottom type — uninhabited.
-    /// Used in streaming type expansion. `T | never → T`.
-    /// A field whose stream type is `never` is omitted entirely.
-    Never,
     Media(MediaKind),
     Literal(Literal),
     Class(TypeName),
@@ -143,14 +139,13 @@ pub enum Ty {
     BuiltinUnknown,
 }
 
-// NOTE: `Unknown` and `Error` are intentionally excluded from this enum.
-// They are TIR-only error recovery types, mapped to `Null` during TIR→baml_type
-// conversion in `convert_tir_ty`. All real type checking happens in TIR (which
-// keeps its own Ty), so VIR+ stages don't need these for error recovery.
-//
-// `Never` IS included — it's the bottom type used by the streaming type system
-// (e.g., `@stream.starts_as(never)`, `@stream.type(never)`). It can appear in
-// `ClassField.field_type` at runtime.
+// NOTE: `Unknown`, `Error`, and `Never` are intentionally excluded from this enum.
+// - Unknown/Error are TIR-only error recovery types. They are mapped to `Null` during
+//   TIR→baml_type conversion in `convert_tir_ty`. All real type checking happens in TIR
+//   (which keeps its own Ty), so VIR+ stages don't need these for error recovery.
+// - Never is a VIR-only bottom type for diverging expressions (return/break/continue).
+//   MIR already collapsed Never→Void via control flow terminators. VIR lowering now
+//   produces `Void` directly instead of `Never`.
 
 impl Ty {
     // --- Opaque type constructors ---
@@ -232,19 +227,13 @@ impl Ty {
     /// Returns true if `self` can be used where `other` is expected.
     /// Ported from VIR `ty.rs:93-140` with literal subtyping rules.
     ///
-    /// Note: Unknown/Error handling is not needed here because:
+    /// Note: Unknown/Error/Never handling is not needed here because:
     /// - Unknown/Error are mapped to Null during TIR→baml_type conversion
+    /// - Never is mapped to Void during VIR lowering
     /// - All real type checking (where those variants matter) happens in TIR
-    ///
-    /// Never IS handled: it's the bottom type, subtype of everything.
     pub fn is_subtype_of(&self, other: &Ty) -> bool {
         // Same types are subtypes
         if self == other {
-            return true;
-        }
-
-        // Never <: T (bottom type is subtype of everything)
-        if matches!(self, Ty::Never) {
             return true;
         }
 
@@ -338,7 +327,6 @@ impl Ty {
             | Ty::String
             | Ty::Bool
             | Ty::Null
-            | Ty::Never
             | Ty::Media(_)
             | Ty::Literal(_)
             | Ty::Class(_)
@@ -382,7 +370,6 @@ impl fmt::Display for Ty {
                     .collect();
                 write!(f, "({}) -> {}", param_strs.join(", "), ret)
             }
-            Ty::Never => write!(f, "never"),
             Ty::Void => write!(f, "void"),
             Ty::WatchAccessor(inner) => write!(f, "{inner}.$watch"),
             Ty::BuiltinUnknown => write!(f, "unknown"),

--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -292,7 +292,6 @@ fn ty_to_field_type(ty: &Ty) -> BamlFieldType {
         }
         Ty::TypeAlias(_)
         | Ty::Function { .. }
-        | Ty::Never
         | Ty::Void
         | Ty::WatchAccessor(_)
         | Ty::BuiltinUnknown => unreachable!("compiler-only variant should not reach FFI"),

--- a/baml_language/crates/sys_llm/src/types/output_format.rs
+++ b/baml_language/crates/sys_llm/src/types/output_format.rs
@@ -196,9 +196,6 @@ impl OutputFormatContent {
             // - Bool: true/false
             Ty::Literal(lit) => Ok(Some(render_literal(lit))),
 
-            // Never is uninhabited — no value to render in the output format.
-            Ty::Never => Ok(None),
-
             // Runtime-only variants that shouldn't appear in LLM prompts
             Ty::Opaque(tn) => Err(RenderError::UnsupportedType(tn.to_string())),
 


### PR DESCRIPTION
This reverts commit 608545a0af33f9427faab9720a7678cdbe80e6c9.

See https://beps.boundaryml.com/beps/6/pages/never-in-vir, or more specifically

```
let t: Type = ...;
print(t)
match t {
  type(int) => 
  ..
  // users should never have to write this arm
  type(never) => 
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `Never` type variant from the type system across all compiler layers.
  * Updated type normalization logic to handle empty unions differently; now resolves to `Unknown` instead of `Never`.
  * Simplified type conversion and subtyping behavior by eliminating bottom-type handling for `Never`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->