### PR TITLE
Remove inlay hints on compiler-generated functions and add parameter name heuristic

### DIFF
--- a/baml_language/crates/baml_compiler_hir/src/body.rs
+++ b/baml_language/crates/baml_compiler_hir/src/body.rs
@@ -2229,7 +2229,10 @@ impl LoweringContext {
             .map(|token| Name::new(token.text()))
             .unwrap_or_else(|| Name::new(""));
 
-        self.alloc_expr(Expr::FieldAccess { base, field }, node.text_range())
+        self.alloc_expr(
+            Expr::FieldAccess { base, field },
+            Self::text_range_skip_trivia(node),
+        )
     }
 
     /// Lower an `ENV_ACCESS_EXPR` to a desugared call.
@@ -2372,7 +2375,7 @@ impl LoweringContext {
             return self.alloc_expr(Expr::Missing, node.text_range());
         }
 
-        self.alloc_expr(Expr::Path(segments), node.text_range())
+        self.alloc_expr(Expr::Path(segments), Self::text_range_skip_trivia(node))
     }
 
     fn lower_string_literal(&mut self, node: &baml_compiler_syntax::SyntaxNode) -> ExprId {

--- a/baml_language/crates/baml_lsp_actions/src/inlay_hints.rs
+++ b/baml_language/crates/baml_lsp_actions/src/inlay_hints.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use baml_db::{
     SourceFile,
     baml_compiler_hir::{
-        ExprBody, FunctionBody, HirSourceMap, ItemId, LetOrigin, Stmt, SymbolTable, file_items,
-        function_body, symbol_table,
+        ExprBody, FunctionBody, HirSourceMap, ItemId, LetOrigin, Stmt, SymbolTable, file_item_tree,
+        file_items, function_body, symbol_table,
     },
     baml_compiler_tir::{self, InferenceResult, Ty},
     baml_workspace::Project,
@@ -236,6 +236,20 @@ fn collect_call_arg_names(ctx: &HintContext<'_>, hints: &mut Vec<InlayHint>) {
             let Some((Some(name), _)) = params.get(i) else {
                 continue;
             };
+
+            // Skip hint when the argument's final path segment matches or
+            // contains the parameter name (e.g. `foo(bar)` or `foo(obj.bar)`
+            // where the param is `bar`, or `foo(my_bar)` containing `bar`).
+            if let Expr::Path(segments) = &ctx.body.exprs[*arg_id] {
+                if let Some(last) = segments.last() {
+                    let last = last.as_str();
+                    let param = name.as_str();
+                    if last.contains(param) {
+                        continue;
+                    }
+                }
+            }
+
             let Some(arg_span) = ctx.source_map.expr_span(*arg_id) else {
                 continue;
             };
@@ -344,6 +358,14 @@ pub fn inlay_hints(db: &ProjectDatabase, file: SourceFile, project: Project) -> 
         let ItemId::Function(func_loc) = item_id else {
             continue;
         };
+
+        // Skip compiler-generated functions (e.g. client resolve, LLM helpers).
+        let file = func_loc.file(db);
+        let item_tree = file_item_tree(db, file);
+        let func = &item_tree[func_loc.id(db)];
+        if func.compiler_generated.is_some() {
+            continue;
+        }
 
         let body = function_body(db, *func_loc);
         let FunctionBody::Expr(expr_body, source_map) = &*body else {

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/inlay_hints/call_arg_names.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/inlay_hints/call_arg_names.baml
@@ -26,6 +26,55 @@ function qux() -> string {
   g("Delta", 30)
 }
 
+// Hint suppressed when arg name matches param name.
+function same_name(name string) -> string {
+  let name = "Alice";
+  greet(name, 30)
+}
+
+// Hint suppressed when arg's final path segment contains param name.
+function contains_name(my_name string) -> string {
+  let my_name = "Bob";
+  greet(my_name, 30)
+}
+
+// Hint NOT suppressed when arg name doesn't match.
+function different_name(x string) -> string {
+  let x = "Charlie";
+  greet(x, 30)
+}
+
+class Info {
+  name string
+  age int
+}
+
+// Hint suppressed when final segment of field access matches param name.
+function field_access(info Info) -> string {
+  greet(info.name, info.age)
+}
+
+// Multi-line call: hints appear on the correct line for each argument.
+function multiline() -> string {
+  greet(
+    "Eve",
+    42
+  )
+}
+
+class Info2 {
+    n string
+    a int
+}
+
+// Multi-line call with field access args.
+function multiline_field(info Info2) -> string {
+  greet(
+    info.n,
+    info.a
+  )
+}
+
 //----
 //- diagnostics
 // <no-diagnostics-expected>
@@ -38,3 +87,17 @@ function qux() -> string {
 // call_arg_names.baml:12:5 (Parameter) "name:"
 // call_arg_names.baml:12:12 (Parameter) "age:"
 // call_arg_names.baml:26:5 (Parameter) "c:"
+// call_arg_names.baml:31:11 (Type) ": string"
+//   edit@31:11 ": string"
+// call_arg_names.baml:32:15 (Parameter) "age:"
+// call_arg_names.baml:37:14 (Type) ": string"
+//   edit@37:14 ": string"
+// call_arg_names.baml:38:18 (Parameter) "age:"
+// call_arg_names.baml:43:8 (Type) ": string"
+//   edit@43:8 ": string"
+// call_arg_names.baml:44:9 (Parameter) "name:"
+// call_arg_names.baml:44:12 (Parameter) "age:"
+// call_arg_names.baml:60:5 (Parameter) "name:"
+// call_arg_names.baml:61:5 (Parameter) "age:"
+// call_arg_names.baml:73:5 (Parameter) "name:"
+// call_arg_names.baml:74:5 (Parameter) "age:"

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/inlay_hints/no_hints.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/inlay_hints/no_hints.baml
@@ -23,6 +23,14 @@ function foo() -> string {
   x
 }
 
+// client blocks are desugared into functions; no hints should appear
+client<llm> GPT4 {
+    provider openai
+    options {
+        model "gpt-4"
+    }
+}
+
 //----
 //- diagnostics
 // <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/expr/builtin.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/expr/builtin.baml
@@ -41,29 +41,28 @@ function GetTodoMissingTypeArg() -> Todo {
 //----
 //- diagnostics
 // Error: Unknown variable `baml`
-//     ╭─[ expr_builtin.baml:15:43 ]
+//     ╭─[ expr_builtin.baml:16:3 ]
 //     │
-//  15 │ ╭─▶ function GetTodoMissingTypeArg() -> Todo {
-//  16 │ ├─▶   baml.fetch_as(baml.HttpRequest {
-//     │ │                                        
-//     │ ╰──────────────────────────────────────── Unknown variable `baml`
-//     │     
-//     │     Note: Error code: E0003
+//  16 │   baml.fetch_as(baml.HttpRequest {
+//     │   ──────┬──────  
+//     │         ╰──────── Unknown variable `baml`
+//     │ 
+//     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable `baml`
-//     ╭─[ expr_builtin.baml:17:12 ]
+//     ╭─[ expr_builtin.baml:17:13 ]
 //     │
 //  17 │     method: baml.HttpMethod.Get,
-//     │            ──────────┬─────────  
+//     │             ─────────┬─────────  
 //     │                      ╰─────────── Unknown variable `baml`
 //     │ 
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable `baml`
-//     ╭─[ expr_builtin.baml:10:12 ]
+//     ╭─[ expr_builtin.baml:10:13 ]
 //     │
 //  10 │     method: baml.HttpMethod.Get,
-//     │            ──────────┬─────────  
+//     │             ─────────┬─────────  
 //     │                      ╰─────────── Unknown variable `baml`
 //     │ 
 //     │ Note: Error code: E0003

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__05_diagnostics.snap
@@ -349,44 +349,39 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-    ╭─[ chain_expr.baml:83:6 ]
+    ╭─[ chain_expr.baml:86:5 ]
     │
- 83 │ ╭─▶     ;
-    ┆ ┆   
- 86 │ ├─▶     user.name.len();
-    │ │                          
-    │ ╰────────────────────────── Type `string` has no field `len`
-    │     
-    │     Note: Error code: E0007
+ 86 │     user.name.len();
+    │     ──────┬──────  
+    │           ╰──────── Type `string` has no field `len`
+    │ 
+    │ Note: Error code: E0007
 ────╯
 
   [type] Error: Type `ChainItem[]` has no field `len`
-    ╭─[ chain_expr.baml:86:21 ]
+    ╭─[ chain_expr.baml:87:5 ]
     │
- 86 │ ╭─▶     user.name.len();
- 87 │ ├─▶     items.len();
-    │ │                      
-    │ ╰────────────────────── Type `ChainItem[]` has no field `len`
-    │     
-    │     Note: Error code: E0007
+ 87 │     items.len();
+    │     ────┬────  
+    │         ╰────── Type `ChainItem[]` has no field `len`
+    │ 
+    │ Note: Error code: E0007
 ────╯
 
   [type] Error: Type `ChainItem[]` has no field `get`
-    ╭─[ chain_expr.baml:87:17 ]
+    ╭─[ chain_expr.baml:90:5 ]
     │
- 87 │ ╭─▶     items.len();
-    ┆ ┆   
- 90 │ ├─▶     user.profile.items.get(0);
-    │ │                                    
-    │ ╰──────────────────────────────────── Type `ChainItem[]` has no field `get`
-    │     
-    │     Note: Error code: E0007
+ 90 │     user.profile.items.get(0);
+    │     ───────────┬──────────  
+    │                ╰──────────── Type `ChainItem[]` has no field `get`
+    │ 
+    │ Note: Error code: E0007
 ────╯
 
   [type] Error: Type `ChainItem[]` has no field `get`
-    ╭─[ chain_expr.baml:90:31 ]
+    ╭─[ chain_expr.baml:94:5 ]
     │
- 90 │ ╭─▶     user.profile.items.get(0);
+ 94 │ ╭─▶     items // 2 callee trailing
     ┆ ┆   
  98 │ ├─▶     get // 6 method trailing
     │ │                                  
@@ -396,9 +391,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ────╯
 
   [type] Error: Type `ChainItem[]` has no field `get`
-     ╭─[ chain_expr.baml:104:6 ]
+     ╭─[ chain_expr.baml:108:5 ]
      │
- 104 │ ╭─▶     ;
+ 108 │ ╭─▶     items /* 2 callee trailing */
      ┆ ┆   
  112 │ ├─▶     get /* 6 method trailing */
      │ │                                     
@@ -408,1959 +403,1633 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:146:6 ]
+     ╭─[ chain_expr.baml:149:5 ]
      │
- 146 │ ╭─▶     ;
-     ┆ ┆   
- 149 │ ├─▶     user.name.len().to_string();
-     │ │                                      
-     │ ╰────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 149 │     user.name.len().to_string();
+     │     ──────┬──────  
+     │           ╰──────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:146:6 ]
+     ╭─[ chain_expr.baml:149:5 ]
      │
- 146 │ ╭─▶     ;
-     ┆ ┆   
- 149 │ ├─▶     user.name.len().to_string();
-     │ │                                      
-     │ ╰────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 149 │     user.name.len().to_string();
+     │     ──────┬──────  
+     │           ╰──────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:149:33 ]
+     ╭─[ chain_expr.baml:152:5 ]
      │
- 149 │ ╭─▶     user.name.len().to_string();
-     ┆ ┆   
- 152 │ ├─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                                          
-     │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 152 │     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬─────────────────────  
+     │                          ╰─────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:152:117 ]
+     ╭─[ chain_expr.baml:155:5 ]
      │
- 152 │ ╭─▶     user.profile.settings.preferences.color.len().to_string().len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 155 │ ├─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     │ │                                                                                                       
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 155 │     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
+     │     ─────────────────────┬────────────────────  
+     │                          ╰────────────────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `get`
-     ╭─[ chain_expr.baml:155:98 ]
+     ╭─[ chain_expr.baml:158:5 ]
      │
- 155 │ ╭─▶     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
-     ┆ ┆   
- 158 │ ├─▶     user.profile.items.get(user.profile.items.len() - 1 + user.profile.items.len() - 2 + user.profile.items.len() - 3).label;
-     │ │                                                                                                                                   
-     │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `ChainItem[]` has no field `get`
-     │     
-     │     Note: Error code: E0007
+ 158 │     user.profile.items.get(user.profile.items.len() - 1 + user.profile.items.len() - 2 + user.profile.items.len() - 3).label;
+     │     ───────────┬──────────  
+     │                ╰──────────── Type `ChainItem[]` has no field `get`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `len`
@@ -2374,51 +2043,49 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `len`
-     ╭─[ chain_expr.baml:158:58 ]
+     ╭─[ chain_expr.baml:158:59 ]
      │
  158 │     user.profile.items.get(user.profile.items.len() - 1 + user.profile.items.len() - 2 + user.profile.items.len() - 3).label;
-     │                                                          ───────────┬───────────  
-     │                                                                     ╰───────────── Type `ChainItem[]` has no field `len`
+     │                                                           ───────────┬──────────  
+     │                                                                      ╰──────────── Type `ChainItem[]` has no field `len`
      │ 
      │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `len`
-     ╭─[ chain_expr.baml:158:89 ]
+     ╭─[ chain_expr.baml:158:90 ]
      │
  158 │     user.profile.items.get(user.profile.items.len() - 1 + user.profile.items.len() - 2 + user.profile.items.len() - 3).label;
-     │                                                                                         ───────────┬───────────  
-     │                                                                                                    ╰───────────── Type `ChainItem[]` has no field `len`
+     │                                                                                          ───────────┬──────────  
+     │                                                                                                     ╰──────────── Type `ChainItem[]` has no field `len`
      │ 
      │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `slice`
-     ╭─[ chain_expr.baml:158:126 ]
+     ╭─[ chain_expr.baml:161:5 ]
      │
- 158 │ ╭─▶     user.profile.items.get(user.profile.items.len() - 1 + user.profile.items.len() - 2 + user.profile.items.len() - 3).label;
-     ┆ ┆   
- 161 │ ├─▶     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
-     │ │                                                                                                            
-     │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────── Type `ChainItem[]` has no field `slice`
-     │     
-     │     Note: Error code: E0007
+ 161 │     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
+     │     ────────────┬───────────  
+     │                 ╰───────────── Type `ChainItem[]` has no field `slice`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `len`
-     ╭─[ chain_expr.baml:161:32 ]
+     ╭─[ chain_expr.baml:161:33 ]
      │
  161 │     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
-     │                                ───────────┬───────────  
-     │                                           ╰───────────── Type `ChainItem[]` has no field `len`
+     │                                 ───────────┬──────────  
+     │                                            ╰──────────── Type `ChainItem[]` has no field `len`
      │ 
      │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:161:103 ]
+     ╭─[ chain_expr.baml:165:5 ]
      │
- 161 │ ╭─▶     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
+ 165 │ ╭─▶     user // 2 trailing
      ┆ ┆   
  180 │ ├─▶     len // 17 trailing
      │ │                            
@@ -2428,9 +2095,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:161:103 ]
+     ╭─[ chain_expr.baml:165:5 ]
      │
- 161 │ ╭─▶     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
+ 165 │ ╭─▶     user // 2 trailing
      ┆ ┆   
  180 │ ├─▶     len // 17 trailing
      │ │                            
@@ -2440,9 +2107,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:161:103 ]
+     ╭─[ chain_expr.baml:165:5 ]
      │
- 161 │ ╭─▶     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
+ 165 │ ╭─▶     user // 2 trailing
      ┆ ┆   
  180 │ ├─▶     len // 17 trailing
      │ │                            
@@ -2452,9 +2119,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:161:103 ]
+     ╭─[ chain_expr.baml:165:5 ]
      │
- 161 │ ╭─▶     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
+ 165 │ ╭─▶     user // 2 trailing
      ┆ ┆   
  180 │ ├─▶     len // 17 trailing
      │ │                            
@@ -2464,9 +2131,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:193:6 ]
+     ╭─[ chain_expr.baml:197:5 ]
      │
- 193 │ ╭─▶     ;
+ 197 │ ╭─▶     user /* 2 trailing */
      ┆ ┆   
  212 │ ├─▶     len /* 17 trailing */
      │ │                               
@@ -2476,9 +2143,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:193:6 ]
+     ╭─[ chain_expr.baml:197:5 ]
      │
- 193 │ ╭─▶     ;
+ 197 │ ╭─▶     user /* 2 trailing */
      ┆ ┆   
  212 │ ├─▶     len /* 17 trailing */
      │ │                               
@@ -2488,9 +2155,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:193:6 ]
+     ╭─[ chain_expr.baml:197:5 ]
      │
- 193 │ ╭─▶     ;
+ 197 │ ╭─▶     user /* 2 trailing */
      ┆ ┆   
  212 │ ├─▶     len /* 17 trailing */
      │ │                               
@@ -2500,9 +2167,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:193:6 ]
+     ╭─[ chain_expr.baml:197:5 ]
      │
- 193 │ ╭─▶     ;
+ 197 │ ╭─▶     user /* 2 trailing */
      ┆ ┆   
  212 │ ├─▶     len /* 17 trailing */
      │ │                               
@@ -2512,9 +2179,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `get`
-     ╭─[ chain_expr.baml:225:6 ]
+     ╭─[ chain_expr.baml:229:5 ]
      │
- 225 │ ╭─▶     ;
+ 229 │ ╭─▶     user // 2 trailing
      ┆ ┆   
  238 │ ├─▶     get // 11 trailing
      │ │                            
@@ -2524,23 +2191,21 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `len`
-     ╭─[ chain_expr.baml:239:6 ]
+     ╭─[ chain_expr.baml:241:5 ]
      │
- 239 │ ╭─▶     ( // 12 trailing
-     ┆ ┆   
- 241 │ ├─▶     user.profile.items.len() - 1 + user.profile.items.len() - 2 // 14 trailing
-     │ │                                                                                    
-     │ ╰──────────────────────────────────────────────────────────────────────────────────── Type `ChainItem[]` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 241 │     user.profile.items.len() - 1 + user.profile.items.len() - 2 // 14 trailing
+     │     ───────────┬──────────  
+     │                ╰──────────── Type `ChainItem[]` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `len`
-     ╭─[ chain_expr.baml:241:35 ]
+     ╭─[ chain_expr.baml:241:36 ]
      │
  241 │     user.profile.items.len() - 1 + user.profile.items.len() - 2 // 14 trailing
-     │                                   ───────────┬───────────  
-     │                                              ╰───────────── Type `ChainItem[]` has no field `len`
+     │                                    ───────────┬──────────  
+     │                                               ╰──────────── Type `ChainItem[]` has no field `len`
      │ 
      │ Note: Error code: E0007
 ─────╯
@@ -2566,37 +2231,33 @@ source: crates/baml_tests/src/generated_tests.rs
 ─────╯
 
   [type] Error: Type `ChainItem[]` has no field `get`
-     ╭─[ chain_expr.baml:255:20 ]
+     ╭─[ chain_expr.baml:256:5 ]
      │
- 255 │ ╭─▶     items  [  0  ];
- 256 │ ├─▶     items  .  get  (  0  );
-     │ │                                 
-     │ ╰───────────────────────────────── Type `ChainItem[]` has no field `get`
-     │     
-     │     Note: Error code: E0007
+ 256 │     items  .  get  (  0  );
+     │     ──────┬──────  
+     │           ╰──────── Type `ChainItem[]` has no field `get`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:256:28 ]
+     ╭─[ chain_expr.baml:259:5 ]
      │
- 256 │ ╭─▶     items  .  get  (  0  );
-     ┆ ┆   
- 259 │ ├─▶     user.tags[0].len();
-     │ │                             
-     │ ╰───────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 259 │     user.tags[0].len();
+     │     ────────┬───────  
+     │             ╰───────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Type `string` has no field `len`
-     ╭─[ chain_expr.baml:260:23 ]
+     ╭─[ chain_expr.baml:261:5 ]
      │
- 260 │ ╭─▶     user.scores[0][0];
- 261 │ ├─▶     items[0].label.len();
-     │ │                               
-     │ ╰─────────────────────────────── Type `string` has no field `len`
-     │     
-     │     Note: Error code: E0007
+ 261 │     items[0].label.len();
+     │     ─────────┬────────  
+     │              ╰────────── Type `string` has no field `len`
+     │ 
+     │ Note: Error code: E0007
 ─────╯
 
   [type] Error: Expected `(x: int) -> (y: int) -> (z: int) -> (w: int) -> map<string, int | string | bool>`, found `int`

--- a/baml_language/crates/baml_tests/snapshots/generics/baml_tests__generics__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/generics/baml_tests__generics__05_diagnostics.snap
@@ -3,10 +3,10 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === DIAGNOSTICS ===
   [type] Error: Unknown variable `baml`
-    ╭─[ fetch_as.baml:10:16 ]
+    ╭─[ fetch_as.baml:10:17 ]
     │
  10 │         method: baml.HttpMethod.Get,
-    │                ──────────┬─────────  
+    │                 ─────────┬─────────  
     │                          ╰─────────── Unknown variable `baml`
     │ 
     │ Note: Error code: E0003


### PR DESCRIPTION
Previously inlay hints would be generated for compiler-generated functions, leading to nonsensical inlay hints in `client` blocks. Now compiler generated functions are skipped in the hint.

Additionally, a heuristic for call arg inlay hints has been added. If the passed expression is a path or field access where the final segment contains the parameter name, the hint will not appear.

A minor bug with multi-line call args inlay hints appearing on the wrong line has also been fixed by adjusting span lowering for paths and field expressions to HIR to not include trivia tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inlay hints to skip compiler-generated functions, reducing visual clutter in the editor.
  * Enhanced inlay hint filtering to avoid redundant parameter name hints when the name already appears in the argument path.

* **Tests**
  * Added test cases for inlay hints covering parameter name matching and field access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->