### PR TITLE
baml-language: add attributes to Ty, to allow modelling @sap.in_progress(value)

### DIFF
--- a/baml_language/crates/baml_base/src/lib.rs
+++ b/baml_language/crates/baml_base/src/lib.rs
@@ -6,9 +6,11 @@ pub mod core_types;
 pub mod debug_log;
 pub mod files;
 pub mod qualified_name;
+pub mod sap;
 
 // Re-export everything for convenience
 pub use core_types::*;
 pub use debug_log::{DebugMessage, drain_debug_log, has_debug_messages};
 pub use files::*;
 pub use qualified_name::{BAML_STD_PREFIX, Namespace, QualifiedName};
+pub use sap::*;

--- a/baml_language/crates/baml_base/src/sap.rs
+++ b/baml_language/crates/baml_base/src/sap.rs
@@ -1,0 +1,154 @@
+//! SAP (Streaming Annotation Protocol) attribute types.
+//!
+//! These types represent compiler-internal streaming annotations that are
+//! populated by Phase 3 (stream type generation) and consumed by the
+//! deserializer at runtime.
+//!
+//! # Compact representation
+//!
+//! `TyAttr` and `FieldAttr` use `Option<Box<...>>` internally so that the
+//! common default case is a single null pointer (8 bytes) with no heap
+//! allocation. Non-default attributes (populated by Phase 3) are
+//! heap-allocated. This keeps the `Ty` enum small enough to avoid stack
+//! overflows in deeply recursive type operations.
+
+/// A SAP attribute value. Shared across all three attributes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SapAttrValue {
+    /// Use the default behavior for this type/field.
+    ///
+    /// What "default" means depends on which attribute this appears in:
+    /// - `sap_in_progress`: type streams normally (partial values visible as they arrive)
+    /// - `sap_on_error`: type uses its natural error fallback
+    /// - `sap_missing`: field uses default missing behavior
+    DefaultForType,
+
+    /// The bottom value — semantics depend on which attribute:
+    /// - `sap_in_progress(never)`: type has no in-progress representation
+    ///   (only appears when complete)
+    /// - `sap_on_error(never)`: errors are not recoverable — propagate failure
+    /// - `sap_missing(never)`: field is absent until streaming begins
+    Never,
+
+    /// A constant value expression (literal, null, empty container, etc.)
+    ConstValueExpr(SapConstValue),
+}
+
+/// A constant value for SAP annotations.
+///
+/// These are the values that can appear in @sap.missing("Loading..."),
+/// @`sap.on_error(0)`, etc.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SapConstValue {
+    Null,
+    String(String),
+    Int(i64),
+    Float(String), // String to avoid f64 Eq/Hash issues
+    Bool(bool),
+    EmptyList,
+    EmptyMap,
+}
+
+/// Non-default type attributes (heap-allocated).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TyAttrInner {
+    sap_in_progress: SapAttrValue,
+    sap_on_error: SapAttrValue,
+}
+
+/// Attributes intrinsic to a type expression.
+///
+/// Carried on every `Ty` variant from HIR through runtime.
+/// Describes how values of this type behave during streaming and on error.
+///
+/// Default values are represented as `None` (8 bytes, no allocation).
+/// Non-default values are heap-allocated behind a `Box`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct TyAttr(Option<Box<TyAttrInner>>);
+
+impl TyAttr {
+    /// Returns true if all attributes are at their default values.
+    pub fn is_default(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// The value this type takes while it is still being streamed.
+    /// `Never` means the type has no in-progress representation — it only
+    /// appears when fully parsed.
+    pub fn sap_in_progress(&self) -> &SapAttrValue {
+        self.0
+            .as_ref()
+            .map_or(&SapAttrValue::DefaultForType, |inner| {
+                &inner.sap_in_progress
+            })
+    }
+
+    /// The fallback value for this type when a parse error occurs during
+    /// streaming. `Never` means errors are not recoverable.
+    pub fn sap_on_error(&self) -> &SapAttrValue {
+        self.0
+            .as_ref()
+            .map_or(&SapAttrValue::DefaultForType, |inner| &inner.sap_on_error)
+    }
+
+    /// Construct a `TyAttr` from explicit values.
+    ///
+    /// Returns the compact default representation when both values are
+    /// `DefaultForType`.
+    pub fn new(sap_in_progress: SapAttrValue, sap_on_error: SapAttrValue) -> Self {
+        if sap_in_progress == SapAttrValue::DefaultForType
+            && sap_on_error == SapAttrValue::DefaultForType
+        {
+            TyAttr(None)
+        } else {
+            TyAttr(Some(Box::new(TyAttrInner {
+                sap_in_progress,
+                sap_on_error,
+            })))
+        }
+    }
+}
+
+/// Non-default field attributes (heap-allocated).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FieldAttrInner {
+    sap_missing: SapAttrValue,
+}
+
+/// Attributes intrinsic to a field (not its type).
+///
+/// Carried on field definitions. Describes what happens when the field's
+/// key is absent from the partial JSON object during streaming.
+///
+/// Default values are represented as `None` (8 bytes, no allocation).
+/// Non-default values are heap-allocated behind a `Box`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct FieldAttr(Option<Box<FieldAttrInner>>);
+
+impl FieldAttr {
+    /// Returns true if all attributes are at their default values.
+    pub fn is_default(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// The value of this field before it begins streaming (when the
+    /// field's JSON key is absent from the partial object).
+    /// `Never` means the field is absent until it starts.
+    pub fn sap_missing(&self) -> &SapAttrValue {
+        self.0
+            .as_ref()
+            .map_or(&SapAttrValue::DefaultForType, |inner| &inner.sap_missing)
+    }
+
+    /// Construct a `FieldAttr` from an explicit value.
+    ///
+    /// Returns the compact default representation when the value is
+    /// `DefaultForType`.
+    pub fn new(sap_missing: SapAttrValue) -> Self {
+        if sap_missing == SapAttrValue::DefaultForType {
+            FieldAttr(None)
+        } else {
+            FieldAttr(Some(Box::new(FieldAttrInner { sap_missing })))
+        }
+    }
+}

--- a/baml_language/crates/baml_builtins_macros/src/codegen_accessors.rs
+++ b/baml_language/crates/baml_builtins_macros/src/codegen_accessors.rs
@@ -103,8 +103,8 @@ fn gen_as_bex_external_field(field: &AccessorFieldDef) -> (Option<TokenStream2>,
         FieldTypeKind::MapStringString => {
             let binding = quote! {
                 let #name = BexExternalValue::Map {
-                    key_type: bex_external_types::Ty::String,
-                    value_type: bex_external_types::Ty::String,
+                    key_type: bex_external_types::Ty::String { attr: baml_type::TyAttr::default() },
+                    value_type: bex_external_types::Ty::String { attr: baml_type::TyAttr::default() },
                     entries: self.#name
                         .into_iter()
                         .map(|(k, v)| (k, BexExternalValue::String(v)))
@@ -117,8 +117,8 @@ fn gen_as_bex_external_field(field: &AccessorFieldDef) -> (Option<TokenStream2>,
         FieldTypeKind::MapStringUnknown => {
             let binding = quote! {
                 let #name = BexExternalValue::Map {
-                    key_type: bex_external_types::Ty::String,
-                    value_type: bex_external_types::Ty::BuiltinUnknown,
+                    key_type: bex_external_types::Ty::String { attr: baml_type::TyAttr::default() },
+                    value_type: bex_external_types::Ty::BuiltinUnknown { attr: baml_type::TyAttr::default() },
                     entries: self.#name,
                 };
             };
@@ -128,7 +128,7 @@ fn gen_as_bex_external_field(field: &AccessorFieldDef) -> (Option<TokenStream2>,
         FieldTypeKind::ArrayString => {
             let binding = quote! {
                 let #name = BexExternalValue::Array {
-                    element_type: bex_external_types::Ty::String,
+                    element_type: bex_external_types::Ty::String { attr: baml_type::TyAttr::default() },
                     items: self.#name
                         .into_iter()
                         .map(BexExternalValue::String)
@@ -148,7 +148,7 @@ fn gen_as_bex_external_field(field: &AccessorFieldDef) -> (Option<TokenStream2>,
         FieldTypeKind::ArrayBuiltinStruct(_) => {
             let binding = quote! {
                 let #name = BexExternalValue::Array {
-                    element_type: bex_external_types::Ty::BuiltinUnknown,
+                    element_type: bex_external_types::Ty::BuiltinUnknown { attr: baml_type::TyAttr::default() },
                     items: self.#name
                         .into_iter()
                         .map(AsBexExternalValue::into_bex_external_value)

--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -258,7 +258,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             Place::Field { base, field } => {
                 let base_ty = self.resolve_place_type(base)?;
                 match &base_ty {
-                    Ty::Class(type_name) => {
+                    Ty::Class(type_name, _) => {
                         let &obj_idx = self
                             .class_object_indices
                             .get(type_name.display_name.as_str())?;
@@ -275,7 +275,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             Place::Index { base, .. } => {
                 let base_ty = self.resolve_place_type(base)?;
                 match base_ty {
-                    Ty::List(inner) => Some(*inner),
+                    Ty::List(inner, _) => Some(*inner),
                     Ty::Map { value, .. } => Some(*value),
                     _ => None,
                 }
@@ -409,7 +409,9 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             span: mir.span.unwrap_or_else(Span::fake),
             block_notifications: self.block_notifications,
             viz_nodes,
-            return_type: baml_type::Ty::Null,
+            return_type: baml_type::Ty::Null {
+                attr: baml_type::TyAttr::default(),
+            },
             param_names: Vec::new(),
             param_types: Vec::new(),
             body_meta: None,
@@ -1639,7 +1641,7 @@ impl PullSink for StackifyCodegen<'_, '_> {
 
     fn is_type(&mut self, ty: &Ty) -> Result<(), Self::Error> {
         // Emit instanceof check using CmpOp::InstanceOf for class aliases.
-        if let Ty::Class(tn) | Ty::TypeAlias(tn) = ty {
+        if let Ty::Class(tn, _) | Ty::TypeAlias(tn, _) = ty {
             let class_name_str = tn.display_name.as_str();
             if let Some(&class_obj_idx) = self.class_object_indices.get(class_name_str) {
                 let class_const =
@@ -1667,7 +1669,7 @@ impl PullSink for StackifyCodegen<'_, '_> {
 
     fn resolve_field_name(&self, base: &Place, field_idx: usize) -> String {
         let class_name = match self.resolve_place_type(base) {
-            Some(Ty::Class(tn)) => tn.display_name.to_string(),
+            Some(Ty::Class(tn, _)) => tn.display_name.to_string(),
             _ => return format!("{field_idx}"),
         };
         self.lookup_class_field_name(&class_name, field_idx)

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -50,7 +50,7 @@ pub(crate) struct MirCodegenContext<'ctx, 'obj> {
 
 use std::collections::{HashMap, HashSet};
 
-use baml_base::{Name, SourceFile, Span};
+use baml_base::{FieldAttr, Name, SourceFile, Span};
 use baml_compiler_hir::{
     self, ItemId, function_body, function_qualified_name, function_signature,
     function_signature_source_map, template_string_body, template_string_signature,
@@ -184,7 +184,7 @@ pub fn compile_files(
                 field_type: field_ty,
                 description: None,
                 alias: None,
-                field_attr: Default::default(),
+                field_attr: FieldAttr::default(),
             });
 
             // Only add public fields to field_types (for type checking)
@@ -256,7 +256,7 @@ pub fn compile_files(
                         field_type: runtime_ty,
                         description: field.description.value().cloned(),
                         alias: field.alias.value().cloned(),
-                        field_attr: Default::default(),
+                        field_attr: FieldAttr::default(),
                     });
                 }
 

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -175,13 +175,16 @@ pub fn compile_files(
             let tir_ty = baml_compiler_tir::builtins::substitute_unknown(&field.ty);
             let field_ty = baml_type::convert_tir_ty(&tir_ty, &type_aliases, &recursive_aliases)
                 .and_then(baml_type::sanitize_for_runtime)
-                .unwrap_or(baml_type::Ty::Null);
+                .unwrap_or(baml_type::Ty::Null {
+                    attr: baml_type::TyAttr::default(),
+                });
 
             fields.push(ClassField {
                 name: field.name.to_string(),
                 field_type: field_ty,
                 description: None,
                 alias: None,
+                field_attr: Default::default(),
             });
 
             // Only add public fields to field_types (for type checking)
@@ -244,13 +247,16 @@ pub fn compile_files(
                     let runtime_ty =
                         baml_type::convert_tir_ty(&ty, &type_aliases, &recursive_aliases)
                             .and_then(baml_type::sanitize_for_runtime)
-                            .unwrap_or(baml_type::Ty::Null);
+                            .unwrap_or(baml_type::Ty::Null {
+                                attr: baml_type::TyAttr::default(),
+                            });
 
                     fields.push(ClassField {
                         name: field.name.to_string(),
                         field_type: runtime_ty,
                         description: field.description.value().cloned(),
                         alias: field.alias.value().cloned(),
+                        field_attr: Default::default(),
                     });
                 }
 
@@ -373,7 +379,9 @@ pub fn compile_files(
         let tir_ty = baml_compiler_tir::builtins::substitute_unknown(&builtin.returns);
         let return_type = baml_type::convert_tir_ty(&tir_ty, &type_aliases, &recursive_aliases)
             .and_then(baml_type::sanitize_for_runtime)
-            .unwrap_or(baml_type::Ty::Null);
+            .unwrap_or(baml_type::Ty::Null {
+                attr: baml_type::TyAttr::default(),
+            });
 
         let builtin_fn = Function {
             name: builtin.path.to_string(),
@@ -448,7 +456,9 @@ pub fn compile_files(
                             span: baml_base::Span::fake(),
                             block_notifications: Vec::new(),
                             viz_nodes: Vec::new(),
-                            return_type: baml_type::Ty::Null,
+                            return_type: baml_type::Ty::Null {
+                                attr: baml_type::TyAttr::default(),
+                            },
                             param_names: Vec::new(),
                             param_types: Vec::new(),
                             body_meta: None,
@@ -706,7 +716,9 @@ pub fn compile_files(
                             let ty = param_types
                                 .and_then(|m| m.get(k.as_str()))
                                 .cloned()
-                                .unwrap_or(baml_type::Ty::Null);
+                                .unwrap_or(baml_type::Ty::Null {
+                                    attr: baml_type::TyAttr::default(),
+                                });
                             (k.clone(), convert_hir_test_arg(v, &ty))
                         })
                         .collect();
@@ -764,8 +776,10 @@ fn convert_hir_test_arg(
         baml_compiler_hir::TestArgValue::String(s) => bex_vm_types::TestArgValue::String(s.clone()),
         baml_compiler_hir::TestArgValue::Array(arr) => {
             let element_type = match ty {
-                baml_type::Ty::List(elem) => elem.as_ref().clone(),
-                _ => baml_type::Ty::Null,
+                baml_type::Ty::List(elem, _) => elem.as_ref().clone(),
+                _ => baml_type::Ty::Null {
+                    attr: baml_type::TyAttr::default(),
+                },
             };
             bex_vm_types::TestArgValue::Array {
                 element_type: element_type.clone(),
@@ -777,8 +791,17 @@ fn convert_hir_test_arg(
         }
         baml_compiler_hir::TestArgValue::Map(map) => {
             let (key_type, value_type) = match ty {
-                baml_type::Ty::Map { key, value } => (key.as_ref().clone(), value.as_ref().clone()),
-                _ => (baml_type::Ty::String, baml_type::Ty::Null),
+                baml_type::Ty::Map { key, value, .. } => {
+                    (key.as_ref().clone(), value.as_ref().clone())
+                }
+                _ => (
+                    baml_type::Ty::String {
+                        attr: baml_type::TyAttr::default(),
+                    },
+                    baml_type::Ty::Null {
+                        attr: baml_type::TyAttr::default(),
+                    },
+                ),
             };
             bex_vm_types::TestArgValue::Map {
                 key_type,
@@ -814,13 +837,17 @@ fn compute_function_metadata(
             let (ty, _) = resolution_ctx.lower_type_ref(&p.type_ref, Span::default());
             baml_type::convert_tir_ty(&ty, type_aliases, recursive_aliases)
                 .and_then(baml_type::sanitize_for_runtime)
-                .unwrap_or(baml_type::Ty::Null)
+                .unwrap_or(baml_type::Ty::Null {
+                    attr: baml_type::TyAttr::default(),
+                })
         })
         .collect();
     let (ret_ty, _) = resolution_ctx.lower_type_ref(&signature.return_type, Span::default());
     let return_type = baml_type::convert_tir_ty(&ret_ty, type_aliases, recursive_aliases)
         .and_then(baml_type::sanitize_for_runtime)
-        .unwrap_or(baml_type::Ty::Null);
+        .unwrap_or(baml_type::Ty::Null {
+            attr: baml_type::TyAttr::default(),
+        });
     (param_names, param_types, return_type)
 }
 
@@ -863,6 +890,7 @@ fn build_typing_context(
                 let func_type = baml_compiler_tir::Ty::Function {
                     params,
                     ret: Box::new(return_type),
+                    attr: baml_base::TyAttr::default(),
                 };
 
                 // Use the display name as the key (e.g., "baml.llm.render_prompt" or "my_func")

--- a/baml_language/crates/baml_compiler_emit/src/verifier.rs
+++ b/baml_language/crates/baml_compiler_emit/src/verifier.rs
@@ -157,7 +157,9 @@ mod tests {
     fn local(name: &str) -> LocalDecl {
         LocalDecl {
             name: Some(Name::new(name)),
-            ty: Ty::Int,
+            ty: Ty::Int {
+                attr: baml_type::TyAttr::default(),
+            },
             span: None,
             scope_span: None,
             is_watched: false,
@@ -167,7 +169,9 @@ mod tests {
     fn local_watched(name: &str) -> LocalDecl {
         LocalDecl {
             name: Some(Name::new(name)),
-            ty: Ty::Int,
+            ty: Ty::Int {
+                attr: baml_type::TyAttr::default(),
+            },
             span: None,
             scope_span: None,
             is_watched: true,

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -1727,6 +1727,8 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                 _ => panic!("instanceof RHS must be a simple type name"),
             };
 
+            // Constructed from the type name in the instanceof expression, not transformed
+            // from an existing typed value, so default attr is correct.
             self.builder.assign(
                 dest,
                 Rvalue::IsType {

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -193,8 +193,11 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
     /// Uses the shared conversion from `baml_type` which handles FQN→TypeName conversion,
     /// alias expansion, and literal preservation.
     fn convert_tir_ty(&self, tir_ty: &baml_compiler_tir::Ty) -> Ty {
-        baml_type::convert_tir_ty(tir_ty, self.type_aliases, self.recursive_aliases)
-            .unwrap_or(Ty::Null)
+        baml_type::convert_tir_ty(tir_ty, self.type_aliases, self.recursive_aliases).unwrap_or(
+            Ty::Null {
+                attr: baml_type::TyAttr::default(),
+            },
+        )
     }
 
     // ========================================================================
@@ -983,7 +986,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                 let base_local = self.builder.temp(base_ty.clone());
                 self.lower_expr(*base, Place::local(base_local), body);
 
-                let index_local = self.builder.temp(Ty::Int);
+                let index_local = self.builder.temp(Ty::Int {
+                    attr: baml_type::TyAttr::default(),
+                });
                 self.lower_expr(*index, Place::local(index_local), body);
 
                 // Determine index kind based on base type
@@ -1104,7 +1109,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                         let body_block = self.builder.create_block();
 
                         // Lower guard expression
-                        let guard_local = self.builder.temp(Ty::Bool);
+                        let guard_local = self.builder.temp(Ty::Bool {
+                            attr: baml_type::TyAttr::default(),
+                        });
                         self.lower_expr(guard, Place::local(guard_local), body);
 
                         // Branch: if guard is true go to body_block, else go to next_block
@@ -1330,19 +1337,19 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
     /// which is not yet implemented.
     fn type_tag_for_ty(&self, ty: &Ty) -> Option<i64> {
         match ty {
-            Ty::Int => Some(baml_type::typetag::INT),
-            Ty::String => Some(baml_type::typetag::STRING),
-            Ty::Bool => Some(baml_type::typetag::BOOL),
-            Ty::Null => Some(baml_type::typetag::NULL),
-            Ty::Float => Some(baml_type::typetag::FLOAT),
-            Ty::Class(tn) => self.class_type_tags.get(tn.name.as_str()).copied(),
+            Ty::Int { .. } => Some(baml_type::typetag::INT),
+            Ty::String { .. } => Some(baml_type::typetag::STRING),
+            Ty::Bool { .. } => Some(baml_type::typetag::BOOL),
+            Ty::Null { .. } => Some(baml_type::typetag::NULL),
+            Ty::Float { .. } => Some(baml_type::typetag::FLOAT),
+            Ty::Class(tn, _) => self.class_type_tags.get(tn.name.as_str()).copied(),
             // TypeAliases: look up by alias name. See doc comment for limitations.
-            Ty::TypeAlias(tn) => self.class_type_tags.get(tn.name.as_str()).copied(),
+            Ty::TypeAlias(tn, _) => self.class_type_tags.get(tn.name.as_str()).copied(),
             // Literal types map to the same tag as their base type
-            Ty::Literal(baml_base::Literal::Int(_)) => Some(baml_type::typetag::INT),
-            Ty::Literal(baml_base::Literal::Float(_)) => Some(baml_type::typetag::FLOAT),
-            Ty::Literal(baml_base::Literal::String(_)) => Some(baml_type::typetag::STRING),
-            Ty::Literal(baml_base::Literal::Bool(_)) => Some(baml_type::typetag::BOOL),
+            Ty::Literal(baml_base::Literal::Int(_), _) => Some(baml_type::typetag::INT),
+            Ty::Literal(baml_base::Literal::Float(_), _) => Some(baml_type::typetag::FLOAT),
+            Ty::Literal(baml_base::Literal::String(_), _) => Some(baml_type::typetag::STRING),
+            Ty::Literal(baml_base::Literal::Bool(_), _) => Some(baml_type::typetag::BOOL),
             _ => None, // Not a type with a known tag
         }
     }
@@ -1379,7 +1386,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             }
             SwitchKind::EnumDiscriminant(_) => {
                 // Emit Discriminant to extract variant index
-                let discriminant_local = self.builder.temp(Ty::Int);
+                let discriminant_local = self.builder.temp(Ty::Int {
+                    attr: baml_type::TyAttr::default(),
+                });
                 self.builder.assign(
                     Place::local(discriminant_local),
                     Rvalue::Discriminant(Place::local(scrutinee_local)),
@@ -1388,7 +1397,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             }
             SwitchKind::TypeTag => {
                 // Emit TypeTag to extract runtime type tag
-                let type_tag_local = self.builder.temp(Ty::Int);
+                let type_tag_local = self.builder.temp(Ty::Int {
+                    attr: baml_type::TyAttr::default(),
+                });
                 self.builder.assign(
                     Place::local(type_tag_local),
                     Rvalue::TypeTag(Place::local(scrutinee_local)),
@@ -1582,7 +1593,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                 let pattern_ty = ty.clone();
 
                 // Emit instanceof check
-                let check_local = self.builder.temp(Ty::Bool);
+                let check_local = self.builder.temp(Ty::Bool {
+                    attr: baml_type::TyAttr::default(),
+                });
                 self.builder.assign(
                     Place::local(check_local),
                     Rvalue::IsType {
@@ -1619,7 +1632,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             Pattern::Literal(lit) => {
                 // Compare scrutinee with literal
                 let lit_const = Self::lower_literal(lit);
-                let cmp_local = self.builder.temp(Ty::Bool);
+                let cmp_local = self.builder.temp(Ty::Bool {
+                    attr: baml_type::TyAttr::default(),
+                });
                 self.builder.assign(
                     Place::local(cmp_local),
                     Rvalue::BinaryOp {
@@ -1640,7 +1655,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                     enum_qn,
                     variant: variant.clone(),
                 };
-                let cmp_local = self.builder.temp(Ty::Bool);
+                let cmp_local = self.builder.temp(Ty::Bool {
+                    attr: baml_type::TyAttr::default(),
+                });
                 self.builder.assign(
                     Place::local(cmp_local),
                     Rvalue::BinaryOp {
@@ -1714,7 +1731,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                 dest,
                 Rvalue::IsType {
                     operand: lhs_operand,
-                    ty: Ty::TypeAlias(TypeName::local(type_name)),
+                    ty: Ty::TypeAlias(TypeName::local(type_name), baml_type::TyAttr::default()),
                 },
             );
             return;
@@ -1775,7 +1792,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
     /// Lower short-circuit AND: `a && b`
     fn lower_short_circuit_and(&mut self, lhs: ExprId, rhs: ExprId, dest: Place, body: &ExprBody) {
-        let lhs_local = self.builder.temp(Ty::Bool);
+        let lhs_local = self.builder.temp(Ty::Bool {
+            attr: baml_type::TyAttr::default(),
+        });
         self.lower_expr(lhs, Place::local(lhs_local), body);
 
         let bb_rhs = self.builder.create_block();
@@ -1803,7 +1822,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
     /// Lower short-circuit OR: `a || b`
     fn lower_short_circuit_or(&mut self, lhs: ExprId, rhs: ExprId, dest: Place, body: &ExprBody) {
-        let lhs_local = self.builder.temp(Ty::Bool);
+        let lhs_local = self.builder.temp(Ty::Bool {
+            attr: baml_type::TyAttr::default(),
+        });
         self.lower_expr(lhs, Place::local(lhs_local), body);
 
         let bb_true = self.builder.create_block();
@@ -1847,7 +1868,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             None
         };
 
-        let cond_local = self.builder.temp(Ty::Bool);
+        let cond_local = self.builder.temp(Ty::Bool {
+            attr: baml_type::TyAttr::default(),
+        });
         self.lower_expr(condition, Place::local(cond_local), body);
 
         let bb_then = self.builder.create_block();
@@ -1900,7 +1923,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
         // Condition block
         self.builder.set_current_block(bb_cond);
-        let cond_local = self.builder.temp(Ty::Bool);
+        let cond_local = self.builder.temp(Ty::Bool {
+            attr: baml_type::TyAttr::default(),
+        });
         self.lower_expr(condition, Place::local(cond_local), body);
         self.builder
             .branch(Operand::copy_local(cond_local), bb_body, bb_exit);
@@ -1914,7 +1939,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
         // Body block
         self.builder.set_current_block(bb_body);
-        let body_result = self.builder.temp(Ty::Void);
+        let body_result = self.builder.temp(Ty::Void {
+            attr: baml_type::TyAttr::default(),
+        });
         self.lower_expr(loop_body, Place::local(body_result), body);
         if !self.builder.is_current_terminated() {
             self.builder.goto(bb_cond);
@@ -1944,7 +1971,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
         // Check if this is a $watch method call (e.g., value.$watch.options(filter))
         if let Expr::FieldAccess { base, field } = callee_expr {
             let base_ty = body.ty(*base);
-            if let baml_compiler_vir::Ty::WatchAccessor(_) = base_ty {
+            if let baml_compiler_vir::Ty::WatchAccessor(..) = base_ty {
                 // This is a $watch method call
                 // The base expression is var.$watch, so we need to get the var
                 let watch_accessor_expr = body.expr(*base);
@@ -2028,12 +2055,12 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             // Get the type name for method path construction
             // Works for both builtin class types and primitive types with methods
             let type_name = match &base_ty {
-                Ty::Class(tn) if !tn.module_path.is_empty() => Some(tn.display_name.to_string()),
-                Ty::Opaque(tn) => Some(tn.display_name.to_string()),
-                Ty::List(_) => Some("baml.Array".to_string()),
-                Ty::String => Some("baml.String".to_string()),
+                Ty::Class(tn, _) if !tn.module_path.is_empty() => Some(tn.display_name.to_string()),
+                Ty::Opaque(tn, _) => Some(tn.display_name.to_string()),
+                Ty::List(..) => Some("baml.Array".to_string()),
+                Ty::String { .. } => Some("baml.String".to_string()),
                 Ty::Map { .. } => Some("baml.Map".to_string()),
-                Ty::Class(_) => Self::class_name_from_ty(base_ty),
+                Ty::Class(..) => Self::class_name_from_ty(base_ty),
                 _ => None,
             };
 
@@ -2155,7 +2182,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             Expr::Index { base, index } => {
                 let base_place = self.lower_lvalue(*base, body);
                 let base_ty = body.ty(*base).clone();
-                let index_local = self.builder.temp(Ty::Int);
+                let index_local = self.builder.temp(Ty::Int {
+                    attr: baml_type::TyAttr::default(),
+                });
                 self.lower_expr(*index, Place::local(index_local), body);
 
                 // Determine index kind based on base type
@@ -2221,7 +2250,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
     /// For user classes, returns just the name (e.g., "`MyClass`").
     fn class_name_from_ty(ty: &Ty) -> Option<String> {
         match ty {
-            Ty::TypeAlias(tn) | Ty::Class(tn) => {
+            Ty::TypeAlias(tn, _) | Ty::Class(tn, _) => {
                 // Use display_name which is pre-computed with the full path for builtins
                 Some(tn.display_name.to_string())
             }
@@ -2265,7 +2294,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
     fn emit_sys_op_call(&mut self, callee: Operand, args: Vec<Operand>, dest: Place) {
         // Create a temp to hold the future handle
         // Future handles are opaque to the VM - we use Null type
-        let future_local = self.builder.temp(Ty::Null);
+        let future_local = self.builder.temp(Ty::Null {
+            attr: baml_type::TyAttr::default(),
+        });
         let future_place = Place::local(future_local);
 
         // Create blocks for the dispatch and await

--- a/baml_language/crates/baml_compiler_tir/src/builtins.rs
+++ b/baml_language/crates/baml_compiler_tir/src/builtins.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use baml_base::{Name, baml_debug};
+use baml_base::{Name, TyAttr, baml_debug};
 use baml_builtins::{BuiltinSignature, TypePattern};
 use baml_compiler_hir::QualifiedName;
 
@@ -84,14 +84,14 @@ fn match_pattern_inner(pattern: &TypePattern, ty: &Ty, bindings: &mut Bindings) 
         }
 
         // Primitive types must match exactly
-        (TypePattern::Int, Ty::Int) => true,
-        (TypePattern::Float, Ty::Float) => true,
-        (TypePattern::String, Ty::String) => true,
-        (TypePattern::Bool, Ty::Bool) => true,
-        (TypePattern::Null, Ty::Null) => true,
+        (TypePattern::Int, Ty::Int { .. }) => true,
+        (TypePattern::Float, Ty::Float { .. }) => true,
+        (TypePattern::String, Ty::String { .. }) => true,
+        (TypePattern::Bool, Ty::Bool { .. }) => true,
+        (TypePattern::Null, Ty::Null { .. }) => true,
 
         // Array/List: match element type
-        (TypePattern::Array(elem_pat), Ty::List(elem_ty)) => {
+        (TypePattern::Array(elem_pat), Ty::List(elem_ty, _)) => {
             match_pattern_inner(elem_pat, elem_ty, bindings)
         }
 
@@ -104,28 +104,29 @@ fn match_pattern_inner(pattern: &TypePattern, ty: &Ty, bindings: &mut Bindings) 
             Ty::Map {
                 key: key_ty,
                 value: value_ty,
+                ..
             },
         ) => {
             match_pattern_inner(key_pat, key_ty, bindings)
                 && match_pattern_inner(value_pat, value_ty, bindings)
         }
-        (TypePattern::Media, Ty::Media(_)) => true,
+        (TypePattern::Media, Ty::Media(_, _)) => true,
 
         // Builtin types match exactly by path - they are represented as Ty::Class now
         // Use full display path (e.g., "baml.fs.File") for comparison
-        (TypePattern::Builtin(pattern_path), Ty::Class(fqn)) => *pattern_path == fqn.display(),
+        (TypePattern::Builtin(pattern_path), Ty::Class(fqn, _)) => *pattern_path == fqn.display(),
 
         // Builtin enums match exactly by path
-        (TypePattern::Enum(path), Ty::Enum(fqn)) => *path == fqn.display(),
+        (TypePattern::Enum(path), Ty::Enum(fqn, _)) => *path == fqn.display(),
 
         // Opaque runtime types match their corresponding patterns
-        (TypePattern::Resource, Ty::Resource) => true,
-        (TypePattern::Type, Ty::Type) => true,
-        (TypePattern::Type, Ty::Unknown | Ty::Error) => true,
+        (TypePattern::Resource, Ty::Resource { .. }) => true,
+        (TypePattern::Type, Ty::Type { .. }) => true,
+        (TypePattern::Type, Ty::Unknown { .. } | Ty::Error { .. }) => true,
         (TypePattern::Type, _) => false,
 
         // Unknown in Ty matches any pattern (for error recovery)
-        (_, Ty::Unknown) => true,
+        (_, Ty::Unknown { .. }) => true,
 
         // BuiltinUnknown accepts any type (for builtins that need heterogeneous values)
         (TypePattern::BuiltinUnknown, _) => true,
@@ -161,34 +162,58 @@ pub fn substitute(pattern: &TypePattern, bindings: &Bindings) -> Ty {
             .get(name)
             .cloned()
             // Fall back to Unknown for unbound type variables (e.g., "Any")
-            .unwrap_or(Ty::Unknown),
+            .unwrap_or(Ty::Unknown {
+                attr: TyAttr::default(),
+            }),
 
-        TypePattern::Int => Ty::Int,
-        TypePattern::Float => Ty::Float,
-        TypePattern::String => Ty::String,
-        TypePattern::Bool => Ty::Bool,
-        TypePattern::Null => Ty::Null,
+        TypePattern::Int => Ty::Int {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Float => Ty::Float {
+            attr: TyAttr::default(),
+        },
+        TypePattern::String => Ty::String {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Bool => Ty::Bool {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Null => Ty::Null {
+            attr: TyAttr::default(),
+        },
 
-        TypePattern::Array(elem) => Ty::List(Box::new(substitute(elem, bindings))),
+        TypePattern::Array(elem) => {
+            Ty::List(Box::new(substitute(elem, bindings)), TyAttr::default())
+        }
 
         TypePattern::Map { key, value } => Ty::Map {
             key: Box::new(substitute(key, bindings)),
             value: Box::new(substitute(value, bindings)),
+            attr: TyAttr::default(),
         },
-        TypePattern::Media => Ty::Media(baml_base::MediaKind::Generic),
-        TypePattern::Optional(inner) => Ty::Optional(Box::new(substitute(inner, bindings))),
-        TypePattern::Builtin(path) => Ty::Class(parse_builtin_path(path)),
+        TypePattern::Media => Ty::Media(baml_base::MediaKind::Generic, TyAttr::default()),
+        TypePattern::Optional(inner) => {
+            Ty::Optional(Box::new(substitute(inner, bindings)), TyAttr::default())
+        }
+        TypePattern::Builtin(path) => Ty::Class(parse_builtin_path(path), TyAttr::default()),
         TypePattern::Function { params, ret } => Ty::Function {
             params: params
                 .iter()
                 .map(|p| (None, substitute(p, bindings)))
                 .collect(),
             ret: Box::new(substitute(ret, bindings)),
+            attr: TyAttr::default(),
         },
-        TypePattern::Resource => Ty::Resource,
-        TypePattern::BuiltinUnknown => Ty::BuiltinUnknown,
-        TypePattern::Enum(path) => Ty::Enum(parse_builtin_path(path)),
-        TypePattern::Type => Ty::Type,
+        TypePattern::Resource => Ty::Resource {
+            attr: TyAttr::default(),
+        },
+        TypePattern::BuiltinUnknown => Ty::BuiltinUnknown {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Enum(path) => Ty::Enum(parse_builtin_path(path), TyAttr::default()),
+        TypePattern::Type => Ty::Type {
+            attr: TyAttr::default(),
+        },
     }
 }
 
@@ -198,31 +223,53 @@ pub fn substitute(pattern: &TypePattern, bindings: &Bindings) -> Ty {
 /// (e.g., `baml.Array.length(arr)` where we don't know the element type yet).
 pub fn substitute_unknown(pattern: &TypePattern) -> Ty {
     match pattern {
-        TypePattern::Var(_) => Ty::Unknown,
-        TypePattern::Int => Ty::Int,
-        TypePattern::Float => Ty::Float,
-        TypePattern::String => Ty::String,
-        TypePattern::Bool => Ty::Bool,
-        TypePattern::Null => Ty::Null,
-        TypePattern::Array(elem) => Ty::List(Box::new(substitute_unknown(elem))),
+        TypePattern::Var(_) => Ty::Unknown {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Int => Ty::Int {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Float => Ty::Float {
+            attr: TyAttr::default(),
+        },
+        TypePattern::String => Ty::String {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Bool => Ty::Bool {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Null => Ty::Null {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Array(elem) => Ty::List(Box::new(substitute_unknown(elem)), TyAttr::default()),
         TypePattern::Map { key, value } => Ty::Map {
             key: Box::new(substitute_unknown(key)),
             value: Box::new(substitute_unknown(value)),
+            attr: TyAttr::default(),
         },
-        TypePattern::Media => Ty::Media(baml_base::MediaKind::Generic),
-        TypePattern::Optional(inner) => Ty::Optional(Box::new(substitute_unknown(inner))),
-        TypePattern::Builtin(path) => Ty::Class(parse_builtin_path(path)),
+        TypePattern::Media => Ty::Media(baml_base::MediaKind::Generic, TyAttr::default()),
+        TypePattern::Optional(inner) => {
+            Ty::Optional(Box::new(substitute_unknown(inner)), TyAttr::default())
+        }
+        TypePattern::Builtin(path) => Ty::Class(parse_builtin_path(path), TyAttr::default()),
         TypePattern::Function { params, ret } => Ty::Function {
             params: params
                 .iter()
                 .map(|p| (None, substitute_unknown(p)))
                 .collect(),
             ret: Box::new(substitute_unknown(ret)),
+            attr: TyAttr::default(),
         },
-        TypePattern::Resource => Ty::Resource,
-        TypePattern::BuiltinUnknown => Ty::BuiltinUnknown,
-        TypePattern::Enum(path) => Ty::Enum(parse_builtin_path(path)),
-        TypePattern::Type => Ty::Type,
+        TypePattern::Resource => Ty::Resource {
+            attr: TyAttr::default(),
+        },
+        TypePattern::BuiltinUnknown => Ty::BuiltinUnknown {
+            attr: TyAttr::default(),
+        },
+        TypePattern::Enum(path) => Ty::Enum(parse_builtin_path(path), TyAttr::default()),
+        TypePattern::Type => Ty::Type {
+            attr: TyAttr::default(),
+        },
     }
 }
 
@@ -309,26 +356,30 @@ pub fn method_param_types(receiver_ty: &Ty, method_name: &str) -> Option<Vec<(&'
 mod tests {
     use super::*;
 
+    fn d() -> TyAttr {
+        TyAttr::default()
+    }
+
     #[test]
     fn test_match_primitive() {
-        assert!(match_pattern(&TypePattern::Int, &Ty::Int).is_some());
-        assert!(match_pattern(&TypePattern::String, &Ty::String).is_some());
-        assert!(match_pattern(&TypePattern::Int, &Ty::String).is_none());
+        assert!(match_pattern(&TypePattern::Int, &Ty::Int { attr: d() }).is_some());
+        assert!(match_pattern(&TypePattern::String, &Ty::String { attr: d() }).is_some());
+        assert!(match_pattern(&TypePattern::Int, &Ty::String { attr: d() }).is_none());
     }
 
     #[test]
     fn test_match_type_var() {
-        let bindings = match_pattern(&TypePattern::Var("T"), &Ty::Int).unwrap();
-        assert_eq!(bindings.get("T"), Some(&Ty::Int));
+        let bindings = match_pattern(&TypePattern::Var("T"), &Ty::Int { attr: d() }).unwrap();
+        assert_eq!(bindings.get("T"), Some(&Ty::Int { attr: d() }));
     }
 
     #[test]
     fn test_match_array() {
         let pattern = TypePattern::Array(Box::new(TypePattern::Var("T")));
-        let ty = Ty::List(Box::new(Ty::String));
+        let ty = Ty::List(Box::new(Ty::String { attr: d() }), d());
 
         let bindings = match_pattern(&pattern, &ty).unwrap();
-        assert_eq!(bindings.get("T"), Some(&Ty::String));
+        assert_eq!(bindings.get("T"), Some(&Ty::String { attr: d() }));
     }
 
     #[test]
@@ -338,52 +389,53 @@ mod tests {
             value: Box::new(TypePattern::Var("V")),
         };
         let ty = Ty::Map {
-            key: Box::new(Ty::String),
-            value: Box::new(Ty::Int),
+            key: Box::new(Ty::String { attr: d() }),
+            value: Box::new(Ty::Int { attr: d() }),
+            attr: d(),
         };
 
         let bindings = match_pattern(&pattern, &ty).unwrap();
-        assert_eq!(bindings.get("K"), Some(&Ty::String));
-        assert_eq!(bindings.get("V"), Some(&Ty::Int));
+        assert_eq!(bindings.get("K"), Some(&Ty::String { attr: d() }));
+        assert_eq!(bindings.get("V"), Some(&Ty::Int { attr: d() }));
     }
 
     #[test]
     fn test_substitute_var() {
         let mut bindings = HashMap::new();
-        bindings.insert("T", Ty::Int);
+        bindings.insert("T", Ty::Int { attr: d() });
 
         let result = substitute(&TypePattern::Var("T"), &bindings);
-        assert_eq!(result, Ty::Int);
+        assert_eq!(result, Ty::Int { attr: d() });
     }
 
     #[test]
     fn test_substitute_array() {
         let mut bindings = HashMap::new();
-        bindings.insert("T", Ty::String);
+        bindings.insert("T", Ty::String { attr: d() });
 
         let pattern = TypePattern::Array(Box::new(TypePattern::Var("T")));
         let result = substitute(&pattern, &bindings);
-        assert_eq!(result, Ty::List(Box::new(Ty::String)));
+        assert_eq!(result, Ty::List(Box::new(Ty::String { attr: d() }), d()));
     }
 
     #[test]
     fn test_lookup_array_length() {
-        let arr_ty = Ty::List(Box::new(Ty::Int));
+        let arr_ty = Ty::List(Box::new(Ty::Int { attr: d() }), d());
         let result = lookup_method(&arr_ty, "length");
 
         assert!(result.is_some());
         let (def, bindings) = result.unwrap();
         assert_eq!(def.path, "baml.Array.length");
-        assert_eq!(bindings.get("T"), Some(&Ty::Int));
+        assert_eq!(bindings.get("T"), Some(&Ty::Int { attr: d() }));
 
         // Return type should be int
         let return_ty = substitute(&def.returns, &bindings);
-        assert_eq!(return_ty, Ty::Int);
+        assert_eq!(return_ty, Ty::Int { attr: d() });
     }
 
     #[test]
     fn test_lookup_string_length() {
-        let result = lookup_method(&Ty::String, "length");
+        let result = lookup_method(&Ty::String { attr: d() }, "length");
 
         assert!(result.is_some());
         let (def, _bindings) = result.unwrap();
@@ -392,55 +444,73 @@ mod tests {
 
     #[test]
     fn test_method_return_type() {
-        let arr_ty = Ty::List(Box::new(Ty::Float));
+        let arr_ty = Ty::List(Box::new(Ty::Float { attr: d() }), d());
 
         // length returns int regardless of element type
-        assert_eq!(method_return_type(&arr_ty, "length"), Some(Ty::Int));
+        assert_eq!(
+            method_return_type(&arr_ty, "length"),
+            Some(Ty::Int { attr: d() })
+        );
 
         // push returns null
-        assert_eq!(method_return_type(&arr_ty, "push"), Some(Ty::Null));
+        assert_eq!(
+            method_return_type(&arr_ty, "push"),
+            Some(Ty::Null { attr: d() })
+        );
     }
 
     #[test]
     fn test_method_param_types() {
-        let arr_ty = Ty::List(Box::new(Ty::String));
+        let arr_ty = Ty::List(Box::new(Ty::String { attr: d() }), d());
 
         // push takes the element type
         let params = method_param_types(&arr_ty, "push").unwrap();
         assert_eq!(params.len(), 1);
-        assert_eq!(params[0], ("item", Ty::String));
+        assert_eq!(params[0], ("item", Ty::String { attr: d() }));
     }
 
     #[test]
     fn test_no_such_method() {
-        let arr_ty = Ty::List(Box::new(Ty::Int));
+        let arr_ty = Ty::List(Box::new(Ty::Int { attr: d() }), d());
         assert!(lookup_method(&arr_ty, "nonexistent").is_none());
     }
 
     #[test]
     fn test_match_opaque_types() {
-        assert!(match_pattern(&TypePattern::Resource, &Ty::Resource).is_some());
-        assert!(match_pattern(&TypePattern::Type, &Ty::Type).is_some());
+        assert!(match_pattern(&TypePattern::Resource, &Ty::Resource { attr: d() }).is_some());
+        assert!(match_pattern(&TypePattern::Type, &Ty::Type { attr: d() }).is_some());
 
         // Type also matches error recovery types
-        assert!(match_pattern(&TypePattern::Type, &Ty::Unknown).is_some());
-        assert!(match_pattern(&TypePattern::Type, &Ty::Error).is_some());
+        assert!(match_pattern(&TypePattern::Type, &Ty::Unknown { attr: d() }).is_some());
+        assert!(match_pattern(&TypePattern::Type, &Ty::Error { attr: d() }).is_some());
 
         // Neither matches unrelated types
-        assert!(match_pattern(&TypePattern::Resource, &Ty::Int).is_none());
-        assert!(match_pattern(&TypePattern::Type, &Ty::Int).is_none());
+        assert!(match_pattern(&TypePattern::Resource, &Ty::Int { attr: d() }).is_none());
+        assert!(match_pattern(&TypePattern::Type, &Ty::Int { attr: d() }).is_none());
     }
 
     #[test]
     fn test_substitute_opaque_types() {
         let bindings = HashMap::new();
-        assert_eq!(substitute(&TypePattern::Resource, &bindings), Ty::Resource);
-        assert_eq!(substitute(&TypePattern::Type, &bindings), Ty::Type);
+        assert_eq!(
+            substitute(&TypePattern::Resource, &bindings),
+            Ty::Resource { attr: d() }
+        );
+        assert_eq!(
+            substitute(&TypePattern::Type, &bindings),
+            Ty::Type { attr: d() }
+        );
     }
 
     #[test]
     fn test_substitute_unknown_opaque_types() {
-        assert_eq!(substitute_unknown(&TypePattern::Resource), Ty::Resource);
-        assert_eq!(substitute_unknown(&TypePattern::Type), Ty::Type);
+        assert_eq!(
+            substitute_unknown(&TypePattern::Resource),
+            Ty::Resource { attr: d() }
+        );
+        assert_eq!(
+            substitute_unknown(&TypePattern::Type),
+            Ty::Type { attr: d() }
+        );
     }
 }

--- a/baml_language/crates/baml_compiler_tir/src/cycles.rs
+++ b/baml_language/crates/baml_compiler_tir/src/cycles.rs
@@ -242,7 +242,7 @@ fn extract_type_alias_deps(ty: &Ty) -> (HashSet<Name>, HashSet<Name>) {
         in_structural_context: bool,
     ) {
         match ty {
-            Ty::TypeAlias(fqn) => {
+            Ty::TypeAlias(fqn, _) => {
                 // Type aliases in Ty are kept unexpanded - this is what we want to track.
                 // They stay as names and never expand, preventing infinite recursion.
                 let name = fqn.name.clone();
@@ -252,7 +252,7 @@ fn extract_type_alias_deps(ty: &Ty) -> (HashSet<Name>, HashSet<Name>) {
                     non_structural_deps.insert(name);
                 }
             }
-            Ty::Optional(inner) => {
+            Ty::Optional(inner, _) => {
                 // Optional doesn't make it structural for type aliases
                 visit(
                     inner,
@@ -261,16 +261,16 @@ fn extract_type_alias_deps(ty: &Ty) -> (HashSet<Name>, HashSet<Name>) {
                     in_structural_context,
                 );
             }
-            Ty::List(inner) => {
+            Ty::List(inner, _) => {
                 // List makes it structural - provides termination via []
                 visit(inner, non_structural_deps, structural_deps, true);
             }
-            Ty::Map { key, value } => {
+            Ty::Map { key, value, .. } => {
                 // Map makes it structural - provides termination via {}
                 visit(key, non_structural_deps, structural_deps, true);
                 visit(value, non_structural_deps, structural_deps, true);
             }
-            Ty::Union(variants) => {
+            Ty::Union(variants, _) => {
                 for variant in variants {
                     visit(
                         variant,
@@ -411,14 +411,14 @@ fn extract_class_deps(ty: &Ty, type_aliases: &HashMap<Name, Ty>) -> HashSet<Name
         visiting: &mut HashSet<Name>,
     ) {
         match ty {
-            Ty::Class(fqn) => {
+            Ty::Class(fqn, _) => {
                 // Only add if not optional and not in list/map.
                 // Optional and structural contexts break the hard dependency.
                 if !optional && !in_list_or_map {
                     deps.insert(fqn.display_name());
                 }
             }
-            Ty::TypeAlias(fqn) => {
+            Ty::TypeAlias(fqn, _) => {
                 // Type aliases are kept unexpanded in Ty - resolve them.
                 // But only if this is a required field (not optional, not in list/map).
                 if !optional && !in_list_or_map {
@@ -440,20 +440,20 @@ fn extract_class_deps(ty: &Ty, type_aliases: &HashMap<Name, Ty>) -> HashSet<Name
                     }
                 }
             }
-            Ty::Optional(inner) => {
+            Ty::Optional(inner, _) => {
                 // Optional breaks cycles - field can be absent
                 visit(inner, deps, true, in_list_or_map, type_aliases, visiting);
             }
-            Ty::List(inner) => {
+            Ty::List(inner, _) => {
                 // Lists break cycles - can be empty
                 visit(inner, deps, optional, true, type_aliases, visiting);
             }
-            Ty::Map { key, value } => {
+            Ty::Map { key, value, .. } => {
                 // Maps break cycles - can be empty
                 visit(key, deps, optional, true, type_aliases, visiting);
                 visit(value, deps, optional, true, type_aliases, visiting);
             }
-            Ty::Union(variants) => {
+            Ty::Union(variants, _) => {
                 // For unions, we need to check if ALL variants lead to the same class.
                 // If they do, then that class is a hard dependency. Otherwise, the
                 // union can be satisfied by choosing a variant without that class.

--- a/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
+++ b/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
@@ -285,13 +285,13 @@ impl<'a> ExhaustivenessChecker<'a> {
     fn expand_type_to_values(&self, ty: &Ty) -> Vec<ValueSet> {
         match ty {
             // Union types: expand each member
-            Ty::Union(members) => members
+            Ty::Union(members, _) => members
                 .iter()
                 .flat_map(|m| self.expand_type_to_values(m))
                 .collect(),
 
             // Optional is T | null
-            Ty::Optional(inner) => {
+            Ty::Optional(inner, _) => {
                 let mut values = self.expand_type_to_values(inner);
                 // Only add null if not already present (handles T?? = T? flattening)
                 let null_value = ValueSet::Literal(Literal::Null);
@@ -302,7 +302,7 @@ impl<'a> ExhaustivenessChecker<'a> {
             }
 
             // Type alias: expand to underlying type
-            Ty::TypeAlias(fqn) => {
+            Ty::TypeAlias(fqn, _) => {
                 // Check if we can resolve the type alias
                 //
                 // TODO(type-alias-architecture): Type alias resolution should be its own
@@ -346,14 +346,14 @@ impl<'a> ExhaustivenessChecker<'a> {
             }
 
             // Bool is finite: {true, false}
-            Ty::Bool => vec![
+            Ty::Bool { .. } => vec![
                 ValueSet::Literal(Literal::Bool(true)),
                 ValueSet::Literal(Literal::Bool(false)),
             ],
 
             // Singleton types (types containing exactly one value)
-            Ty::Null => vec![ValueSet::Literal(Literal::Null)],
-            Ty::Literal(value) => match value {
+            Ty::Null { .. } => vec![ValueSet::Literal(Literal::Null)],
+            Ty::Literal(value, _) => match value {
                 LiteralValue::Int(v) => vec![ValueSet::Literal(Literal::Int(*v))],
                 LiteralValue::Float(v) => {
                     vec![ValueSet::Literal(Literal::Float(v.clone()))]
@@ -365,19 +365,19 @@ impl<'a> ExhaustivenessChecker<'a> {
             },
 
             // Infinite types: int, float, string, resource, classes, etc.
-            Ty::Int => vec![ValueSet::OfType(Name::new("int"))],
-            Ty::Float => vec![ValueSet::OfType(Name::new("float"))],
-            Ty::String => vec![ValueSet::OfType(Name::new("string"))],
-            Ty::Resource => vec![ValueSet::OfType(Name::new("resource"))],
-            Ty::Type => vec![ValueSet::OfType(Name::new("type"))],
-            Ty::Media(kind) => vec![ValueSet::OfType(Name::new(kind.to_string()))],
+            Ty::Int { .. } => vec![ValueSet::OfType(Name::new("int"))],
+            Ty::Float { .. } => vec![ValueSet::OfType(Name::new("float"))],
+            Ty::String { .. } => vec![ValueSet::OfType(Name::new("string"))],
+            Ty::Resource { .. } => vec![ValueSet::OfType(Name::new("resource"))],
+            Ty::Type { .. } => vec![ValueSet::OfType(Name::new("type"))],
+            Ty::Media(kind, _) => vec![ValueSet::OfType(Name::new(kind.to_string()))],
 
             // User-defined class and enum types (resolved by FQN).
-            Ty::Class(fqn) => {
+            Ty::Class(fqn, _) => {
                 // Class types are treated like named types for exhaustiveness
                 vec![ValueSet::OfType(fqn.display_name())]
             }
-            Ty::Enum(fqn) => {
+            Ty::Enum(fqn, _) => {
                 // Enum types: look up variants for exhaustiveness checking
                 // Use display_name (FQN for builtins, short name for locals)
                 let display = fqn.display_name();
@@ -395,16 +395,18 @@ impl<'a> ExhaustivenessChecker<'a> {
             }
 
             // List types: include element type for proper distinction between e.g. int[] vs string[]
-            Ty::List(inner) => vec![ValueSet::OfType(Name::new(format!("{inner}[]")))],
+            Ty::List(inner, _) => vec![ValueSet::OfType(Name::new(format!("{inner}[]")))],
 
             // Map types are not yet fully implemented in HIR (see tests/maps.rs).
             // When they are, this should include key/value types: map<{key}, {value}>
             Ty::Map { .. } => vec![ValueSet::OfType(Name::new("<map>"))],
 
             // Special types
-            Ty::Unknown | Ty::Error | Ty::Void | Ty::BuiltinUnknown => Vec::new(),
+            Ty::Unknown { .. } | Ty::Error { .. } | Ty::Void { .. } | Ty::BuiltinUnknown { .. } => {
+                Vec::new()
+            }
             Ty::Function { .. } => vec![ValueSet::OfType(Name::new("<function>"))],
-            Ty::WatchAccessor(_) => vec![ValueSet::OfType(Name::new("<$watch>"))],
+            Ty::WatchAccessor(..) => vec![ValueSet::OfType(Name::new("<$watch>"))],
         }
     }
 
@@ -471,7 +473,7 @@ impl<'a> ExhaustivenessChecker<'a> {
     /// Convert a type to a value set (for typed bindings).
     fn ty_to_value_set(ty: &Ty) -> ValueSet {
         match ty {
-            Ty::Union(members) => {
+            Ty::Union(members, _) => {
                 let sub_sets: Vec<ValueSet> = members.iter().map(Self::ty_to_value_set).collect();
                 if sub_sets.len() == 1 {
                     sub_sets.into_iter().next().unwrap()
@@ -479,28 +481,28 @@ impl<'a> ExhaustivenessChecker<'a> {
                     ValueSet::Union(sub_sets)
                 }
             }
-            Ty::Optional(inner) => {
+            Ty::Optional(inner, _) => {
                 let inner_set = Self::ty_to_value_set(inner);
                 ValueSet::Union(vec![inner_set, ValueSet::Literal(Literal::Null)])
             }
-            Ty::TypeAlias(fqn) => {
+            Ty::TypeAlias(fqn, _) => {
                 // For type aliases, keep the alias name (don't expand)
                 // The coverage check will handle expansion
                 ValueSet::OfType(fqn.name.clone())
             }
-            Ty::Class(fqn) => ValueSet::OfType(fqn.display_name()),
-            Ty::Enum(fqn) => ValueSet::OfType(fqn.display_name()),
-            Ty::Literal(value) => match value {
+            Ty::Class(fqn, _) => ValueSet::OfType(fqn.display_name()),
+            Ty::Enum(fqn, _) => ValueSet::OfType(fqn.display_name()),
+            Ty::Literal(value, _) => match value {
                 LiteralValue::Int(v) => ValueSet::Literal(Literal::Int(*v)),
                 LiteralValue::Float(v) => ValueSet::Literal(Literal::Float(v.clone())),
                 LiteralValue::String(v) => ValueSet::Literal(Literal::String(v.clone())),
                 LiteralValue::Bool(v) => ValueSet::Literal(Literal::Bool(*v)),
             },
-            Ty::Bool => ValueSet::OfType(Name::new("bool")),
-            Ty::Int => ValueSet::OfType(Name::new("int")),
-            Ty::Float => ValueSet::OfType(Name::new("float")),
-            Ty::String => ValueSet::OfType(Name::new("string")),
-            Ty::Null => ValueSet::Literal(Literal::Null),
+            Ty::Bool { .. } => ValueSet::OfType(Name::new("bool")),
+            Ty::Int { .. } => ValueSet::OfType(Name::new("int")),
+            Ty::Float { .. } => ValueSet::OfType(Name::new("float")),
+            Ty::String { .. } => ValueSet::OfType(Name::new("string")),
+            Ty::Null { .. } => ValueSet::Literal(Literal::Null),
             _ => ValueSet::OfType(Name::new(ty.to_string())),
         }
     }

--- a/baml_language/crates/baml_compiler_tir/src/jinja.rs
+++ b/baml_language/crates/baml_compiler_tir/src/jinja.rs
@@ -200,32 +200,36 @@ impl JinjaType {
 impl From<&Ty> for JinjaType {
     fn from(ty: &Ty) -> Self {
         match ty {
-            Ty::Unknown => JinjaType::Unknown,
-            Ty::Null => JinjaType::None,
-            Ty::Int => JinjaType::Int,
-            Ty::Float => JinjaType::Float,
-            Ty::String => JinjaType::String,
-            Ty::Bool => JinjaType::Bool,
-            Ty::List(elem) => JinjaType::List(Box::new(JinjaType::from(elem.as_ref()))),
-            Ty::Map { key, value } => JinjaType::Map(
+            Ty::Unknown { .. } => JinjaType::Unknown,
+            Ty::Null { .. } => JinjaType::None,
+            Ty::Int { .. } => JinjaType::Int,
+            Ty::Float { .. } => JinjaType::Float,
+            Ty::String { .. } => JinjaType::String,
+            Ty::Bool { .. } => JinjaType::Bool,
+            Ty::List(elem, _) => JinjaType::List(Box::new(JinjaType::from(elem.as_ref()))),
+            Ty::Map { key, value, .. } => JinjaType::Map(
                 Box::new(JinjaType::from(key.as_ref())),
                 Box::new(JinjaType::from(value.as_ref())),
             ),
-            Ty::Union(items) => JinjaType::Union(items.iter().map(JinjaType::from).collect()),
-            Ty::Optional(inner) => {
+            Ty::Union(items, _) => JinjaType::Union(items.iter().map(JinjaType::from).collect()),
+            Ty::Optional(inner, _) => {
                 JinjaType::Union(vec![JinjaType::None, JinjaType::from(inner.as_ref())])
             }
-            Ty::Class(name) => JinjaType::ClassRef(name.to_string()),
-            Ty::Literal(crate::LiteralValue::String(s)) => {
+            Ty::Class(name, _) => JinjaType::ClassRef(name.to_string()),
+            Ty::Literal(crate::LiteralValue::String(s), _) => {
                 JinjaType::Literal(LiteralValue::String(s.clone()))
             }
-            Ty::Literal(crate::LiteralValue::Int(i)) => JinjaType::Literal(LiteralValue::Int(*i)),
-            Ty::Literal(crate::LiteralValue::Bool(b)) => JinjaType::Literal(LiteralValue::Bool(*b)),
-            Ty::Literal(crate::LiteralValue::Float(_)) => JinjaType::Float,
-            Ty::Enum(name) => JinjaType::EnumRef(name.to_string()),
-            Ty::Media(baml_base::MediaKind::Image) => JinjaType::Image,
-            Ty::Media(baml_base::MediaKind::Audio) => JinjaType::Audio,
-            Ty::Media(_) => JinjaType::Audio, // TODO: Do we need more jinja media types?
+            Ty::Literal(crate::LiteralValue::Int(i), _) => {
+                JinjaType::Literal(LiteralValue::Int(*i))
+            }
+            Ty::Literal(crate::LiteralValue::Bool(b), _) => {
+                JinjaType::Literal(LiteralValue::Bool(*b))
+            }
+            Ty::Literal(crate::LiteralValue::Float(_), _) => JinjaType::Float,
+            Ty::Enum(name, _) => JinjaType::EnumRef(name.to_string()),
+            Ty::Media(baml_base::MediaKind::Image, _) => JinjaType::Image,
+            Ty::Media(baml_base::MediaKind::Audio, _) => JinjaType::Audio,
+            Ty::Media(_, _) => JinjaType::Audio, // TODO: Do we need more jinja media types?
             _ => JinjaType::Unknown,
         }
     }
@@ -247,7 +251,7 @@ impl JinjaType {
         expanding: &mut HashSet<baml_base::Name>,
     ) -> Self {
         match ty {
-            Ty::TypeAlias(fqn) => {
+            Ty::TypeAlias(fqn, _) => {
                 if expanding.contains(&fqn.name) {
                     return JinjaType::RecursiveTypeAlias(fqn.name.to_string());
                 }
@@ -263,20 +267,20 @@ impl JinjaType {
                     JinjaType::RecursiveTypeAlias(fqn.name.to_string())
                 }
             }
-            Ty::List(elem) => {
+            Ty::List(elem, _) => {
                 JinjaType::List(Box::new(Self::from_ty_impl(elem, aliases, expanding)))
             }
-            Ty::Map { key, value } => JinjaType::Map(
+            Ty::Map { key, value, .. } => JinjaType::Map(
                 Box::new(Self::from_ty_impl(key, aliases, expanding)),
                 Box::new(Self::from_ty_impl(value, aliases, expanding)),
             ),
-            Ty::Union(items) => JinjaType::Union(
+            Ty::Union(items, _) => JinjaType::Union(
                 items
                     .iter()
                     .map(|t| Self::from_ty_impl(t, aliases, expanding))
                     .collect(),
             ),
-            Ty::Optional(inner) => JinjaType::Union(vec![
+            Ty::Optional(inner, _) => JinjaType::Union(vec![
                 JinjaType::None,
                 Self::from_ty_impl(inner, aliases, expanding),
             ]),

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     sync::Arc,
 };
 
-use baml_base::{FileId, Name, Span};
+use baml_base::{FileId, Name, Span, TyAttr};
 use baml_compiler_diagnostics::TypeError;
 use baml_compiler_hir::{
     ErrorLocation, ExprBody, ExprId, FunctionBody, FunctionLoc, FunctionSignature, HirSourceMap,
@@ -61,6 +61,11 @@ pub use resolve::{ResolvedMethod, ResolvedValue};
 use text_size::TextRange;
 pub use types::*;
 
+/// Shorthand for `TyAttr::default()` to reduce verbosity.
+fn d() -> TyAttr {
+    TyAttr::default()
+}
+
 /// Substitute type variable bindings into a `TypePattern`, falling back to `Ty::Unknown`
 /// for unbound type variables.
 ///
@@ -69,33 +74,40 @@ pub use types::*;
 fn substitute_with_fallback(pattern: &baml_builtins::TypePattern, bindings: &Bindings) -> Ty {
     use baml_builtins::TypePattern;
     match pattern {
-        TypePattern::Var(name) => bindings.get(name).cloned().unwrap_or(Ty::Unknown),
-        TypePattern::Int => Ty::Int,
-        TypePattern::Float => Ty::Float,
-        TypePattern::String => Ty::String,
-        TypePattern::Bool => Ty::Bool,
-        TypePattern::Null => Ty::Null,
-        TypePattern::Array(elem) => Ty::List(Box::new(substitute_with_fallback(elem, bindings))),
+        TypePattern::Var(name) => bindings
+            .get(name)
+            .cloned()
+            .unwrap_or(Ty::Unknown { attr: d() }),
+        TypePattern::Int => Ty::Int { attr: d() },
+        TypePattern::Float => Ty::Float { attr: d() },
+        TypePattern::String => Ty::String { attr: d() },
+        TypePattern::Bool => Ty::Bool { attr: d() },
+        TypePattern::Null => Ty::Null { attr: d() },
+        TypePattern::Array(elem) => {
+            Ty::List(Box::new(substitute_with_fallback(elem, bindings)), d())
+        }
         TypePattern::Map { key, value } => Ty::Map {
             key: Box::new(substitute_with_fallback(key, bindings)),
             value: Box::new(substitute_with_fallback(value, bindings)),
+            attr: d(),
         },
-        TypePattern::Media => Ty::Media(baml_base::MediaKind::Generic),
+        TypePattern::Media => Ty::Media(baml_base::MediaKind::Generic, d()),
         TypePattern::Optional(inner) => {
-            Ty::Optional(Box::new(substitute_with_fallback(inner, bindings)))
+            Ty::Optional(Box::new(substitute_with_fallback(inner, bindings)), d())
         }
-        TypePattern::Builtin(path) => Ty::Class(builtins::parse_builtin_path(path)),
+        TypePattern::Builtin(path) => Ty::Class(builtins::parse_builtin_path(path), d()),
         TypePattern::Function { params, ret } => Ty::Function {
             params: params
                 .iter()
                 .map(|p| (None, substitute_with_fallback(p, bindings)))
                 .collect(),
             ret: Box::new(substitute_with_fallback(ret, bindings)),
+            attr: d(),
         },
-        TypePattern::Resource => Ty::Resource,
-        TypePattern::BuiltinUnknown => Ty::BuiltinUnknown,
-        TypePattern::Enum(path) => Ty::Enum(builtins::parse_builtin_path(path)),
-        TypePattern::Type => Ty::Type,
+        TypePattern::Resource => Ty::Resource { attr: d() },
+        TypePattern::BuiltinUnknown => Ty::BuiltinUnknown { attr: d() },
+        TypePattern::Enum(path) => Ty::Enum(builtins::parse_builtin_path(path), d()),
+        TypePattern::Type => Ty::Type { attr: d() },
     }
 }
 
@@ -322,6 +334,7 @@ pub fn typing_context(db: &dyn Db, project: Project) -> TypingContextMap<'_> {
                     let func_type = Ty::Function {
                         params,
                         ret: Box::new(return_type),
+                        attr: d(),
                     };
 
                     // Use the qualified display name so builtin BAML functions are only
@@ -344,11 +357,12 @@ pub fn typing_context(db: &dyn Db, project: Project) -> TypingContextMap<'_> {
                         .collect();
 
                     // Template strings always return String
-                    let return_type = Ty::String;
+                    let return_type = Ty::String { attr: d() };
 
                     let func_type = Ty::Function {
                         params,
                         ret: Box::new(return_type),
+                        attr: d(),
                     };
 
                     let ts_name = hir_signature.name.clone();
@@ -879,11 +893,11 @@ impl<'db> TypeContext<'db> {
     pub fn resolve_named_type(&self, name: &Name) -> Ty {
         use baml_compiler_hir::QualifiedName;
         if let Some(qn) = self.class_names.get(name) {
-            Ty::Class(qn.clone())
+            Ty::Class(qn.clone(), d())
         } else if let Some(qn) = self.enum_names.get(name) {
-            Ty::Enum(qn.clone())
+            Ty::Enum(qn.clone(), d())
         } else {
-            Ty::TypeAlias(QualifiedName::local(name.clone()))
+            Ty::TypeAlias(QualifiedName::local(name.clone()), d())
         }
     }
 
@@ -1003,7 +1017,7 @@ pub fn infer_function_body<'db>(
                 (ty, ErrorLocation::Expr(root_expr))
             } else {
                 (
-                    Ty::Void,
+                    Ty::Void { attr: d() },
                     ErrorLocation::Span(return_type_span.unwrap_or_default()),
                 )
             }
@@ -1065,7 +1079,7 @@ pub fn infer_function_body<'db>(
     } else if !trailing_expr_type.is_void() {
         trailing_expr_type
     } else {
-        Ty::Void
+        Ty::Void { attr: d() }
     };
 
     InferenceResult {
@@ -1371,7 +1385,7 @@ fn validate_llm_prompt(
     // We add them both as functions (for signature checking) and as variables
     // (so {{ Foo() }} resolves "Foo" as a callable)
     for (func_name, func_ty) in ctx.scopes.first().unwrap_or(&HashMap::new()) {
-        if let Ty::Function { params, ret } = func_ty {
+        if let Ty::Function { params, ret, .. } = func_ty {
             // Extract parameter names and types from Ty::Function
             // Names are stored directly in params as (Option<Name>, Ty)
             let jinja_params: Vec<(String, JinjaType)> = params
@@ -1596,7 +1610,7 @@ pub fn validate_template_string_body(
 
     // Add functions (including other template strings) from globals
     for (func_name, func_ty) in globals {
-        if let Ty::Function { params, ret } = func_ty {
+        if let Ty::Function { params, ret, .. } = func_ty {
             // Extract parameter names and types from Ty::Function
             // Names are stored directly in params as (Option<Name>, Ty)
             let jinja_params: Vec<(String, JinjaType)> = params
@@ -1798,7 +1812,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
 
         Expr::Path(segments) => {
             if segments.is_empty() {
-                Ty::Unknown
+                Ty::Unknown { attr: d() }
             } else if segments.len() == 1 {
                 // Single segment: variable, function, class, or enum lookup
                 let name = &segments[0];
@@ -1845,7 +1859,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         name: name.to_string(),
                         location,
                     });
-                    Ty::Unknown
+                    Ty::Unknown { attr: d() }
                 }
             } else {
                 // Multi-segment path: use HIR name resolution first, then
@@ -1883,9 +1897,10 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                                 Ty::Function {
                                     params: param_types,
                                     ret: Box::new(return_type),
+                                    attr: d(),
                                 }
                             } else {
-                                Ty::Unknown
+                                Ty::Unknown { attr: d() }
                             };
                             ctx.set_expr_type(expr_id, ty.clone());
                             return ty;
@@ -1894,7 +1909,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                             ctx.set_expr_resolution(expr_id, ResolvedValue::Function(qn.clone()));
                             let path_name = qn.display_name();
                             let Some(ty) = ctx.lookup(&path_name).cloned() else {
-                                return Ty::Unknown;
+                                return Ty::Unknown { attr: d() };
                             };
                             ctx.set_expr_type(expr_id, ty.clone());
                             return ty;
@@ -1909,7 +1924,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                             );
                             let enum_name = enum_fqn.display_name();
                             ctx.enum_variant_exprs.insert(expr_id, (enum_name, variant));
-                            let ty = Ty::Enum(enum_fqn);
+                            let ty = Ty::Enum(enum_fqn, d());
                             ctx.set_expr_type(expr_id, ty.clone());
                             return ty;
                         }
@@ -1925,7 +1940,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         name: first.to_string(),
                         location,
                     });
-                    return Ty::Unknown;
+                    return Ty::Unknown { attr: d() };
                 };
 
                 // Record segment types and resolutions for codegen
@@ -1967,7 +1982,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         ResolvedValue::BuiltinFunction(baml_base::QualifiedName::from_builtin_path(
                             def.path,
                         ))
-                    } else if let Ty::Class(class_fqn) = &ty {
+                    } else if let Ty::Class(class_fqn, _) = &ty {
                         // Check if this is a method (function type) or a data field
                         if matches!(field_ty, Ty::Function { .. }) {
                             // Method reference - use qualified name
@@ -2026,7 +2041,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                 // For instanceof, don't try to resolve RHS as a variable.
                 // The RHS is a type name and will be resolved at runtime.
                 // Just return bool since instanceof always returns a boolean.
-                Ty::Bool
+                Ty::Bool { attr: d() }
             } else {
                 let lhs_ty = infer_expr(ctx, *lhs, body);
                 let rhs_ty = infer_expr(ctx, *rhs, body);
@@ -2072,6 +2087,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         let callee_ty = Ty::Function {
                             params: param_types,
                             ret: Box::new(return_type),
+                            attr: d(),
                         };
                         // Store the callee type so downstream passes (VIR, MIR) can find it
                         ctx.set_expr_type(*callee, callee_ty.clone());
@@ -2189,6 +2205,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         let callee_ty = Ty::Function {
                             params,
                             ret: Box::new(return_type),
+                            attr: d(),
                         };
                         // Store the callee type so downstream passes (VIR, MIR) can find it
                         ctx.set_expr_type(*callee, callee_ty.clone());
@@ -2242,11 +2259,14 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                             // Simple receiver: `baz.method()`
                             ctx.lookup(&receiver_segments[0])
                                 .cloned()
-                                .unwrap_or(Ty::Unknown)
+                                .unwrap_or(Ty::Unknown { attr: d() })
                         } else {
                             // Nested receiver: `obj.field.method()`
                             let first = &receiver_segments[0];
-                            let mut ty = ctx.lookup(first).cloned().unwrap_or(Ty::Unknown);
+                            let mut ty = ctx
+                                .lookup(first)
+                                .cloned()
+                                .unwrap_or(Ty::Unknown { attr: d() });
                             for field in &receiver_segments[1..] {
                                 ty = infer_field_access(ctx, &ty, field, location.clone(), None);
                             }
@@ -2282,7 +2302,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
 
             // If the callee is a function type, check arguments and return the return type
             match &callee_ty {
-                Ty::Function { params, ret } => {
+                Ty::Function { params, ret, .. } => {
                     // Check argument count
                     if effective_args.len() != params.len() {
                         ctx.push_error(TypeError::ArgumentCountMismatch {
@@ -2312,13 +2332,13 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                     // Return the function's return type
                     (**ret).clone()
                 }
-                Ty::Unknown => Ty::Unknown,
+                Ty::Unknown { .. } => Ty::Unknown { attr: d() },
                 _ => {
                     ctx.push_error(TypeError::NotCallable {
                         ty: callee_ty,
                         location,
                     });
-                    Ty::Unknown
+                    Ty::Unknown { attr: d() }
                 }
             }
         }
@@ -2360,7 +2380,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
 
         Expr::Array { elements } => {
             if elements.is_empty() {
-                Ty::List(Box::new(Ty::Unknown))
+                Ty::List(Box::new(Ty::Unknown { attr: d() }), d())
             } else {
                 // Infer element type from first element, but generalize literals to base types
                 // This ensures [1, 2, 3] is int[] not "1"[]
@@ -2373,7 +2393,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                 for &elem in &elements[1..] {
                     infer_expr(ctx, elem, body);
                 }
-                Ty::List(Box::new(elem_ty))
+                Ty::List(Box::new(elem_ty), d())
             }
         }
 
@@ -2391,7 +2411,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
             let obj_ty = if let Some(name) = type_name {
                 ctx.resolve_named_type(name)
             } else {
-                Ty::Unknown
+                Ty::Unknown { attr: d() }
             };
 
             // Store resolution for IDE features if this is a class instantiation
@@ -2405,7 +2425,8 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
             for spread in spreads {
                 let spread_ty = infer_expr(ctx, spread.expr, body);
                 // If we have a named type, verify the spread is compatible
-                if !matches!(obj_ty, Ty::Unknown) && !ctx.is_subtype_of(&spread_ty, &obj_ty) {
+                if !matches!(obj_ty, Ty::Unknown { .. }) && !ctx.is_subtype_of(&spread_ty, &obj_ty)
+                {
                     ctx.push_error(TypeError::TypeMismatch {
                         expected: obj_ty.clone(),
                         found: spread_ty,
@@ -2421,8 +2442,9 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
         Expr::Map { entries } => {
             if entries.is_empty() {
                 Ty::Map {
-                    key: Box::new(Ty::Unknown),
-                    value: Box::new(Ty::Unknown),
+                    key: Box::new(Ty::Unknown { attr: d() }),
+                    value: Box::new(Ty::Unknown { attr: d() }),
+                    attr: d(),
                 }
             } else {
                 // Infer key and value types from first entry, but generalize literals to base types
@@ -2443,6 +2465,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                 Ty::Map {
                     key: Box::new(key_ty),
                     value: Box::new(value_ty),
+                    attr: d(),
                 }
             }
         }
@@ -2463,7 +2486,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
             let result = if let Some(tail) = tail_expr {
                 infer_expr(ctx, *tail, body)
             } else {
-                Ty::Void
+                Ty::Void { attr: d() }
             };
 
             ctx.pop_scope();
@@ -2507,7 +2530,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                     infer_expr(ctx, *else_expr, body)
                 }
             } else {
-                Ty::Void
+                Ty::Void { attr: d() }
             };
 
             // Generalize literal types for the result, similar to arrays.
@@ -2520,9 +2543,9 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                 then_ty
             } else if else_branch.is_none() {
                 // if without else returns optional
-                Ty::Union(vec![then_ty, Ty::Null])
+                Ty::Union(vec![then_ty, Ty::Null { attr: d() }], d())
             } else {
-                Ty::Union(vec![then_ty, else_ty])
+                Ty::Union(vec![then_ty, else_ty], d())
             }
         }
 
@@ -2555,7 +2578,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         location: ErrorLocation::Expr(expr_id),
                     });
                 }
-                Ty::Unknown
+                Ty::Unknown { attr: d() }
             } else {
                 let arms_and_patterns: Vec<(MatchArmId, PatId)> = arms
                     .iter()
@@ -2589,9 +2612,11 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         // Type-check the guard (if present)
                         if let Some(guard) = arm.guard {
                             let guard_ty = infer_expr(ctx, guard, body);
-                            if !ctx.is_subtype_of(&guard_ty, &Ty::Bool) && !guard_ty.is_unknown() {
+                            if !ctx.is_subtype_of(&guard_ty, &Ty::Bool { attr: d() })
+                                && !guard_ty.is_unknown()
+                            {
                                 ctx.push_error(TypeError::TypeMismatch {
-                                    expected: Ty::Bool,
+                                    expected: Ty::Bool { attr: d() },
                                     found: guard_ty,
                                     location: location.clone(),
                                     info_location: None,
@@ -2609,14 +2634,17 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
 
                 // If all arms have the same type, use that; otherwise union
                 if arm_types.iter().all(|t| t == &arm_types[0]) {
-                    arm_types.into_iter().next().unwrap_or(Ty::Unknown)
+                    arm_types
+                        .into_iter()
+                        .next()
+                        .unwrap_or(Ty::Unknown { attr: d() })
                 } else {
-                    Ty::Union(arm_types)
+                    Ty::Union(arm_types, d())
                 }
             }
         }
 
-        Expr::Missing => Ty::Unknown,
+        Expr::Missing => Ty::Unknown { attr: d() },
     };
 
     ctx.set_expr_type(expr_id, ty.clone());
@@ -2672,7 +2700,7 @@ fn check_expr_with_info_location(
             } else {
                 // No tail expression means the block evaluates to void
                 // This is fine - the function might return via explicit return statements
-                Ty::Void
+                Ty::Void { attr: d() }
             };
 
             ctx.pop_scope();
@@ -2716,7 +2744,7 @@ fn check_expr_with_info_location(
                     check_expr(ctx, *else_expr, body, expected)
                 }
             } else {
-                Ty::Void
+                Ty::Void { attr: d() }
             };
 
             // In checking mode, don't generalize - the branches were checked against
@@ -2725,17 +2753,17 @@ fn check_expr_with_info_location(
                 then_ty
             } else if else_branch.is_none() {
                 // if without else returns optional
-                Ty::Union(vec![then_ty, Ty::Null])
+                Ty::Union(vec![then_ty, Ty::Null { attr: d() }], d())
             } else {
-                Ty::Union(vec![then_ty, else_ty])
+                Ty::Union(vec![then_ty, else_ty], d())
             }
         }
 
         Expr::Array { elements } => {
             // If we expect a specific list type, use it to check elements
-            if let Ty::List(expected_elem) = expected {
+            if let Ty::List(expected_elem, _) = expected {
                 if elements.is_empty() {
-                    Ty::List(expected_elem.clone())
+                    Ty::List(expected_elem.clone(), d())
                 } else {
                     // Check all elements against the expected element type
                     // check_expr already emits type mismatch errors, no need for redundant check
@@ -2775,7 +2803,7 @@ fn check_expr_with_info_location(
             }
 
             // If we expect a specific class type, we can use its field types
-            if let Ty::Class(expected_fqn) = expected {
+            if let Ty::Class(expected_fqn, _) = expected {
                 // Check field types against the expected class fields
                 for (field_name, value_expr) in fields {
                     // Clone the field type to avoid borrow issues
@@ -2795,9 +2823,9 @@ fn check_expr_with_info_location(
                 } else if let Some(name) = type_name {
                     ctx.resolve_named_type(name)
                 } else {
-                    Ty::Unknown
+                    Ty::Unknown { attr: d() }
                 }
-            } else if let Ty::TypeAlias(expected_fqn) = expected {
+            } else if let Ty::TypeAlias(expected_fqn, _) = expected {
                 use baml_compiler_hir::QualifiedName;
                 // Similar handling for TypeAlias types
                 let alias_key = expected_fqn.display_name();
@@ -2813,9 +2841,9 @@ fn check_expr_with_info_location(
                 if type_name.as_ref() == Some(&expected_fqn.name) {
                     expected.clone()
                 } else if let Some(name) = type_name {
-                    Ty::TypeAlias(QualifiedName::local(name.clone()))
+                    Ty::TypeAlias(QualifiedName::local(name.clone()), d())
                 } else {
-                    Ty::Unknown
+                    Ty::Unknown { attr: d() }
                 }
             } else {
                 // Fall back to synthesis
@@ -2840,12 +2868,14 @@ fn check_expr_with_info_location(
             if let Ty::Map {
                 key: expected_key,
                 value: expected_value,
+                ..
             } = expected
             {
                 if entries.is_empty() {
                     Ty::Map {
                         key: expected_key.clone(),
                         value: expected_value.clone(),
+                        attr: d(),
                     }
                 } else {
                     // Check all entries against the expected key/value types
@@ -3037,11 +3067,11 @@ fn check_match_exhaustiveness(
 fn infer_literal(lit: &baml_compiler_hir::Literal) -> Ty {
     use crate::types::LiteralValue;
     match lit {
-        baml_compiler_hir::Literal::Int(n) => Ty::Literal(LiteralValue::Int(*n)),
-        baml_compiler_hir::Literal::Float(f) => Ty::Literal(LiteralValue::Float(f.clone())),
-        baml_compiler_hir::Literal::String(s) => Ty::Literal(LiteralValue::String(s.clone())),
-        baml_compiler_hir::Literal::Bool(b) => Ty::Literal(LiteralValue::Bool(*b)),
-        baml_compiler_hir::Literal::Null => Ty::Null,
+        baml_compiler_hir::Literal::Int(n) => Ty::Literal(LiteralValue::Int(*n), d()),
+        baml_compiler_hir::Literal::Float(f) => Ty::Literal(LiteralValue::Float(f.clone()), d()),
+        baml_compiler_hir::Literal::String(s) => Ty::Literal(LiteralValue::String(s.clone()), d()),
+        baml_compiler_hir::Literal::Bool(b) => Ty::Literal(LiteralValue::Bool(*b), d()),
+        baml_compiler_hir::Literal::Null => Ty::Null { attr: d() },
     }
 }
 
@@ -3052,10 +3082,10 @@ fn infer_literal(lit: &baml_compiler_hir::Literal) -> Ty {
 fn generalize(ty: &Ty) -> Ty {
     use crate::types::LiteralValue;
     match ty {
-        Ty::Literal(LiteralValue::Int(_)) => Ty::Int,
-        Ty::Literal(LiteralValue::Float(_)) => Ty::Float,
-        Ty::Literal(LiteralValue::String(_)) => Ty::String,
-        Ty::Literal(LiteralValue::Bool(_)) => Ty::Bool,
+        Ty::Literal(LiteralValue::Int(_), _) => Ty::Int { attr: d() },
+        Ty::Literal(LiteralValue::Float(_), _) => Ty::Float { attr: d() },
+        Ty::Literal(LiteralValue::String(_), _) => Ty::String { attr: d() },
+        Ty::Literal(LiteralValue::Bool(_), _) => Ty::Bool { attr: d() },
         other => other.clone(),
     }
 }
@@ -3066,7 +3096,7 @@ fn generalize(ty: &Ty) -> Ty {
 /// rather than "Expected `4`, found `int`". But when expected is a base type like `int[]`,
 /// we want to show "Expected `int[]`, found `int`" rather than "Expected `int[]`, found `42`".
 fn generalize_for_error(expected: &Ty, found: &Ty) -> Ty {
-    if matches!(expected, Ty::Literal(_)) {
+    if matches!(expected, Ty::Literal(..)) {
         // Keep literal types when expected is also a literal
         found.clone()
     } else {
@@ -3093,29 +3123,29 @@ fn infer_binary_op(
     // e.g., `20 | 0` is int-like because all members are int literals.
     fn is_int_like(ty: &Ty) -> bool {
         match ty {
-            Ty::Int | Ty::Literal(LiteralValue::Int(_)) => true,
-            Ty::Union(members) => members.iter().all(is_int_like),
+            Ty::Int { .. } | Ty::Literal(LiteralValue::Int(_), _) => true,
+            Ty::Union(members, _) => members.iter().all(is_int_like),
             _ => false,
         }
     }
     fn is_float_like(ty: &Ty) -> bool {
         match ty {
-            Ty::Float | Ty::Literal(LiteralValue::Float(_)) => true,
-            Ty::Union(members) => members.iter().all(is_float_like),
+            Ty::Float { .. } | Ty::Literal(LiteralValue::Float(_), _) => true,
+            Ty::Union(members, _) => members.iter().all(is_float_like),
             _ => false,
         }
     }
     fn is_string_like(ty: &Ty) -> bool {
         match ty {
-            Ty::String | Ty::Literal(LiteralValue::String(_)) => true,
-            Ty::Union(members) => members.iter().all(is_string_like),
+            Ty::String { .. } | Ty::Literal(LiteralValue::String(_), _) => true,
+            Ty::Union(members, _) => members.iter().all(is_string_like),
             _ => false,
         }
     }
     fn is_bool_like(ty: &Ty) -> bool {
         match ty {
-            Ty::Bool | Ty::Literal(LiteralValue::Bool(_)) => true,
-            Ty::Union(members) => members.iter().all(is_bool_like),
+            Ty::Bool { .. } | Ty::Literal(LiteralValue::Bool(_), _) => true,
+            Ty::Union(members, _) => members.iter().all(is_bool_like),
             _ => false,
         }
     }
@@ -3123,21 +3153,21 @@ fn infer_binary_op(
     // Don't emit errors for operations involving unknown or error types - the root cause
     // (e.g., unknown variable) has already been reported
     if lhs.is_unknown() || lhs.is_error() || rhs.is_unknown() || rhs.is_error() {
-        return Ty::Unknown;
+        return Ty::Unknown { attr: d() };
     }
 
     match op {
         // Arithmetic operations (and string concatenation for Add)
         Add => {
             if is_int_like(lhs) && is_int_like(rhs) {
-                Ty::Int
+                Ty::Int { attr: d() }
             } else if (is_int_like(lhs) || is_float_like(lhs))
                 && (is_int_like(rhs) || is_float_like(rhs))
             {
-                Ty::Float
+                Ty::Float { attr: d() }
             } else if is_string_like(lhs) && is_string_like(rhs) {
                 // String concatenation
-                Ty::String
+                Ty::String { attr: d() }
             } else {
                 ctx.push_error(TypeError::InvalidBinaryOp {
                     op: format!("{op:?}"),
@@ -3145,16 +3175,16 @@ fn infer_binary_op(
                     rhs: generalize(rhs),
                     location,
                 });
-                Ty::Error
+                Ty::Error { attr: d() }
             }
         }
         Sub | Mul | Div | Mod => {
             if is_int_like(lhs) && is_int_like(rhs) {
-                Ty::Int
+                Ty::Int { attr: d() }
             } else if (is_int_like(lhs) || is_float_like(lhs))
                 && (is_int_like(rhs) || is_float_like(rhs))
             {
-                Ty::Float
+                Ty::Float { attr: d() }
             } else {
                 ctx.push_error(TypeError::InvalidBinaryOp {
                     op: format!("{op:?}"),
@@ -3162,18 +3192,18 @@ fn infer_binary_op(
                     rhs: generalize(rhs),
                     location,
                 });
-                Ty::Error
+                Ty::Error { attr: d() }
             }
         }
 
         // Comparison operations
-        Eq | Ne => Ty::Bool,
+        Eq | Ne => Ty::Bool { attr: d() },
 
         Lt | Le | Gt | Ge => {
             let numeric_lhs = is_int_like(lhs) || is_float_like(lhs);
             let numeric_rhs = is_int_like(rhs) || is_float_like(rhs);
             if (numeric_lhs && numeric_rhs) || (is_string_like(lhs) && is_string_like(rhs)) {
-                Ty::Bool
+                Ty::Bool { attr: d() }
             } else {
                 ctx.push_error(TypeError::InvalidBinaryOp {
                     op: format!("{op:?}"),
@@ -3181,14 +3211,14 @@ fn infer_binary_op(
                     rhs: generalize(rhs),
                     location,
                 });
-                Ty::Error
+                Ty::Error { attr: d() }
             }
         }
 
         // Logical operations
         And | Or => {
             if is_bool_like(lhs) && is_bool_like(rhs) {
-                Ty::Bool
+                Ty::Bool { attr: d() }
             } else {
                 ctx.push_error(TypeError::InvalidBinaryOp {
                     op: format!("{op:?}"),
@@ -3196,14 +3226,14 @@ fn infer_binary_op(
                     rhs: generalize(rhs),
                     location,
                 });
-                Ty::Error
+                Ty::Error { attr: d() }
             }
         }
 
         // Bitwise operations
         BitAnd | BitOr | BitXor | Shl | Shr => {
             if is_int_like(lhs) && is_int_like(rhs) {
-                Ty::Int
+                Ty::Int { attr: d() }
             } else {
                 ctx.push_error(TypeError::InvalidBinaryOp {
                     op: format!("{op:?}"),
@@ -3211,12 +3241,12 @@ fn infer_binary_op(
                     rhs: generalize(rhs),
                     location,
                 });
-                Ty::Error
+                Ty::Error { attr: d() }
             }
         }
 
         // Type checking operations
-        Instanceof => Ty::Bool,
+        Instanceof => Ty::Bool { attr: d() },
     }
 }
 
@@ -3234,7 +3264,7 @@ fn infer_unary_op(
     // Don't emit errors for operations involving unknown or error types - the root cause
     // has already been reported
     if operand.is_unknown() || operand.is_error() {
-        return Ty::Unknown;
+        return Ty::Unknown { attr: d() };
     }
 
     match op {
@@ -3242,18 +3272,18 @@ fn infer_unary_op(
             // `!` is a truthiness check: accepts any type, returns bool.
             // For bool operands this is logical negation; for other types
             // it converts to bool (falsy: null, false; truthy: everything else).
-            Ty::Bool
+            Ty::Bool { attr: d() }
         }
         Neg => match operand {
-            Ty::Int | Ty::Literal(LiteralValue::Int(_)) => Ty::Int,
-            Ty::Float | Ty::Literal(LiteralValue::Float(_)) => Ty::Float,
+            Ty::Int { .. } | Ty::Literal(LiteralValue::Int(_), _) => Ty::Int { attr: d() },
+            Ty::Float { .. } | Ty::Literal(LiteralValue::Float(_), _) => Ty::Float { attr: d() },
             _ => {
                 ctx.push_error(TypeError::InvalidUnaryOp {
                     op: "-".to_string(),
                     operand: generalize(operand),
                     location,
                 });
-                Ty::Error
+                Ty::Error { attr: d() }
             }
         },
     }
@@ -3277,11 +3307,11 @@ fn infer_field_access(
     // Special case: $watch accessor on any type
     // The actual watched check happens at MIR lowering time
     if field.as_str() == "$watch" {
-        return Ty::WatchAccessor(Box::new(base.clone()));
+        return Ty::WatchAccessor(Box::new(base.clone()), d());
     }
 
     // Special case: methods on WatchAccessor type
-    if let Ty::WatchAccessor(_inner_ty) = base {
+    if let Ty::WatchAccessor(_inner_ty, _) = base {
         match field.as_str() {
             "options" => {
                 // $watch.options(filter) - filter can be a function, "manual", or "never"
@@ -3290,9 +3320,10 @@ fn infer_field_access(
                     // First param is receiver (the WatchAccessor), second is filter
                     params: vec![
                         (None, base.clone()),
-                        (Some(Name::new("filter")), Ty::Unknown),
+                        (Some(Name::new("filter")), Ty::Unknown { attr: d() }),
                     ], // Filter type is flexible
-                    ret: Box::new(Ty::Null),
+                    ret: Box::new(Ty::Null { attr: d() }),
+                    attr: d(),
                 };
             }
             "notify" => {
@@ -3300,7 +3331,8 @@ fn infer_field_access(
                 // Returns null (void operation)
                 return Ty::Function {
                     params: vec![(None, base.clone())], // Just the receiver
-                    ret: Box::new(Ty::Null),
+                    ret: Box::new(Ty::Null { attr: d() }),
+                    attr: d(),
                 };
             }
             _ => {
@@ -3309,20 +3341,20 @@ fn infer_field_access(
                     field: field.to_string(),
                     location,
                 });
-                return Ty::Unknown;
+                return Ty::Unknown { attr: d() };
             }
         }
     }
 
     // First, try class field lookup for named types
     let found_field = match base {
-        Ty::TypeAlias(fqn) => {
+        Ty::TypeAlias(fqn, _) => {
             let key = fqn.display_name();
             ctx.lookup(field)
                 .or(ctx.lookup_class_field(&key, field))
                 .cloned()
         }
-        Ty::Class(fqn) => {
+        Ty::Class(fqn, _) => {
             // First try to find a method using a class-qualified name in the same
             // namespace as the class (e.g., `baml.llm.Foo.bar`).
             let method_qn = QualifiedName {
@@ -3345,7 +3377,7 @@ fn infer_field_access(
         }
         // Union field access: x.field where x: A | B is allowed if all members
         // have the field. Result type is the union of field types across members.
-        Ty::Union(members) => {
+        Ty::Union(members, _) => {
             let field_types: Vec<Ty> = members
                 .iter()
                 .filter_map(|member| infer_union_member_field(ctx, member, field))
@@ -3356,13 +3388,13 @@ fn infer_field_access(
                 if field_types.iter().all(|t| t == &field_types[0]) {
                     Some(field_types.into_iter().next().unwrap())
                 } else {
-                    Some(Ty::Union(field_types))
+                    Some(Ty::Union(field_types, d()))
                 }
             } else {
                 None
             }
         }
-        Ty::Unknown => return Ty::Unknown,
+        Ty::Unknown { .. } => return Ty::Unknown { attr: d() },
         _ => None,
     };
 
@@ -3396,6 +3428,7 @@ fn infer_field_access(
         return Ty::Function {
             params,
             ret: Box::new(return_type),
+            attr: d(),
         };
     }
 
@@ -3405,7 +3438,7 @@ fn infer_field_access(
         field: field.to_string(),
         location,
     });
-    Ty::Unknown
+    Ty::Unknown { attr: d() }
 }
 
 /// Infer the type of an index access.
@@ -3416,11 +3449,11 @@ fn infer_index_access(
     location: ErrorLocation,
 ) -> Ty {
     match base {
-        Ty::List(elem) => {
+        Ty::List(elem, _) => {
             // Index must be int
-            if !ctx.is_subtype_of(index, &Ty::Int) {
+            if !ctx.is_subtype_of(index, &Ty::Int { attr: d() }) {
                 ctx.push_error(TypeError::TypeMismatch {
-                    expected: Ty::Int,
+                    expected: Ty::Int { attr: d() },
                     found: index.clone(),
                     location,
                     info_location: None,
@@ -3428,7 +3461,7 @@ fn infer_index_access(
             }
             (**elem).clone()
         }
-        Ty::Map { key, value } => {
+        Ty::Map { key, value, .. } => {
             // Index must match key type
             if !ctx.is_subtype_of(index, key) {
                 ctx.push_error(TypeError::TypeMismatch {
@@ -3440,25 +3473,25 @@ fn infer_index_access(
             }
             (**value).clone()
         }
-        Ty::String => {
+        Ty::String { .. } => {
             // String indexing returns a character (string of length 1)
-            if !ctx.is_subtype_of(index, &Ty::Int) {
+            if !ctx.is_subtype_of(index, &Ty::Int { attr: d() }) {
                 ctx.push_error(TypeError::TypeMismatch {
-                    expected: Ty::Int,
+                    expected: Ty::Int { attr: d() },
                     found: index.clone(),
                     location,
                     info_location: None,
                 });
             }
-            Ty::String
+            Ty::String { attr: d() }
         }
-        Ty::Unknown => Ty::Unknown,
+        Ty::Unknown { .. } => Ty::Unknown { attr: d() },
         _ => {
             ctx.push_error(TypeError::NotIndexable {
                 ty: base.clone(),
                 location,
             });
-            Ty::Unknown
+            Ty::Unknown { attr: d() }
         }
     }
 }
@@ -3518,7 +3551,9 @@ fn check_stmt_with_return(
                 let span = ctx.type_span(*type_id);
                 ctx.lower_type(type_ref, span)
             } else {
-                Ty::Unknown
+                Ty::Unknown {
+                    attr: TyAttr::default(),
+                }
             };
 
             // Extract variable name from pattern and track watched status
@@ -3557,7 +3592,9 @@ fn check_stmt_with_return(
                     infer_expr(ctx, *e, body)
                 }
             } else {
-                Ty::Void
+                Ty::Void {
+                    attr: TyAttr::default(),
+                }
             };
             // Record return type (span resolved at render time if needed)
             ctx.record_return(return_ty, Span::default());
@@ -3619,7 +3656,14 @@ fn check_stmt_with_return(
 
         Stmt::Assert { condition } => {
             // Type-check the condition expression (bidirectional)
-            check_expr(ctx, *condition, body, &Ty::Bool);
+            check_expr(
+                ctx,
+                *condition,
+                body,
+                &Ty::Bool {
+                    attr: TyAttr::default(),
+                },
+            );
         }
 
         Stmt::Missing => {}

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -2763,7 +2763,7 @@ fn check_expr_with_info_location(
             // If we expect a specific list type, use it to check elements
             if let Ty::List(expected_elem, _) = expected {
                 if elements.is_empty() {
-                    Ty::List(expected_elem.clone(), d())
+                    expected.clone()
                 } else {
                     // Check all elements against the expected element type
                     // check_expr already emits type mismatch errors, no need for redundant check
@@ -2872,11 +2872,7 @@ fn check_expr_with_info_location(
             } = expected
             {
                 if entries.is_empty() {
-                    Ty::Map {
-                        key: expected_key.clone(),
-                        value: expected_value.clone(),
-                        attr: d(),
-                    }
+                    expected.clone()
                 } else {
                     // Check all entries against the expected key/value types
                     // check_expr already emits type mismatch errors, no need for redundant check
@@ -3082,10 +3078,10 @@ fn infer_literal(lit: &baml_compiler_hir::Literal) -> Ty {
 fn generalize(ty: &Ty) -> Ty {
     use crate::types::LiteralValue;
     match ty {
-        Ty::Literal(LiteralValue::Int(_), _) => Ty::Int { attr: d() },
-        Ty::Literal(LiteralValue::Float(_), _) => Ty::Float { attr: d() },
-        Ty::Literal(LiteralValue::String(_), _) => Ty::String { attr: d() },
-        Ty::Literal(LiteralValue::Bool(_), _) => Ty::Bool { attr: d() },
+        Ty::Literal(LiteralValue::Int(_), attr) => Ty::Int { attr: attr.clone() },
+        Ty::Literal(LiteralValue::Float(_), attr) => Ty::Float { attr: attr.clone() },
+        Ty::Literal(LiteralValue::String(_), attr) => Ty::String { attr: attr.clone() },
+        Ty::Literal(LiteralValue::Bool(_), attr) => Ty::Bool { attr: attr.clone() },
         other => other.clone(),
     }
 }

--- a/baml_language/crates/baml_compiler_tir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lower.rs
@@ -348,6 +348,10 @@ fn is_simple_type_name(name: &str) -> bool {
 }
 
 /// Normalize a union type by flattening nested unions and removing duplicates.
+///
+/// Uses `TyAttr::default()` for the output union because this is only called during
+/// type lowering from `TypeRef` syntax nodes, which construct fresh types rather than
+/// transforming existing ones — there is no source `TyAttr` to preserve.
 fn normalize_union(types: Vec<Ty>) -> Ty {
     let mut normalized = Vec::new();
 

--- a/baml_language/crates/baml_compiler_tir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lower.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use baml_base::Name;
+use baml_base::{Name, TyAttr};
 use baml_compiler_diagnostics::TypeError;
 use baml_compiler_hir::{ErrorLocation, TypeRef};
 
@@ -92,15 +92,17 @@ impl<'a> TypeLoweringContextResolved<'a> {
             name: name.to_string(),
             location: self.current_location(),
         });
-        Ty::Error
+        Ty::Error {
+            attr: TyAttr::default(),
+        }
     }
 
     fn resolve_name(&self, name: &Name) -> Option<Ty> {
         if let Some(qn) = self.class_names.get(name) {
-            return Some(Ty::Class(qn.clone()));
+            return Some(Ty::Class(qn.clone(), TyAttr::default()));
         }
         if let Some(qn) = self.enum_names.get(name) {
-            return Some(Ty::Enum(qn.clone()));
+            return Some(Ty::Enum(qn.clone(), TyAttr::default()));
         }
         None
     }
@@ -113,14 +115,24 @@ fn lower_type_ref_resolved_with_ctx(
 ) -> Ty {
     match type_ref {
         // Primitives
-        TypeRef::Int => Ty::Int,
-        TypeRef::Float => Ty::Float,
-        TypeRef::String => Ty::String,
-        TypeRef::Bool => Ty::Bool,
-        TypeRef::Null => Ty::Null,
+        TypeRef::Int => Ty::Int {
+            attr: TyAttr::default(),
+        },
+        TypeRef::Float => Ty::Float {
+            attr: TyAttr::default(),
+        },
+        TypeRef::String => Ty::String {
+            attr: TyAttr::default(),
+        },
+        TypeRef::Bool => Ty::Bool {
+            attr: TyAttr::default(),
+        },
+        TypeRef::Null => Ty::Null {
+            attr: TyAttr::default(),
+        },
 
         // Media types
-        TypeRef::Media(kind) => Ty::Media(*kind),
+        TypeRef::Media(kind) => Ty::Media(*kind, TyAttr::default()),
 
         // Named type via path
         TypeRef::Path(path) => lower_path_type_resolved_with_ctx(ctx, path),
@@ -130,14 +142,14 @@ fn lower_type_ref_resolved_with_ctx(
             ctx.current_path.push(0); // Optional inner is at index 0
             let inner_ty = lower_type_ref_resolved_with_ctx(ctx, inner);
             ctx.current_path.pop();
-            Ty::Optional(Box::new(inner_ty))
+            Ty::Optional(Box::new(inner_ty), TyAttr::default())
         }
 
         TypeRef::List(inner) => {
             ctx.current_path.push(0); // List element is at index 0
             let inner_ty = lower_type_ref_resolved_with_ctx(ctx, inner);
             ctx.current_path.pop();
-            Ty::List(Box::new(inner_ty))
+            Ty::List(Box::new(inner_ty), TyAttr::default())
         }
 
         TypeRef::Map { key, value } => {
@@ -152,6 +164,7 @@ fn lower_type_ref_resolved_with_ctx(
             Ty::Map {
                 key: Box::new(key_ty),
                 value: Box::new(value_ty),
+                attr: TyAttr::default(),
             }
         }
 
@@ -169,10 +182,12 @@ fn lower_type_ref_resolved_with_ctx(
             normalize_union(tys)
         }
 
-        TypeRef::StringLiteral(s) => Ty::Literal(LiteralValue::String(s.clone())),
-        TypeRef::IntLiteral(i) => Ty::Literal(LiteralValue::Int(*i)),
-        TypeRef::FloatLiteral(f) => Ty::Literal(LiteralValue::Float(f.clone())),
-        TypeRef::BoolLiteral(b) => Ty::Literal(LiteralValue::Bool(*b)),
+        TypeRef::StringLiteral(s) => {
+            Ty::Literal(LiteralValue::String(s.clone()), TyAttr::default())
+        }
+        TypeRef::IntLiteral(i) => Ty::Literal(LiteralValue::Int(*i), TyAttr::default()),
+        TypeRef::FloatLiteral(f) => Ty::Literal(LiteralValue::Float(f.clone()), TyAttr::default()),
+        TypeRef::BoolLiteral(b) => Ty::Literal(LiteralValue::Bool(*b), TyAttr::default()),
 
         // Function types: (x: int, y: int) -> bool
         TypeRef::Function { params, ret } => {
@@ -192,22 +207,35 @@ fn lower_type_ref_resolved_with_ctx(
             Ty::Function {
                 params: param_tys,
                 ret: Box::new(ret_ty),
+                attr: TyAttr::default(),
             }
         }
 
         // Generics - not yet supported
-        TypeRef::Generic { .. } => Ty::Unknown,
-        TypeRef::TypeParam(_) => Ty::Unknown,
+        TypeRef::Generic { .. } => Ty::Unknown {
+            attr: TyAttr::default(),
+        },
+        TypeRef::TypeParam(_) => Ty::Unknown {
+            attr: TyAttr::default(),
+        },
 
         // Error/Unknown
-        TypeRef::Error => Ty::Error,
-        TypeRef::Unknown => Ty::Unknown,
+        TypeRef::Error => Ty::Error {
+            attr: TyAttr::default(),
+        },
+        TypeRef::Unknown => Ty::Unknown {
+            attr: TyAttr::default(),
+        },
 
         // BuiltinUnknown - the `unknown` type keyword for builtin functions
-        TypeRef::BuiltinUnknown => Ty::BuiltinUnknown,
+        TypeRef::BuiltinUnknown => Ty::BuiltinUnknown {
+            attr: TyAttr::default(),
+        },
 
         // Type - the `type` keyword for the meta-type
-        TypeRef::Type => Ty::Type,
+        TypeRef::Type => Ty::Type {
+            attr: TyAttr::default(),
+        },
     }
 }
 
@@ -221,25 +249,40 @@ fn lower_path_type_resolved_with_ctx(
             let name = &path.segments[0];
             match name.as_str() {
                 // Primitive type names
-                "int" => Ty::Int,
-                "float" => Ty::Float,
-                "string" => Ty::String,
-                "bool" => Ty::Bool,
-                "null" => Ty::Null,
-                "image" => Ty::Media(baml_base::MediaKind::Image),
-                "audio" => Ty::Media(baml_base::MediaKind::Audio),
-                "video" => Ty::Media(baml_base::MediaKind::Video),
-                "pdf" => Ty::Media(baml_base::MediaKind::Pdf),
+                "int" => Ty::Int {
+                    attr: TyAttr::default(),
+                },
+                "float" => Ty::Float {
+                    attr: TyAttr::default(),
+                },
+                "string" => Ty::String {
+                    attr: TyAttr::default(),
+                },
+                "bool" => Ty::Bool {
+                    attr: TyAttr::default(),
+                },
+                "null" => Ty::Null {
+                    attr: TyAttr::default(),
+                },
+                "image" => Ty::Media(baml_base::MediaKind::Image, TyAttr::default()),
+                "audio" => Ty::Media(baml_base::MediaKind::Audio, TyAttr::default()),
+                "video" => Ty::Media(baml_base::MediaKind::Video, TyAttr::default()),
+                "pdf" => Ty::Media(baml_base::MediaKind::Pdf, TyAttr::default()),
                 // map with wrong arity - the arity error is already reported by HIR,
                 // so we don't report an unknown type error here
-                "map" => Ty::Error,
+                "map" => Ty::Error {
+                    attr: TyAttr::default(),
+                },
                 // User-defined type - resolve to Class/Enum or validate
                 _ => {
                     use baml_compiler_hir::QualifiedName;
 
                     // Skip validation for complex type expressions
                     if !is_simple_type_name(name.as_str()) {
-                        return Ty::TypeAlias(QualifiedName::local(name.clone()));
+                        return Ty::TypeAlias(
+                            QualifiedName::local(name.clone()),
+                            TyAttr::default(),
+                        );
                     }
 
                     // Try to resolve to Class/Enum
@@ -249,7 +292,7 @@ fn lower_path_type_resolved_with_ctx(
 
                     // Check if it's a type alias
                     if ctx.is_type_alias_name(name) {
-                        Ty::TypeAlias(QualifiedName::local(name.clone()))
+                        Ty::TypeAlias(QualifiedName::local(name.clone()), TyAttr::default())
                     } else {
                         ctx.unknown_type_error(name)
                     }
@@ -268,7 +311,7 @@ fn lower_path_type_resolved_with_ctx(
             let name = Name::new(&full_path);
 
             if !is_simple_type_name(&full_path) {
-                return Ty::TypeAlias(QualifiedName::local(name));
+                return Ty::TypeAlias(QualifiedName::local(name), TyAttr::default());
             }
 
             // Resolve as class/enum (builtin types like "baml.http.Request" are in class_names)
@@ -277,7 +320,7 @@ fn lower_path_type_resolved_with_ctx(
             }
 
             if ctx.is_type_alias_name(&name) {
-                Ty::TypeAlias(QualifiedName::local(name))
+                Ty::TypeAlias(QualifiedName::local(name), TyAttr::default())
             } else {
                 ctx.unknown_type_error(&name)
             }
@@ -311,7 +354,7 @@ fn normalize_union(types: Vec<Ty>) -> Ty {
     for ty in types {
         match ty {
             // Flatten nested unions
-            Ty::Union(inner) => {
+            Ty::Union(inner, _) => {
                 for inner_ty in inner {
                     if !normalized.contains(&inner_ty) {
                         normalized.push(inner_ty);
@@ -329,9 +372,11 @@ fn normalize_union(types: Vec<Ty>) -> Ty {
 
     // Simplify
     match normalized.len() {
-        0 => Ty::Unknown, // Empty union becomes Unknown (could be Never in a more complete type system)
+        0 => Ty::Unknown {
+            attr: TyAttr::default(),
+        }, // Empty union becomes Unknown (could be Never in a more complete type system)
         1 => normalized.pop().unwrap(),
-        _ => Ty::Union(normalized),
+        _ => Ty::Union(normalized, TyAttr::default()),
     }
 }
 
@@ -339,28 +384,49 @@ fn normalize_union(types: Vec<Ty>) -> Ty {
 mod tests {
     use super::*;
 
+    fn d() -> TyAttr {
+        TyAttr::default()
+    }
+
     #[test]
     fn test_normalize_union_empty() {
         let result = normalize_union(vec![]);
-        assert_eq!(result, Ty::Unknown);
+        assert_eq!(result, Ty::Unknown { attr: d() });
     }
 
     #[test]
     fn test_normalize_union_single() {
-        let result = normalize_union(vec![Ty::Int]);
-        assert_eq!(result, Ty::Int);
+        let result = normalize_union(vec![Ty::Int { attr: d() }]);
+        assert_eq!(result, Ty::Int { attr: d() });
     }
 
     #[test]
     fn test_normalize_union_removes_duplicates() {
-        let result = normalize_union(vec![Ty::Int, Ty::String, Ty::Int]);
-        assert_eq!(result, Ty::Union(vec![Ty::Int, Ty::String]));
+        let result = normalize_union(vec![
+            Ty::Int { attr: d() },
+            Ty::String { attr: d() },
+            Ty::Int { attr: d() },
+        ]);
+        assert_eq!(
+            result,
+            Ty::Union(vec![Ty::Int { attr: d() }, Ty::String { attr: d() }], d())
+        );
     }
 
     #[test]
     fn test_normalize_union_flattens() {
-        let inner = Ty::Union(vec![Ty::Int, Ty::Float]);
-        let result = normalize_union(vec![inner, Ty::String]);
-        assert_eq!(result, Ty::Union(vec![Ty::Int, Ty::Float, Ty::String]));
+        let inner = Ty::Union(vec![Ty::Int { attr: d() }, Ty::Float { attr: d() }], d());
+        let result = normalize_union(vec![inner, Ty::String { attr: d() }]);
+        assert_eq!(
+            result,
+            Ty::Union(
+                vec![
+                    Ty::Int { attr: d() },
+                    Ty::Float { attr: d() },
+                    Ty::String { attr: d() }
+                ],
+                d()
+            )
+        );
     }
 }

--- a/baml_language/crates/baml_compiler_tir/src/narrowing.rs
+++ b/baml_language/crates/baml_compiler_tir/src/narrowing.rs
@@ -8,7 +8,7 @@
 //! - **Early-return narrowing**: Applying the negation of an if-condition to code
 //!   after the if, when the if-body definitely diverges.
 
-use baml_base::Name;
+use baml_base::{Name, TyAttr};
 use baml_compiler_hir::{ExprBody, ExprId, StmtId};
 
 use crate::{TypeContext, types::Ty};
@@ -81,8 +81,8 @@ fn stmt_definitely_diverges(stmt_id: StmtId, body: &ExprBody) -> bool {
 /// Check if a type is nullable (Optional or Union containing Null).
 fn is_nullable(ty: &Ty) -> bool {
     match ty {
-        Ty::Optional(_) | Ty::Null => true,
-        Ty::Union(members) => members.iter().any(|m| matches!(m, Ty::Null)),
+        Ty::Optional(..) | Ty::Null { .. } => true,
+        Ty::Union(members, _) => members.iter().any(|m| matches!(m, Ty::Null { .. })),
         _ => false,
     }
 }
@@ -95,20 +95,24 @@ fn is_nullable(ty: &Ty) -> bool {
 /// - Other → unchanged
 fn remove_null(ty: &Ty) -> Ty {
     match ty {
-        Ty::Optional(inner) => (**inner).clone(),
-        Ty::Union(members) => {
+        Ty::Optional(inner, _) => (**inner).clone(),
+        Ty::Union(members, _) => {
             let non_null: Vec<Ty> = members
                 .iter()
-                .filter(|m| !matches!(m, Ty::Null))
+                .filter(|m| !matches!(m, Ty::Null { .. }))
                 .cloned()
                 .collect();
             match non_null.len() {
-                0 => Ty::Unknown,
+                0 => Ty::Unknown {
+                    attr: TyAttr::default(),
+                },
                 1 => non_null.into_iter().next().unwrap(),
-                _ => Ty::Union(non_null),
+                _ => Ty::Union(non_null, TyAttr::default()),
             }
         }
-        Ty::Null => Ty::Unknown,
+        Ty::Null { .. } => Ty::Unknown {
+            attr: TyAttr::default(),
+        },
         other => other.clone(),
     }
 }
@@ -116,7 +120,7 @@ fn remove_null(ty: &Ty) -> Ty {
 /// Get the simple name of a named type (Class, Enum, or `TypeAlias`).
 fn named_type_name(ty: &Ty) -> Option<&Name> {
     match ty {
-        Ty::Class(qn) | Ty::Enum(qn) | Ty::TypeAlias(qn) => Some(&qn.name),
+        Ty::Class(qn, _) | Ty::Enum(qn, _) | Ty::TypeAlias(qn, _) => Some(&qn.name),
         _ => None,
     }
 }
@@ -136,19 +140,23 @@ fn same_named_type(a: &Ty, b: &Ty) -> bool {
 /// Remove a specific type from a union (for instanceof false-branch narrowing).
 fn remove_type_from(ty: &Ty, to_remove: &Ty) -> Ty {
     match ty {
-        Ty::Union(members) => {
+        Ty::Union(members, _) => {
             let remaining: Vec<Ty> = members
                 .iter()
                 .filter(|m| !same_named_type(m, to_remove))
                 .cloned()
                 .collect();
             match remaining.len() {
-                0 => Ty::Unknown,
+                0 => Ty::Unknown {
+                    attr: TyAttr::default(),
+                },
                 1 => remaining.into_iter().next().unwrap(),
-                _ => Ty::Union(remaining),
+                _ => Ty::Union(remaining, TyAttr::default()),
             }
         }
-        Ty::Optional(inner) if same_named_type(inner.as_ref(), to_remove) => Ty::Null,
+        Ty::Optional(inner, _) if same_named_type(inner.as_ref(), to_remove) => Ty::Null {
+            attr: TyAttr::default(),
+        },
         _ => ty.clone(),
     }
 }
@@ -161,11 +169,11 @@ pub(crate) fn infer_union_member_field(
     field: &Name,
 ) -> Option<Ty> {
     match member {
-        Ty::Class(fqn) => {
+        Ty::Class(fqn, _) => {
             let key = fqn.display_name();
             ctx.lookup_class_field(&key, field).cloned()
         }
-        Ty::TypeAlias(fqn) => {
+        Ty::TypeAlias(fqn, _) => {
             let key = fqn.display_name();
             ctx.lookup_class_field(&key, field).cloned()
         }
@@ -203,7 +211,7 @@ fn extract_instanceof_narrowing(
                             let type_name = type_segments[0].clone();
                             return Some((
                                 var_name,
-                                Ty::TypeAlias(QualifiedName::local(type_name)),
+                                Ty::TypeAlias(QualifiedName::local(type_name), TyAttr::default()),
                             ));
                         }
                     }
@@ -299,7 +307,7 @@ fn extract_discriminated_union_narrowing(
 
     // Look up the variable's type — must be a union
     let var_ty = ctx.lookup(var_name)?;
-    let Ty::Union(members) = var_ty else {
+    let Ty::Union(members, _) = var_ty else {
         return None;
     };
 
@@ -308,7 +316,9 @@ fn extract_discriminated_union_narrowing(
     for member in members {
         if let Some(field_ty) = infer_union_member_field(ctx, member, field_name) {
             match &field_ty {
-                Ty::Literal(crate::types::LiteralValue::String(s)) if s.as_str() == literal_str => {
+                Ty::Literal(crate::types::LiteralValue::String(s), _)
+                    if s.as_str() == literal_str =>
+                {
                     matching_members.push(member.clone());
                 }
                 _ => {}
@@ -327,7 +337,7 @@ fn extract_discriminated_union_narrowing(
         // Narrow to matching members
         let narrowed = match matching_members.len() {
             1 => matching_members.into_iter().next().unwrap(),
-            _ => Ty::Union(matching_members),
+            _ => Ty::Union(matching_members, TyAttr::default()),
         };
         Some(vec![(var_name.clone(), narrowed)])
     } else {
@@ -342,7 +352,7 @@ fn extract_discriminated_union_narrowing(
         } else {
             let narrowed = match non_matching.len() {
                 1 => non_matching.into_iter().next().unwrap(),
-                _ => Ty::Union(non_matching),
+                _ => Ty::Union(non_matching, TyAttr::default()),
             };
             Some(vec![(var_name.clone(), narrowed)])
         }
@@ -382,7 +392,12 @@ pub(crate) fn extract_condition_narrowing(
             BinaryOp::Eq => {
                 if let Some((var_name, var_ty)) = extract_null_comparison(ctx, *lhs, *rhs, body) {
                     if when_true {
-                        vec![(var_name, Ty::Null)]
+                        vec![(
+                            var_name,
+                            Ty::Null {
+                                attr: TyAttr::default(),
+                            },
+                        )]
                     } else {
                         vec![(var_name, remove_null(&var_ty))]
                     }
@@ -398,7 +413,12 @@ pub(crate) fn extract_condition_narrowing(
                     if when_true {
                         vec![(var_name, remove_null(&var_ty))]
                     } else {
-                        vec![(var_name, Ty::Null)]
+                        vec![(
+                            var_name,
+                            Ty::Null {
+                                attr: TyAttr::default(),
+                            },
+                        )]
                     }
                 } else {
                     extract_discriminated_union_narrowing(ctx, *lhs, *rhs, body, !when_true)

--- a/baml_language/crates/baml_compiler_tir/src/narrowing.rs
+++ b/baml_language/crates/baml_compiler_tir/src/narrowing.rs
@@ -96,7 +96,7 @@ fn is_nullable(ty: &Ty) -> bool {
 fn remove_null(ty: &Ty) -> Ty {
     match ty {
         Ty::Optional(inner, _) => (**inner).clone(),
-        Ty::Union(members, _) => {
+        Ty::Union(members, union_attr) => {
             let non_null: Vec<Ty> = members
                 .iter()
                 .filter(|m| !matches!(m, Ty::Null { .. }))
@@ -104,15 +104,13 @@ fn remove_null(ty: &Ty) -> Ty {
                 .collect();
             match non_null.len() {
                 0 => Ty::Unknown {
-                    attr: TyAttr::default(),
+                    attr: union_attr.clone(),
                 },
                 1 => non_null.into_iter().next().unwrap(),
-                _ => Ty::Union(non_null, TyAttr::default()),
+                _ => Ty::Union(non_null, union_attr.clone()),
             }
         }
-        Ty::Null { .. } => Ty::Unknown {
-            attr: TyAttr::default(),
-        },
+        Ty::Null { attr } => Ty::Unknown { attr: attr.clone() },
         other => other.clone(),
     }
 }
@@ -140,7 +138,7 @@ fn same_named_type(a: &Ty, b: &Ty) -> bool {
 /// Remove a specific type from a union (for instanceof false-branch narrowing).
 fn remove_type_from(ty: &Ty, to_remove: &Ty) -> Ty {
     match ty {
-        Ty::Union(members, _) => {
+        Ty::Union(members, union_attr) => {
             let remaining: Vec<Ty> = members
                 .iter()
                 .filter(|m| !same_named_type(m, to_remove))
@@ -148,14 +146,14 @@ fn remove_type_from(ty: &Ty, to_remove: &Ty) -> Ty {
                 .collect();
             match remaining.len() {
                 0 => Ty::Unknown {
-                    attr: TyAttr::default(),
+                    attr: union_attr.clone(),
                 },
                 1 => remaining.into_iter().next().unwrap(),
-                _ => Ty::Union(remaining, TyAttr::default()),
+                _ => Ty::Union(remaining, union_attr.clone()),
             }
         }
-        Ty::Optional(inner, _) if same_named_type(inner.as_ref(), to_remove) => Ty::Null {
-            attr: TyAttr::default(),
+        Ty::Optional(inner, opt_attr) if same_named_type(inner.as_ref(), to_remove) => Ty::Null {
+            attr: opt_attr.clone(),
         },
         _ => ty.clone(),
     }
@@ -307,7 +305,7 @@ fn extract_discriminated_union_narrowing(
 
     // Look up the variable's type — must be a union
     let var_ty = ctx.lookup(var_name)?;
-    let Ty::Union(members, _) = var_ty else {
+    let Ty::Union(members, union_attr) = var_ty else {
         return None;
     };
 
@@ -337,7 +335,7 @@ fn extract_discriminated_union_narrowing(
         // Narrow to matching members
         let narrowed = match matching_members.len() {
             1 => matching_members.into_iter().next().unwrap(),
-            _ => Ty::Union(matching_members, TyAttr::default()),
+            _ => Ty::Union(matching_members, union_attr.clone()),
         };
         Some(vec![(var_name.clone(), narrowed)])
     } else {
@@ -352,7 +350,7 @@ fn extract_discriminated_union_narrowing(
         } else {
             let narrowed = match non_matching.len() {
                 1 => non_matching.into_iter().next().unwrap(),
-                _ => Ty::Union(non_matching, TyAttr::default()),
+                _ => Ty::Union(non_matching, union_attr.clone()),
             };
             Some(vec![(var_name.clone(), narrowed)])
         }

--- a/baml_language/crates/baml_compiler_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler_tir/src/normalize.rs
@@ -316,21 +316,21 @@ fn find_invalid_map_keys_recursive(
     invalid_keys: &mut Vec<Ty>,
 ) {
     match ty {
-        Ty::Map { key, value } => {
+        Ty::Map { key, value, .. } => {
             if !is_valid_map_key_type(key, aliases) {
                 invalid_keys.push((**key).clone());
             }
             find_invalid_map_keys_recursive(key, aliases, invalid_keys);
             find_invalid_map_keys_recursive(value, aliases, invalid_keys);
         }
-        Ty::List(inner) => find_invalid_map_keys_recursive(inner, aliases, invalid_keys),
-        Ty::Optional(inner) => find_invalid_map_keys_recursive(inner, aliases, invalid_keys),
-        Ty::Union(types) => {
+        Ty::List(inner, _) => find_invalid_map_keys_recursive(inner, aliases, invalid_keys),
+        Ty::Optional(inner, _) => find_invalid_map_keys_recursive(inner, aliases, invalid_keys),
+        Ty::Union(types, _) => {
             for t in types {
                 find_invalid_map_keys_recursive(t, aliases, invalid_keys);
             }
         }
-        Ty::Function { params, ret } => {
+        Ty::Function { params, ret, .. } => {
             for (_, p) in params {
                 find_invalid_map_keys_recursive(p, aliases, invalid_keys);
             }
@@ -357,27 +357,27 @@ fn normalize_impl(
 ) -> StructuralTy {
     match ty {
         // Direct conversions
-        Ty::Int => StructuralTy::Int,
-        Ty::Float => StructuralTy::Float,
-        Ty::String => StructuralTy::String,
-        Ty::Bool => StructuralTy::Bool,
-        Ty::Null => StructuralTy::Null,
-        Ty::Media(kind) => StructuralTy::Media(*kind),
-        Ty::Unknown => StructuralTy::Unknown,
-        Ty::Error => StructuralTy::Error,
-        Ty::Void => StructuralTy::Void,
-        Ty::Resource => StructuralTy::Resource,
-        Ty::BuiltinUnknown => StructuralTy::BuiltinUnknown,
-        Ty::Type => StructuralTy::Type,
-        Ty::Literal(lit) => StructuralTy::Literal(lit.clone()),
-        Ty::Class(fqn) => StructuralTy::Class(fqn.name.clone()),
-        Ty::Enum(fqn) => StructuralTy::Enum(fqn.name.clone()),
-        Ty::WatchAccessor(inner) => StructuralTy::WatchAccessor(Box::new(normalize_impl(
+        Ty::Int { .. } => StructuralTy::Int,
+        Ty::Float { .. } => StructuralTy::Float,
+        Ty::String { .. } => StructuralTy::String,
+        Ty::Bool { .. } => StructuralTy::Bool,
+        Ty::Null { .. } => StructuralTy::Null,
+        Ty::Media(kind, _) => StructuralTy::Media(*kind),
+        Ty::Unknown { .. } => StructuralTy::Unknown,
+        Ty::Error { .. } => StructuralTy::Error,
+        Ty::Void { .. } => StructuralTy::Void,
+        Ty::Resource { .. } => StructuralTy::Resource,
+        Ty::BuiltinUnknown { .. } => StructuralTy::BuiltinUnknown,
+        Ty::Type { .. } => StructuralTy::Type,
+        Ty::Literal(lit, _) => StructuralTy::Literal(lit.clone()),
+        Ty::Class(fqn, _) => StructuralTy::Class(fqn.name.clone()),
+        Ty::Enum(fqn, _) => StructuralTy::Enum(fqn.name.clone()),
+        Ty::WatchAccessor(inner, _) => StructuralTy::WatchAccessor(Box::new(normalize_impl(
             inner, aliases, recursive, expanding,
         ))),
 
         // TypeAlias: resolve alias
-        Ty::TypeAlias(fqn) => {
+        Ty::TypeAlias(fqn, _) => {
             let name = &fqn.name;
             if expanding.contains(name) {
                 // Back-reference in recursive expansion
@@ -406,23 +406,23 @@ fn normalize_impl(
         }
 
         // Type constructors
-        Ty::Optional(inner) => StructuralTy::Optional(Box::new(normalize_impl(
+        Ty::Optional(inner, _) => StructuralTy::Optional(Box::new(normalize_impl(
             inner, aliases, recursive, expanding,
         ))),
-        Ty::List(inner) => StructuralTy::List(Box::new(normalize_impl(
+        Ty::List(inner, _) => StructuralTy::List(Box::new(normalize_impl(
             inner, aliases, recursive, expanding,
         ))),
-        Ty::Map { key, value } => StructuralTy::Map {
+        Ty::Map { key, value, .. } => StructuralTy::Map {
             key: Box::new(normalize_impl(key, aliases, recursive, expanding)),
             value: Box::new(normalize_impl(value, aliases, recursive, expanding)),
         },
-        Ty::Union(types) => StructuralTy::Union(
+        Ty::Union(types, _) => StructuralTy::Union(
             types
                 .iter()
                 .map(|t| normalize_impl(t, aliases, recursive, expanding))
                 .collect(),
         ),
-        Ty::Function { params, ret } => StructuralTy::Function {
+        Ty::Function { params, ret, .. } => StructuralTy::Function {
             params: params
                 .iter()
                 .map(|(_, t)| normalize_impl(t, aliases, recursive, expanding))
@@ -477,18 +477,18 @@ fn ty_has_cycle(
     stack: &mut HashSet<Name>,
 ) -> bool {
     match ty {
-        Ty::TypeAlias(fqn) if aliases.contains_key(&fqn.name) => {
+        Ty::TypeAlias(fqn, _) if aliases.contains_key(&fqn.name) => {
             has_cycle(&fqn.name, aliases, visited, stack)
         }
-        Ty::Optional(inner) | Ty::List(inner) => ty_has_cycle(inner, aliases, visited, stack),
-        Ty::Map { key, value } => {
+        Ty::Optional(inner, _) | Ty::List(inner, _) => ty_has_cycle(inner, aliases, visited, stack),
+        Ty::Map { key, value, .. } => {
             ty_has_cycle(key, aliases, visited, stack)
                 || ty_has_cycle(value, aliases, visited, stack)
         }
-        Ty::Union(types) => types
+        Ty::Union(types, _) => types
             .iter()
             .any(|t| ty_has_cycle(t, aliases, visited, stack)),
-        Ty::Function { params, ret } => {
+        Ty::Function { params, ret, .. } => {
             params
                 .iter()
                 .any(|(_, t)| ty_has_cycle(t, aliases, visited, stack))
@@ -500,35 +500,64 @@ fn ty_has_cycle(
 
 #[cfg(test)]
 mod tests {
+    use baml_base::TyAttr;
     use baml_compiler_hir::QualifiedName;
 
     use super::*;
 
     /// Helper to create a type alias type
     fn type_alias(name: &str) -> Ty {
-        Ty::TypeAlias(QualifiedName::local(Name::new(name)))
+        Ty::TypeAlias(QualifiedName::local(Name::new(name)), TyAttr::default())
     }
 
     #[test]
     fn test_simple_alias() {
         let mut aliases = HashMap::new();
-        aliases.insert(Name::new("MyInt"), Ty::Int);
+        aliases.insert(
+            Name::new("MyInt"),
+            Ty::Int {
+                attr: TyAttr::default(),
+            },
+        );
 
         // MyInt <: int should be true
-        assert!(is_subtype_of(&type_alias("MyInt"), &Ty::Int, &aliases));
+        assert!(is_subtype_of(
+            &type_alias("MyInt"),
+            &Ty::Int {
+                attr: TyAttr::default()
+            },
+            &aliases
+        ));
 
         // int <: MyInt should also be true (same structural type)
-        assert!(is_subtype_of(&Ty::Int, &type_alias("MyInt"), &aliases));
+        assert!(is_subtype_of(
+            &Ty::Int {
+                attr: TyAttr::default()
+            },
+            &type_alias("MyInt"),
+            &aliases
+        ));
     }
 
     #[test]
     fn test_transitive_alias() {
         let mut aliases = HashMap::new();
-        aliases.insert(Name::new("MyInt"), Ty::Int);
+        aliases.insert(
+            Name::new("MyInt"),
+            Ty::Int {
+                attr: TyAttr::default(),
+            },
+        );
         aliases.insert(Name::new("AnotherInt"), type_alias("MyInt"));
 
         // AnotherInt <: int
-        assert!(is_subtype_of(&type_alias("AnotherInt"), &Ty::Int, &aliases));
+        assert!(is_subtype_of(
+            &type_alias("AnotherInt"),
+            &Ty::Int {
+                attr: TyAttr::default()
+            },
+            &aliases
+        ));
 
         // AnotherInt <: MyInt
         assert!(is_subtype_of(
@@ -543,26 +572,42 @@ mod tests {
         let mut aliases = HashMap::new();
         aliases.insert(
             Name::new("IntOrString"),
-            Ty::Union(vec![Ty::Int, Ty::String]),
+            Ty::Union(
+                vec![
+                    Ty::Int {
+                        attr: TyAttr::default(),
+                    },
+                    Ty::String {
+                        attr: TyAttr::default(),
+                    },
+                ],
+                TyAttr::default(),
+            ),
         );
 
         // int <: IntOrString
         assert!(is_subtype_of(
-            &Ty::Int,
+            &Ty::Int {
+                attr: TyAttr::default()
+            },
             &type_alias("IntOrString"),
             &aliases
         ));
 
         // string <: IntOrString
         assert!(is_subtype_of(
-            &Ty::String,
+            &Ty::String {
+                attr: TyAttr::default()
+            },
             &type_alias("IntOrString"),
             &aliases
         ));
 
         // bool NOT <: IntOrString
         assert!(!is_subtype_of(
-            &Ty::Bool,
+            &Ty::Bool {
+                attr: TyAttr::default()
+            },
             &type_alias("IntOrString"),
             &aliases
         ));
@@ -574,7 +619,15 @@ mod tests {
         // type List = int | List (simplified recursive type)
         aliases.insert(
             Name::new("List"),
-            Ty::Union(vec![Ty::Null, type_alias("List")]),
+            Ty::Union(
+                vec![
+                    Ty::Null {
+                        attr: TyAttr::default(),
+                    },
+                    type_alias("List"),
+                ],
+                TyAttr::default(),
+            ),
         );
 
         let recursive = find_recursive_aliases(&aliases);
@@ -584,7 +637,12 @@ mod tests {
     #[test]
     fn test_non_recursive_not_marked() {
         let mut aliases = HashMap::new();
-        aliases.insert(Name::new("MyInt"), Ty::Int);
+        aliases.insert(
+            Name::new("MyInt"),
+            Ty::Int {
+                attr: TyAttr::default(),
+            },
+        );
 
         let recursive = find_recursive_aliases(&aliases);
         assert!(!recursive.contains(&Name::new("MyInt")));
@@ -593,10 +651,17 @@ mod tests {
     #[test]
     fn test_void_not_subtype_of_map() {
         let aliases = HashMap::new();
-        let void_ty = Ty::Void;
+        let void_ty = Ty::Void {
+            attr: TyAttr::default(),
+        };
         let map_ty = Ty::Map {
-            key: Box::new(Ty::String),
-            value: Box::new(Ty::Bool),
+            key: Box::new(Ty::String {
+                attr: TyAttr::default(),
+            }),
+            value: Box::new(Ty::Bool {
+                attr: TyAttr::default(),
+            }),
+            attr: TyAttr::default(),
         };
 
         // Void should NOT be a subtype of Map
@@ -612,6 +677,7 @@ mod tests {
         Ty::Function {
             params: params.into_iter().map(|t| (None, t)).collect(),
             ret: Box::new(ret),
+            attr: TyAttr::default(),
         }
     }
 
@@ -620,7 +686,14 @@ mod tests {
         let aliases = HashMap::new();
 
         // (int) -> string <: (int) -> string
-        let f = func(vec![Ty::Int], Ty::String);
+        let f = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
         assert!(is_subtype_of(&f, &f, &aliases));
     }
 
@@ -629,8 +702,22 @@ mod tests {
         let aliases = HashMap::new();
 
         // (int) -> int <: (int) -> float  (because int <: float)
-        let f1 = func(vec![Ty::Int], Ty::Int);
-        let f2 = func(vec![Ty::Int], Ty::Float);
+        let f1 = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::Int {
+                attr: TyAttr::default(),
+            },
+        );
+        let f2 = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::Float {
+                attr: TyAttr::default(),
+            },
+        );
         assert!(is_subtype_of(&f1, &f2, &aliases));
 
         // (int) -> float NOT <: (int) -> int
@@ -643,8 +730,22 @@ mod tests {
 
         // (float) -> string <: (int) -> string  (because int <: float, contravariance)
         // A function that accepts float can be used where one accepting int is expected
-        let f1 = func(vec![Ty::Float], Ty::String);
-        let f2 = func(vec![Ty::Int], Ty::String);
+        let f1 = func(
+            vec![Ty::Float {
+                attr: TyAttr::default(),
+            }],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
+        let f2 = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
         assert!(is_subtype_of(&f1, &f2, &aliases));
 
         // (int) -> string NOT <: (float) -> string
@@ -658,8 +759,20 @@ mod tests {
         // () -> string is a supertype of (int) -> string
         // A nullary function can be used where a unary function is expected
         // (it just ignores the argument)
-        let nullary = func(vec![], Ty::String);
-        let unary = func(vec![Ty::Int], Ty::String);
+        let nullary = func(
+            vec![],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
+        let unary = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
 
         // (int) -> string <: () -> string
         assert!(is_subtype_of(&unary, &nullary, &aliases));
@@ -675,8 +788,27 @@ mod tests {
 
         // (int, string) -> bool <: (int) -> bool
         // A function with more params can be used where fewer are expected
-        let binary = func(vec![Ty::Int, Ty::String], Ty::Bool);
-        let unary = func(vec![Ty::Int], Ty::Bool);
+        let binary = func(
+            vec![
+                Ty::Int {
+                    attr: TyAttr::default(),
+                },
+                Ty::String {
+                    attr: TyAttr::default(),
+                },
+            ],
+            Ty::Bool {
+                attr: TyAttr::default(),
+            },
+        );
+        let unary = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::Bool {
+                attr: TyAttr::default(),
+            },
+        );
 
         assert!(is_subtype_of(&binary, &unary, &aliases));
 
@@ -691,8 +823,22 @@ mod tests {
         // (float) -> int <: (int) -> float
         // - Param: int <: float (contravariant, so float in sub, int in sup)
         // - Return: int <: float (covariant)
-        let f1 = func(vec![Ty::Float], Ty::Int);
-        let f2 = func(vec![Ty::Int], Ty::Float);
+        let f1 = func(
+            vec![Ty::Float {
+                attr: TyAttr::default(),
+            }],
+            Ty::Int {
+                attr: TyAttr::default(),
+            },
+        );
+        let f2 = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::Float {
+                attr: TyAttr::default(),
+            },
+        );
         assert!(is_subtype_of(&f1, &f2, &aliases));
     }
 
@@ -703,8 +849,32 @@ mod tests {
         // (float, string) -> bool <: (int, string) -> bool
         // First param: int <: float (contravariant)
         // Second param: string = string
-        let f1 = func(vec![Ty::Float, Ty::String], Ty::Bool);
-        let f2 = func(vec![Ty::Int, Ty::String], Ty::Bool);
+        let f1 = func(
+            vec![
+                Ty::Float {
+                    attr: TyAttr::default(),
+                },
+                Ty::String {
+                    attr: TyAttr::default(),
+                },
+            ],
+            Ty::Bool {
+                attr: TyAttr::default(),
+            },
+        );
+        let f2 = func(
+            vec![
+                Ty::Int {
+                    attr: TyAttr::default(),
+                },
+                Ty::String {
+                    attr: TyAttr::default(),
+                },
+            ],
+            Ty::Bool {
+                attr: TyAttr::default(),
+            },
+        );
         assert!(is_subtype_of(&f1, &f2, &aliases));
 
         // (int, string) -> bool NOT <: (float, string) -> bool
@@ -715,28 +885,74 @@ mod tests {
     fn test_function_not_subtype_of_non_function() {
         let aliases = HashMap::new();
 
-        let f = func(vec![Ty::Int], Ty::String);
+        let f = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
 
         // Function is not a subtype of primitive types
-        assert!(!is_subtype_of(&f, &Ty::Int, &aliases));
-        assert!(!is_subtype_of(&f, &Ty::String, &aliases));
+        assert!(!is_subtype_of(
+            &f,
+            &Ty::Int {
+                attr: TyAttr::default()
+            },
+            &aliases
+        ));
+        assert!(!is_subtype_of(
+            &f,
+            &Ty::String {
+                attr: TyAttr::default()
+            },
+            &aliases
+        ));
 
         // Primitive types are not subtypes of functions
-        assert!(!is_subtype_of(&Ty::Int, &f, &aliases));
+        assert!(!is_subtype_of(
+            &Ty::Int {
+                attr: TyAttr::default()
+            },
+            &f,
+            &aliases
+        ));
     }
 
     #[test]
     fn test_function_in_union() {
         let aliases = HashMap::new();
 
-        let f = func(vec![Ty::Int], Ty::String);
-        let union = Ty::Union(vec![f.clone(), Ty::Null]);
+        let f = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
+        let union = Ty::Union(
+            vec![
+                f.clone(),
+                Ty::Null {
+                    attr: TyAttr::default(),
+                },
+            ],
+            TyAttr::default(),
+        );
 
         // (int) -> string <: ((int) -> string) | null
         assert!(is_subtype_of(&f, &union, &aliases));
 
         // null <: ((int) -> string) | null
-        assert!(is_subtype_of(&Ty::Null, &union, &aliases));
+        assert!(is_subtype_of(
+            &Ty::Null {
+                attr: TyAttr::default()
+            },
+            &union,
+            &aliases
+        ));
     }
 
     #[test]
@@ -745,8 +961,20 @@ mod tests {
 
         // A function that takes a function as parameter
         // ((int) -> string) -> bool
-        let inner_fn_int = func(vec![Ty::Int], Ty::String);
-        let higher_order_int = func(vec![inner_fn_int], Ty::Bool);
+        let inner_fn_int = func(
+            vec![Ty::Int {
+                attr: TyAttr::default(),
+            }],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
+        let higher_order_int = func(
+            vec![inner_fn_int],
+            Ty::Bool {
+                attr: TyAttr::default(),
+            },
+        );
 
         // Reflexivity
         assert!(is_subtype_of(
@@ -765,8 +993,20 @@ mod tests {
         //   - params are contravariant: need float <: int (FALSE! float is supertype of int)
         //
         // So ((float) -> string) -> bool is NOT <: ((int) -> string) -> bool
-        let inner_fn_float = func(vec![Ty::Float], Ty::String);
-        let higher_order_float = func(vec![inner_fn_float], Ty::Bool);
+        let inner_fn_float = func(
+            vec![Ty::Float {
+                attr: TyAttr::default(),
+            }],
+            Ty::String {
+                attr: TyAttr::default(),
+            },
+        );
+        let higher_order_float = func(
+            vec![inner_fn_float],
+            Ty::Bool {
+                attr: TyAttr::default(),
+            },
+        );
         assert!(!is_subtype_of(
             &higher_order_float,
             &higher_order_int,

--- a/baml_language/crates/baml_compiler_tir/src/types.rs
+++ b/baml_language/crates/baml_compiler_tir/src/types.rs
@@ -226,6 +226,8 @@ impl Ty {
     }
 
     /// Make this type optional.
+    // The wrapper gets default attr because SAP attrs describe the wrapped type itself,
+    // not the container. The inner type's attr is preserved on the inner type.
     #[must_use]
     #[allow(dead_code)]
     pub fn into_optional(self) -> Self {

--- a/baml_language/crates/baml_compiler_tir/src/types.rs
+++ b/baml_language/crates/baml_compiler_tir/src/types.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use baml_base::TyAttr;
 use baml_compiler_hir::QualifiedName;
 
 /// The value component of a literal type.
@@ -39,14 +40,24 @@ impl fmt::Display for LiteralValue {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Ty {
     // Primitive types
-    Int,
-    Float,
-    String,
-    Bool,
-    Null,
+    Int {
+        attr: TyAttr,
+    },
+    Float {
+        attr: TyAttr,
+    },
+    String {
+        attr: TyAttr,
+    },
+    Bool {
+        attr: TyAttr,
+    },
+    Null {
+        attr: TyAttr,
+    },
 
     // Media types
-    Media(baml_base::MediaKind),
+    Media(baml_base::MediaKind, TyAttr),
 
     /// Literal type: a type inhabited by exactly one value (also called singleton type).
     /// Used for exhaustiveness checking of literal unions like `200 | 201 | 204`.
@@ -54,27 +65,28 @@ pub enum Ty {
     ///
     /// Note: `Ty::Null` is also a singleton type but is kept as a separate variant
     /// for convenience, since null is fundamental to optional types.
-    Literal(LiteralValue),
+    Literal(LiteralValue, TyAttr),
 
     // User-defined types (resolved with fully-qualified names)
     /// A class type with its fully-qualified name.
-    Class(QualifiedName),
+    Class(QualifiedName, TyAttr),
     /// An enum type with its fully-qualified name.
-    Enum(QualifiedName),
+    Enum(QualifiedName, TyAttr),
     /// A type alias with its fully-qualified name.
     /// Type aliases are NOT expanded during resolution - they stay as `TypeAlias(FQN)`.
     /// Expansion happens later during normalization when needed for subtype checks.
     /// This preserves user spelling for error messages and handles recursive types.
-    TypeAlias(QualifiedName),
+    TypeAlias(QualifiedName, TyAttr),
 
     // Type constructors
-    Optional(Box<Ty>),
-    List(Box<Ty>),
+    Optional(Box<Ty>, TyAttr),
+    List(Box<Ty>, TyAttr),
     Map {
         key: Box<Ty>,
         value: Box<Ty>,
+        attr: TyAttr,
     },
-    Union(Vec<Ty>),
+    Union(Vec<Ty>, TyAttr),
 
     /// Function/arrow type: `(T1, T2, ...) -> R`
     ///
@@ -83,19 +95,28 @@ pub enum Ty {
     Function {
         params: Vec<(Option<baml_base::Name>, Ty)>,
         ret: Box<Ty>,
+        attr: TyAttr,
     },
 
     // Special types
     /// Type inference failed - used for error recovery.
     /// Treated as uninhabited to prevent cascading errors.
-    Unknown,
+    Unknown {
+        attr: TyAttr,
+    },
     /// A type error occurred.
-    Error,
+    Error {
+        attr: TyAttr,
+    },
     /// The void/unit type for functions that return nothing.
-    Void,
+    Void {
+        attr: TyAttr,
+    },
 
     /// Opaque resource handle (file, socket, HTTP response body).
-    Resource,
+    Resource {
+        attr: TyAttr,
+    },
     /// Internal-only type for builtin functions that accept any argument.
     ///
     /// Similar to TypeScript's `unknown` - any value can be passed where
@@ -126,31 +147,35 @@ pub enum Ty {
     /// But we don't yet know the BAML syntax for this. `BuiltinUnknown` is the
     /// interim solution that allows builtins to type-check while we design
     /// the proper generic system.
-    BuiltinUnknown,
+    BuiltinUnknown {
+        attr: TyAttr,
+    },
 
     /// Watch accessor type: represents `x.$watch` on a watched variable.
     /// Contains the inner type being watched for method resolution.
-    WatchAccessor(Box<Ty>),
+    WatchAccessor(Box<Ty>, TyAttr),
 
     /// Meta-type — the type of type values at the TIR level.
     /// Matches `TypePattern::Type` in builtin signatures.
-    Type,
+    Type {
+        attr: TyAttr,
+    },
 }
 
 impl Ty {
     /// Check if this type is an error type.
     pub fn is_error(&self) -> bool {
-        matches!(self, Ty::Error)
+        matches!(self, Ty::Error { .. })
     }
 
     /// Check if this type is unknown.
     pub fn is_unknown(&self) -> bool {
-        matches!(self, Ty::Unknown)
+        matches!(self, Ty::Unknown { .. })
     }
 
     /// Check if this type is void.
     pub fn is_void(&self) -> bool {
-        matches!(self, Ty::Void)
+        matches!(self, Ty::Void { .. })
     }
 
     /// Check if this type is uninhabited (has no possible values).
@@ -172,9 +197,9 @@ impl Ty {
     pub fn is_uninhabited(&self) -> bool {
         match self {
             // Error recovery: don't emit additional errors when type inference failed
-            Ty::Unknown | Ty::Error => true,
+            Ty::Unknown { .. } | Ty::Error { .. } => true,
             // Empty union has no members, therefore no possible values
-            Ty::Union(types) => types.is_empty(),
+            Ty::Union(types, _) => types.is_empty(),
             // All other types are inhabited
             // TODO(exhaustiveness): Check for zero-variant enums. This requires access
             // to enum variants map. Currently only empty unions are detected.
@@ -184,34 +209,41 @@ impl Ty {
 
     /// Check if this type is a primitive type.
     pub fn is_primitive(&self) -> bool {
-        matches!(self, Ty::Int | Ty::Float | Ty::String | Ty::Bool | Ty::Null)
+        matches!(
+            self,
+            Ty::Int { .. }
+                | Ty::Float { .. }
+                | Ty::String { .. }
+                | Ty::Bool { .. }
+                | Ty::Null { .. }
+        )
     }
 
     /// Check if this type is a media type.
     #[allow(dead_code)]
     pub fn is_media(&self) -> bool {
-        matches!(self, Ty::Media(_))
+        matches!(self, Ty::Media(..))
     }
 
     /// Make this type optional.
     #[must_use]
     #[allow(dead_code)]
     pub fn into_optional(self) -> Self {
-        Ty::Optional(Box::new(self))
+        Ty::Optional(Box::new(self), TyAttr::default())
     }
 
     /// Make a list of this type.
     #[must_use]
     #[allow(dead_code)]
     pub fn into_list(self) -> Self {
-        Ty::List(Box::new(self))
+        Ty::List(Box::new(self), TyAttr::default())
     }
 
     /// Get the element type if this is a list type.
     #[allow(dead_code)]
     pub fn list_element(&self) -> Option<&Ty> {
         match self {
-            Ty::List(inner) => Some(inner),
+            Ty::List(inner, _) => Some(inner),
             _ => None,
         }
     }
@@ -220,7 +252,7 @@ impl Ty {
     #[allow(dead_code)]
     pub fn map_types(&self) -> Option<(&Ty, &Ty)> {
         match self {
-            Ty::Map { key, value } => Some((key, value)),
+            Ty::Map { key, value, .. } => Some((key, value)),
             _ => None,
         }
     }
@@ -229,7 +261,7 @@ impl Ty {
     #[allow(dead_code)]
     pub fn unwrap_optional(&self) -> &Ty {
         match self {
-            Ty::Optional(inner) => inner,
+            Ty::Optional(inner, _) => inner,
             _ => self,
         }
     }
@@ -238,25 +270,25 @@ impl Ty {
 impl fmt::Display for Ty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Ty::Int => write!(f, "int"),
-            Ty::Float => write!(f, "float"),
-            Ty::String => write!(f, "string"),
-            Ty::Bool => write!(f, "bool"),
-            Ty::Null => write!(f, "null"),
-            Ty::Media(kind) => write!(f, "{kind}"),
-            Ty::Literal(val) => write!(f, "{val}"),
-            Ty::Class(fqn) => write!(f, "{fqn}"),
-            Ty::Enum(fqn) => write!(f, "{fqn}"),
-            Ty::TypeAlias(fqn) => write!(f, "{fqn}"),
-            Ty::Optional(inner) => write!(f, "{inner}?"),
-            Ty::List(inner) => write!(f, "{inner}[]"),
-            Ty::Map { key, value } => write!(f, "map<{key}, {value}>"),
-            Ty::Union(types) => {
+            Ty::Int { .. } => write!(f, "int"),
+            Ty::Float { .. } => write!(f, "float"),
+            Ty::String { .. } => write!(f, "string"),
+            Ty::Bool { .. } => write!(f, "bool"),
+            Ty::Null { .. } => write!(f, "null"),
+            Ty::Media(kind, _) => write!(f, "{kind}"),
+            Ty::Literal(val, _) => write!(f, "{val}"),
+            Ty::Class(fqn, _) => write!(f, "{fqn}"),
+            Ty::Enum(fqn, _) => write!(f, "{fqn}"),
+            Ty::TypeAlias(fqn, _) => write!(f, "{fqn}"),
+            Ty::Optional(inner, _) => write!(f, "{inner}?"),
+            Ty::List(inner, _) => write!(f, "{inner}[]"),
+            Ty::Map { key, value, .. } => write!(f, "map<{key}, {value}>"),
+            Ty::Union(types, _) => {
                 let parts: Vec<std::string::String> =
                     types.iter().map(std::string::ToString::to_string).collect();
                 write!(f, "{}", parts.join(" | "))
             }
-            Ty::Function { params, ret } => {
+            Ty::Function { params, ret, .. } => {
                 let param_strs: Vec<std::string::String> = params
                     .iter()
                     .map(|(name, ty)| {
@@ -269,13 +301,13 @@ impl fmt::Display for Ty {
                     .collect();
                 write!(f, "({}) -> {}", param_strs.join(", "), ret)
             }
-            Ty::Unknown => write!(f, "unknown"),
-            Ty::Error => write!(f, "error"),
-            Ty::Void => write!(f, "void"),
-            Ty::Resource => write!(f, "resource"),
-            Ty::BuiltinUnknown => write!(f, "unknown"),
-            Ty::WatchAccessor(inner) => write!(f, "{inner}.$watch"),
-            Ty::Type => write!(f, "type"),
+            Ty::Unknown { .. } => write!(f, "unknown"),
+            Ty::Error { .. } => write!(f, "error"),
+            Ty::Void { .. } => write!(f, "void"),
+            Ty::Resource { .. } => write!(f, "resource"),
+            Ty::BuiltinUnknown { .. } => write!(f, "unknown"),
+            Ty::WatchAccessor(inner, _) => write!(f, "{inner}.$watch"),
+            Ty::Type { .. } => write!(f, "type"),
         }
     }
 }
@@ -287,13 +319,23 @@ mod tests {
     // NOTE: Subtyping tests are now in normalize.rs which handles
     // type alias resolution and equirecursive subtyping.
 
+    fn d() -> TyAttr {
+        TyAttr::default()
+    }
+
     #[test]
     fn test_display() {
-        assert_eq!(Ty::Int.to_string(), "int");
-        assert_eq!(Ty::Optional(Box::new(Ty::String)).to_string(), "string?");
-        assert_eq!(Ty::List(Box::new(Ty::Int)).to_string(), "int[]");
+        assert_eq!(Ty::Int { attr: d() }.to_string(), "int");
         assert_eq!(
-            Ty::Union(vec![Ty::Int, Ty::String]).to_string(),
+            Ty::Optional(Box::new(Ty::String { attr: d() }), d()).to_string(),
+            "string?"
+        );
+        assert_eq!(
+            Ty::List(Box::new(Ty::Int { attr: d() }), d()).to_string(),
+            "int[]"
+        );
+        assert_eq!(
+            Ty::Union(vec![Ty::Int { attr: d() }, Ty::String { attr: d() }], d()).to_string(),
             "int | string"
         );
     }
@@ -301,23 +343,25 @@ mod tests {
     #[test]
     fn test_is_uninhabited() {
         // Unknown and Error are treated as uninhabited for error recovery
-        assert!(Ty::Unknown.is_uninhabited());
-        assert!(Ty::Error.is_uninhabited());
+        assert!(Ty::Unknown { attr: d() }.is_uninhabited());
+        assert!(Ty::Error { attr: d() }.is_uninhabited());
 
         // Empty union is uninhabited (no possible values)
-        assert!(Ty::Union(vec![]).is_uninhabited());
+        assert!(Ty::Union(vec![], d()).is_uninhabited());
 
         // Non-empty union is inhabited
-        assert!(!Ty::Union(vec![Ty::Int]).is_uninhabited());
-        assert!(!Ty::Union(vec![Ty::Int, Ty::String]).is_uninhabited());
+        assert!(!Ty::Union(vec![Ty::Int { attr: d() }], d()).is_uninhabited());
+        assert!(
+            !Ty::Union(vec![Ty::Int { attr: d() }, Ty::String { attr: d() }], d()).is_uninhabited()
+        );
 
         // Regular types are inhabited
-        assert!(!Ty::Int.is_uninhabited());
-        assert!(!Ty::String.is_uninhabited());
-        assert!(!Ty::Bool.is_uninhabited());
-        assert!(!Ty::Null.is_uninhabited());
-        assert!(!Ty::Void.is_uninhabited());
-        assert!(!Ty::List(Box::new(Ty::Int)).is_uninhabited());
-        assert!(!Ty::Optional(Box::new(Ty::Int)).is_uninhabited());
+        assert!(!Ty::Int { attr: d() }.is_uninhabited());
+        assert!(!Ty::String { attr: d() }.is_uninhabited());
+        assert!(!Ty::Bool { attr: d() }.is_uninhabited());
+        assert!(!Ty::Null { attr: d() }.is_uninhabited());
+        assert!(!Ty::Void { attr: d() }.is_uninhabited());
+        assert!(!Ty::List(Box::new(Ty::Int { attr: d() }), d()).is_uninhabited());
+        assert!(!Ty::Optional(Box::new(Ty::Int { attr: d() }), d()).is_uninhabited());
     }
 }

--- a/baml_language/crates/baml_compiler_vir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/lower.rs
@@ -195,6 +195,13 @@ pub fn lower_from_hir(
 /// Sentinel value for dangling Let scopes (body not yet filled in).
 const DANGLING_SCOPE: u32 = u32::MAX;
 
+/// Default Null type used as a fallback in expression type lookups.
+fn ty_null_default() -> Ty {
+    Ty::Null {
+        attr: baml_type::TyAttr::default(),
+    }
+}
+
 /// Builder for constructing `ExprBody`.
 struct ExprBodyBuilder {
     exprs: Arena<Expr>,
@@ -228,11 +235,19 @@ impl ExprBodyBuilder {
     }
 
     fn alloc_unit(&mut self) -> ExprId {
-        self.alloc(Expr::Unit, Ty::Void)
+        self.alloc(
+            Expr::Unit,
+            Ty::Void {
+                attr: baml_type::TyAttr::default(),
+            },
+        )
     }
 
-    fn ty(&self, id: ExprId) -> &Ty {
-        self.expr_types.get(&id).unwrap_or(&Ty::Null)
+    fn ty(&self, id: ExprId) -> Ty {
+        self.expr_types
+            .get(&id)
+            .cloned()
+            .unwrap_or_else(ty_null_default)
     }
 
     fn finish(self, root: ExprId) -> ExprBody {
@@ -313,7 +328,9 @@ impl<'a> LoweringContext<'a> {
 
         // Get type from TIR inference
         let tir_ty = self.inference.expr_types.get(&hir_id);
-        let ty = tir_ty.map(|ty| self.lower_ty(ty)).unwrap_or(Ty::Null);
+        let ty = tir_ty.map(|ty| self.lower_ty(ty)).unwrap_or(Ty::Null {
+            attr: baml_type::TyAttr::default(),
+        });
 
         let result = match hir_expr {
             HirExpr::Missing => {
@@ -657,13 +674,13 @@ impl<'a> LoweringContext<'a> {
             // Fill in the dangling scope with result
             self.fill_let_body(curr, result);
             // Update the Let's type to match the body's type
-            let result_ty = self.builder.ty(result).clone();
+            let result_ty = self.builder.ty(result);
             self.builder.expr_types.insert(curr, result_ty);
             return curr;
         }
 
         // Not a dangling Let - wrap with Seq
-        let result_ty = self.builder.ty(result).clone();
+        let result_ty = self.builder.ty(result);
         self.builder.alloc(
             Expr::Seq {
                 first: curr,
@@ -687,7 +704,12 @@ impl<'a> LoweringContext<'a> {
         if self.is_dangling_let(expr_id) {
             let unit = self.builder.alloc_unit();
             self.fill_let_body(expr_id, unit);
-            self.builder.expr_types.insert(expr_id, Ty::Void);
+            self.builder.expr_types.insert(
+                expr_id,
+                Ty::Void {
+                    attr: baml_type::TyAttr::default(),
+                },
+            );
         }
     }
 
@@ -733,9 +755,13 @@ impl<'a> LoweringContext<'a> {
                         .expr_types
                         .get(init)
                         .map(|ty| self.lower_ty(ty))
-                        .unwrap_or(Ty::Null)
+                        .unwrap_or(Ty::Null {
+                            attr: baml_type::TyAttr::default(),
+                        })
                 } else {
-                    Ty::Null
+                    Ty::Null {
+                        attr: baml_type::TyAttr::default(),
+                    }
                 };
 
                 // Lower the initializer (or unit if missing)
@@ -756,7 +782,9 @@ impl<'a> LoweringContext<'a> {
                         body: dangling_body,
                         is_watched: *is_watched,
                     },
-                    Ty::Null, // Will be updated when body is filled
+                    Ty::Null {
+                        attr: baml_type::TyAttr::default(),
+                    }, // Will be updated when body is filled
                 ))
             }
 
@@ -784,7 +812,9 @@ impl<'a> LoweringContext<'a> {
                         condition: cond,
                         body: final_body,
                     },
-                    Ty::Void,
+                    Ty::Void {
+                        attr: baml_type::TyAttr::default(),
+                    },
                 ))
             }
 
@@ -793,12 +823,27 @@ impl<'a> LoweringContext<'a> {
                     Some(e) => Some(self.lower_expr(*e, hir_body)?),
                     None => None,
                 };
-                Ok(self.builder.alloc(Expr::Return(ret_expr), Ty::Void))
+                Ok(self.builder.alloc(
+                    Expr::Return(ret_expr),
+                    Ty::Void {
+                        attr: baml_type::TyAttr::default(),
+                    },
+                ))
             }
 
-            HirStmt::Break => Ok(self.builder.alloc(Expr::Break, Ty::Void)),
+            HirStmt::Break => Ok(self.builder.alloc(
+                Expr::Break,
+                Ty::Void {
+                    attr: baml_type::TyAttr::default(),
+                },
+            )),
 
-            HirStmt::Continue => Ok(self.builder.alloc(Expr::Continue, Ty::Void)),
+            HirStmt::Continue => Ok(self.builder.alloc(
+                Expr::Continue,
+                Ty::Void {
+                    attr: baml_type::TyAttr::default(),
+                },
+            )),
 
             HirStmt::Assign { target, value } => {
                 let target_id = self.lower_expr(*target, hir_body)?;
@@ -808,7 +853,9 @@ impl<'a> LoweringContext<'a> {
                         target: target_id,
                         value: value_id,
                     },
-                    Ty::Void,
+                    Ty::Void {
+                        attr: baml_type::TyAttr::default(),
+                    },
                 ))
             }
 
@@ -821,7 +868,9 @@ impl<'a> LoweringContext<'a> {
                         op: AssignOp::from(*op),
                         value: value_id,
                     },
-                    Ty::Void,
+                    Ty::Void {
+                        attr: baml_type::TyAttr::default(),
+                    },
                 ))
             }
 
@@ -831,7 +880,9 @@ impl<'a> LoweringContext<'a> {
                     Expr::Assert {
                         condition: condition_id,
                     },
-                    Ty::Void,
+                    Ty::Void {
+                        attr: baml_type::TyAttr::default(),
+                    },
                 ))
             }
 
@@ -840,7 +891,9 @@ impl<'a> LoweringContext<'a> {
                     name: name.clone(),
                     level: *level,
                 },
-                Ty::Void,
+                Ty::Void {
+                    attr: baml_type::TyAttr::default(),
+                },
             )),
         };
 
@@ -862,8 +915,11 @@ impl<'a> LoweringContext<'a> {
     /// - Literal type preservation (no erasure)
     /// - TIR Unknown/Error → Null (error recovery types don't propagate)
     fn lower_ty(&self, thir_ty: &baml_compiler_tir::Ty) -> Ty {
-        baml_type::convert_tir_ty(thir_ty, self.type_aliases, self.recursive_aliases)
-            .unwrap_or(Ty::Null)
+        baml_type::convert_tir_ty(thir_ty, self.type_aliases, self.recursive_aliases).unwrap_or(
+            Ty::Null {
+                attr: baml_type::TyAttr::default(),
+            },
+        )
     }
 
     /// Lower an HIR `TypeRef` to VIR type.

--- a/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
@@ -103,7 +103,9 @@ fn convert_ty(
 ) -> Ty {
     baml_type::convert_tir_ty(tir_ty, type_aliases, recursive_aliases)
         .and_then(baml_type::sanitize_for_runtime)
-        .unwrap_or(Ty::Null)
+        .unwrap_or(Ty::Null {
+            attr: baml_type::TyAttr::default(),
+        })
 }
 
 fn lower_class(
@@ -123,6 +125,7 @@ fn lower_class(
                 description: attr_to_option(&field.description),
                 alias: attr_to_option(&field.alias),
                 skip: attr_to_bool(&field.skip),
+                field_attr: Default::default(),
             }
         })
         .collect();

--- a/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use baml_base::{Name, Span};
+use baml_base::{FieldAttr, Name, Span};
 use baml_compiler_hir::{
     self, Attribute, FunctionBody, ItemId, file_item_tree, file_items, function_body,
     function_signature,
@@ -125,7 +125,7 @@ fn lower_class(
                 description: attr_to_option(&field.description),
                 alias: attr_to_option(&field.alias),
                 skip: attr_to_bool(&field.skip),
-                field_attr: Default::default(),
+                field_attr: FieldAttr::default(),
             }
         })
         .collect();

--- a/baml_language/crates/baml_lsp_actions/src/inlay_hints.rs
+++ b/baml_language/crates/baml_lsp_actions/src/inlay_hints.rs
@@ -77,11 +77,19 @@ pub struct HintContext<'a> {
 fn display_ty(ty: &baml_db::baml_compiler_tir::Ty) -> Option<baml_db::baml_compiler_tir::Ty> {
     use baml_db::baml_compiler_tir::{LiteralValue, Ty};
     match ty {
-        Ty::Unknown | Ty::Error | Ty::BuiltinUnknown => None,
-        Ty::Literal(LiteralValue::Int(_)) => Some(Ty::Int),
-        Ty::Literal(LiteralValue::Float(_)) => Some(Ty::Float),
-        Ty::Literal(LiteralValue::String(_)) => Some(Ty::String),
-        Ty::Literal(LiteralValue::Bool(_)) => Some(Ty::Bool),
+        Ty::Unknown { .. } | Ty::Error { .. } | Ty::BuiltinUnknown { .. } => None,
+        Ty::Literal(LiteralValue::Int(_), _) => Some(Ty::Int {
+            attr: Default::default(),
+        }),
+        Ty::Literal(LiteralValue::Float(_), _) => Some(Ty::Float {
+            attr: Default::default(),
+        }),
+        Ty::Literal(LiteralValue::String(_), _) => Some(Ty::String {
+            attr: Default::default(),
+        }),
+        Ty::Literal(LiteralValue::Bool(_), _) => Some(Ty::Bool {
+            attr: Default::default(),
+        }),
         other => Some(other.clone()),
     }
 }
@@ -97,7 +105,7 @@ fn plain_label(text: impl Into<String>) -> Vec<InlayHintLabelPart> {
 /// Convert a [`Ty`] into label parts, wrapping in parentheses if it's a
 /// compound type (union or function) that would be ambiguous without them.
 fn wrap_if_compound(db: &ProjectDatabase, ty: &Ty) -> Vec<InlayHintLabelPart> {
-    if matches!(ty, Ty::Union(_) | Ty::Function { .. }) {
+    if matches!(ty, Ty::Union(..) | Ty::Function { .. }) {
         let mut parts = vec![InlayHintLabelPart {
             value: "(".into(),
             target: None,
@@ -116,14 +124,14 @@ fn wrap_if_compound(db: &ProjectDatabase, ty: &Ty) -> Vec<InlayHintLabelPart> {
 /// Convert a [`Ty`] into label parts, resolving named types to clickable links.
 fn ty_to_label_parts(db: &ProjectDatabase, ty: &Ty) -> Vec<InlayHintLabelPart> {
     match ty {
-        Ty::Class(fqn) | Ty::Enum(fqn) | Ty::TypeAlias(fqn) => {
+        Ty::Class(fqn, _) | Ty::Enum(fqn, _) | Ty::TypeAlias(fqn, _) => {
             let target = lookup_symbol_definition(db, fqn);
             vec![InlayHintLabelPart {
                 value: fqn.to_string(),
                 target,
             }]
         }
-        Ty::Optional(inner) => {
+        Ty::Optional(inner, _) => {
             let mut parts = wrap_if_compound(db, inner);
             parts.push(InlayHintLabelPart {
                 value: "?".into(),
@@ -132,7 +140,7 @@ fn ty_to_label_parts(db: &ProjectDatabase, ty: &Ty) -> Vec<InlayHintLabelPart> {
 
             parts
         }
-        Ty::List(inner) => {
+        Ty::List(inner, _) => {
             let mut parts = wrap_if_compound(db, inner);
             parts.push(InlayHintLabelPart {
                 value: "[]".into(),
@@ -141,7 +149,7 @@ fn ty_to_label_parts(db: &ProjectDatabase, ty: &Ty) -> Vec<InlayHintLabelPart> {
 
             parts
         }
-        Ty::Map { key, value } => {
+        Ty::Map { key, value, .. } => {
             let mut parts = vec![InlayHintLabelPart {
                 value: "map<".into(),
                 target: None,
@@ -159,7 +167,7 @@ fn ty_to_label_parts(db: &ProjectDatabase, ty: &Ty) -> Vec<InlayHintLabelPart> {
 
             parts
         }
-        Ty::Union(types) => {
+        Ty::Union(types, _) => {
             let mut parts = Vec::new();
             for (i, t) in types.iter().enumerate() {
                 if i > 0 {
@@ -173,7 +181,7 @@ fn ty_to_label_parts(db: &ProjectDatabase, ty: &Ty) -> Vec<InlayHintLabelPart> {
 
             parts
         }
-        Ty::Function { params, ret } => {
+        Ty::Function { params, ret, .. } => {
             let mut parts = vec![InlayHintLabelPart {
                 value: "(".into(),
                 target: None,

--- a/baml_language/crates/baml_lsp_actions/src/inlay_hints.rs
+++ b/baml_language/crates/baml_lsp_actions/src/inlay_hints.rs
@@ -78,18 +78,10 @@ fn display_ty(ty: &baml_db::baml_compiler_tir::Ty) -> Option<baml_db::baml_compi
     use baml_db::baml_compiler_tir::{LiteralValue, Ty};
     match ty {
         Ty::Unknown { .. } | Ty::Error { .. } | Ty::BuiltinUnknown { .. } => None,
-        Ty::Literal(LiteralValue::Int(_), _) => Some(Ty::Int {
-            attr: Default::default(),
-        }),
-        Ty::Literal(LiteralValue::Float(_), _) => Some(Ty::Float {
-            attr: Default::default(),
-        }),
-        Ty::Literal(LiteralValue::String(_), _) => Some(Ty::String {
-            attr: Default::default(),
-        }),
-        Ty::Literal(LiteralValue::Bool(_), _) => Some(Ty::Bool {
-            attr: Default::default(),
-        }),
+        Ty::Literal(LiteralValue::Int(_), attr) => Some(Ty::Int { attr: attr.clone() }),
+        Ty::Literal(LiteralValue::Float(_), attr) => Some(Ty::Float { attr: attr.clone() }),
+        Ty::Literal(LiteralValue::String(_), attr) => Some(Ty::String { attr: attr.clone() }),
+        Ty::Literal(LiteralValue::Bool(_), attr) => Some(Ty::Bool { attr: attr.clone() }),
         other => Some(other.clone()),
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_5_mir.snap
@@ -400,7 +400,7 @@ fn build_plan_with_state(llm_client: baml.llm.Client, planner_state: baml.llm.Pl
     }
 
     bb5: {
-        _9 = is_type(copy _3, Class(TypeName { name: "RetryPolicy", module_path: ["baml", "llm"], display_name: "baml.llm.RetryPolicy" }));
+        _9 = is_type(copy _3, Class(TypeName { name: "RetryPolicy", module_path: ["baml", "llm"], display_name: "baml.llm.RetryPolicy" }, TyAttr(None)));
         branch copy _9 -> [bb8, bb3];
     }
 
@@ -816,7 +816,7 @@ fn execute_client(llm_client: baml.llm.Client, context: baml.llm.ExecutionContex
     }
 
     bb5: {
-        _11 = is_type(copy _4, Class(TypeName { name: "RetryPolicy", module_path: ["baml", "llm"], display_name: "baml.llm.RetryPolicy" }));
+        _11 = is_type(copy _4, Class(TypeName { name: "RetryPolicy", module_path: ["baml", "llm"], display_name: "baml.llm.RetryPolicy" }, TyAttr(None)));
         branch copy _11 -> [bb8, bb3];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_tir.snap
@@ -3,26 +3,26 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function build_attempt_with_state:
-    Return: Union([List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" })), List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" })), Union([List(Unknown), List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }))])])
+    Return: Union([List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }, TyAttr(None)), TyAttr(None)), List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }, TyAttr(None)), TyAttr(None)), Union([List(Unknown { attr: TyAttr(None) }, TyAttr(None)), List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }, TyAttr(None)), TyAttr(None))], TyAttr(None))], TyAttr(None))
   Function build_plan_with_state:
-    Return: List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }))
+    Return: List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }, TyAttr(None)), TyAttr(None))
   Function render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function resolve_primitive:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function build_attempt:
-    Return: List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }))
+    Return: List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }, TyAttr(None)), TyAttr(None))
   Function execute_client:
-    Return: Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "ExecutionResult" })
+    Return: Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "ExecutionResult" }, TyAttr(None))
   Function execute_client_once:
-    Return: Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "ExecutionResult" })
+    Return: Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "ExecutionResult" }, TyAttr(None))
   Function build_plan:
-    Return: List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }))
+    Return: List(Class(QualifiedName { namespace: BamlStd { path: ["llm"] }, name: "OrchestrationStep" }, TyAttr(None)), TyAttr(None))
   Function build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function call_llm_function:
-    Return: BuiltinUnknown
+    Return: BuiltinUnknown { attr: TyAttr(None) }
   Function PlannerState.rr_local_offset:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function PlannerState.rr_pick_index:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__04_tir.snap
@@ -3,26 +3,26 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function GetMixedMap:
-    Return: Map { key: String, value: Union([Int, String]) }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }], TyAttr(None)), attr: TyAttr(None) }
   Function GetMixedMap.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function GetUser.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function GetMixedMap.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function GetMixedList:
-    Return: List(Union([Int, String]))
+    Return: List(Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }], TyAttr(None)), TyAttr(None))
   Function GetStatus.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function GetStatus:
-    Return: Enum(QualifiedName { namespace: Local, name: "Status" })
+    Return: Enum(QualifiedName { namespace: Local, name: "Status" }, TyAttr(None))
   Function GetUser:
-    Return: Class(QualifiedName { namespace: Local, name: "User" })
+    Return: Class(QualifiedName { namespace: Local, name: "User" }, TyAttr(None))
   Function GetUser.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function GetStatus.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function GetMixedList.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function GetMixedList.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__04_tir.snap
@@ -3,24 +3,24 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function ReadAndClose:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ReadMultipleFiles:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ReadFile:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ReadFileInline:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function MultipleConnections:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ConnectAndReadInline:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ConnectAndRead:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ConnectReadAndClose:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ChainCommands:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function RunCommandWithVar:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function RunCommand:
-    Return: String
+    Return: String { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__04_tir.snap
@@ -3,4 +3,4 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function OpenRouterMistralSmall3_1_24b.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__04_tir.snap
@@ -3,16 +3,16 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function FunctionWithComments.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function FunctionWithComments.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function CommentAfterArrow:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function CommentAfterArrow.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function CommentAfterArrow.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function FunctionWithComments:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function TestClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__04_tir.snap
@@ -3,4 +3,4 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function MyClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__04_tir.snap
@@ -3,26 +3,26 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function IfElseWithHeaders:
-    Return: Union([Literal(String("yes")), Literal(String("no"))])
+    Return: Union([Literal(String("yes"), TyAttr(None)), Literal(String("no"), TyAttr(None))], TyAttr(None))
   Function Headers:
-    Return: Unknown
+    Return: Unknown { attr: TyAttr(None) }
     Errors:
       - int has no field to_string
   Function SimpleFunction:
-    Return: Literal(Int(42))
+    Return: Literal(Int(42), TyAttr(None))
   Function LlmFunction:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function NestedControlFlow:
-    Return: Union([Union([Literal(String("large")), Literal(String("small"))]), Literal(String("zero or negative"))])
+    Return: Union([Union([Literal(String("large"), TyAttr(None)), Literal(String("small"), TyAttr(None))], TyAttr(None)), Literal(String("zero or negative"), TyAttr(None))], TyAttr(None))
   Function ElseIfChain:
-    Return: Union([Literal(String("one")), Union([Literal(String("two")), Union([Literal(String("three")), Literal(String("other"))])])])
+    Return: Union([Literal(String("one"), TyAttr(None)), Union([Literal(String("two"), TyAttr(None)), Union([Literal(String("three"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))], TyAttr(None))], TyAttr(None))
   Function WhileWithHeaders:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function MatchExpression:
-    Return: Union([Literal(String("one")), Literal(String("two")), Literal(String("other"))])
+    Return: Union([Literal(String("one"), TyAttr(None)), Literal(String("two"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
   Function LlmFunction.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function LlmFunction.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function TestClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_5_mir.snap
@@ -33,7 +33,7 @@ fn Broken.MixedLiteralAndTyped(x: int) -> string {
     }
 
     bb5: {
-        _3 = is_type(copy _1, Int);
+        _3 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _3 -> [bb6, bb3];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_tir.snap
@@ -3,10 +3,10 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function Broken.MixedLiteralAndTyped:
-    Return: Literal(String("mixed"))
+    Return: Literal(String("mixed"), TyAttr(None))
   Function Broken.Invalid:
-    Return: Void
+    Return: Void { attr: TyAttr(None) }
   Function Broken.BadUnionPattern:
-    Return: Union([Unknown, Literal(String("bad"))])
+    Return: Union([Unknown { attr: TyAttr(None) }, Literal(String("bad"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unknown type b

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_5_mir.snap
@@ -9812,7 +9812,7 @@ fn LoopStmts(items: int[], flag: bool) -> int {
     }
 
     bb245: {
-        _787 = is_type(copy _782, Int);
+        _787 = is_type(copy _782, Int { attr: TyAttr(None) });
         branch copy _787 -> [bb248, bb247];
     }
 
@@ -9824,7 +9824,7 @@ fn LoopStmts(items: int[], flag: bool) -> int {
     }
 
     bb247: {
-        _793 = is_type(copy _782, Int);
+        _793 = is_type(copy _782, Int { attr: TyAttr(None) });
         branch copy _793 -> [bb251, bb243];
     }
 
@@ -10787,7 +10787,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb18: {
-        _16 = is_type(copy _1, Int);
+        _16 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _16 -> [bb25, bb24];
     }
 
@@ -10802,7 +10802,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb21: {
-        _22 = is_type(copy _1, Int);
+        _22 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _22 -> [bb32, bb31];
     }
 
@@ -10953,7 +10953,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb52: {
-        _38 = is_type(copy _1, Int);
+        _38 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _38 -> [bb58, bb56];
     }
 
@@ -11050,7 +11050,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb72: {
-        _47 = is_type(copy _3, Class(TypeName { name: "MatchSuccess", module_path: [], display_name: "MatchSuccess" }));
+        _47 = is_type(copy _3, Class(TypeName { name: "MatchSuccess", module_path: [], display_name: "MatchSuccess" }, TyAttr(None)));
         branch copy _47 -> [bb80, bb79];
     }
 
@@ -11069,7 +11069,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb76: {
-        _54 = is_type(copy _3, Union([Class(TypeName { name: "MatchSuccess", module_path: [], display_name: "MatchSuccess" }), Class(TypeName { name: "MatchFailure", module_path: [], display_name: "MatchFailure" })]));
+        _54 = is_type(copy _3, Union([Class(TypeName { name: "MatchSuccess", module_path: [], display_name: "MatchSuccess" }, TyAttr(None)), Class(TypeName { name: "MatchFailure", module_path: [], display_name: "MatchFailure" }, TyAttr(None))], TyAttr(None)));
         branch copy _54 -> [bb86, bb84];
     }
 
@@ -11084,7 +11084,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb79: {
-        _50 = is_type(copy _3, Class(TypeName { name: "MatchFailure", module_path: [], display_name: "MatchFailure" }));
+        _50 = is_type(copy _3, Class(TypeName { name: "MatchFailure", module_path: [], display_name: "MatchFailure" }, TyAttr(None)));
         branch copy _50 -> [bb82, bb77];
     }
 
@@ -11123,7 +11123,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb87: {
-        _58 = is_type(copy _55, Int);
+        _58 = is_type(copy _55, Int { attr: TyAttr(None) });
         branch copy _58 -> [bb94, bb93];
     }
 
@@ -11138,7 +11138,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb90: {
-        _69 = is_type(copy _55, Int);
+        _69 = is_type(copy _55, Int { attr: TyAttr(None) });
         branch copy _69 -> [bb105, bb104];
     }
 
@@ -11154,7 +11154,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb93: {
-        _63 = is_type(copy _55, Int);
+        _63 = is_type(copy _55, Int { attr: TyAttr(None) });
         branch copy _63 -> [bb98, bb97];
     }
 
@@ -11356,7 +11356,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb133: {
-        _97 = is_type(copy _55, Int);
+        _97 = is_type(copy _55, Int { attr: TyAttr(None) });
         branch copy _97 -> [bb143, bb142];
     }
 
@@ -11386,7 +11386,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb139: {
-        _115 = is_type(copy _55, Int);
+        _115 = is_type(copy _55, Int { attr: TyAttr(None) });
         branch copy _115 -> [bb162, bb161];
     }
 
@@ -11730,7 +11730,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb199: {
-        _188 = is_type(copy _3, Class(TypeName { name: "MatchSuccess", module_path: [], display_name: "MatchSuccess" }));
+        _188 = is_type(copy _3, Class(TypeName { name: "MatchSuccess", module_path: [], display_name: "MatchSuccess" }, TyAttr(None)));
         branch copy _188 -> [bb215, bb214];
     }
 
@@ -11799,7 +11799,7 @@ fn MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bool) -
     }
 
     bb214: {
-        _193 = is_type(copy _3, Class(TypeName { name: "MatchFailure", module_path: [], display_name: "MatchFailure" }));
+        _193 = is_type(copy _3, Class(TypeName { name: "MatchFailure", module_path: [], display_name: "MatchFailure" }, TyAttr(None)));
         branch copy _193 -> [bb222, bb212];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_tir.snap
@@ -3,9 +3,9 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function BinaryExprs:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function ChainExprs:
-    Return: String
+    Return: String { attr: TyAttr(None) }
     Errors:
       - string has no field len
       - ChainItem[] has no field len
@@ -197,177 +197,177 @@ source: crates/baml_tests/src/generated_tests.rs
       - string has no field len
       - string has no field len
   Function WithMethod.greet:
-    Return: Literal(String("hello"))
+    Return: Literal(String("hello"), TyAttr(None))
   Function WithLongMethod.processData:
-    Return: Map { key: String, value: Union([Int, String, Bool]) }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }, Bool { attr: TyAttr(None) }], TyAttr(None)), attr: TyAttr(None) }
   Function ManyOptionsClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TestTarget:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function TriviaDeeplyNestedClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function LongArrayOfObjectsClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TestTarget.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function StringProviderClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TriviaClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TypedValuesClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function FullClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function SameLineClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function LongArrayClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TriviaLongValueClientBlock.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function EnvClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function LongNestedValuesClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function DeeplyNestedClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TriviaLongValueClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function BasicClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function ExtraWhitespaceClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function CommaClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function C.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function RawStringConfigClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function ArrayOfObjectsClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function NestedConfigClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TriviaDeeplyNestedClientBlock.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function ArrayConfigClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function MixedValuesClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TestTarget.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function ThisIsAnExtremelyLongClientNameThatDefinitelyExceedsTheDefaultLineLimitOfOneHundredColumns.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function LongOptionClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TriviaClientBlock.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function TriviaWrapParamsBlock:
-    Return: Literal(String("result"))
+    Return: Literal(String("result"), TyAttr(None))
   Function SingleParam:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function SixLongParams:
-    Return: Literal(String("result"))
+    Return: Literal(String("result"), TyAttr(None))
   Function LlmMultiLine:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function NestedGenericReturn:
-    Return: Map { key: String, value: Map { key: String, value: Map { key: String, value: Union([Int, String, Bool, Null, Float]) } } }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Map { key: String { attr: TyAttr(None) }, value: Map { key: String { attr: TyAttr(None) }, value: Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }, Bool { attr: TyAttr(None) }, Null { attr: TyAttr(None) }, Float { attr: TyAttr(None) }], TyAttr(None)), attr: TyAttr(None) }, attr: TyAttr(None) }, attr: TyAttr(None) }
   Function LlmBasic.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function MultiParamTrivia:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function F:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
   Function LlmMultiLine.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function MultipleParams:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function ConstrainedParams:
-    Return: Literal(String("done"))
+    Return: Literal(String("done"), TyAttr(None))
   Function ExtraWhitespace:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function ThisIsAnExtremelyLongFunctionNameThatDefinitelyCausesWrappingAllByItselfWithNoParamsNeeded:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
   Function NestedLoops:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function TriviaEverythingLong_NameAndParamsAndReturn:
-    Return: Map { key: String, value: Union([Int, String, Bool, Float, Null]) }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }, Bool { attr: TyAttr(None) }, Float { attr: TyAttr(None) }, Null { attr: TyAttr(None) }], TyAttr(None)), attr: TyAttr(None) }
   Function LlmBasic:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function LongNameWithManyParameters_ThisFunctionExceedsLimit:
-    Return: Literal(String("result"))
+    Return: Literal(String("result"), TyAttr(None))
   Function LlmBasic.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function LlmStringClient.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function TriviaEverythingLong_NameAndParamsAndReturnBlock:
-    Return: Map { key: String, value: Union([Int, String, Bool, Float, Null]) }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }, Bool { attr: TyAttr(None) }, Float { attr: TyAttr(None) }, Null { attr: TyAttr(None) }], TyAttr(None)), attr: TyAttr(None) }
   Function LlmWithLongSignature.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function LlmReversedOrder:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function VeryLongParamList:
-    Return: Literal(String("result"))
+    Return: Literal(String("result"), TyAttr(None))
   Function LlmStringClient:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function DeepParamTypes:
-    Return: Literal(String("done"))
+    Return: Literal(String("done"), TyAttr(None))
   Function NoColonParams:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function TriviaWrapReturnTypeBlock:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function LlmWithLongSignature:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ManyNestedExprs:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function LongNameWithLongReturnType_ExceedsTheLineLimit:
-    Return: Map { key: String, value: Map { key: String, value: Union([Int, String, Bool, Float, Null]) } }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Map { key: String { attr: TyAttr(None) }, value: Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }, Bool { attr: TyAttr(None) }, Float { attr: TyAttr(None) }, Null { attr: TyAttr(None) }], TyAttr(None)), attr: TyAttr(None) }, attr: TyAttr(None) }
   Function ManyParams:
-    Return: Literal(String("result"))
+    Return: Literal(String("result"), TyAttr(None))
   Function Minimal:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
   Function LlmReversedOrder.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function TriviaWrapParams:
-    Return: Literal(String("result"))
+    Return: Literal(String("result"), TyAttr(None))
   Function LlmWithLongSignature.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function ComplexReturn:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function LlmMultiLine.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function LlmStringClient.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function EverythingIsLong_NameParamsReturnType:
-    Return: Map { key: String, value: Union([Int, String, Bool, Float, Null]) }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }, Bool { attr: TyAttr(None) }, Float { attr: TyAttr(None) }, Null { attr: TyAttr(None) }], TyAttr(None)), attr: TyAttr(None) }
   Function TriviaFuncBlock:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function TriviaFunc:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function LlmReversedOrder.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function DeepNestLongExpr:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function MultiStatement:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function DeepFnReturn:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
     Errors:
       - Expected (x: int) -> (y: int) -> (z: int) -> (w: int) -> map<string, int | string | bool>. Found int
   Function TriviaWrapReturnType:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function DeeplyNestedBody:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function FinalExpr:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function MultiParamTriviaBlock:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function MyFunction:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
   Function AssertStmts:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function LoopStmts:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function MatchExprs:
-    Return: Union([Literal(String("zero")), Literal(String("other"))])
+    Return: Union([Literal(String("zero"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
       - Unreachable match arm
@@ -377,4 +377,4 @@ source: crates/baml_tests/src/generated_tests.rs
       - Invalid op Mul for int and bool
       - Invalid op Mul for bool and int
   Function OtherExprs:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__04_tir.snap
@@ -3,14 +3,14 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function array_length:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function param_in_if_statement:
-    Return: Union([Literal(Int(1)), Literal(Int(2))])
+    Return: Union([Literal(Int(1), TyAttr(None)), Literal(Int(2), TyAttr(None))], TyAttr(None))
   Function Bar:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function Foo:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function GreetBaz:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Baz.Greeting:
-    Return: String
+    Return: String { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__04_tir.snap
@@ -3,6 +3,6 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function GetTransform:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
     Errors:
       - Expected (x: int) -> int. Found int

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__04_tir.snap
@@ -3,8 +3,8 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function GetUser.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function GetUser:
-    Return: Class(QualifiedName { namespace: Local, name: "MyClass" })
+    Return: Class(QualifiedName { namespace: Local, name: "MyClass" }, TyAttr(None))
   Function GetUser.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/generics/baml_tests__generics__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/generics/baml_tests__generics__04_tir.snap
@@ -3,6 +3,6 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function GetTodo:
-    Return: Unknown
+    Return: Unknown { attr: TyAttr(None) }
     Errors:
       - Unknown type for variable `baml`

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__04_tir.snap
@@ -3,10 +3,10 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function FetchDatax:
-    Return: Class(QualifiedName { namespace: Local, name: "Hi" })
+    Return: Class(QualifiedName { namespace: Local, name: "Hi" }, TyAttr(None))
   Function VertexGCP.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function FetchDatax.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function FetchDatax.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__04_tir.snap
@@ -3,24 +3,24 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function HeaderOnlyFunction:
-    Return: Literal(String("default"))
+    Return: Literal(String("default"), TyAttr(None))
   Function VeryLongHeaderTitle:
-    Return: Literal(String("long headers"))
+    Return: Literal(String("long headers"), TyAttr(None))
   Function HeadersAroundExpressions:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
     Errors:
       - Expected string. Found int
   Function HeadersInComplexNesting:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function HeadersAndComments:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ConsecutiveHeaders:
-    Return: Literal(String("multiple consecutive headers"))
+    Return: Literal(String("multiple consecutive headers"), TyAttr(None))
   Function UnicodeHeaders:
-    Return: Literal(String("test"))
+    Return: Literal(String("test"), TyAttr(None))
   Function HeaderLevels:
-    Return: Literal(String("deep nesting"))
+    Return: Literal(String("deep nesting"), TyAttr(None))
   Function HeadersWithSpecialChars:
-    Return: Literal(String("special chars"))
+    Return: Literal(String("special chars"), TyAttr(None))
   Function HeadersWithWhitespace:
-    Return: String
+    Return: String { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -43,7 +43,7 @@ fn ExhaustiveEnumWithTypedPattern(s: Status) -> string {
     let _3: Status // x
 
     bb0: {
-        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: [], display_name: "Status" }));
+        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: [], display_name: "Status" }, TyAttr(None)));
         branch copy _2 -> [bb5, bb3];
     }
 
@@ -212,7 +212,7 @@ fn UnreachableMultiple(x: int) -> string {
     }
 
     bb5: {
-        _2 = is_type(copy _1, Int);
+        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _2 -> [bb8, bb7];
     }
 
@@ -222,7 +222,7 @@ fn UnreachableMultiple(x: int) -> string {
     }
 
     bb7: {
-        _4 = is_type(copy _1, Int);
+        _4 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _4 -> [bb10, bb3];
     }
 
@@ -253,7 +253,7 @@ fn OverlappingWithBindings(r: Success | Failure) -> string {
     let _6: Success | Failure // x
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -276,7 +276,7 @@ fn OverlappingWithBindings(r: Success | Failure) -> string {
     }
 
     bb5: {
-        _5 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
+        _5 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
         branch copy _5 -> [bb8, bb3];
     }
 
@@ -482,7 +482,7 @@ fn ExhaustiveTypeAlias(r: Success | Failure) -> string {
     let _7: Failure
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -505,7 +505,7 @@ fn ExhaustiveTypeAlias(r: Success | Failure) -> string {
     }
 
     bb5: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None)));
         branch copy _5 -> [bb8, bb3];
     }
 
@@ -535,7 +535,7 @@ fn EnumVariantAfterTypedEnum(s: Status) -> string {
     let _4: bool
 
     bb0: {
-        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: [], display_name: "Status" }));
+        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: [], display_name: "Status" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -581,7 +581,7 @@ fn BoolLiteralAfterTypedBool(b: bool) -> string {
     let _4: bool
 
     bb0: {
-        _2 = is_type(copy _1, Bool);
+        _2 = is_type(copy _1, Bool { attr: TyAttr(None) });
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -748,7 +748,7 @@ fn ExhaustiveTypeAliasWithCatchAll(r: Success | Failure) -> string {
     let _4: Success
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -828,7 +828,7 @@ fn ExhaustiveClassPlusLiteral(x: Success | 200) -> string {
     let _5: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -897,7 +897,7 @@ fn ExhaustiveLiteralWithBaseType(x: int) -> string {
     }
 
     bb5: {
-        _3 = is_type(copy _1, Int);
+        _3 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _3 -> [bb7, bb3];
     }
 
@@ -960,7 +960,7 @@ fn NonExhaustiveTypeAliasMissingOne(r: Success | Failure) -> string {
     let _4: Success
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb5, bb4];
     }
 
@@ -1121,7 +1121,7 @@ fn NonExhaustiveDoubleMaybeMissingNull(dm: Success | Failure??) -> string {
     let _7: Failure
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb5, bb4];
     }
 
@@ -1140,7 +1140,7 @@ fn NonExhaustiveDoubleMaybeMissingNull(dm: Success | Failure??) -> string {
     }
 
     bb4: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None)));
         branch copy _5 -> [bb8, bb7];
     }
 
@@ -1178,7 +1178,7 @@ fn ExhaustiveDoubleMaybe(dm: Success | Failure??) -> string {
     let _8: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -1201,7 +1201,7 @@ fn ExhaustiveDoubleMaybe(dm: Success | Failure??) -> string {
     }
 
     bb5: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None)));
         branch copy _5 -> [bb9, bb8];
     }
 
@@ -1331,7 +1331,7 @@ fn GuardedOnlyNonExhaustive(x: int) -> int {
     let _16: 1
 
     bb0: {
-        _2 = is_type(copy _1, Int);
+        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _2 -> [bb5, bb4];
     }
 
@@ -1351,7 +1351,7 @@ fn GuardedOnlyNonExhaustive(x: int) -> int {
     }
 
     bb4: {
-        _9 = is_type(copy _1, Int);
+        _9 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _9 -> [bb9, bb8];
     }
 
@@ -1722,7 +1722,7 @@ fn PartialUnionPlusCatchAll(r: Success | Failure | Pending) -> string {
     let _4: bool
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
+        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -1744,7 +1744,7 @@ fn PartialUnionPlusCatchAll(r: Success | Failure | Pending) -> string {
     }
 
     bb5: {
-        _4 = is_type(copy _1, Class(TypeName { name: "Pending", module_path: [], display_name: "Pending" }));
+        _4 = is_type(copy _1, Class(TypeName { name: "Pending", module_path: [], display_name: "Pending" }, TyAttr(None)));
         branch copy _4 -> [bb8, bb3];
     }
 
@@ -1947,7 +1947,7 @@ fn NestedTypeAlias(mr: Success | Failure?) -> string {
     let _8: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -1970,7 +1970,7 @@ fn NestedTypeAlias(mr: Success | Failure?) -> string {
     }
 
     bb5: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None)));
         branch copy _5 -> [bb9, bb8];
     }
 
@@ -2182,7 +2182,7 @@ fn NestedTypeBindings(r: Success | Failure) -> int {
     let _5: Failure // f
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
+        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -2204,7 +2204,7 @@ fn NestedTypeBindings(r: Success | Failure) -> int {
     }
 
     bb5: {
-        _4 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }));
+        _4 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None)));
         branch copy _4 -> [bb8, bb3];
     }
 
@@ -2355,7 +2355,7 @@ fn GuardedWithFallback(x: int) -> int {
     let _8: 2
 
     bb0: {
-        _2 = is_type(copy _1, Int);
+        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -2559,7 +2559,7 @@ fn NonExhaustiveFullResultMissingOne(r: Success | Failure | Pending) -> string {
     let _7: Failure
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb5, bb4];
     }
 
@@ -2578,7 +2578,7 @@ fn NonExhaustiveFullResultMissingOne(r: Success | Failure | Pending) -> string {
     }
 
     bb4: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None)));
         branch copy _5 -> [bb8, bb7];
     }
 
@@ -2639,7 +2639,7 @@ fn NonExhaustiveClassPlusLiteralMissingLiteral(x: Success | 200) -> string {
     let _4: Success
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb5, bb4];
     }
 
@@ -2676,7 +2676,7 @@ fn ExhaustiveNullableEnumWithTypedPattern(s: Status?) -> string {
     let _4: bool
 
     bb0: {
-        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: [], display_name: "Status" }));
+        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: [], display_name: "Status" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -2861,7 +2861,7 @@ fn ExhaustiveOptional(x: int?) -> string {
     let _4: bool
 
     bb0: {
-        _2 = is_type(copy _1, Int);
+        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -3023,7 +3023,7 @@ fn UnreachableAfterCatchAll(x: int) -> string {
     }
 
     bb5: {
-        _2 = is_type(copy _1, Int);
+        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _2 -> [bb7, bb3];
     }
 
@@ -3135,7 +3135,7 @@ fn OverlappingTypedPatterns(r: Success | Failure) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)));
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -3157,7 +3157,7 @@ fn OverlappingTypedPatterns(r: Success | Failure) -> string {
     }
 
     bb5: {
-        _3 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
+        _3 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
         branch copy _3 -> [bb8, bb3];
     }
 
@@ -3184,7 +3184,7 @@ fn StringLiteralAfterStringType(s: string) -> string {
     let _4: bool
 
     bb0: {
-        _2 = is_type(copy _1, String);
+        _2 = is_type(copy _1, String { attr: TyAttr(None) });
         branch copy _2 -> [bb6, bb5];
     }
 
@@ -3258,7 +3258,7 @@ fn UnionPatternCoversAll(r: Success | Failure) -> string {
     let _3: Success | Failure // x
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
+        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
         branch copy _2 -> [bb5, bb3];
     }
 
@@ -3326,7 +3326,7 @@ fn PartialUnionPatternCoverage(r: Success | Failure | Pending) -> string {
     let _3: Success | Failure // x
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" })]));
+        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: [], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: [], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
         branch copy _2 -> [bb5, bb4];
     }
 
@@ -3613,7 +3613,7 @@ fn MixedPatterns(x: int) -> string {
     }
 
     bb7: {
-        _4 = is_type(copy _1, Int);
+        _4 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _4 -> [bb10, bb9];
     }
 
@@ -3685,7 +3685,7 @@ fn LiteralAfterTypedPattern(x: int) -> string {
     let _4: bool
 
     bb0: {
-        _2 = is_type(copy _1, Int);
+        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
         branch copy _2 -> [bb6, bb5];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_tir.snap
@@ -3,256 +3,256 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function NestedLiteralUnions:
-    Return: Union([Literal(String("success")), Literal(String("client error")), Literal(String("other"))])
+    Return: Union([Literal(String("success"), TyAttr(None)), Literal(String("client error"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveEnumWithTypedPattern:
-    Return: Literal(String("any status"))
+    Return: Literal(String("any status"), TyAttr(None))
   Function ParenthesizedSingleLiteral:
-    Return: Union([Literal(String("yes")), Literal(String("no"))])
+    Return: Union([Literal(String("yes"), TyAttr(None)), Literal(String("no"), TyAttr(None))], TyAttr(None))
   Function DuplicateEnumVariant:
-    Return: Union([Literal(String("first")), Literal(String("second")), Literal(String("inactive")), Literal(String("pending"))])
+    Return: Union([Literal(String("first"), TyAttr(None)), Literal(String("second"), TyAttr(None)), Literal(String("inactive"), TyAttr(None)), Literal(String("pending"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function WrongLiteralTypeBoolWithInt:
-    Return: Literal(String("wrong type"))
+    Return: Literal(String("wrong type"), TyAttr(None))
     Errors:
       - Non-exhaustive match on bool: missing true, false
   Function UnreachableMultiple:
-    Return: Union([Literal(String("catch all")), Literal(String("unreachable 1")), Literal(String("unreachable 2"))])
+    Return: Union([Literal(String("catch all"), TyAttr(None)), Literal(String("unreachable 1"), TyAttr(None)), Literal(String("unreachable 2"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
       - Unreachable match arm
   Function OverlappingWithBindings:
-    Return: Union([String, Literal(String("remaining"))])
+    Return: Union([String { attr: TyAttr(None) }, Literal(String("remaining"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveNullableEnum:
-    Return: Union([Literal(String("active")), Literal(String("inactive")), Literal(String("pending")), Literal(String("no status"))])
+    Return: Union([Literal(String("active"), TyAttr(None)), Literal(String("inactive"), TyAttr(None)), Literal(String("pending"), TyAttr(None)), Literal(String("no status"), TyAttr(None))], TyAttr(None))
   Function NonExhaustiveBoolMissingTrue:
-    Return: Literal(String("no"))
+    Return: Literal(String("no"), TyAttr(None))
     Errors:
       - Non-exhaustive match on bool: missing true
   Function ExhaustiveEnumAllVariants:
-    Return: Union([Literal(String("active")), Literal(String("inactive")), Literal(String("pending"))])
+    Return: Union([Literal(String("active"), TyAttr(None)), Literal(String("inactive"), TyAttr(None)), Literal(String("pending"), TyAttr(None))], TyAttr(None))
   Function JumpTableEnumDiscriminant:
-    Return: Union([Literal(Int(10)), Literal(Int(20)), Literal(Int(30)), Literal(Int(40))])
+    Return: Union([Literal(Int(10), TyAttr(None)), Literal(Int(20), TyAttr(None)), Literal(Int(30), TyAttr(None)), Literal(Int(40), TyAttr(None))], TyAttr(None))
   Function ExhaustiveTypeAlias:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function EnumVariantAfterTypedEnum:
-    Return: Union([Literal(String("any status")), Literal(String("unreachable"))])
+    Return: Union([Literal(String("any status"), TyAttr(None)), Literal(String("unreachable"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function BoolLiteralAfterTypedBool:
-    Return: Union([Literal(String("any bool")), Literal(String("unreachable"))])
+    Return: Union([Literal(String("any bool"), TyAttr(None)), Literal(String("unreachable"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function LiteralUnionWithCatchAll:
-    Return: Union([Literal(String("success")), Literal(String("client error")), Literal(String("other"))])
+    Return: Union([Literal(String("success"), TyAttr(None)), Literal(String("client error"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveIntLiterals:
-    Return: Union([Literal(String("OK")), Literal(String("Created")), Literal(String("No Content"))])
+    Return: Union([Literal(String("OK"), TyAttr(None)), Literal(String("Created"), TyAttr(None)), Literal(String("No Content"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveStringLiterals:
-    Return: Union([Literal(String("User")), Literal(String("Assistant")), Literal(String("System"))])
+    Return: Union([Literal(String("User"), TyAttr(None)), Literal(String("Assistant"), TyAttr(None)), Literal(String("System"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveTypeAliasWithCatchAll:
-    Return: Union([String, Literal(String("fallback"))])
+    Return: Union([String { attr: TyAttr(None) }, Literal(String("fallback"), TyAttr(None))], TyAttr(None))
   Function DuplicateIntLiteral:
-    Return: Union([Literal(String("first one")), Literal(String("second one")), Literal(String("other"))])
+    Return: Union([Literal(String("first one"), TyAttr(None)), Literal(String("second one"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function ExhaustiveClassPlusLiteral:
-    Return: Union([String, Literal(String("http ok"))])
+    Return: Union([String { attr: TyAttr(None) }, Literal(String("http ok"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveLiteralWithBaseType:
-    Return: Union([Literal(String("ok")), Literal(String("other"))])
+    Return: Union([Literal(String("ok"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
   Function NonExhaustiveNullableEnumMissingNull:
-    Return: Union([Literal(String("active")), Literal(String("inactive")), Literal(String("pending"))])
+    Return: Union([Literal(String("active"), TyAttr(None)), Literal(String("inactive"), TyAttr(None)), Literal(String("pending"), TyAttr(None))], TyAttr(None))
     Errors:
       - Non-exhaustive match on Status?: missing null
   Function NonExhaustiveTypeAliasMissingOne:
-    Return: String
+    Return: String { attr: TyAttr(None) }
     Errors:
       - Non-exhaustive match on Result: missing Failure
   Function BoolUnionPattern:
-    Return: Literal(String("covered"))
+    Return: Literal(String("covered"), TyAttr(None))
   Function StringLiteralUnionPattern:
-    Return: Union([Literal(String("chat participant")), Literal(String("system"))])
+    Return: Union([Literal(String("chat participant"), TyAttr(None)), Literal(String("system"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveBool:
-    Return: Union([Literal(String("yes")), Literal(String("no"))])
+    Return: Union([Literal(String("yes"), TyAttr(None)), Literal(String("no"), TyAttr(None))], TyAttr(None))
   Function NonExhaustiveDoubleMaybeMissingNull:
-    Return: String
+    Return: String { attr: TyAttr(None) }
     Errors:
       - Non-exhaustive match on DoubleMaybe: missing null
   Function ExhaustiveDoubleMaybe:
-    Return: Union([String, String, Literal(String("nothing"))])
+    Return: Union([String { attr: TyAttr(None) }, String { attr: TyAttr(None) }, Literal(String("nothing"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveOptionalSingleton:
-    Return: Union([Literal(String("OK")), Literal(String("no code"))])
+    Return: Union([Literal(String("OK"), TyAttr(None)), Literal(String("no code"), TyAttr(None))], TyAttr(None))
   Function BoolWithCatchAll:
-    Return: Union([Literal(String("yes")), Literal(String("no"))])
+    Return: Union([Literal(String("yes"), TyAttr(None)), Literal(String("no"), TyAttr(None))], TyAttr(None))
   Function GuardedOnlyNonExhaustive:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
     Errors:
       - Non-exhaustive match on int: missing int
   Function NonExhaustiveBoolMissingFalse:
-    Return: Literal(String("yes"))
+    Return: Literal(String("yes"), TyAttr(None))
     Errors:
       - Non-exhaustive match on bool: missing false
   Function IntLiteralUnionPattern:
-    Return: Union([Literal(String("success with body")), Literal(String("no content"))])
+    Return: Union([Literal(String("success with body"), TyAttr(None)), Literal(String("no content"), TyAttr(None))], TyAttr(None))
   Function ThreeLevelNestedMatch:
-    Return: Union([Union([Union([Literal(String("all zero")), Literal(String("z nonzero"))]), Literal(String("y nonzero"))]), Literal(String("x nonzero"))])
+    Return: Union([Union([Union([Literal(String("all zero"), TyAttr(None)), Literal(String("z nonzero"), TyAttr(None))], TyAttr(None)), Literal(String("y nonzero"), TyAttr(None))], TyAttr(None)), Literal(String("x nonzero"), TyAttr(None))], TyAttr(None))
   Function MultipleUnreachableSpans:
-    Return: Union([Literal(String("active")), Literal(String("duplicate 1")), Literal(String("inactive")), Literal(String("duplicate 2")), Literal(String("pending"))])
+    Return: Union([Literal(String("active"), TyAttr(None)), Literal(String("duplicate 1"), TyAttr(None)), Literal(String("inactive"), TyAttr(None)), Literal(String("duplicate 2"), TyAttr(None)), Literal(String("pending"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
       - Unreachable match arm
   Function ExhaustiveCustomBool:
-    Return: Union([Literal(String("yes")), Literal(String("no"))])
+    Return: Union([Literal(String("yes"), TyAttr(None)), Literal(String("no"), TyAttr(None))], TyAttr(None))
   Function NestedEnumMatch:
-    Return: Union([Union([Literal(String("both active")), Literal(String("first active, second inactive")), Literal(String("first active, second pending"))]), Literal(String("first inactive")), Literal(String("first pending"))])
+    Return: Union([Union([Literal(String("both active"), TyAttr(None)), Literal(String("first active, second inactive"), TyAttr(None)), Literal(String("first active, second pending"), TyAttr(None))], TyAttr(None)), Literal(String("first inactive"), TyAttr(None)), Literal(String("first pending"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveMixedLiterals:
-    Return: Union([Literal(String("http ok")), Literal(String("string success")), Literal(String("boolean true"))])
+    Return: Union([Literal(String("http ok"), TyAttr(None)), Literal(String("string success"), TyAttr(None)), Literal(String("boolean true"), TyAttr(None))], TyAttr(None))
   Function PartialUnionPlusCatchAll:
-    Return: Union([Literal(String("success or failure")), Literal(String("pending"))])
+    Return: Union([Literal(String("success or failure"), TyAttr(None)), Literal(String("pending"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveTrueType:
-    Return: Literal(String("always true"))
+    Return: Literal(String("always true"), TyAttr(None))
   Function NestedMatchSpans:
-    Return: Union([Union([Literal(String("zero true")), Literal(String("zero false")), Literal(String("unreachable nested"))]), Literal(String("other"))])
+    Return: Union([Union([Literal(String("zero true"), TyAttr(None)), Literal(String("zero false"), TyAttr(None)), Literal(String("unreachable nested"), TyAttr(None))], TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function NonExhaustiveOptionalMissingValue:
-    Return: Literal(String("no code"))
+    Return: Literal(String("no code"), TyAttr(None))
     Errors:
       - Non-exhaustive match on MaybeOk: missing 200
   Function GetStatus:
-    Return: Enum(QualifiedName { namespace: Local, name: "Status" })
+    Return: Enum(QualifiedName { namespace: Local, name: "Status" }, TyAttr(None))
   Function EnumVariantUnion:
-    Return: Union([Literal(String("actionable")), Literal(String("inactive"))])
+    Return: Union([Literal(String("actionable"), TyAttr(None)), Literal(String("inactive"), TyAttr(None))], TyAttr(None))
   Function NestedTypeAlias:
-    Return: Union([String, String, Literal(String("nothing"))])
+    Return: Union([String { attr: TyAttr(None) }, String { attr: TyAttr(None) }, Literal(String("nothing"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveFalseType:
-    Return: Literal(String("always false"))
+    Return: Literal(String("always false"), TyAttr(None))
   Function NonExhaustiveOptionalMissingNull:
-    Return: Literal(String("OK"))
+    Return: Literal(String("OK"), TyAttr(None))
     Errors:
       - Non-exhaustive match on MaybeOk: missing null
   Function NonExhaustiveTrueTypeWrongLiteral:
-    Return: Literal(String("wrong!"))
+    Return: Literal(String("wrong!"), TyAttr(None))
     Errors:
       - Non-exhaustive match on AlwaysTrue: missing true
   Function ExhaustiveWithNamedCatchAll:
-    Return: Union([Literal(Int(100)), Int])
+    Return: Union([Literal(Int(100), TyAttr(None)), Int { attr: TyAttr(None) }], TyAttr(None))
   Function JumpTableTypeTag:
-    Return: Union([Literal(String("int")), Literal(String("string")), Literal(String("bool")), Literal(String("float"))])
+    Return: Union([Literal(String("int"), TyAttr(None)), Literal(String("string"), TyAttr(None)), Literal(String("bool"), TyAttr(None)), Literal(String("float"), TyAttr(None))], TyAttr(None))
   Function NestedTypeBindings:
-    Return: Union([Literal(Int(0)), Literal(Int(1))])
+    Return: Union([Literal(Int(0), TyAttr(None)), Literal(Int(1), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function NonExhaustiveAliasOfLiterals:
-    Return: Literal(String("ok"))
+    Return: Literal(String("ok"), TyAttr(None))
     Errors:
       - Non-exhaustive match on OkOrCreated: missing 201
   Function ExhaustiveAliasOfLiterals:
-    Return: Union([Literal(String("ok")), Literal(String("created"))])
+    Return: Union([Literal(String("ok"), TyAttr(None)), Literal(String("created"), TyAttr(None))], TyAttr(None))
   Function WrongLiteralTypeIntWithString:
-    Return: Literal(String("wrong type"))
+    Return: Literal(String("wrong type"), TyAttr(None))
     Errors:
       - Non-exhaustive match on int: missing int
   Function ExhaustiveEnumWithCatchAll:
-    Return: Union([Literal(String("active")), Literal(String("other"))])
+    Return: Union([Literal(String("active"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
   Function GuardedWithFallback:
-    Return: Union([Int, Literal(Int(0))])
+    Return: Union([Int { attr: TyAttr(None) }, Literal(Int(0), TyAttr(None))], TyAttr(None))
   Function MatchArithmeticScrutinee:
-    Return: Union([Literal(String("zero")), Literal(String("one")), Literal(String("other"))])
+    Return: Union([Literal(String("zero"), TyAttr(None)), Literal(String("one"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
   Function HighLineNumberNonExhaustive:
-    Return: Literal(String("active only"))
+    Return: Literal(String("active only"), TyAttr(None))
     Errors:
       - Non-exhaustive match on Status: missing Status.Inactive, Status.Pending
   Function NonExhaustiveNullableEnumMissingVariant:
-    Return: Union([Literal(String("active")), Literal(String("inactive")), Literal(String("no status"))])
+    Return: Union([Literal(String("active"), TyAttr(None)), Literal(String("inactive"), TyAttr(None)), Literal(String("no status"), TyAttr(None))], TyAttr(None))
     Errors:
       - Non-exhaustive match on Status?: missing Status.Pending
   Function DeeplyNestedLiterals:
-    Return: Literal(String("all success codes"))
+    Return: Literal(String("all success codes"), TyAttr(None))
   Function NonExhaustiveFullResultMissingOne:
-    Return: String
+    Return: String { attr: TyAttr(None) }
     Errors:
       - Non-exhaustive match on FullResult: missing Pending
   Function ExhaustiveSingletonInt:
-    Return: Literal(String("OK"))
+    Return: Literal(String("OK"), TyAttr(None))
   Function NonExhaustiveClassPlusLiteralMissingLiteral:
-    Return: String
+    Return: String { attr: TyAttr(None) }
     Errors:
       - Non-exhaustive match on SuccessOr200: missing 200
   Function ExhaustiveNullableEnumWithTypedPattern:
-    Return: Union([Literal(String("some status")), Literal(String("no status"))])
+    Return: Union([Literal(String("some status"), TyAttr(None)), Literal(String("no status"), TyAttr(None))], TyAttr(None))
   Function DuplicateStringLiteral:
-    Return: Union([Literal(String("first user")), Literal(String("second user")), Literal(String("assistant")), Literal(String("system"))])
+    Return: Union([Literal(String("first user"), TyAttr(None)), Literal(String("second user"), TyAttr(None)), Literal(String("assistant"), TyAttr(None)), Literal(String("system"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function NonExhaustiveEnumMissingOne:
-    Return: Union([Literal(String("active")), Literal(String("inactive"))])
+    Return: Union([Literal(String("active"), TyAttr(None)), Literal(String("inactive"), TyAttr(None))], TyAttr(None))
     Errors:
       - Non-exhaustive match on Status: missing Status.Pending
   Function MatchComplexScrutinee:
-    Return: Union([Literal(String("x was 0")), Literal(String("x was 1")), Literal(String("other"))])
+    Return: Union([Literal(String("x was 0"), TyAttr(None)), Literal(String("x was 1"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))
   Function ExhaustiveOptional:
-    Return: Union([Literal(String("has value")), Literal(String("no value"))])
+    Return: Union([Literal(String("has value"), TyAttr(None)), Literal(String("no value"), TyAttr(None))], TyAttr(None))
   Function NonExhaustiveCustomBoolMissing:
-    Return: Literal(String("yes"))
+    Return: Literal(String("yes"), TyAttr(None))
     Errors:
       - Non-exhaustive match on CustomBool: missing false
   Function NonExhaustiveMixedLiterals:
-    Return: Union([Literal(String("http ok")), Literal(String("string success"))])
+    Return: Union([Literal(String("http ok"), TyAttr(None)), Literal(String("string success"), TyAttr(None))], TyAttr(None))
     Errors:
       - Non-exhaustive match on MixedLiterals: missing true
   Function NonExhaustiveClassPlusLiteralMissingClass:
-    Return: Literal(String("http ok"))
+    Return: Literal(String("http ok"), TyAttr(None))
     Errors:
       - Non-exhaustive match on SuccessOr200: missing Success
   Function UnreachableAfterCatchAll:
-    Return: Union([Literal(String("catch all")), Literal(String("never reached"))])
+    Return: Union([Literal(String("catch all"), TyAttr(None)), Literal(String("never reached"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function OptionalWithCatchAll:
-    Return: Union([Literal(String("no value")), Literal(String("has value"))])
+    Return: Union([Literal(String("no value"), TyAttr(None)), Literal(String("has value"), TyAttr(None))], TyAttr(None))
   Function DuplicateBoolLiteral:
-    Return: Union([Literal(String("first true")), Literal(String("second true")), Literal(String("false"))])
+    Return: Union([Literal(String("first true"), TyAttr(None)), Literal(String("second true"), TyAttr(None)), Literal(String("false"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function OverlappingTypedPatterns:
-    Return: Union([Literal(String("success")), Literal(String("covers failure only (success already handled)"))])
+    Return: Union([Literal(String("success"), TyAttr(None)), Literal(String("covers failure only (success already handled)"), TyAttr(None))], TyAttr(None))
   Function StringLiteralAfterStringType:
-    Return: Union([Literal(String("any string")), Literal(String("unreachable"))])
+    Return: Union([Literal(String("any string"), TyAttr(None)), Literal(String("unreachable"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function NestedEnumVariantUnions:
-    Return: Literal(String("all statuses"))
+    Return: Literal(String("all statuses"), TyAttr(None))
   Function UnionPatternCoversAll:
-    Return: Literal(String("covered"))
+    Return: Literal(String("covered"), TyAttr(None))
   Function ExhaustiveWithUnderscore:
-    Return: Union([Literal(Int(100)), Literal(Int(200)), Literal(Int(0))])
+    Return: Union([Literal(Int(100), TyAttr(None)), Literal(Int(200), TyAttr(None)), Literal(Int(0), TyAttr(None))], TyAttr(None))
   Function PartialUnionPatternCoverage:
-    Return: Literal(String("not pending"))
+    Return: Literal(String("not pending"), TyAttr(None))
     Errors:
       - Non-exhaustive match on FullResult: missing Pending
   Function NonExhaustiveStringLiteral:
-    Return: Union([Literal(String("User")), Literal(String("Assistant"))])
+    Return: Union([Literal(String("User"), TyAttr(None)), Literal(String("Assistant"), TyAttr(None))], TyAttr(None))
     Errors:
       - Non-exhaustive match on Role: missing "system"
   Function MatchFunctionCallScrutinee:
-    Return: Union([Literal(String("active")), Literal(String("inactive")), Literal(String("pending"))])
+    Return: Union([Literal(String("active"), TyAttr(None)), Literal(String("inactive"), TyAttr(None)), Literal(String("pending"), TyAttr(None))], TyAttr(None))
   Function StringLiteralWithCatchAll:
-    Return: Union([Literal(String("User message")), Literal(String("Assistant message")), Literal(String("Other"))])
+    Return: Union([Literal(String("User message"), TyAttr(None)), Literal(String("Assistant message"), TyAttr(None)), Literal(String("Other"), TyAttr(None))], TyAttr(None))
   Function JumpTableClassTypeTag:
-    Return: Union([Literal(String("cat")), Literal(String("dog")), Literal(String("bird")), Literal(String("fish"))])
+    Return: Union([Literal(String("cat"), TyAttr(None)), Literal(String("dog"), TyAttr(None)), Literal(String("bird"), TyAttr(None)), Literal(String("fish"), TyAttr(None))], TyAttr(None))
   Function NonExhaustiveEnumMissingMultiple:
-    Return: Literal(String("active"))
+    Return: Literal(String("active"), TyAttr(None))
     Errors:
       - Non-exhaustive match on Status: missing Status.Inactive, Status.Pending
   Function MixedPatterns:
-    Return: Union([Literal(String("zero")), Literal(String("one")), Literal(String("positive")), Literal(String("negative"))])
+    Return: Union([Literal(String("zero"), TyAttr(None)), Literal(String("one"), TyAttr(None)), Literal(String("positive"), TyAttr(None)), Literal(String("negative"), TyAttr(None))], TyAttr(None))
   Function NonExhaustiveIntLiteral:
-    Return: Union([Literal(String("OK")), Literal(String("Created"))])
+    Return: Union([Literal(String("OK"), TyAttr(None)), Literal(String("Created"), TyAttr(None))], TyAttr(None))
     Errors:
       - Non-exhaustive match on SuccessCode: missing 204
   Function LiteralAfterTypedPattern:
-    Return: Union([Literal(String("int")), Literal(String("unreachable"))])
+    Return: Union([Literal(String("int"), TyAttr(None)), Literal(String("unreachable"), TyAttr(None))], TyAttr(None))
     Errors:
       - Unreachable match arm
   Function EnumVariantUnionWithCatchAll:
-    Return: Union([Literal(String("actionable")), Literal(String("other"))])
+    Return: Union([Literal(String("actionable"), TyAttr(None)), Literal(String("other"), TyAttr(None))], TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__04_tir.snap
@@ -3,26 +3,26 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function floatArray:
-    Return: List(Float)
+    Return: List(Float { attr: TyAttr(None) }, TyAttr(None))
   Function stringArray:
-    Return: List(String)
+    Return: List(String { attr: TyAttr(None) }, TyAttr(None))
   Function pointArray:
-    Return: List(Class(QualifiedName { namespace: Local, name: "Point" }))
+    Return: List(Class(QualifiedName { namespace: Local, name: "Point" }, TyAttr(None)), TyAttr(None))
   Function boolArray:
-    Return: List(Bool)
+    Return: List(Bool { attr: TyAttr(None) }, TyAttr(None))
   Function mixedArray:
-    Return: List(Union([Int, String]))
+    Return: List(Union([Int { attr: TyAttr(None) }, String { attr: TyAttr(None) }], TyAttr(None)), TyAttr(None))
   Function intArray:
-    Return: List(Int)
+    Return: List(Int { attr: TyAttr(None) }, TyAttr(None))
   Function point:
-    Return: Class(QualifiedName { namespace: Local, name: "Point" })
+    Return: Class(QualifiedName { namespace: Local, name: "Point" }, TyAttr(None))
   Function vec2d:
-    Return: Class(QualifiedName { namespace: Local, name: "Vec2D" })
+    Return: Class(QualifiedName { namespace: Local, name: "Vec2D" }, TyAttr(None))
   Function boolValues:
-    Return: Map { key: String, value: Bool }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Bool { attr: TyAttr(None) }, attr: TyAttr(None) }
   Function intValues:
-    Return: Map { key: String, value: Int }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Int { attr: TyAttr(None) }, attr: TyAttr(None) }
   Function stringValues:
-    Return: Map { key: String, value: String }
+    Return: Map { key: String { attr: TyAttr(None) }, value: String { attr: TyAttr(None) }, attr: TyAttr(None) }
   Function floatValues:
-    Return: Map { key: String, value: Float }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Float { attr: TyAttr(None) }, attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__04_tir.snap
@@ -1,13 +1,12 @@
 ---
-source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
-expression: output
+source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function Foo:
-    Return: Void
+    Return: Void { attr: TyAttr(None) }
   Function GPT4.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))
   Function Incomplete:
-    Return: Unknown
+    Return: Unknown { attr: TyAttr(None) }
   Function NextFunction:
-    Return: String
+    Return: String { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__04_tir.snap
@@ -3,10 +3,10 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function Calculate:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function FieldAccess:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function IndexAccess:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function TestPrecedence:
-    Return: Bool
+    Return: Bool { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__04_tir.snap
@@ -3,38 +3,38 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function AnotherLLM:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function AnotherLLM.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Ambiguous.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function AnotherLLM.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Ambiguous.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Ambiguous:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ProcessData:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function ExtractData.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function ExtractData:
-    Return: Class(QualifiedName { namespace: Local, name: "JsonData" })
+    Return: Class(QualifiedName { namespace: Local, name: "JsonData" }, TyAttr(None))
   Function ExtractData.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function SimpleCalc:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function ChainedProcess.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function LLMAnalyze.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function ProcessAnalysis:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function LLMAnalyze:
-    Return: Class(QualifiedName { namespace: Local, name: "Analysis" })
+    Return: Class(QualifiedName { namespace: Local, name: "Analysis" }, TyAttr(None))
   Function ChainedProcess:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function LLMAnalyze.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function ChainedProcess.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__04_tir.snap
@@ -3,44 +3,44 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function mul_assign:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function assign_in_loop:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function multi_assign:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function sub_assign:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function add_assign:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function simple_assign:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function block_with_tail:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function break_in_for:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function simple_continue:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function continue_with_locals:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function simple_break:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function nested_break:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function continue_in_for:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function break_with_locals:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function c_style_for_loop:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function iterator_style_for_loop:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function nested_for_loop:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function ConditionalLogic:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function let_statements:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function simple_while_loop:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function nested_while_loop:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__04_tir.snap
@@ -3,610 +3,610 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function ComplexType:
-    Return: Map { key: String, value: Map { key: String, value: Map { key: String, value: Optional(List(Int)) } } }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Map { key: String { attr: TyAttr(None) }, value: Map { key: String { attr: TyAttr(None) }, value: Optional(List(Int { attr: TyAttr(None) }, TyAttr(None)), TyAttr(None)), attr: TyAttr(None) }, attr: TyAttr(None) }, attr: TyAttr(None) }
   Function DeepExpression:
-    Return: Int
+    Return: Int { attr: TyAttr(None) }
   Function Process24.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process22:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process66.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process30.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process54:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process95:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process60:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process68:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process58.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process36.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process53.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process14:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process22.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process79:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process84:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process62.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process97.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process9.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process33:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process33.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process12:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process59.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process37.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process59.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process74:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process45.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process13.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process99:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process76.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process64:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process52:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process40.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process7:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process32.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process80:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process88.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process31.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process58:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process42.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process97:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process36:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process63.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process51.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process54.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process47.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process26.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process63:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process37.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process19:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process95.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process33.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process56.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process80.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process13.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process94.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process60.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process83:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process36.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process18:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process56.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process26:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process43:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process41.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process46:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process91.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process62:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process87:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process44:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process47:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process35:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process38:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process29.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process25.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process41:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process98.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process18.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process28:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process65:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process17.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process5.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process95.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process6:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process32:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process52.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process92:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process90.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process55:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process66:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process97.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process27.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process93.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process8.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process16.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process86.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process85.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process56:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process67.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process11.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process67:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process76.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process78.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process12.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process79.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process57.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process12.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process75.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process77.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process93.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process64.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process48.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process3:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process43.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process75:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process48:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process49:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process96.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process41.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process20.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process50.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process44.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process60.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process61:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process96:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process15.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process82.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process34:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process96.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process49.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process59:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process54.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process89:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process45:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process1.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process25.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process86:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process19.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process38.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process23.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process65.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process23.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process72.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process35.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process100.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process46.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process4.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process86.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process73.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process16:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process65.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process39:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process78.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process68.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process82:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process35.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process2:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process27:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process11.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process100.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process61.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process53:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process62.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process23:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process16.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process21.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process74.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process55.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process9:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process61.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process84.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process89.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process52.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process74.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process30.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process32.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process48.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process28.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process19.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process31.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process89.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process72:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process38.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process77:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process40:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process30:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process20.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process26.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process8:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process83.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process63.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process39.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process11:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process28.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process24.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process37:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process4:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process91:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process46.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process31:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process70.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process3.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process29.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process9.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process84.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process43.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process50:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process20:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process98:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process88.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process87.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process91.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process71.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process85:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process6.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process71.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process47.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process67.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process72.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process69.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process17.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process79.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process78:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process2.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process1:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process94.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process5.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process98.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process81.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process81.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process2.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process90:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process17:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process50.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process49.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process27.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process22.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process64.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process81:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process58.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process83.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process71:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process15:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process8.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process42:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process92.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process6.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process51:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process7.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process5:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process21.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process13:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process10.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process14.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process92.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process7.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process85.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process73.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process55.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process82.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process44.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process99.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process29:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process93:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process51.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process90.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process34.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process87.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process1.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process53.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process39.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process70:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process75.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process76:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process10:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process68.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process21:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process15.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process14.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process57.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process66.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process40.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process77.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process99.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process100:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process80.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process18.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process70.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process94:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process25:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process69:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process24:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process88:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process69.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process73:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function Process45.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process4.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process10.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process42.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Process34.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process3.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Process57:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function BodyTorture:
-    Return: Void
+    Return: Void { attr: TyAttr(None) }
     Errors:
       - Missing return expression. Function expects `int` but body has no final expression.

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__04_tir.snap
@@ -3,18 +3,18 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function FormatMessage:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function FormatMessage.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function FormatMessage.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function ProcessText.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function ProcessText.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function ProcessText:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function GetRole:
-    Return: Union([Literal(String("admin")), Literal(String("user")), Literal(String("guest"))])
+    Return: Union([Literal(String("admin"), TyAttr(None)), Literal(String("user"), TyAttr(None)), Literal(String("guest"), TyAttr(None))], TyAttr(None))
   Function GPT4.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__04_tir.snap
@@ -3,14 +3,14 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function BadParam.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function BadParam.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function BadReturnType.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function BadReturnType:
-    Return: Map { key: String, value: Int }
+    Return: Map { key: String { attr: TyAttr(None) }, value: Int { attr: TyAttr(None) }, attr: TyAttr(None) }
   Function BadReturnType.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function BadParam:
-    Return: String
+    Return: String { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__04_tir.snap
@@ -3,4 +3,4 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function MyClient.resolve:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PrimitiveClient" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__04_tir.snap
@@ -3,8 +3,8 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function HelloWorld.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function HelloWorld.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function HelloWorld:
-    Return: String
+    Return: String { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__04_tir.snap
@@ -3,6 +3,6 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function Foo:
-    Return: Error
+    Return: Error { attr: TyAttr(None) }
     Errors:
       - Invalid op Add for int and string

--- a/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__04_tir.snap
@@ -3,4 +3,4 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function Foo:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__04_tir.snap
@@ -3,14 +3,14 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function Bar:
-    Return: Literal(Bool(true))
+    Return: Literal(Bool(true), TyAttr(None))
     Errors:
       - Expected foo. Found bool
   Function Foo:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
   Function Baz:
-    Return: Literal(String("hello"))
+    Return: Literal(String("hello"), TyAttr(None))
   Function EchoJSON:
-    Return: TypeAlias(QualifiedName { namespace: Local, name: "NotJSON" })
+    Return: TypeAlias(QualifiedName { namespace: Local, name: "NotJSON" }, TyAttr(None))
   Function MakeJSON:
-    Return: Error
+    Return: Error { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/type_annotation/baml_tests__type_annotation__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_annotation/baml_tests__type_annotation__04_tir.snap
@@ -1,21 +1,20 @@
 ---
-source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
-expression: output
+source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function test_type_annotation:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function test_optional:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function test_let_binding:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function test_param:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function test_list:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function test_union:
-    Return: String
+    Return: String { attr: TyAttr(None) }
   Function test_return_type:
-    Return: Type
+    Return: Type { attr: TyAttr(None) }
   Function test_map:
-    Return: String
+    Return: String { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__04_tir.snap
@@ -3,8 +3,8 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function TypeBuilderFn.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function TypeBuilderFn.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function TypeBuilderFn:
-    Return: Class(QualifiedName { namespace: Local, name: "Resume" })
+    Return: Class(QualifiedName { namespace: Local, name: "Resume" }, TyAttr(None))

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__04_tir.snap
@@ -3,8 +3,8 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function Fn.build_request:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["http"] }, name: "Request" }, TyAttr(None))
   Function Fn.render_prompt:
-    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" })
+    Return: Class(QualifiedName { namespace: Builtin { path: ["llm"] }, name: "PromptAst" }, TyAttr(None))
   Function Fn:
-    Return: String
+    Return: String { attr: TyAttr(None) }

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__04_tir.snap
@@ -3,14 +3,14 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TYPE INFERENCE ===
   Function Bar:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
     Errors:
       - Unknown type unknown_param_type
   Function Foo:
-    Return: Literal(Int(1))
+    Return: Literal(Int(1), TyAttr(None))
     Errors:
       - Unknown type blah
   Function Baz:
-    Return: Null
+    Return: Null { attr: TyAttr(None) }
     Errors:
       - Unknown type unknown_optional

--- a/baml_language/crates/baml_tests/src/bytecode.rs
+++ b/baml_language/crates/baml_tests/src/bytecode.rs
@@ -322,7 +322,9 @@ pub fn assert_vm_executes_bytecode_with_inspection(
         span: baml_base::Span::fake(),
         block_notifications: Vec::new(),
         viz_nodes: Vec::new(),
-        return_type: baml_type::Ty::Null,
+        return_type: baml_type::Ty::Null {
+            attr: baml_type::TyAttr::default(),
+        },
         param_names: Vec::new(),
         param_types: Vec::new(),
         body_meta: None,

--- a/baml_language/crates/baml_type/src/convert.rs
+++ b/baml_language/crates/baml_type/src/convert.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use baml_base::{Literal, Name};
 use baml_compiler_tir::{self, LiteralValue, Namespace, QualifiedName};
 
-use crate::{Ty, TypeName};
+use crate::{Ty, TyAttr, TypeName};
 
 /// Convert a `QualifiedName` to a `TypeName`, pre-computing the display string.
 pub fn fqn_to_type_name(fqn: &QualifiedName) -> TypeName {
@@ -68,65 +68,71 @@ pub fn convert_tir_ty(
     aliases: &HashMap<Name, baml_compiler_tir::Ty>,
     recursive_aliases: &HashSet<Name>,
 ) -> Result<Ty, String> {
+    let d = TyAttr::default();
     match tir_ty {
-        baml_compiler_tir::Ty::Int => Ok(Ty::Int),
-        baml_compiler_tir::Ty::Float => Ok(Ty::Float),
-        baml_compiler_tir::Ty::String => Ok(Ty::String),
-        baml_compiler_tir::Ty::Bool => Ok(Ty::Bool),
-        baml_compiler_tir::Ty::Null => Ok(Ty::Null),
-        baml_compiler_tir::Ty::Media(kind) => Ok(Ty::Media(*kind)),
+        baml_compiler_tir::Ty::Int { attr } => Ok(Ty::Int { attr: attr.clone() }),
+        baml_compiler_tir::Ty::Float { attr } => Ok(Ty::Float { attr: attr.clone() }),
+        baml_compiler_tir::Ty::String { attr } => Ok(Ty::String { attr: attr.clone() }),
+        baml_compiler_tir::Ty::Bool { attr } => Ok(Ty::Bool { attr: attr.clone() }),
+        baml_compiler_tir::Ty::Null { attr } => Ok(Ty::Null { attr: attr.clone() }),
+        baml_compiler_tir::Ty::Media(kind, attr) => Ok(Ty::Media(*kind, attr.clone())),
 
-        baml_compiler_tir::Ty::Literal(lit) => Ok(Ty::Literal(convert_literal(lit))),
+        baml_compiler_tir::Ty::Literal(lit, attr) => {
+            Ok(Ty::Literal(convert_literal(lit), attr.clone()))
+        }
 
-        baml_compiler_tir::Ty::Class(fqn) => {
+        baml_compiler_tir::Ty::Class(fqn, attr) => {
             // Check if this builtin type has a dedicated VM heap variant.
             // Most builtins are Object::Instance, but PromptAst wraps an opaque
             // Rust ADT and has its own Object variant.
             if baml_compiler_tir::is_prompt_ast_class(fqn) {
-                return Ok(Ty::prompt_ast());
+                return Ok(Ty::opaque_builtin(
+                    "baml.llm.PromptAst",
+                    "baml.llm.PromptAst",
+                    attr.clone(),
+                ));
             }
-            Ok(Ty::Class(fqn_to_type_name(fqn)))
+            Ok(Ty::Class(fqn_to_type_name(fqn), attr.clone()))
         }
-        baml_compiler_tir::Ty::Enum(fqn) => Ok(Ty::Enum(fqn_to_type_name(fqn))),
+        baml_compiler_tir::Ty::Enum(fqn, attr) => Ok(Ty::Enum(fqn_to_type_name(fqn), attr.clone())),
 
-        baml_compiler_tir::Ty::TypeAlias(fqn) => {
+        baml_compiler_tir::Ty::TypeAlias(fqn, attr) => {
             let name = &fqn.name;
             if recursive_aliases.contains(name) {
                 // Recursive alias — cannot expand. Return as TypeAlias for
                 // compiler-level subtyping, or error at runtime boundary.
-                Ok(Ty::TypeAlias(fqn_to_type_name(fqn)))
+                Ok(Ty::TypeAlias(fqn_to_type_name(fqn), attr.clone()))
             } else if let Some(resolved) = aliases.get(name) {
                 // Non-recursive alias — expand inline
                 convert_tir_ty(resolved, aliases, recursive_aliases)
             } else {
                 // Alias not found — shouldn't happen after validation
-                Ok(Ty::Null)
+                Ok(Ty::Null { attr: d })
             }
         }
 
-        baml_compiler_tir::Ty::Optional(inner) => Ok(Ty::Optional(Box::new(convert_tir_ty(
-            inner,
-            aliases,
-            recursive_aliases,
-        )?))),
-        baml_compiler_tir::Ty::List(inner) => Ok(Ty::List(Box::new(convert_tir_ty(
-            inner,
-            aliases,
-            recursive_aliases,
-        )?))),
-        baml_compiler_tir::Ty::Map { key, value } => Ok(Ty::Map {
+        baml_compiler_tir::Ty::Optional(inner, attr) => Ok(Ty::Optional(
+            Box::new(convert_tir_ty(inner, aliases, recursive_aliases)?),
+            attr.clone(),
+        )),
+        baml_compiler_tir::Ty::List(inner, attr) => Ok(Ty::List(
+            Box::new(convert_tir_ty(inner, aliases, recursive_aliases)?),
+            attr.clone(),
+        )),
+        baml_compiler_tir::Ty::Map { key, value, attr } => Ok(Ty::Map {
             key: Box::new(convert_tir_ty(key, aliases, recursive_aliases)?),
             value: Box::new(convert_tir_ty(value, aliases, recursive_aliases)?),
+            attr: attr.clone(),
         }),
-        baml_compiler_tir::Ty::Union(types) => {
+        baml_compiler_tir::Ty::Union(types, attr) => {
             let converted: Result<Vec<_>, _> = types
                 .iter()
                 .map(|t| convert_tir_ty(t, aliases, recursive_aliases))
                 .collect();
-            Ok(Ty::Union(converted?))
+            Ok(Ty::Union(converted?, attr.clone()))
         }
 
-        baml_compiler_tir::Ty::Function { params, ret } => {
+        baml_compiler_tir::Ty::Function { params, ret, attr } => {
             let converted_params: Result<Vec<_>, _> = params
                 .iter()
                 .map(|(_, t)| convert_tir_ty(t, aliases, recursive_aliases))
@@ -134,23 +140,35 @@ pub fn convert_tir_ty(
             Ok(Ty::Function {
                 params: converted_params?,
                 ret: Box::new(convert_tir_ty(ret, aliases, recursive_aliases)?),
+                attr: attr.clone(),
             })
         }
 
         // Unknown and Error are TIR-only error recovery types.
         // All real type checking happens in TIR; by the time we convert to
         // baml_type, these just mean "no meaningful type" → map to Null.
-        baml_compiler_tir::Ty::Unknown => Ok(Ty::Null),
-        baml_compiler_tir::Ty::Error => Ok(Ty::Null),
-        baml_compiler_tir::Ty::Void => Ok(Ty::Void),
-        baml_compiler_tir::Ty::Resource => Ok(Ty::resource()),
+        baml_compiler_tir::Ty::Unknown { .. } => Ok(Ty::Null { attr: d }),
+        baml_compiler_tir::Ty::Error { .. } => Ok(Ty::Null { attr: d }),
+        baml_compiler_tir::Ty::Void { attr } => Ok(Ty::Void { attr: attr.clone() }),
+        baml_compiler_tir::Ty::Resource { attr } => Ok(Ty::opaque_builtin(
+            "baml.llm.Resource",
+            "baml.llm.Resource",
+            attr.clone(),
+        )),
         // BuiltinUnknown is preserved for VIR type checking at call sites.
-        baml_compiler_tir::Ty::BuiltinUnknown => Ok(Ty::BuiltinUnknown),
-        baml_compiler_tir::Ty::Type => Ok(Ty::type_type()),
+        baml_compiler_tir::Ty::BuiltinUnknown { attr } => {
+            Ok(Ty::BuiltinUnknown { attr: attr.clone() })
+        }
+        baml_compiler_tir::Ty::Type { attr } => Ok(Ty::opaque_builtin(
+            "baml.reflect.Type",
+            "type",
+            attr.clone(),
+        )),
 
-        baml_compiler_tir::Ty::WatchAccessor(inner) => Ok(Ty::WatchAccessor(Box::new(
-            convert_tir_ty(inner, aliases, recursive_aliases)?,
-        ))),
+        baml_compiler_tir::Ty::WatchAccessor(inner, attr) => Ok(Ty::WatchAccessor(
+            Box::new(convert_tir_ty(inner, aliases, recursive_aliases)?),
+            attr.clone(),
+        )),
     }
 }
 
@@ -164,33 +182,42 @@ pub fn sanitize_for_runtime(ty: Ty) -> Result<Ty, String> {
         // Compiler-only → Null (preserves backwards compatibility)
         // Note: Unknown/Error/Never don't exist in baml_type::Ty — they were
         // already mapped to Null/Void during convert_tir_ty.
-        Ty::Void => Ok(Ty::Null),
-        Ty::BuiltinUnknown => Ok(Ty::BuiltinUnknown),
-        Ty::Function { params, ret } => Ok(Ty::Function {
+        Ty::Void { attr } => Ok(Ty::Null { attr }),
+        Ty::BuiltinUnknown { attr } => Ok(Ty::BuiltinUnknown { attr }),
+        Ty::Function {
+            params, ret, attr, ..
+        } => Ok(Ty::Function {
             params: params
                 .into_iter()
                 .map(sanitize_for_runtime)
                 .collect::<Result<Vec<_>, _>>()?,
             ret: Box::new(sanitize_for_runtime(*ret)?),
+            attr,
         }),
         // WatchAccessor → recursively sanitize inner type, preserving wrapper
-        Ty::WatchAccessor(inner) => Ok(Ty::WatchAccessor(Box::new(sanitize_for_runtime(*inner)?))),
+        Ty::WatchAccessor(inner, attr) => Ok(Ty::WatchAccessor(
+            Box::new(sanitize_for_runtime(*inner)?),
+            attr,
+        )),
         // Recursive TypeAlias → error
-        Ty::TypeAlias(ref tn) => Err(format!(
+        Ty::TypeAlias(ref tn, _) => Err(format!(
             "Recursive type alias '{}' cannot be used in class fields or function return types",
             tn.display_name
         )),
         // Recurse into containers
-        Ty::Optional(inner) => Ok(Ty::Optional(Box::new(sanitize_for_runtime(*inner)?))),
-        Ty::List(inner) => Ok(Ty::List(Box::new(sanitize_for_runtime(*inner)?))),
-        Ty::Map { key, value } => Ok(Ty::Map {
+        Ty::Optional(inner, attr) => {
+            Ok(Ty::Optional(Box::new(sanitize_for_runtime(*inner)?), attr))
+        }
+        Ty::List(inner, attr) => Ok(Ty::List(Box::new(sanitize_for_runtime(*inner)?), attr)),
+        Ty::Map { key, value, attr } => Ok(Ty::Map {
             key: Box::new(sanitize_for_runtime(*key)?),
             value: Box::new(sanitize_for_runtime(*value)?),
+            attr,
         }),
-        Ty::Union(members) => {
+        Ty::Union(members, attr) => {
             let sanitized: Result<Vec<_>, _> =
                 members.into_iter().map(sanitize_for_runtime).collect();
-            Ok(Ty::Union(sanitized?))
+            Ok(Ty::Union(sanitized?, attr))
         }
         // All other variants pass through
         other => Ok(other),

--- a/baml_language/crates/baml_type/src/convert.rs
+++ b/baml_language/crates/baml_type/src/convert.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use baml_base::{Literal, Name};
 use baml_compiler_tir::{self, LiteralValue, Namespace, QualifiedName};
 
-use crate::{Ty, TyAttr, TypeName};
+use crate::{Ty, TypeName};
 
 /// Convert a `QualifiedName` to a `TypeName`, pre-computing the display string.
 pub fn fqn_to_type_name(fqn: &QualifiedName) -> TypeName {
@@ -68,7 +68,6 @@ pub fn convert_tir_ty(
     aliases: &HashMap<Name, baml_compiler_tir::Ty>,
     recursive_aliases: &HashSet<Name>,
 ) -> Result<Ty, String> {
-    let d = TyAttr::default();
     match tir_ty {
         baml_compiler_tir::Ty::Int { attr } => Ok(Ty::Int { attr: attr.clone() }),
         baml_compiler_tir::Ty::Float { attr } => Ok(Ty::Float { attr: attr.clone() }),
@@ -103,11 +102,16 @@ pub fn convert_tir_ty(
                 // compiler-level subtyping, or error at runtime boundary.
                 Ok(Ty::TypeAlias(fqn_to_type_name(fqn), attr.clone()))
             } else if let Some(resolved) = aliases.get(name) {
-                // Non-recursive alias — expand inline
-                convert_tir_ty(resolved, aliases, recursive_aliases)
+                // Non-recursive alias — expand inline, preserving source attr if non-default
+                let expanded = convert_tir_ty(resolved, aliases, recursive_aliases)?;
+                if attr.is_default() {
+                    Ok(expanded)
+                } else {
+                    Ok(expanded.with_attr(attr.clone()))
+                }
             } else {
                 // Alias not found — shouldn't happen after validation
-                Ok(Ty::Null { attr: d })
+                Ok(Ty::Null { attr: attr.clone() })
             }
         }
 
@@ -147,8 +151,8 @@ pub fn convert_tir_ty(
         // Unknown and Error are TIR-only error recovery types.
         // All real type checking happens in TIR; by the time we convert to
         // baml_type, these just mean "no meaningful type" → map to Null.
-        baml_compiler_tir::Ty::Unknown { .. } => Ok(Ty::Null { attr: d }),
-        baml_compiler_tir::Ty::Error { .. } => Ok(Ty::Null { attr: d }),
+        baml_compiler_tir::Ty::Unknown { attr } => Ok(Ty::Null { attr: attr.clone() }),
+        baml_compiler_tir::Ty::Error { attr, .. } => Ok(Ty::Null { attr: attr.clone() }),
         baml_compiler_tir::Ty::Void { attr } => Ok(Ty::Void { attr: attr.clone() }),
         baml_compiler_tir::Ty::Resource { attr } => Ok(Ty::opaque_builtin(
             "baml.llm.Resource",

--- a/baml_language/crates/baml_type/src/defs.rs
+++ b/baml_language/crates/baml_type/src/defs.rs
@@ -5,7 +5,7 @@
 
 use baml_base::Name;
 
-use crate::Ty;
+use crate::{FieldAttr, Ty};
 
 /// Top-level container for all schema definitions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,6 +34,7 @@ pub struct FieldDef {
     pub description: Option<String>,
     pub alias: Option<String>,
     pub skip: bool,
+    pub field_attr: FieldAttr,
 }
 
 /// An enum definition with propagated attributes.

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -15,9 +15,11 @@ pub use baml_base::{Literal, MediaKind, Name, Span};
 
 mod convert;
 mod defs;
+mod sap;
 pub mod typetag;
 pub use convert::{convert_tir_ty, fqn_to_type_name, sanitize_for_runtime};
 pub use defs::*;
+pub use sap::*;
 
 /// A lightweight name type for class/enum/type-alias references.
 ///
@@ -74,25 +76,41 @@ impl fmt::Display for TypeName {
 /// Contains both core runtime variants and compiler-only variants.
 /// Runtime code should use `unreachable!()` for compiler-only variants.
 /// Runtime code should call `validate_runtime()` to catch any that leak.
+///
+/// Every variant carries an `attr: TyAttr` (or trailing `TyAttr` for tuple
+/// variants) that holds SAP streaming annotations. All existing code uses
+/// `TyAttr::default()` — only Phase 3 (stream type generation) will populate
+/// non-default values.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Ty {
     // --- Core: used by all VIR+ stages ---
-    Int,
-    Float,
-    String,
-    Bool,
-    Null,
-    Media(MediaKind),
-    Literal(Literal),
-    Class(TypeName),
-    Enum(TypeName),
-    Optional(Box<Ty>),
-    List(Box<Ty>),
+    Int {
+        attr: TyAttr,
+    },
+    Float {
+        attr: TyAttr,
+    },
+    String {
+        attr: TyAttr,
+    },
+    Bool {
+        attr: TyAttr,
+    },
+    Null {
+        attr: TyAttr,
+    },
+    Media(MediaKind, TyAttr),
+    Literal(Literal, TyAttr),
+    Class(TypeName, TyAttr),
+    Enum(TypeName, TyAttr),
+    Optional(Box<Ty>, TyAttr),
+    List(Box<Ty>, TyAttr),
     Map {
         key: Box<Ty>,
         value: Box<Ty>,
+        attr: TyAttr,
     },
-    Union(Vec<Ty>),
+    Union(Vec<Ty>, TyAttr),
 
     // --- Runtime-only: present at runtime, not in user-facing type syntax ---
     /// Opaque runtime-only type, identified by its qualified name.
@@ -108,22 +126,25 @@ pub enum Ty {
     ///
     /// Use the convenience constructors `Ty::resource()`, `Ty::prompt_ast()`,
     /// `Ty::type_type()` instead of constructing directly.
-    Opaque(TypeName),
+    Opaque(TypeName, TyAttr),
 
     // --- Compiler-specific: present in VIR/MIR, absent at runtime ---
     /// Only recursive aliases survive lower_ty; non-recursive are expanded.
-    TypeAlias(TypeName),
+    TypeAlias(TypeName, TyAttr),
     /// Function/arrow type: `(T1, T2, ...) -> R`
     Function {
         params: Vec<Ty>,
         ret: Box<Ty>,
+        attr: TyAttr,
     },
     /// Void type — the type of effectful expressions (was VIR `Unit`).
     /// Also used for diverging expressions (return, break, continue) since
     /// MIR encodes divergence via control flow terminators, not the type.
-    Void,
+    Void {
+        attr: TyAttr,
+    },
     /// Watch accessor type: represents `x.$watch` on a watched variable.
-    WatchAccessor(Box<Ty>),
+    WatchAccessor(Box<Ty>, TyAttr),
     /// Internal-only type for builtin functions that accept any argument.
     ///
     /// Similar to TypeScript's `unknown` - any value can be passed where
@@ -136,7 +157,9 @@ pub enum Ty {
     /// ```
     ///
     /// This is a compiler-only variant that should never reach runtime.
-    BuiltinUnknown,
+    BuiltinUnknown {
+        attr: TyAttr,
+    },
 }
 
 // NOTE: `Unknown`, `Error`, and `Never` are intentionally excluded from this enum.
@@ -148,6 +171,33 @@ pub enum Ty {
 //   produces `Void` directly instead of `Never`.
 
 impl Ty {
+    // --- TyAttr accessor ---
+
+    /// Get the TyAttr for this type.
+    pub fn attr(&self) -> &TyAttr {
+        match self {
+            Ty::Int { attr }
+            | Ty::Float { attr }
+            | Ty::String { attr }
+            | Ty::Bool { attr }
+            | Ty::Null { attr }
+            | Ty::Void { attr }
+            | Ty::BuiltinUnknown { attr }
+            | Ty::Map { attr, .. }
+            | Ty::Function { attr, .. } => attr,
+            Ty::Media(_, attr)
+            | Ty::Literal(_, attr)
+            | Ty::Class(_, attr)
+            | Ty::Enum(_, attr)
+            | Ty::Optional(_, attr)
+            | Ty::List(_, attr)
+            | Ty::Union(_, attr)
+            | Ty::Opaque(_, attr)
+            | Ty::TypeAlias(_, attr)
+            | Ty::WatchAccessor(_, attr) => attr,
+        }
+    }
+
     // --- Opaque type constructors ---
 
     /// Helper to build a TypeName for a builtin opaque type.
@@ -157,40 +207,47 @@ impl Ty {
     ///
     /// `display`: the user-facing display string (may differ from the
     /// qualified name).
-    fn opaque_builtin(qualified_name: &str, display: &str) -> Self {
+    fn opaque_builtin(qualified_name: &str, display: &str, attr: TyAttr) -> Self {
         let segments: Vec<&str> = qualified_name.split('.').collect();
         let name = Name::new(*segments.last().expect("qualified_name must be non-empty"));
         let module_path = segments[..segments.len() - 1]
             .iter()
             .map(Name::new)
             .collect();
-        Ty::Opaque(TypeName {
-            name,
-            module_path,
-            display_name: Name::new(display),
-        })
+        Ty::Opaque(
+            TypeName {
+                name,
+                module_path,
+                display_name: Name::new(display),
+            },
+            attr,
+        )
     }
 
     /// Opaque resource handle type (file, socket, HTTP response body).
     pub fn resource() -> Self {
-        Self::opaque_builtin("baml.llm.Resource", "baml.llm.Resource")
+        Self::opaque_builtin("baml.llm.Resource", "baml.llm.Resource", TyAttr::default())
     }
 
     /// Opaque structured prompt tree type for LLM calls.
     pub fn prompt_ast() -> Self {
-        Self::opaque_builtin("baml.llm.PromptAst", "baml.llm.PromptAst")
+        Self::opaque_builtin(
+            "baml.llm.PromptAst",
+            "baml.llm.PromptAst",
+            TyAttr::default(),
+        )
     }
 
     /// Meta-type — a runtime value that wraps a `Ty`.
     pub fn type_type() -> Self {
-        Self::opaque_builtin("baml.reflect.Type", "type")
+        Self::opaque_builtin("baml.reflect.Type", "type", TyAttr::default())
     }
 
     /// Check if this is an opaque type with the given qualified name
     /// (e.g. `"baml.llm.PromptAst"`).
     pub fn is_opaque(&self, qualified_name: &str) -> bool {
         match self {
-            Ty::Opaque(tn) => {
+            Ty::Opaque(tn, _) => {
                 // Build "module.path.Name" and compare.
                 let mut parts: Vec<&str> = tn.module_path.iter().map(|n| n.as_str()).collect();
                 parts.push(tn.name.as_str());
@@ -204,21 +261,26 @@ impl Ty {
     /// If this is an opaque type, return its TypeName.
     pub fn as_opaque(&self) -> Option<&TypeName> {
         match self {
-            Ty::Opaque(tn) => Some(tn),
+            Ty::Opaque(tn, _) => Some(tn),
             _ => None,
         }
     }
 
     /// Check if this is the void type.
     pub fn is_void(&self) -> bool {
-        matches!(self, Ty::Void)
+        matches!(self, Ty::Void { .. })
     }
 
     /// Check if this is a primitive type (including literals of primitive types).
     pub fn is_primitive(&self) -> bool {
         matches!(
             self,
-            Ty::Int | Ty::Float | Ty::String | Ty::Bool | Ty::Null | Ty::Literal(_)
+            Ty::Int { .. }
+                | Ty::Float { .. }
+                | Ty::String { .. }
+                | Ty::Bool { .. }
+                | Ty::Null { .. }
+                | Ty::Literal(..)
         )
     }
 
@@ -226,6 +288,10 @@ impl Ty {
     ///
     /// Returns true if `self` can be used where `other` is expected.
     /// Ported from VIR `ty.rs:93-140` with literal subtyping rules.
+    ///
+    /// Note: TyAttr does NOT affect subtyping. Two types with different
+    /// attrs are not subtypes of each other (they're different types via
+    /// PartialEq), but attr content isn't checked for subtype relationships.
     ///
     /// Note: Unknown/Error/Never handling is not needed here because:
     /// - Unknown/Error are mapped to Null during TIR→baml_type conversion
@@ -238,41 +304,46 @@ impl Ty {
         }
 
         // Any type is a subtype of BuiltinUnknown (it accepts everything)
-        if matches!(other, Ty::BuiltinUnknown) {
+        if matches!(other, Ty::BuiltinUnknown { .. }) {
             return true;
         }
 
         match (self, other) {
             // Literal types are subtypes of their corresponding primitives
-            (Ty::Literal(Literal::Int(_)), Ty::Int) => true,
-            (Ty::Literal(Literal::Float(_)), Ty::Float) => true,
-            (Ty::Literal(Literal::String(_)), Ty::String) => true,
-            (Ty::Literal(Literal::Bool(_)), Ty::Bool) => true,
+            (Ty::Literal(Literal::Int(_), _), Ty::Int { .. }) => true,
+            (Ty::Literal(Literal::Float(_), _), Ty::Float { .. }) => true,
+            (Ty::Literal(Literal::String(_), _), Ty::String { .. }) => true,
+            (Ty::Literal(Literal::Bool(_), _), Ty::Bool { .. }) => true,
             // Literal int widens to float
-            (Ty::Literal(Literal::Int(_)), Ty::Float) => true,
+            (Ty::Literal(Literal::Int(_), _), Ty::Float { .. }) => true,
 
             // Null is a subtype of Optional<T>
-            (Ty::Null, Ty::Optional(_)) => true,
+            (Ty::Null { .. }, Ty::Optional(..)) => true,
 
             // T is a subtype of Optional<T>
-            (inner, Ty::Optional(opt_inner)) => inner.is_subtype_of(opt_inner),
+            (inner, Ty::Optional(opt_inner, _)) => inner.is_subtype_of(opt_inner),
 
             // T is a subtype of T | U (union containing T)
-            (inner, Ty::Union(types)) => types.iter().any(|t| inner.is_subtype_of(t)),
+            (inner, Ty::Union(types, _)) => types.iter().any(|t| inner.is_subtype_of(t)),
 
             // Union<T1, T2> is a subtype of U if all Ti are subtypes of U
-            (Ty::Union(types), other) => types.iter().all(|t| t.is_subtype_of(other)),
+            (Ty::Union(types, _), other) => types.iter().all(|t| t.is_subtype_of(other)),
 
             // List covariance
-            (Ty::List(inner1), Ty::List(inner2)) => inner1.is_subtype_of(inner2),
+            (Ty::List(inner1, _), Ty::List(inner2, _)) => inner1.is_subtype_of(inner2),
 
             // Map covariance in value (key invariant)
-            (Ty::Map { key: k1, value: v1 }, Ty::Map { key: k2, value: v2 }) => {
-                k1 == k2 && v1.is_subtype_of(v2)
-            }
+            (
+                Ty::Map {
+                    key: k1, value: v1, ..
+                },
+                Ty::Map {
+                    key: k2, value: v2, ..
+                },
+            ) => k1 == k2 && v1.is_subtype_of(v2),
 
             // Int is a subtype of Float (numeric widening)
-            (Ty::Int, Ty::Float) => true,
+            (Ty::Int { .. }, Ty::Float { .. }) => true,
 
             _ => false,
         }
@@ -283,11 +354,11 @@ impl Ty {
     pub fn is_compiler_only(&self) -> bool {
         matches!(
             self,
-            Ty::TypeAlias(_)
+            Ty::TypeAlias(..)
                 | Ty::Function { .. }
-                | Ty::Void
-                | Ty::WatchAccessor(_)
-                | Ty::BuiltinUnknown
+                | Ty::Void { .. }
+                | Ty::WatchAccessor(..)
+                | Ty::BuiltinUnknown { .. }
         )
     }
 
@@ -295,43 +366,43 @@ impl Ty {
     /// variants are found.
     pub fn validate_runtime(&self) -> Result<(), String> {
         match self {
-            Ty::TypeAlias(tn) => Err(format!(
+            Ty::TypeAlias(tn, _) => Err(format!(
                 "TypeAlias '{}' should be expanded before reaching runtime",
                 tn.display_name
             )),
-            Ty::Void => Err("Void type should not reach runtime".to_string()),
-            Ty::WatchAccessor(inner) => inner.validate_runtime(),
-            Ty::BuiltinUnknown => Ok(()),
+            Ty::Void { .. } => Err("Void type should not reach runtime".to_string()),
+            Ty::WatchAccessor(inner, _) => inner.validate_runtime(),
+            Ty::BuiltinUnknown { .. } => Ok(()),
             // Recurse into containers
-            Ty::Optional(inner) => inner.validate_runtime(),
-            Ty::List(inner) => inner.validate_runtime(),
-            Ty::Map { key, value } => {
+            Ty::Optional(inner, _) => inner.validate_runtime(),
+            Ty::List(inner, _) => inner.validate_runtime(),
+            Ty::Map { key, value, .. } => {
                 key.validate_runtime()?;
                 value.validate_runtime()
             }
-            Ty::Union(members) => {
+            Ty::Union(members, _) => {
                 for m in members {
                     m.validate_runtime()?;
                 }
                 Ok(())
             }
             // All other variants are fine at runtime
-            Ty::Function { params, ret } => {
+            Ty::Function { params, ret, .. } => {
                 for p in params {
                     p.validate_runtime()?;
                 }
                 ret.validate_runtime()
             }
-            Ty::Int
-            | Ty::Float
-            | Ty::String
-            | Ty::Bool
-            | Ty::Null
-            | Ty::Media(_)
-            | Ty::Literal(_)
-            | Ty::Class(_)
-            | Ty::Enum(_)
-            | Ty::Opaque(_) => Ok(()),
+            Ty::Int { .. }
+            | Ty::Float { .. }
+            | Ty::String { .. }
+            | Ty::Bool { .. }
+            | Ty::Null { .. }
+            | Ty::Media(..)
+            | Ty::Literal(..)
+            | Ty::Class(..)
+            | Ty::Enum(..)
+            | Ty::Opaque(..) => Ok(()),
         }
     }
 }
@@ -339,40 +410,40 @@ impl Ty {
 impl fmt::Display for Ty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Ty::Int => write!(f, "int"),
-            Ty::Float => write!(f, "float"),
-            Ty::String => write!(f, "string"),
-            Ty::Bool => write!(f, "bool"),
-            Ty::Null => write!(f, "null"),
-            Ty::Media(kind) => write!(f, "{kind}"),
-            Ty::Literal(lit) => match lit {
+            Ty::Int { .. } => write!(f, "int"),
+            Ty::Float { .. } => write!(f, "float"),
+            Ty::String { .. } => write!(f, "string"),
+            Ty::Bool { .. } => write!(f, "bool"),
+            Ty::Null { .. } => write!(f, "null"),
+            Ty::Media(kind, _) => write!(f, "{kind}"),
+            Ty::Literal(lit, _) => match lit {
                 Literal::Int(i) => write!(f, "{i}"),
                 Literal::Float(s) => write!(f, "{s}"),
                 Literal::String(s) => write!(f, "\"{s}\""),
                 Literal::Bool(b) => write!(f, "{b}"),
             },
-            Ty::Class(tn) => write!(f, "{tn}"),
-            Ty::Enum(tn) => write!(f, "{tn}"),
-            Ty::Opaque(tn) => write!(f, "{tn}"),
-            Ty::TypeAlias(tn) => write!(f, "{tn}"),
-            Ty::Optional(inner) => write!(f, "{inner}?"),
-            Ty::List(inner) => write!(f, "{inner}[]"),
-            Ty::Map { key, value } => write!(f, "map<{key}, {value}>"),
-            Ty::Union(types) => {
+            Ty::Class(tn, _) => write!(f, "{tn}"),
+            Ty::Enum(tn, _) => write!(f, "{tn}"),
+            Ty::Opaque(tn, _) => write!(f, "{tn}"),
+            Ty::TypeAlias(tn, _) => write!(f, "{tn}"),
+            Ty::Optional(inner, _) => write!(f, "{inner}?"),
+            Ty::List(inner, _) => write!(f, "{inner}[]"),
+            Ty::Map { key, value, .. } => write!(f, "map<{key}, {value}>"),
+            Ty::Union(types, _) => {
                 let parts: Vec<std::string::String> =
                     types.iter().map(std::string::ToString::to_string).collect();
                 write!(f, "{}", parts.join(" | "))
             }
-            Ty::Function { params, ret } => {
+            Ty::Function { params, ret, .. } => {
                 let param_strs: Vec<std::string::String> = params
                     .iter()
                     .map(std::string::ToString::to_string)
                     .collect();
                 write!(f, "({}) -> {}", param_strs.join(", "), ret)
             }
-            Ty::Void => write!(f, "void"),
-            Ty::WatchAccessor(inner) => write!(f, "{inner}.$watch"),
-            Ty::BuiltinUnknown => write!(f, "unknown"),
+            Ty::Void { .. } => write!(f, "void"),
+            Ty::WatchAccessor(inner, _) => write!(f, "{inner}.$watch"),
+            Ty::BuiltinUnknown { .. } => write!(f, "unknown"),
         }
     }
 }
@@ -381,82 +452,112 @@ impl fmt::Display for Ty {
 mod tests {
     use super::*;
 
+    // Shorthand helpers for tests — all use default TyAttr.
+    fn ty_int() -> Ty {
+        Ty::Int {
+            attr: TyAttr::default(),
+        }
+    }
+    fn ty_float() -> Ty {
+        Ty::Float {
+            attr: TyAttr::default(),
+        }
+    }
+    fn ty_string() -> Ty {
+        Ty::String {
+            attr: TyAttr::default(),
+        }
+    }
+    fn ty_bool() -> Ty {
+        Ty::Bool {
+            attr: TyAttr::default(),
+        }
+    }
+    fn ty_null() -> Ty {
+        Ty::Null {
+            attr: TyAttr::default(),
+        }
+    }
+
     #[test]
     fn test_literal_int_subtype_of_int() {
-        let lit_42 = Ty::Literal(Literal::Int(42));
-        assert!(lit_42.is_subtype_of(&Ty::Int));
+        let lit_42 = Ty::Literal(Literal::Int(42), TyAttr::default());
+        assert!(lit_42.is_subtype_of(&ty_int()));
     }
 
     #[test]
     fn test_literal_float_subtype_of_float() {
-        let lit_3_14 = Ty::Literal(Literal::Float("3.14".to_string()));
-        assert!(lit_3_14.is_subtype_of(&Ty::Float));
+        let lit_3_14 = Ty::Literal(Literal::Float("3.14".to_string()), TyAttr::default());
+        assert!(lit_3_14.is_subtype_of(&ty_float()));
     }
 
     #[test]
     fn test_literal_int_widens_to_float() {
-        let lit_42 = Ty::Literal(Literal::Int(42));
-        assert!(lit_42.is_subtype_of(&Ty::Float));
+        let lit_42 = Ty::Literal(Literal::Int(42), TyAttr::default());
+        assert!(lit_42.is_subtype_of(&ty_float()));
     }
 
     #[test]
     fn test_literal_string_subtype_of_string() {
-        let lit_hello = Ty::Literal(Literal::String("hello".to_string()));
-        assert!(lit_hello.is_subtype_of(&Ty::String));
+        let lit_hello = Ty::Literal(Literal::String("hello".to_string()), TyAttr::default());
+        assert!(lit_hello.is_subtype_of(&ty_string()));
     }
 
     #[test]
     fn test_literal_bool_subtype_of_bool() {
-        let lit_true = Ty::Literal(Literal::Bool(true));
-        assert!(lit_true.is_subtype_of(&Ty::Bool));
+        let lit_true = Ty::Literal(Literal::Bool(true), TyAttr::default());
+        assert!(lit_true.is_subtype_of(&ty_bool()));
     }
 
     #[test]
     fn test_literal_in_union() {
-        let lit_42 = Ty::Literal(Literal::Int(42));
-        let union_type = Ty::Union(vec![Ty::String, Ty::Int]);
+        let lit_42 = Ty::Literal(Literal::Int(42), TyAttr::default());
+        let union_type = Ty::Union(vec![ty_string(), ty_int()], TyAttr::default());
         assert!(lit_42.is_subtype_of(&union_type));
     }
 
     #[test]
     fn test_literal_float_in_union() {
-        let lit_3_14 = Ty::Literal(Literal::Float("3.14".to_string()));
-        let union_type = Ty::Union(vec![Ty::String, Ty::Float]);
+        let lit_3_14 = Ty::Literal(Literal::Float("3.14".to_string()), TyAttr::default());
+        let union_type = Ty::Union(vec![ty_string(), ty_float()], TyAttr::default());
         assert!(lit_3_14.is_subtype_of(&union_type));
     }
 
     #[test]
     fn test_literal_in_optional() {
-        let lit_42 = Ty::Literal(Literal::Int(42));
-        let opt_int = Ty::Optional(Box::new(Ty::Int));
+        let lit_42 = Ty::Literal(Literal::Int(42), TyAttr::default());
+        let opt_int = Ty::Optional(Box::new(ty_int()), TyAttr::default());
         assert!(lit_42.is_subtype_of(&opt_int));
     }
 
     #[test]
     fn test_null_subtype_of_optional() {
-        let opt_string = Ty::Optional(Box::new(Ty::String));
-        assert!(Ty::Null.is_subtype_of(&opt_string));
+        let opt_string = Ty::Optional(Box::new(ty_string()), TyAttr::default());
+        assert!(ty_null().is_subtype_of(&opt_string));
     }
 
     #[test]
     fn test_int_subtype_of_float() {
-        assert!(Ty::Int.is_subtype_of(&Ty::Float));
+        assert!(ty_int().is_subtype_of(&ty_float()));
     }
 
     #[test]
     fn test_list_covariance() {
-        let list_lit = Ty::List(Box::new(Ty::Literal(Literal::Int(42))));
-        let list_int = Ty::List(Box::new(Ty::Int));
+        let list_lit = Ty::List(
+            Box::new(Ty::Literal(Literal::Int(42), TyAttr::default())),
+            TyAttr::default(),
+        );
+        let list_int = Ty::List(Box::new(ty_int()), TyAttr::default());
         assert!(list_lit.is_subtype_of(&list_int));
     }
 
     #[test]
     fn test_validate_runtime_accepts_core_types() {
-        assert!(Ty::Int.validate_runtime().is_ok());
-        assert!(Ty::Float.validate_runtime().is_ok());
-        assert!(Ty::String.validate_runtime().is_ok());
+        assert!(ty_int().validate_runtime().is_ok());
+        assert!(ty_float().validate_runtime().is_ok());
+        assert!(ty_string().validate_runtime().is_ok());
         assert!(
-            Ty::Literal(Literal::Float("3.14".to_string()))
+            Ty::Literal(Literal::Float("3.14".to_string()), TyAttr::default())
                 .validate_runtime()
                 .is_ok()
         );
@@ -484,14 +585,20 @@ mod tests {
             Ty::prompt_ast().as_opaque().map(|tn| tn.name.as_str()),
             Some("PromptAst"),
         );
-        assert_eq!(Ty::Int.as_opaque(), None);
+        assert_eq!(ty_int().as_opaque(), None);
     }
 
     #[test]
     fn test_validate_runtime_rejects_compiler_types() {
-        assert!(Ty::Void.validate_runtime().is_err());
         assert!(
-            Ty::TypeAlias(TypeName::local(Name::new("MyAlias")))
+            (Ty::Void {
+                attr: TyAttr::default()
+            })
+            .validate_runtime()
+            .is_err()
+        );
+        assert!(
+            Ty::TypeAlias(TypeName::local(Name::new("MyAlias")), TyAttr::default())
                 .validate_runtime()
                 .is_err()
         );

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -173,6 +173,31 @@ pub enum Ty {
 impl Ty {
     // --- TyAttr accessor ---
 
+    /// Replace the TyAttr on this type, returning a new Ty with the given attr.
+    pub fn with_attr(self, attr: TyAttr) -> Ty {
+        match self {
+            Ty::Int { .. } => Ty::Int { attr },
+            Ty::Float { .. } => Ty::Float { attr },
+            Ty::String { .. } => Ty::String { attr },
+            Ty::Bool { .. } => Ty::Bool { attr },
+            Ty::Null { .. } => Ty::Null { attr },
+            Ty::Void { .. } => Ty::Void { attr },
+            Ty::BuiltinUnknown { .. } => Ty::BuiltinUnknown { attr },
+            Ty::Media(kind, _) => Ty::Media(kind, attr),
+            Ty::Literal(lit, _) => Ty::Literal(lit, attr),
+            Ty::Class(tn, _) => Ty::Class(tn, attr),
+            Ty::Enum(tn, _) => Ty::Enum(tn, attr),
+            Ty::Optional(inner, _) => Ty::Optional(inner, attr),
+            Ty::List(inner, _) => Ty::List(inner, attr),
+            Ty::Map { key, value, .. } => Ty::Map { key, value, attr },
+            Ty::Union(members, _) => Ty::Union(members, attr),
+            Ty::Opaque(tn, _) => Ty::Opaque(tn, attr),
+            Ty::TypeAlias(tn, _) => Ty::TypeAlias(tn, attr),
+            Ty::Function { params, ret, .. } => Ty::Function { params, ret, attr },
+            Ty::WatchAccessor(inner, _) => Ty::WatchAccessor(inner, attr),
+        }
+    }
+
     /// Get the TyAttr for this type.
     pub fn attr(&self) -> &TyAttr {
         match self {
@@ -225,11 +250,13 @@ impl Ty {
     }
 
     /// Opaque resource handle type (file, socket, HTTP response body).
+    /// NOTE: Uses TyAttr::default(). Callers with a source attr should use opaque_builtin() directly.
     pub fn resource() -> Self {
         Self::opaque_builtin("baml.llm.Resource", "baml.llm.Resource", TyAttr::default())
     }
 
     /// Opaque structured prompt tree type for LLM calls.
+    /// NOTE: Uses TyAttr::default(). Callers with a source attr should use opaque_builtin() directly.
     pub fn prompt_ast() -> Self {
         Self::opaque_builtin(
             "baml.llm.PromptAst",
@@ -239,6 +266,7 @@ impl Ty {
     }
 
     /// Meta-type — a runtime value that wraps a `Ty`.
+    /// NOTE: Uses TyAttr::default(). Callers with a source attr should use opaque_builtin() directly.
     pub fn type_type() -> Self {
         Self::opaque_builtin("baml.reflect.Type", "type", TyAttr::default())
     }

--- a/baml_language/crates/baml_type/src/sap.rs
+++ b/baml_language/crates/baml_type/src/sap.rs
@@ -1,0 +1,6 @@
+//! SAP types re-exported from `baml_base`.
+//!
+//! The canonical definitions live in `baml_base::sap` so that both
+//! `baml_type` and `baml_compiler_tir` can use them without a cyclic dependency.
+
+pub use baml_base::{FieldAttr, SapAttrValue, SapConstValue, TyAttr};

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -66,8 +66,10 @@ impl BexEngine {
                 // Get element type from declared type, falling back to Null when
                 // the declared type doesn't resolve (e.g., builtin class arrays)
                 let element_type = match effective_type {
-                    Ty::List(elem_ty) => elem_ty.as_ref(),
-                    _ => &Ty::Null,
+                    Ty::List(elem_ty, _) => elem_ty.as_ref(),
+                    _ => &Ty::Null {
+                        attr: baml_type::TyAttr::default(),
+                    },
                 };
 
                 let items: Result<Vec<_>, _> = arr
@@ -84,8 +86,15 @@ impl BexEngine {
                 // Get key and value types from declared type, falling back to
                 // Null when the declared type doesn't resolve
                 let (key_type, value_type) = match effective_type {
-                    Ty::Map { key, value } => (key.as_ref(), value.as_ref()),
-                    _ => (&Ty::String, &Ty::Null),
+                    Ty::Map { key, value, .. } => (key.as_ref(), value.as_ref()),
+                    _ => (
+                        &Ty::String {
+                            attr: baml_type::TyAttr::default(),
+                        },
+                        &Ty::Null {
+                            attr: baml_type::TyAttr::default(),
+                        },
+                    ),
                 };
 
                 let entries: Result<indexmap::IndexMap<String, BexExternalValue>, EngineError> =
@@ -365,7 +374,7 @@ pub(crate) fn maybe_wrap_union(
     declared_type: &Ty,
 ) -> Result<BexExternalValue, EngineError> {
     match declared_type {
-        Ty::Union(members) => {
+        Ty::Union(members, _) => {
             let selected = find_matching_member(&value, members)?;
             let metadata = UnionMetadata::new(declared_type.clone(), selected);
             Ok(BexExternalValue::Union {
@@ -373,9 +382,11 @@ pub(crate) fn maybe_wrap_union(
                 metadata,
             })
         }
-        Ty::Optional(inner) => {
+        Ty::Optional(inner, _) => {
             let selected = if matches!(value, BexExternalValue::Null) {
-                Ty::Null
+                Ty::Null {
+                    attr: baml_type::TyAttr::default(),
+                }
             } else {
                 (**inner).clone()
             };
@@ -409,25 +420,25 @@ fn find_matching_member(value: &BexExternalValue, members: &[Ty]) -> Result<Ty, 
 /// Check if a value matches a declared type.
 fn value_matches_type(value: &BexExternalValue, ty: &Ty) -> bool {
     match (value, ty) {
-        (BexExternalValue::Null, Ty::Null) => true,
-        (BexExternalValue::Int(_), Ty::Int) => true,
-        (BexExternalValue::Float(_), Ty::Float) => true,
-        (BexExternalValue::Bool(_), Ty::Bool) => true,
-        (BexExternalValue::String(_), Ty::String) => true,
+        (BexExternalValue::Null, Ty::Null { .. }) => true,
+        (BexExternalValue::Int(_), Ty::Int { .. }) => true,
+        (BexExternalValue::Float(_), Ty::Float { .. }) => true,
+        (BexExternalValue::Bool(_), Ty::Bool { .. }) => true,
+        (BexExternalValue::String(_), Ty::String { .. }) => true,
         // Literal types match their corresponding runtime values
-        (BexExternalValue::Int(_), Ty::Literal(Literal::Int(_))) => true,
-        (BexExternalValue::Float(_), Ty::Literal(Literal::Float(_))) => true,
-        (BexExternalValue::String(_), Ty::Literal(Literal::String(_))) => true,
-        (BexExternalValue::Bool(_), Ty::Literal(Literal::Bool(_))) => true,
-        (BexExternalValue::Array { .. }, Ty::List(_)) => true,
+        (BexExternalValue::Int(_), Ty::Literal(Literal::Int(_), _)) => true,
+        (BexExternalValue::Float(_), Ty::Literal(Literal::Float(_), _)) => true,
+        (BexExternalValue::String(_), Ty::Literal(Literal::String(_), _)) => true,
+        (BexExternalValue::Bool(_), Ty::Literal(Literal::Bool(_), _)) => true,
+        (BexExternalValue::Array { .. }, Ty::List(_, _)) => true,
         (BexExternalValue::Map { .. }, Ty::Map { .. }) => true,
-        (BexExternalValue::Instance { class_name, .. }, Ty::Class(tn)) => {
+        (BexExternalValue::Instance { class_name, .. }, Ty::Class(tn, _)) => {
             class_name.as_str() == tn.display_name.as_str()
         }
-        (BexExternalValue::Variant { enum_name, .. }, Ty::Enum(tn)) => {
+        (BexExternalValue::Variant { enum_name, .. }, Ty::Enum(tn, _)) => {
             enum_name.as_str() == tn.display_name.as_str()
         }
-        (BexExternalValue::Adt(BexExternalAdt::Media(_)), Ty::Media(_)) => true,
+        (BexExternalValue::Adt(BexExternalAdt::Media(_)), Ty::Media(_, _)) => true,
         (BexExternalValue::Adt(BexExternalAdt::PromptAst(_)), ty)
             if ty.is_opaque("baml.llm.PromptAst") =>
         {
@@ -441,8 +452,8 @@ fn value_matches_type(value: &BexExternalValue, ty: &Ty) -> bool {
         }
         (BexExternalValue::Union { value, .. }, ty) => value_matches_type(value, ty),
         // Handle nested unions/optionals in the type
-        (value, Ty::Union(members)) => members.iter().any(|m| value_matches_type(value, m)),
-        (value, Ty::Optional(inner)) => {
+        (value, Ty::Union(members, _)) => members.iter().any(|m| value_matches_type(value, m)),
+        (value, Ty::Optional(inner, _)) => {
             matches!(value, BexExternalValue::Null) || value_matches_type(value, inner)
         }
         _ => false,
@@ -454,7 +465,7 @@ fn value_matches_type(value: &BexExternalValue, ty: &Ty) -> bool {
 /// If the declared type is not a union, returns it unchanged.
 fn resolve_effective_type<'a>(value: &Value, declared_type: &'a Ty) -> &'a Ty {
     match declared_type {
-        Ty::Union(members) => find_matching_union_member(value, members)
+        Ty::Union(members, _) => find_matching_union_member(value, members)
             .unwrap_or_else(|| members.first().unwrap_or(declared_type)),
         _ => declared_type,
     }
@@ -463,28 +474,28 @@ fn resolve_effective_type<'a>(value: &Value, declared_type: &'a Ty) -> &'a Ty {
 /// Find the union member that matches the runtime value's type.
 fn find_matching_union_member<'a>(value: &Value, members: &'a [Ty]) -> Option<&'a Ty> {
     match value {
-        Value::Null => members.iter().find(|m| matches!(m, Ty::Null)),
+        Value::Null => members.iter().find(|m| matches!(m, Ty::Null { .. })),
         Value::Int(_) => members
             .iter()
-            .find(|m| matches!(m, Ty::Int | Ty::Literal(Literal::Int(_)))),
+            .find(|m| matches!(m, Ty::Int { .. } | Ty::Literal(Literal::Int(_), _))),
         Value::Float(_) => members
             .iter()
-            .find(|m| matches!(m, Ty::Float | Ty::Literal(Literal::Float(_)))),
+            .find(|m| matches!(m, Ty::Float { .. } | Ty::Literal(Literal::Float(_), _))),
         Value::Bool(_) => members
             .iter()
-            .find(|m| matches!(m, Ty::Bool | Ty::Literal(Literal::Bool(_)))),
+            .find(|m| matches!(m, Ty::Bool { .. } | Ty::Literal(Literal::Bool(_), _))),
         Value::Object(ptr) => {
             let obj = unsafe { ptr.get() };
             match obj {
                 Object::String(_) => members
                     .iter()
-                    .find(|m| matches!(m, Ty::String | Ty::Literal(Literal::String(_)))),
+                    .find(|m| matches!(m, Ty::String { .. } | Ty::Literal(Literal::String(_), _))),
                 Object::Instance(inst) => {
                     let class_obj = unsafe { inst.class.get() };
                     if let Object::Class(class) = class_obj {
                         members
                             .iter()
-                            .find(|m| matches!(m, Ty::Class(tn) if tn.display_name.as_str() == class.name.as_str()))
+                            .find(|m| matches!(m, Ty::Class(tn, _) if tn.display_name.as_str() == class.name.as_str()))
                     } else {
                         None
                     }
@@ -494,7 +505,7 @@ fn find_matching_union_member<'a>(value: &Value, members: &'a [Ty]) -> Option<&'
                     if let Object::Enum(enm) = enum_obj {
                         members
                             .iter()
-                            .find(|m| matches!(m, Ty::Enum(tn) if tn.display_name.as_str() == enm.name.as_str()))
+                            .find(|m| matches!(m, Ty::Enum(tn, _) if tn.display_name.as_str() == enm.name.as_str()))
                     } else {
                         None
                     }
@@ -503,7 +514,7 @@ fn find_matching_union_member<'a>(value: &Value, members: &'a [Ty]) -> Option<&'
                     // For arrays, check first element to determine which List type
                     if let Some(first) = elements.first() {
                         members.iter().find(|m| {
-                            if let Ty::List(elem_ty) = m {
+                            if let Ty::List(elem_ty, _) = m {
                                 find_matching_union_member(first, &[elem_ty.as_ref().clone()])
                                     .is_some()
                             } else {
@@ -512,11 +523,11 @@ fn find_matching_union_member<'a>(value: &Value, members: &'a [Ty]) -> Option<&'
                         })
                     } else {
                         // Empty array - match any List type
-                        members.iter().find(|m| matches!(m, Ty::List(_)))
+                        members.iter().find(|m| matches!(m, Ty::List(_, _)))
                     }
                 }
                 Object::Map(_) => members.iter().find(|m| matches!(m, Ty::Map { .. })),
-                Object::Media(_) => members.iter().find(|m| matches!(m, Ty::Media(_))),
+                Object::Media(_) => members.iter().find(|m| matches!(m, Ty::Media(_, _))),
                 Object::PromptAst(_) => members.iter().find(|m| m.is_opaque("baml.llm.PromptAst")),
                 _ => None,
             }
@@ -542,7 +553,9 @@ pub(crate) fn vm_arg_to_external(vm: &BexVm, value: &Value) -> BexExternalValue 
                     let items: Vec<BexExternalValue> =
                         arr.iter().map(|v| vm_arg_to_external(vm, v)).collect();
                     BexExternalValue::Array {
-                        element_type: bex_external_types::Ty::Null,
+                        element_type: bex_external_types::Ty::Null {
+                            attr: baml_type::TyAttr::default(),
+                        },
                         items,
                     }
                 }
@@ -552,8 +565,12 @@ pub(crate) fn vm_arg_to_external(vm: &BexVm, value: &Value) -> BexExternalValue 
                         .map(|(k, v)| (k.clone(), vm_arg_to_external(vm, v)))
                         .collect();
                     BexExternalValue::Map {
-                        key_type: bex_external_types::Ty::String,
-                        value_type: bex_external_types::Ty::Null,
+                        key_type: bex_external_types::Ty::String {
+                            attr: baml_type::TyAttr::default(),
+                        },
+                        value_type: bex_external_types::Ty::Null {
+                            attr: baml_type::TyAttr::default(),
+                        },
                         entries,
                     }
                 }

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -65,6 +65,7 @@ impl BexEngine {
             Object::Array(arr) => {
                 // Get element type from declared type, falling back to Null when
                 // the declared type doesn't resolve (e.g., builtin class arrays)
+
                 let element_type = match effective_type {
                     Ty::List(elem_ty, _) => elem_ty.as_ref(),
                     _ => &Ty::Null {
@@ -85,6 +86,7 @@ impl BexEngine {
             Object::Map(map) => {
                 // Get key and value types from declared type, falling back to
                 // Null when the declared type doesn't resolve
+
                 let (key_type, value_type) = match effective_type {
                     Ty::Map { key, value, .. } => (key.as_ref(), value.as_ref()),
                     _ => (
@@ -382,10 +384,10 @@ pub(crate) fn maybe_wrap_union(
                 metadata,
             })
         }
-        Ty::Optional(inner, _) => {
+        Ty::Optional(inner, opt_attr) => {
             let selected = if matches!(value, BexExternalValue::Null) {
                 Ty::Null {
-                    attr: baml_type::TyAttr::default(),
+                    attr: opt_attr.clone(),
                 }
             } else {
                 (**inner).clone()
@@ -467,6 +469,13 @@ fn resolve_effective_type<'a>(value: &Value, declared_type: &'a Ty) -> &'a Ty {
     match declared_type {
         Ty::Union(members, _) => find_matching_union_member(value, members)
             .unwrap_or_else(|| members.first().unwrap_or(declared_type)),
+        Ty::Optional(inner, _) => {
+            if matches!(value, Value::Null) {
+                declared_type
+            } else {
+                resolve_effective_type(value, inner)
+            }
+        }
         _ => declared_type,
     }
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -792,7 +792,11 @@ impl BexEngine {
         let _call_guard = ActiveCallGuard::new(&self.active_calls, call_id, &cancel)?;
 
         let function_index = self.lookup_function(function_name)?;
-        let return_type = self.function_return_type(function_name).unwrap_or(Ty::Null);
+        let return_type = self
+            .function_return_type(function_name)
+            .unwrap_or(Ty::Null {
+                attr: baml_type::TyAttr::default(),
+            });
 
         // Register with current epoch
         let my_epoch = self.current_epoch.load(Ordering::Acquire);

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -1127,11 +1127,13 @@ impl BexEngine {
                                 },
                                 call_stack: full_call_stack,
                                 timestamp: SystemTime::now(),
-                                event: EventKind::Function(FunctionEvent::End(FunctionEnd {
-                                    name: root_span.label,
-                                    result: external_result,
-                                    duration: root_span.started_at.elapsed(),
-                                })),
+                                event: EventKind::Function(FunctionEvent::End(Box::new(
+                                    FunctionEnd {
+                                        name: root_span.label,
+                                        result: external_result,
+                                        duration: root_span.started_at.elapsed(),
+                                    },
+                                ))),
                             };
                             self.emit(end_event);
                         }
@@ -1378,13 +1380,13 @@ impl BexEngine {
                                         },
                                         call_stack,
                                         timestamp: SystemTime::now(),
-                                        event: EventKind::Function(FunctionEvent::End(
+                                        event: EventKind::Function(FunctionEvent::End(Box::new(
                                             FunctionEnd {
                                                 name: function_name,
                                                 result: external_result,
                                                 duration: span.started_at.elapsed(),
                                             },
-                                        )),
+                                        ))),
                                     };
                                     self.emit(exit_event);
                                 }

--- a/baml_language/crates/bex_engine/tests/concurrent.rs
+++ b/baml_language/crates/bex_engine/tests/concurrent.rs
@@ -11,6 +11,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
+use baml_type::TyAttr;
 use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder, Ty};
 use common::compile_for_engine;
 use sys_native::SysOpsExt;
@@ -114,7 +115,9 @@ async fn test_concurrent_allocations_no_overlap() {
         // Verify the result is correct
         let value = result.unwrap();
         let expected = BexExternalValue::Array {
-            element_type: Ty::String,
+            element_type: Ty::String {
+                attr: TyAttr::default(),
+            },
             items: vec![
                 BexExternalValue::String("a".to_string()),
                 BexExternalValue::String("b".to_string()),
@@ -298,7 +301,9 @@ async fn test_concurrent_array_allocations() {
 
         // Build expected array [0, 1, 2, ..., size-1]
         let expected = BexExternalValue::Array {
-            element_type: Ty::Int,
+            element_type: Ty::Int {
+                attr: TyAttr::default(),
+            },
             items: (0..size).map(BexExternalValue::Int).collect(),
         };
         assert_eq!(value, expected, "Array mismatch for size {size}");
@@ -349,7 +354,9 @@ async fn test_call_function_with_external_args() {
 
     // Test passing an array via BexExternalValue
     let arr = BexExternalValue::Array {
-        element_type: Ty::Int,
+        element_type: Ty::Int {
+            attr: TyAttr::default(),
+        },
         items: vec![
             BexExternalValue::Int(1),
             BexExternalValue::Int(2),

--- a/baml_language/crates/bex_engine/tests/env.rs
+++ b/baml_language/crates/bex_engine/tests/env.rs
@@ -4,6 +4,7 @@
 
 mod common;
 
+use baml_type::TyAttr;
 use bex_engine::BexExternalValue;
 use common::{EngineProgram, assert_engine_executes};
 use indexmap::indexmap;
@@ -58,8 +59,15 @@ async fn env_get_existing_var() -> anyhow::Result<()> {
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::String("hello_env".to_string())),
             metadata: bex_engine::UnionMetadata::new(
-                bex_engine::Ty::Optional(Box::new(bex_engine::Ty::String)),
-                bex_engine::Ty::String,
+                bex_engine::Ty::Optional(
+                    Box::new(bex_engine::Ty::String {
+                        attr: TyAttr::default(),
+                    }),
+                    TyAttr::default(),
+                ),
+                bex_engine::Ty::String {
+                    attr: TyAttr::default(),
+                },
             ),
         }),
     })
@@ -81,8 +89,15 @@ async fn env_get_missing_var_returns_null() -> anyhow::Result<()> {
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Null),
             metadata: bex_engine::UnionMetadata::new(
-                bex_engine::Ty::Optional(Box::new(bex_engine::Ty::String)),
-                bex_engine::Ty::Null,
+                bex_engine::Ty::Optional(
+                    Box::new(bex_engine::Ty::String {
+                        attr: TyAttr::default(),
+                    }),
+                    TyAttr::default(),
+                ),
+                bex_engine::Ty::Null {
+                    attr: TyAttr::default(),
+                },
             ),
         }),
     })

--- a/baml_language/crates/bex_engine/tests/llm_render.rs
+++ b/baml_language/crates/bex_engine/tests/llm_render.rs
@@ -6,6 +6,7 @@
 //! 3. `render_prompt` correctly renders templates with arguments
 
 use baml_builtins::{PromptAst as BuiltinPromptAst, PromptAstSimple};
+use baml_type::TyAttr;
 use bex_engine::{FunctionCallContextBuilder, Ty};
 use bex_external_types::BexExternalAdt;
 use bex_heap::{BexExternalValue, builtin_types::owned::LlmPrimitiveClient};
@@ -42,7 +43,9 @@ async fn test_render_prompt_directly() {
             default_role: client.default_role.clone(),
             allowed_roles: client.allowed_roles,
         },
-        output_format: sys_llm::OutputFormatContent::new(Ty::String),
+        output_format: sys_llm::OutputFormatContent::new(Ty::String {
+            attr: TyAttr::default(),
+        }),
         tags: IndexMap::new(),
         enums: std::collections::HashMap::new(),
     };
@@ -95,7 +98,9 @@ You are a helpful assistant.
             default_role: client.default_role.clone(),
             allowed_roles: client.allowed_roles,
         },
-        output_format: sys_llm::OutputFormatContent::new(Ty::String),
+        output_format: sys_llm::OutputFormatContent::new(Ty::String {
+            attr: TyAttr::default(),
+        }),
         tags: IndexMap::new(),
         enums: std::collections::HashMap::new(),
     };
@@ -173,7 +178,9 @@ async fn test_render_prompt_with_enums() {
             default_role: "user".to_string(),
             allowed_roles: vec!["user".to_string()],
         },
-        output_format: sys_llm::OutputFormatContent::new(Ty::String),
+        output_format: sys_llm::OutputFormatContent::new(Ty::String {
+            attr: TyAttr::default(),
+        }),
         tags: IndexMap::new(),
         enums,
     };

--- a/baml_language/crates/bex_engine/tests/typed_inputs.rs
+++ b/baml_language/crates/bex_engine/tests/typed_inputs.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use baml_type::TyAttr;
 use bex_engine::{BexExternalValue, Ty};
 use common::{EngineProgram, assert_engine_executes};
 use indexmap::indexmap;
@@ -104,7 +105,9 @@ async fn array_input() -> anyhow::Result<()> {
         "#,
         entry: "sum",
         inputs: vec![BexExternalValue::Array {
-            element_type: Ty::Int,
+            element_type: Ty::Int {
+                attr: TyAttr::default(),
+            },
             items: vec![
                 BexExternalValue::Int(1),
                 BexExternalValue::Int(2),
@@ -157,8 +160,12 @@ async fn map_input() -> anyhow::Result<()> {
         entry: "get_value",
         inputs: vec![
             BexExternalValue::Map {
-                key_type: Ty::String,
-                value_type: Ty::Int,
+                key_type: Ty::String {
+                    attr: TyAttr::default(),
+                },
+                value_type: Ty::Int {
+                    attr: TyAttr::default(),
+                },
                 entries: indexmap! {
                     "foo".to_string() => BexExternalValue::Int(42),
                     "bar".to_string() => BexExternalValue::Int(100),

--- a/baml_language/crates/bex_engine/tests/typed_outputs.rs
+++ b/baml_language/crates/bex_engine/tests/typed_outputs.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use baml_type::TyAttr;
 use bex_engine::{BexExternalValue, Ty, UnionMetadata};
 use common::{EngineProgram, assert_engine_executes};
 use indexmap::indexmap;
@@ -22,7 +23,22 @@ async fn union_int_or_string_returns_int() -> anyhow::Result<()> {
         inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Int(42)),
-            metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::Int),
+            metadata: UnionMetadata::new(
+                Ty::Union(
+                    vec![
+                        Ty::Int {
+                            attr: TyAttr::default(),
+                        },
+                        Ty::String {
+                            attr: TyAttr::default(),
+                        },
+                    ],
+                    TyAttr::default(),
+                ),
+                Ty::Int {
+                    attr: TyAttr::default(),
+                },
+            ),
         }),
     })
     .await
@@ -41,7 +57,22 @@ async fn union_int_or_string_returns_string() -> anyhow::Result<()> {
         inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::String("hello".to_string())),
-            metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::String),
+            metadata: UnionMetadata::new(
+                Ty::Union(
+                    vec![
+                        Ty::Int {
+                            attr: TyAttr::default(),
+                        },
+                        Ty::String {
+                            attr: TyAttr::default(),
+                        },
+                    ],
+                    TyAttr::default(),
+                ),
+                Ty::String {
+                    attr: TyAttr::default(),
+                },
+            ),
         }),
     })
     .await
@@ -60,7 +91,17 @@ async fn optional_int_returns_value() -> anyhow::Result<()> {
         inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Int(42)),
-            metadata: UnionMetadata::new(Ty::Optional(Box::new(Ty::Int)), Ty::Int),
+            metadata: UnionMetadata::new(
+                Ty::Optional(
+                    Box::new(Ty::Int {
+                        attr: TyAttr::default(),
+                    }),
+                    TyAttr::default(),
+                ),
+                Ty::Int {
+                    attr: TyAttr::default(),
+                },
+            ),
         }),
     })
     .await
@@ -79,7 +120,17 @@ async fn optional_int_returns_null() -> anyhow::Result<()> {
         inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Null),
-            metadata: UnionMetadata::new(Ty::Optional(Box::new(Ty::Int)), Ty::Null),
+            metadata: UnionMetadata::new(
+                Ty::Optional(
+                    Box::new(Ty::Int {
+                        attr: TyAttr::default(),
+                    }),
+                    TyAttr::default(),
+                ),
+                Ty::Null {
+                    attr: TyAttr::default(),
+                },
+            ),
         }),
     })
     .await
@@ -105,7 +156,7 @@ async fn class_with_union_field() -> anyhow::Result<()> {
             fields: indexmap! {
                 "data".to_string() => BexExternalValue::Union {
                     value: Box::new(BexExternalValue::Int(42)),
-                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::Int),
+                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int { attr: TyAttr::default() }, Ty::String { attr: TyAttr::default() }], TyAttr::default()), Ty::Int { attr: TyAttr::default() }),
                 },
             },
         }),
@@ -140,11 +191,23 @@ async fn union_of_classes_returns_success() -> anyhow::Result<()> {
                 },
             }),
             metadata: UnionMetadata::new(
-                Ty::Union(vec![
-                    Ty::Class(bex_engine::TypeName::local("Success".into())),
-                    Ty::Class(bex_engine::TypeName::local("Failure".into())),
-                ]),
-                Ty::Class(bex_engine::TypeName::local("Success".into())),
+                Ty::Union(
+                    vec![
+                        Ty::Class(
+                            bex_engine::TypeName::local("Success".into()),
+                            TyAttr::default(),
+                        ),
+                        Ty::Class(
+                            bex_engine::TypeName::local("Failure".into()),
+                            TyAttr::default(),
+                        ),
+                    ],
+                    TyAttr::default(),
+                ),
+                Ty::Class(
+                    bex_engine::TypeName::local("Success".into()),
+                    TyAttr::default(),
+                ),
             ),
         }),
     })
@@ -179,10 +242,10 @@ async fn union_of_classes_returns_failure() -> anyhow::Result<()> {
             }),
             metadata: UnionMetadata::new(
                 Ty::Union(vec![
-                    Ty::Class(bex_engine::TypeName::local("Success".into())),
-                    Ty::Class(bex_engine::TypeName::local("Failure".into())),
-                ]),
-                Ty::Class(bex_engine::TypeName::local("Failure".into())),
+                    Ty::Class(bex_engine::TypeName::local("Success".into()), TyAttr::default()),
+                    Ty::Class(bex_engine::TypeName::local("Failure".into()), TyAttr::default()),
+                ], TyAttr::default()),
+                Ty::Class(bex_engine::TypeName::local("Failure".into()), TyAttr::default()),
             ),
         }),
     })
@@ -202,7 +265,9 @@ async fn union_of_arrays() -> anyhow::Result<()> {
         inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Array {
-                element_type: Ty::Int,
+                element_type: Ty::Int {
+                    attr: TyAttr::default(),
+                },
                 items: vec![
                     BexExternalValue::Int(1),
                     BexExternalValue::Int(2),
@@ -210,11 +275,29 @@ async fn union_of_arrays() -> anyhow::Result<()> {
                 ],
             }),
             metadata: UnionMetadata::new(
-                Ty::Union(vec![
-                    Ty::List(Box::new(Ty::Int)),
-                    Ty::List(Box::new(Ty::String)),
-                ]),
-                Ty::List(Box::new(Ty::Int)),
+                Ty::Union(
+                    vec![
+                        Ty::List(
+                            Box::new(Ty::Int {
+                                attr: TyAttr::default(),
+                            }),
+                            TyAttr::default(),
+                        ),
+                        Ty::List(
+                            Box::new(Ty::String {
+                                attr: TyAttr::default(),
+                            }),
+                            TyAttr::default(),
+                        ),
+                    ],
+                    TyAttr::default(),
+                ),
+                Ty::List(
+                    Box::new(Ty::Int {
+                        attr: TyAttr::default(),
+                    }),
+                    TyAttr::default(),
+                ),
             ),
         }),
     })
@@ -233,19 +316,74 @@ async fn array_of_unions() -> anyhow::Result<()> {
         entry: "main",
         inputs: vec![],
         expected: Ok(BexExternalValue::Array {
-            element_type: Ty::Union(vec![Ty::Int, Ty::String]),
+            element_type: Ty::Union(
+                vec![
+                    Ty::Int {
+                        attr: TyAttr::default(),
+                    },
+                    Ty::String {
+                        attr: TyAttr::default(),
+                    },
+                ],
+                TyAttr::default(),
+            ),
             items: vec![
                 BexExternalValue::Union {
                     value: Box::new(BexExternalValue::Int(1)),
-                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::Int),
+                    metadata: UnionMetadata::new(
+                        Ty::Union(
+                            vec![
+                                Ty::Int {
+                                    attr: TyAttr::default(),
+                                },
+                                Ty::String {
+                                    attr: TyAttr::default(),
+                                },
+                            ],
+                            TyAttr::default(),
+                        ),
+                        Ty::Int {
+                            attr: TyAttr::default(),
+                        },
+                    ),
                 },
                 BexExternalValue::Union {
                     value: Box::new(BexExternalValue::String("two".to_string())),
-                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::String),
+                    metadata: UnionMetadata::new(
+                        Ty::Union(
+                            vec![
+                                Ty::Int {
+                                    attr: TyAttr::default(),
+                                },
+                                Ty::String {
+                                    attr: TyAttr::default(),
+                                },
+                            ],
+                            TyAttr::default(),
+                        ),
+                        Ty::String {
+                            attr: TyAttr::default(),
+                        },
+                    ),
                 },
                 BexExternalValue::Union {
                     value: Box::new(BexExternalValue::Int(3)),
-                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::Int),
+                    metadata: UnionMetadata::new(
+                        Ty::Union(
+                            vec![
+                                Ty::Int {
+                                    attr: TyAttr::default(),
+                                },
+                                Ty::String {
+                                    attr: TyAttr::default(),
+                                },
+                            ],
+                            TyAttr::default(),
+                        ),
+                        Ty::Int {
+                            attr: TyAttr::default(),
+                        },
+                    ),
                 },
             ],
         }),
@@ -276,10 +414,17 @@ async fn optional_class() -> anyhow::Result<()> {
                 },
             }),
             metadata: UnionMetadata::new(
-                Ty::Optional(Box::new(Ty::Class(bex_engine::TypeName::local(
-                    "Data".into(),
-                )))),
-                Ty::Class(bex_engine::TypeName::local("Data".into())),
+                Ty::Optional(
+                    Box::new(Ty::Class(
+                        bex_engine::TypeName::local("Data".into()),
+                        TyAttr::default(),
+                    )),
+                    TyAttr::default(),
+                ),
+                Ty::Class(
+                    bex_engine::TypeName::local("Data".into()),
+                    TyAttr::default(),
+                ),
             ),
         }),
     })
@@ -304,10 +449,16 @@ async fn optional_class_returns_null() -> anyhow::Result<()> {
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Null),
             metadata: UnionMetadata::new(
-                Ty::Optional(Box::new(Ty::Class(bex_engine::TypeName::local(
-                    "Data".into(),
-                )))),
-                Ty::Null,
+                Ty::Optional(
+                    Box::new(Ty::Class(
+                        bex_engine::TypeName::local("Data".into()),
+                        TyAttr::default(),
+                    )),
+                    TyAttr::default(),
+                ),
+                Ty::Null {
+                    attr: TyAttr::default(),
+                },
             ),
         }),
     })
@@ -336,7 +487,7 @@ async fn class_with_optional_field() -> anyhow::Result<()> {
                 "name".to_string() => BexExternalValue::String("Alice".to_string()),
                 "age".to_string() => BexExternalValue::Union {
                     value: Box::new(BexExternalValue::Null),
-                    metadata: UnionMetadata::new(Ty::Optional(Box::new(Ty::Int)), Ty::Null),
+                    metadata: UnionMetadata::new(Ty::Optional(Box::new(Ty::Int { attr: TyAttr::default() }), TyAttr::default()), Ty::Null { attr: TyAttr::default() }),
                 },
             },
         }),
@@ -356,16 +507,16 @@ async fn map_with_union_values() -> anyhow::Result<()> {
         entry: "main",
         inputs: vec![],
         expected: Ok(BexExternalValue::Map {
-            key_type: Ty::String,
-            value_type: Ty::Union(vec![Ty::Int, Ty::String]),
+            key_type: Ty::String { attr: TyAttr::default() },
+            value_type: Ty::Union(vec![Ty::Int { attr: TyAttr::default() }, Ty::String { attr: TyAttr::default() }], TyAttr::default()),
             entries: indexmap! {
                 "count".to_string() => BexExternalValue::Union {
                     value: Box::new(BexExternalValue::Int(42)),
-                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::Int),
+                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int { attr: TyAttr::default() }, Ty::String { attr: TyAttr::default() }], TyAttr::default()), Ty::Int { attr: TyAttr::default() }),
                 },
                 "name".to_string() => BexExternalValue::Union {
                     value: Box::new(BexExternalValue::String("test".to_string())),
-                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::String),
+                    metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int { attr: TyAttr::default() }, Ty::String { attr: TyAttr::default() }], TyAttr::default()), Ty::String { attr: TyAttr::default() }),
                 },
             },
         }),
@@ -388,30 +539,116 @@ async fn union_of_array_with_union_elements_or_string() -> anyhow::Result<()> {
         inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Array {
-                element_type: Ty::Union(vec![Ty::Int, Ty::Bool]),
+                element_type: Ty::Union(
+                    vec![
+                        Ty::Int {
+                            attr: TyAttr::default(),
+                        },
+                        Ty::Bool {
+                            attr: TyAttr::default(),
+                        },
+                    ],
+                    TyAttr::default(),
+                ),
                 items: vec![
                     BexExternalValue::Union {
                         value: Box::new(BexExternalValue::Int(1)),
-                        metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::Bool]), Ty::Int),
+                        metadata: UnionMetadata::new(
+                            Ty::Union(
+                                vec![
+                                    Ty::Int {
+                                        attr: TyAttr::default(),
+                                    },
+                                    Ty::Bool {
+                                        attr: TyAttr::default(),
+                                    },
+                                ],
+                                TyAttr::default(),
+                            ),
+                            Ty::Int {
+                                attr: TyAttr::default(),
+                            },
+                        ),
                     },
                     BexExternalValue::Union {
                         value: Box::new(BexExternalValue::Bool(true)),
-                        metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::Bool]), Ty::Bool),
+                        metadata: UnionMetadata::new(
+                            Ty::Union(
+                                vec![
+                                    Ty::Int {
+                                        attr: TyAttr::default(),
+                                    },
+                                    Ty::Bool {
+                                        attr: TyAttr::default(),
+                                    },
+                                ],
+                                TyAttr::default(),
+                            ),
+                            Ty::Bool {
+                                attr: TyAttr::default(),
+                            },
+                        ),
                     },
                     BexExternalValue::Union {
                         value: Box::new(BexExternalValue::Int(2)),
-                        metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::Bool]), Ty::Int),
+                        metadata: UnionMetadata::new(
+                            Ty::Union(
+                                vec![
+                                    Ty::Int {
+                                        attr: TyAttr::default(),
+                                    },
+                                    Ty::Bool {
+                                        attr: TyAttr::default(),
+                                    },
+                                ],
+                                TyAttr::default(),
+                            ),
+                            Ty::Int {
+                                attr: TyAttr::default(),
+                            },
+                        ),
                     },
                 ],
             }),
             // Key assertion: selected_option is the full declared type (int | bool)[]
-            // not Ty::List(Ty::Int) inferred from first element
+            // not Ty::List(Ty::Int { attr: TyAttr::default() }) inferred from first element
             metadata: UnionMetadata::new(
-                Ty::Union(vec![
-                    Ty::List(Box::new(Ty::Union(vec![Ty::Int, Ty::Bool]))),
-                    Ty::String,
-                ]),
-                Ty::List(Box::new(Ty::Union(vec![Ty::Int, Ty::Bool]))),
+                Ty::Union(
+                    vec![
+                        Ty::List(
+                            Box::new(Ty::Union(
+                                vec![
+                                    Ty::Int {
+                                        attr: TyAttr::default(),
+                                    },
+                                    Ty::Bool {
+                                        attr: TyAttr::default(),
+                                    },
+                                ],
+                                TyAttr::default(),
+                            )),
+                            TyAttr::default(),
+                        ),
+                        Ty::String {
+                            attr: TyAttr::default(),
+                        },
+                    ],
+                    TyAttr::default(),
+                ),
+                Ty::List(
+                    Box::new(Ty::Union(
+                        vec![
+                            Ty::Int {
+                                attr: TyAttr::default(),
+                            },
+                            Ty::Bool {
+                                attr: TyAttr::default(),
+                            },
+                        ],
+                        TyAttr::default(),
+                    )),
+                    TyAttr::default(),
+                ),
             ),
         }),
     })

--- a/baml_language/crates/bex_events/src/collector.rs
+++ b/baml_language/crates/bex_events/src/collector.rs
@@ -323,11 +323,11 @@ mod tests {
             },
             call_stack: vec![],
             timestamp: SystemTime::now(),
-            event: EventKind::Function(FunctionEvent::End(FunctionEnd {
+            event: EventKind::Function(FunctionEvent::End(Box::new(FunctionEnd {
                 name: name.to_string(),
                 result,
                 duration,
-            })),
+            }))),
         }
     }
 

--- a/baml_language/crates/bex_events/src/types.rs
+++ b/baml_language/crates/bex_events/src/types.rs
@@ -31,7 +31,7 @@ pub enum EventKind {
 #[derive(Clone, Debug)]
 pub enum FunctionEvent {
     Start(FunctionStart),
-    End(FunctionEnd),
+    End(Box<FunctionEnd>),
 }
 
 /// Emitted when a traced function begins execution.

--- a/baml_language/crates/bex_external_types/src/bex_external_value.rs
+++ b/baml_language/crates/bex_external_types/src/bex_external_value.rs
@@ -23,7 +23,7 @@
 //! ```
 
 // Re-export Ty and TypeName from baml_type for convenience
-pub use baml_type::{Ty, TypeName};
+pub use baml_type::{Ty, TyAttr, TypeName};
 use bex_resource_types::ResourceHandle;
 use indexmap::IndexMap;
 
@@ -55,12 +55,15 @@ impl UnionMetadata {
     /// Create metadata for a union type.
     pub fn new(union_type: Ty, selected_option: Ty) -> Self {
         let (is_optional, is_single_pattern) = match &union_type {
-            Ty::Union(members) => {
-                let has_null = members.iter().any(|m| matches!(m, Ty::Null));
-                let non_null_count = members.iter().filter(|m| !matches!(m, Ty::Null)).count();
+            Ty::Union(members, _) => {
+                let has_null = members.iter().any(|m| matches!(m, Ty::Null { .. }));
+                let non_null_count = members
+                    .iter()
+                    .filter(|m| !matches!(m, Ty::Null { .. }))
+                    .count();
                 (has_null, non_null_count == 1)
             }
-            Ty::Optional(_) => (true, true),
+            Ty::Optional(..) => (true, true),
             _ => (false, false),
         };
 

--- a/baml_language/crates/bex_external_types/src/builtins.rs
+++ b/baml_language/crates/bex_external_types/src/builtins.rs
@@ -30,8 +30,8 @@ pub fn new_http_response(
             "_handle".to_string() => BexExternalValue::Resource(handle),
             "status_code".to_string() => BexExternalValue::Int(i64::from(status_code)),
             "headers".to_string() => BexExternalValue::Map {
-                key_type: Ty::String,
-                value_type: Ty::String,
+                key_type: Ty::String { attr: baml_type::TyAttr::default() },
+                value_type: Ty::String { attr: baml_type::TyAttr::default() },
                 entries: headers.into_iter().map(|(k, v)| (k, BexExternalValue::String(v))).collect(),
             },
             "url".to_string() => BexExternalValue::String(url),
@@ -66,8 +66,8 @@ pub fn new_http_request_get(url: String) -> BexExternalValue {
             "method".to_string() => BexExternalValue::String("GET".to_string()),
             "url".to_string() => BexExternalValue::String(url),
             "headers".to_string() => BexExternalValue::Map {
-                key_type: Ty::String,
-                value_type: Ty::String,
+                key_type: Ty::String { attr: baml_type::TyAttr::default() },
+                value_type: Ty::String { attr: baml_type::TyAttr::default() },
                 entries: indexmap::IndexMap::new(),
             },
             "body".to_string() => BexExternalValue::String(String::new()),

--- a/baml_language/crates/bex_external_types/src/lib.rs
+++ b/baml_language/crates/bex_external_types/src/lib.rs
@@ -28,7 +28,7 @@ mod handle;
 
 pub use baml_type::MediaKind;
 pub use bex_external_value::{
-    AsBexExternalValue, BexExternalAdt, BexExternalValue, Ty, TypeName, UnionMetadata,
+    AsBexExternalValue, BexExternalAdt, BexExternalValue, Ty, TyAttr, TypeName, UnionMetadata,
 };
 pub use epoch_guard::EpochGuard;
 pub use handle::{Handle, HandleInner, WeakHeapRef};

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -679,6 +679,8 @@ impl<'a> BexValue<'a> {
                     }),
 
                     Object::String(s) => Ok(BexExternalValue::String(s.clone())),
+                    // Deep-copy path for trace payloads: no declared type is available here,
+                    // so placeholder types with default attr are used.
                     Object::Array(array) => Ok(BexExternalValue::Array {
                         element_type: Ty::BuiltinUnknown {
                             attr: baml_type::TyAttr::default(),

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -680,15 +680,21 @@ impl<'a> BexValue<'a> {
 
                     Object::String(s) => Ok(BexExternalValue::String(s.clone())),
                     Object::Array(array) => Ok(BexExternalValue::Array {
-                        element_type: Ty::BuiltinUnknown,
+                        element_type: Ty::BuiltinUnknown {
+                            attr: baml_type::TyAttr::default(),
+                        },
                         items: array
                             .iter()
                             .map(|item| BexValue::Value(item).as_owned_but_very_slow(heap))
                             .collect::<Result<_, _>>()?,
                     }),
                     Object::Map(map) => Ok(BexExternalValue::Map {
-                        key_type: Ty::String,
-                        value_type: Ty::BuiltinUnknown,
+                        key_type: Ty::String {
+                            attr: baml_type::TyAttr::default(),
+                        },
+                        value_type: Ty::BuiltinUnknown {
+                            attr: baml_type::TyAttr::default(),
+                        },
                         entries: map
                             .iter()
                             .map(|(k, v)| {

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -459,15 +459,21 @@ mod tests {
             fields: vec![
                 bex_vm_types::ClassField {
                     name: "x".to_string(),
-                    field_type: baml_type::Ty::Int,
+                    field_type: baml_type::Ty::Int {
+                        attr: baml_type::TyAttr::default(),
+                    },
                     description: None,
                     alias: None,
+                    field_attr: Default::default(),
                 },
                 bex_vm_types::ClassField {
                     name: "y".to_string(),
-                    field_type: baml_type::Ty::Int,
+                    field_type: baml_type::Ty::Int {
+                        attr: baml_type::TyAttr::default(),
+                    },
                     description: None,
                     alias: None,
+                    field_attr: Default::default(),
                 },
             ],
             description: None,

--- a/baml_language/crates/bex_project/src/lib.rs
+++ b/baml_language/crates/bex_project/src/lib.rs
@@ -13,7 +13,7 @@ pub use baml_builtins::{MediaContent, MediaValue, PromptAst, PromptAstSimple};
 pub use bex::Bex;
 pub use bex_engine::{EngineError, FunctionCallContextBuilder};
 pub use bex_events::EventSink;
-pub use bex_external_types::{BexExternalAdt, BexExternalValue, Handle, MediaKind, Ty};
+pub use bex_external_types::{BexExternalAdt, BexExternalValue, Handle, MediaKind, Ty, TyAttr};
 pub use sys_types::{CallId, CancellationToken, SysOps};
 use thiserror::Error;
 

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -327,6 +327,7 @@ pub struct ClassField {
     pub field_type: Ty,
     pub description: Option<String>,
     pub alias: Option<String>,
+    pub field_attr: baml_type::FieldAttr,
 }
 
 /// Runtime class representation.

--- a/baml_language/crates/bridge_cffi/src/host_spans.rs
+++ b/baml_language/crates/bridge_cffi/src/host_spans.rs
@@ -227,12 +227,18 @@ fn json_value_to_bex(value: &serde_json::Value) -> bex_project::BexExternalValue
         }
         serde_json::Value::String(s) => BexExternalValue::String(s.clone()),
         serde_json::Value::Array(items) => BexExternalValue::Array {
-            element_type: bex_project::Ty::Null,
+            element_type: bex_project::Ty::Null {
+                attr: bex_project::TyAttr::default(),
+            },
             items: items.iter().map(json_value_to_bex).collect(),
         },
         serde_json::Value::Object(map) => BexExternalValue::Map {
-            key_type: bex_project::Ty::String,
-            value_type: bex_project::Ty::Null,
+            key_type: bex_project::Ty::String {
+                attr: bex_project::TyAttr::default(),
+            },
+            value_type: bex_project::Ty::Null {
+                attr: bex_project::TyAttr::default(),
+            },
             entries: map
                 .iter()
                 .map(|(k, v)| (k.clone(), json_value_to_bex(v)))

--- a/baml_language/crates/bridge_cffi/src/host_spans.rs
+++ b/baml_language/crates/bridge_cffi/src/host_spans.rs
@@ -178,11 +178,11 @@ impl HostSpanManager {
             },
             call_stack,
             timestamp: std::time::SystemTime::now(),
-            event: EventKind::Function(FunctionEvent::End(bex_events::FunctionEnd {
+            event: EventKind::Function(FunctionEvent::End(Box::new(bex_events::FunctionEnd {
                 name: entry.function_name,
                 result,
                 duration: entry.started_at.elapsed(),
-            })),
+            }))),
         };
         event_store::emit(&event);
         if let Some(sink) = &self.sink {

--- a/baml_language/crates/bridge_ctypes/src/value_decode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_decode.rs
@@ -55,7 +55,26 @@ fn convert_list(
         .map(|v| inbound_to_external(v, handle_table))
         .collect();
     Ok(BexExternalValue::Array {
-        element_type: Ty::Union(vec![Ty::Int, Ty::Float, Ty::String, Ty::Bool, Ty::Null]),
+        element_type: Ty::Union(
+            vec![
+                Ty::Int {
+                    attr: baml_type::TyAttr::default(),
+                },
+                Ty::Float {
+                    attr: baml_type::TyAttr::default(),
+                },
+                Ty::String {
+                    attr: baml_type::TyAttr::default(),
+                },
+                Ty::Bool {
+                    attr: baml_type::TyAttr::default(),
+                },
+                Ty::Null {
+                    attr: baml_type::TyAttr::default(),
+                },
+            ],
+            baml_type::TyAttr::default(),
+        ),
         items: items?,
     })
 }
@@ -75,8 +94,29 @@ fn convert_map(
         entries.insert(key, value);
     }
     Ok(BexExternalValue::Map {
-        key_type: Ty::String,
-        value_type: Ty::Union(vec![Ty::Int, Ty::Float, Ty::String, Ty::Bool, Ty::Null]),
+        key_type: Ty::String {
+            attr: baml_type::TyAttr::default(),
+        },
+        value_type: Ty::Union(
+            vec![
+                Ty::Int {
+                    attr: baml_type::TyAttr::default(),
+                },
+                Ty::Float {
+                    attr: baml_type::TyAttr::default(),
+                },
+                Ty::String {
+                    attr: baml_type::TyAttr::default(),
+                },
+                Ty::Bool {
+                    attr: baml_type::TyAttr::default(),
+                },
+                Ty::Null {
+                    attr: baml_type::TyAttr::default(),
+                },
+            ],
+            baml_type::TyAttr::default(),
+        ),
         entries,
     })
 }

--- a/baml_language/crates/bridge_ctypes/src/value_decode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_decode.rs
@@ -45,6 +45,21 @@ pub fn inbound_to_external(
     }
 }
 
+/// Build the default "any scalar" union type for untyped inbound values.
+fn default_scalar_union_ty() -> Ty {
+    let d = baml_type::TyAttr::default();
+    Ty::Union(
+        vec![
+            Ty::Int { attr: d.clone() },
+            Ty::Float { attr: d.clone() },
+            Ty::String { attr: d.clone() },
+            Ty::Bool { attr: d.clone() },
+            Ty::Null { attr: d.clone() },
+        ],
+        d,
+    )
+}
+
 fn convert_list(
     list: InboundListValue,
     handle_table: &HandleTable,
@@ -55,26 +70,7 @@ fn convert_list(
         .map(|v| inbound_to_external(v, handle_table))
         .collect();
     Ok(BexExternalValue::Array {
-        element_type: Ty::Union(
-            vec![
-                Ty::Int {
-                    attr: baml_type::TyAttr::default(),
-                },
-                Ty::Float {
-                    attr: baml_type::TyAttr::default(),
-                },
-                Ty::String {
-                    attr: baml_type::TyAttr::default(),
-                },
-                Ty::Bool {
-                    attr: baml_type::TyAttr::default(),
-                },
-                Ty::Null {
-                    attr: baml_type::TyAttr::default(),
-                },
-            ],
-            baml_type::TyAttr::default(),
-        ),
+        element_type: default_scalar_union_ty(),
         items: items?,
     })
 }
@@ -97,26 +93,7 @@ fn convert_map(
         key_type: Ty::String {
             attr: baml_type::TyAttr::default(),
         },
-        value_type: Ty::Union(
-            vec![
-                Ty::Int {
-                    attr: baml_type::TyAttr::default(),
-                },
-                Ty::Float {
-                    attr: baml_type::TyAttr::default(),
-                },
-                Ty::String {
-                    attr: baml_type::TyAttr::default(),
-                },
-                Ty::Bool {
-                    attr: baml_type::TyAttr::default(),
-                },
-                Ty::Null {
-                    attr: baml_type::TyAttr::default(),
-                },
-            ],
-            baml_type::TyAttr::default(),
-        ),
+        value_type: default_scalar_union_ty(),
         entries,
     })
 }

--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -254,19 +254,19 @@ fn bex_prompt_ast_simple_to_proto_prompt_ast_simple(
 
 fn ty_to_field_type(ty: &Ty) -> BamlFieldType {
     let field_type = match ty {
-        Ty::Null => Some(FieldType::NullType(BamlFieldTypeNull {})),
-        Ty::Int => Some(FieldType::IntType(BamlFieldTypeInt {})),
-        Ty::Float => Some(FieldType::FloatType(BamlFieldTypeFloat {})),
-        Ty::Bool => Some(FieldType::BoolType(BamlFieldTypeBool {})),
-        Ty::String => Some(FieldType::StringType(BamlFieldTypeString {})),
-        Ty::List(inner) => Some(FieldType::ListType(Box::new(BamlFieldTypeList {
+        Ty::Null { .. } => Some(FieldType::NullType(BamlFieldTypeNull {})),
+        Ty::Int { .. } => Some(FieldType::IntType(BamlFieldTypeInt {})),
+        Ty::Float { .. } => Some(FieldType::FloatType(BamlFieldTypeFloat {})),
+        Ty::Bool { .. } => Some(FieldType::BoolType(BamlFieldTypeBool {})),
+        Ty::String { .. } => Some(FieldType::StringType(BamlFieldTypeString {})),
+        Ty::List(inner, _) => Some(FieldType::ListType(Box::new(BamlFieldTypeList {
             item_type: Some(Box::new(ty_to_field_type(inner))),
         }))),
-        Ty::Map { key, value } => Some(FieldType::MapType(Box::new(BamlFieldTypeMap {
+        Ty::Map { key, value, .. } => Some(FieldType::MapType(Box::new(BamlFieldTypeMap {
             key_type: Some(Box::new(ty_to_field_type(key))),
             value_type: Some(Box::new(ty_to_field_type(value))),
         }))),
-        Ty::Class(tn) => Some(FieldType::ClassType(
+        Ty::Class(tn, _) => Some(FieldType::ClassType(
             crate::baml::cffi::BamlFieldTypeClass {
                 name: Some(BamlTypeName {
                     namespace: BamlTypeNamespace::Types as i32,
@@ -274,27 +274,27 @@ fn ty_to_field_type(ty: &Ty) -> BamlFieldType {
                 }),
             },
         )),
-        Ty::Enum(tn) => Some(FieldType::EnumType(crate::baml::cffi::BamlFieldTypeEnum {
+        Ty::Enum(tn, _) => Some(FieldType::EnumType(crate::baml::cffi::BamlFieldTypeEnum {
             name: tn.display_name.to_string(),
         })),
-        Ty::Union(_) => Some(FieldType::UnionVariantType(BamlFieldTypeUnionVariant {
+        Ty::Union(_, _) => Some(FieldType::UnionVariantType(BamlFieldTypeUnionVariant {
             name: None,
         })),
-        Ty::Optional(inner) => Some(FieldType::OptionalType(Box::new(BamlFieldTypeOptional {
+        Ty::Optional(inner, _) => Some(FieldType::OptionalType(Box::new(BamlFieldTypeOptional {
             value: Some(Box::new(ty_to_field_type(inner))),
         }))),
-        Ty::Media(kind) => Some(FieldType::MediaType(BamlFieldTypeMedia {
+        Ty::Media(kind, _) => Some(FieldType::MediaType(BamlFieldTypeMedia {
             media: media_kind_to_proto_enum(*kind).into(),
         })),
-        Ty::Literal(lit) => Some(FieldType::LiteralType(literal_to_field_type_literal(lit))),
-        Ty::Opaque(tn) => {
+        Ty::Literal(lit, _) => Some(FieldType::LiteralType(literal_to_field_type_literal(lit))),
+        Ty::Opaque(tn, _) => {
             unreachable!("runtime-only {tn} should not reach FFI type encoding")
         }
-        Ty::TypeAlias(_)
+        Ty::TypeAlias(_, _)
         | Ty::Function { .. }
-        | Ty::Void
-        | Ty::WatchAccessor(_)
-        | Ty::BuiltinUnknown => unreachable!("compiler-only variant should not reach FFI"),
+        | Ty::Void { .. }
+        | Ty::WatchAccessor(_, _)
+        | Ty::BuiltinUnknown { .. } => unreachable!("compiler-only variant should not reach FFI"),
     };
 
     BamlFieldType { r#type: field_type }

--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -554,15 +554,21 @@ mod tests {
                 (
                     "allowed_role_metadata",
                     BexExternalValue::Array {
-                        element_type: Ty::String,
+                        element_type: Ty::String {
+                            attr: baml_type::TyAttr::default(),
+                        },
                         items: vec![BexExternalValue::String("cache_control".into())],
                     },
                 ),
                 (
                     "headers",
                     BexExternalValue::Map {
-                        key_type: Ty::String,
-                        value_type: Ty::String,
+                        key_type: Ty::String {
+                            attr: baml_type::TyAttr::default(),
+                        },
+                        value_type: Ty::String {
+                            attr: baml_type::TyAttr::default(),
+                        },
                         entries: header_entries,
                     },
                 ),

--- a/baml_language/crates/sys_llm/src/jinja/render.rs
+++ b/baml_language/crates/sys_llm/src/jinja/render.rs
@@ -338,7 +338,9 @@ mod tests {
                     "system".to_string(),
                 ],
             },
-            output_format: OutputFormatContent::new(Ty::String),
+            output_format: OutputFormatContent::new(Ty::String {
+                attr: baml_type::TyAttr::default(),
+            }),
             tags: IndexMap::new(),
             enums: HashMap::new(),
         }
@@ -461,7 +463,9 @@ mod tests {
         args.insert(
             "items".to_string(),
             BexExternalValue::Array {
-                element_type: Ty::String,
+                element_type: Ty::String {
+                    attr: baml_type::TyAttr::default(),
+                },
                 items: vec![
                     BexExternalValue::String("apple".to_string()),
                     BexExternalValue::String("banana".to_string()),
@@ -482,7 +486,9 @@ mod tests {
 
         // Create a context with an int output format
         let mut ctx = test_ctx();
-        ctx.output_format = OutputFormatContent::new(Ty::Int);
+        ctx.output_format = OutputFormatContent::new(Ty::Int {
+            attr: baml_type::TyAttr::default(),
+        });
 
         let result = render_prompt(template, &args, &ctx).unwrap();
 
@@ -495,7 +501,9 @@ mod tests {
         let args = IndexMap::new();
 
         let mut ctx = test_ctx();
-        ctx.output_format = OutputFormatContent::new(Ty::Int);
+        ctx.output_format = OutputFormatContent::new(Ty::Int {
+            attr: baml_type::TyAttr::default(),
+        });
 
         let result = render_prompt(template, &args, &ctx).unwrap();
 

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -62,7 +62,9 @@ pub fn execute_render_prompt_from_owned(
             default_role: client.default_role.clone(),
             allowed_roles: client.allowed_roles.clone(),
         },
-        output_format: types::OutputFormatContent::new(bex_external_types::Ty::String),
+        output_format: types::OutputFormatContent::new(bex_external_types::Ty::String {
+            attr: baml_type::TyAttr::default(),
+        }),
         tags: indexmap::IndexMap::new(),
         enums: std::collections::HashMap::new(),
     };
@@ -111,7 +113,7 @@ pub fn execute_parse_response_from_owned(
     }
 
     match return_type {
-        baml_type::Ty::String => Ok(bex_external_types::BexExternalValue::String(
+        baml_type::Ty::String { .. } => Ok(bex_external_types::BexExternalValue::String(
             response.content,
         )),
         _ => Err(LlmOpError::NotImplemented {
@@ -179,7 +181,9 @@ mod tests {
 
     fn single_string_array(value: &str) -> BexExternalValue {
         BexExternalValue::Array {
-            element_type: baml_type::Ty::String,
+            element_type: baml_type::Ty::String {
+                attr: baml_type::TyAttr::default(),
+            },
             items: vec![BexExternalValue::String(value.to_string())],
         }
     }
@@ -211,15 +215,22 @@ mod tests {
         let allow_client = make_client_with_options(allow_options);
 
         // "stop" is allowed.
-        let allowed =
-            execute_parse_response_from_owned(&allow_client, response_stop, &baml_type::Ty::String);
+        let allowed = execute_parse_response_from_owned(
+            &allow_client,
+            response_stop,
+            &baml_type::Ty::String {
+                attr: baml_type::TyAttr::default(),
+            },
+        );
         assert!(allowed.is_ok());
 
         // "length" is rejected.
         let blocked = execute_parse_response_from_owned(
             &allow_client,
             response_length,
-            &baml_type::Ty::String,
+            &baml_type::Ty::String {
+                attr: baml_type::TyAttr::default(),
+            },
         );
         assert!(blocked.is_err());
 
@@ -234,7 +245,9 @@ mod tests {
         let denied = execute_parse_response_from_owned(
             &deny_client,
             response_length,
-            &baml_type::Ty::String,
+            &baml_type::Ty::String {
+                attr: baml_type::TyAttr::default(),
+            },
         );
         assert!(denied.is_err());
     }

--- a/baml_language/crates/sys_llm/src/types/output_format.rs
+++ b/baml_language/crates/sys_llm/src/types/output_format.rs
@@ -78,7 +78,8 @@ impl OutputFormatContent {
 
     fn render_impl(&self, options: &RenderOptions) -> Result<Option<String>, RenderError> {
         // For string target with no explicit prefix, return None
-        if matches!(self.target, Ty::String) && matches!(options.prefix, RenderSetting::Auto) {
+        if matches!(self.target, Ty::String { .. }) && matches!(options.prefix, RenderSetting::Auto)
+        {
             return Ok(None);
         }
 
@@ -86,8 +87,10 @@ impl OutputFormatContent {
 
         // For simple primitives (int, float, bool) with Auto prefix, the prefix IS the full message
         // But with explicit prefix, we need to append the type
-        if matches!(self.target, Ty::Int | Ty::Float | Ty::Bool)
-            && matches!(options.prefix, RenderSetting::Auto)
+        if matches!(
+            self.target,
+            Ty::Int { .. } | Ty::Float { .. } | Ty::Bool { .. }
+        ) && matches!(options.prefix, RenderSetting::Auto)
         {
             return Ok(prefix);
         }
@@ -107,17 +110,17 @@ impl OutputFormatContent {
             RenderSetting::Always(p) => Some(p.clone()),
             RenderSetting::Never => None,
             RenderSetting::Auto => match &self.target {
-                Ty::String => None,
-                Ty::Int => Some("Answer as an int".to_string()),
-                Ty::Float => Some("Answer as a float".to_string()),
-                Ty::Bool => Some("Answer as a bool".to_string()),
-                Ty::List(_) => Some("Answer with a JSON Array using this schema:\n".to_string()),
-                Ty::Class(_) | Ty::Map { .. } => {
+                Ty::String { .. } => None,
+                Ty::Int { .. } => Some("Answer as an int".to_string()),
+                Ty::Float { .. } => Some("Answer as a float".to_string()),
+                Ty::Bool { .. } => Some("Answer as a bool".to_string()),
+                Ty::List(..) => Some("Answer with a JSON Array using this schema:\n".to_string()),
+                Ty::Class(..) | Ty::Map { .. } => {
                     Some("Answer in JSON using this schema:\n".to_string())
                 }
-                Ty::Enum(_) => None, // Enum prefix handled differently
-                Ty::Union(_) => Some("Answer in JSON using this schema:\n".to_string()),
-                Ty::Literal(_) => Some("Answer using this specific value:\n".to_string()),
+                Ty::Enum(..) => None, // Enum prefix handled differently
+                Ty::Union(..) => Some("Answer in JSON using this schema:\n".to_string()),
+                Ty::Literal(..) => Some("Answer using this specific value:\n".to_string()),
                 _ => None,
             },
         }
@@ -125,27 +128,27 @@ impl OutputFormatContent {
 
     fn render_type(&self, ty: &Ty, options: &RenderOptions) -> Result<Option<String>, RenderError> {
         match ty {
-            Ty::String => Ok(Some("string".to_string())),
-            Ty::Int => Ok(Some("int".to_string())),
-            Ty::Float => Ok(Some("float".to_string())),
-            Ty::Bool => Ok(Some("bool".to_string())),
-            Ty::Null => Ok(Some("null".to_string())),
+            Ty::String { .. } => Ok(Some("string".to_string())),
+            Ty::Int { .. } => Ok(Some("int".to_string())),
+            Ty::Float { .. } => Ok(Some("float".to_string())),
+            Ty::Bool { .. } => Ok(Some("bool".to_string())),
+            Ty::Null { .. } => Ok(Some("null".to_string())),
 
-            Ty::Optional(inner) => {
+            Ty::Optional(inner, _) => {
                 let inner_str = self
                     .render_type(inner, options)?
                     .unwrap_or_else(|| "unknown".to_string());
                 Ok(Some(format!("{inner_str} | null")))
             }
 
-            Ty::List(inner) => {
+            Ty::List(inner, _) => {
                 let inner_str = self
                     .render_type(inner, options)?
                     .unwrap_or_else(|| "unknown".to_string());
                 Ok(Some(format!("{inner_str}[]")))
             }
 
-            Ty::Map { key, value } => {
+            Ty::Map { key, value, .. } => {
                 let key_str = self
                     .render_type(key, options)?
                     .unwrap_or_else(|| "string".to_string());
@@ -160,7 +163,7 @@ impl OutputFormatContent {
                 }
             }
 
-            Ty::Union(variants) => {
+            Ty::Union(variants, _) => {
                 let rendered: Vec<String> = variants
                     .iter()
                     .filter_map(|v| self.render_type(v, options).ok().flatten())
@@ -172,7 +175,7 @@ impl OutputFormatContent {
                 Ok(Some(rendered.join(splitter)))
             }
 
-            Ty::Enum(tn) => {
+            Ty::Enum(tn, _) => {
                 if let Some(enm) = self.find_enum(tn.display_name.as_str()) {
                     Ok(Some(self.render_enum(enm, options)))
                 } else {
@@ -180,7 +183,7 @@ impl OutputFormatContent {
                 }
             }
 
-            Ty::Class(tn) => {
+            Ty::Class(tn, _) => {
                 if let Some(cls) = self.find_class(tn.display_name.as_str()) {
                     Ok(Some(self.render_class(cls, options)?))
                 } else {
@@ -188,23 +191,23 @@ impl OutputFormatContent {
                 }
             }
 
-            Ty::Media(_) => Err(RenderError::UnsupportedType("media".to_string())),
+            Ty::Media(_, _) => Err(RenderError::UnsupportedType("media".to_string())),
 
             // Literal rendering follows LiteralValue::Display from engine:
             // - String: "value" (quoted with double quotes)
             // - Int: 42 (plain number)
             // - Bool: true/false
-            Ty::Literal(lit) => Ok(Some(render_literal(lit))),
+            Ty::Literal(lit, _) => Ok(Some(render_literal(lit))),
 
             // Runtime-only variants that shouldn't appear in LLM prompts
-            Ty::Opaque(tn) => Err(RenderError::UnsupportedType(tn.to_string())),
+            Ty::Opaque(tn, _) => Err(RenderError::UnsupportedType(tn.to_string())),
 
             // Compiler-only variants should never reach runtime
-            Ty::TypeAlias(_)
+            Ty::TypeAlias(..)
             | Ty::Function { .. }
-            | Ty::Void
-            | Ty::WatchAccessor(_)
-            | Ty::BuiltinUnknown => {
+            | Ty::Void { .. }
+            | Ty::WatchAccessor(..)
+            | Ty::BuiltinUnknown { .. } => {
                 unreachable!(
                     "compiler-only variant {:?} should not reach output_format",
                     ty
@@ -349,39 +352,54 @@ impl RenderOptions {
 
 #[cfg(test)]
 mod tests {
+    use baml_type::TyAttr;
+
     use super::*;
 
     #[test]
     fn test_render_string() {
-        let content = OutputFormatContent::new(Ty::String);
+        let content = OutputFormatContent::new(Ty::String {
+            attr: TyAttr::default(),
+        });
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(rendered, None);
     }
 
     #[test]
     fn test_render_int() {
-        let content = OutputFormatContent::new(Ty::Int);
+        let content = OutputFormatContent::new(Ty::Int {
+            attr: TyAttr::default(),
+        });
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(rendered, Some("Answer as an int".to_string()));
     }
 
     #[test]
     fn test_render_float() {
-        let content = OutputFormatContent::new(Ty::Float);
+        let content = OutputFormatContent::new(Ty::Float {
+            attr: TyAttr::default(),
+        });
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(rendered, Some("Answer as a float".to_string()));
     }
 
     #[test]
     fn test_render_bool() {
-        let content = OutputFormatContent::new(Ty::Bool);
+        let content = OutputFormatContent::new(Ty::Bool {
+            attr: TyAttr::default(),
+        });
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(rendered, Some("Answer as a bool".to_string()));
     }
 
     #[test]
     fn test_render_list() {
-        let content = OutputFormatContent::new(Ty::List(Box::new(Ty::String)));
+        let content = OutputFormatContent::new(Ty::List(
+            Box::new(Ty::String {
+                attr: TyAttr::default(),
+            }),
+            TyAttr::default(),
+        ));
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
             rendered,
@@ -391,7 +409,12 @@ mod tests {
 
     #[test]
     fn test_render_list_of_int() {
-        let content = OutputFormatContent::new(Ty::List(Box::new(Ty::Int)));
+        let content = OutputFormatContent::new(Ty::List(
+            Box::new(Ty::Int {
+                attr: TyAttr::default(),
+            }),
+            TyAttr::default(),
+        ));
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
             rendered,
@@ -401,7 +424,12 @@ mod tests {
 
     #[test]
     fn test_render_optional() {
-        let content = OutputFormatContent::new(Ty::Optional(Box::new(Ty::String)));
+        let content = OutputFormatContent::new(Ty::Optional(
+            Box::new(Ty::String {
+                attr: TyAttr::default(),
+            }),
+            TyAttr::default(),
+        ));
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(rendered, Some("string | null".to_string()));
     }
@@ -409,8 +437,13 @@ mod tests {
     #[test]
     fn test_render_map() {
         let content = OutputFormatContent::new(Ty::Map {
-            key: Box::new(Ty::String),
-            value: Box::new(Ty::Int),
+            key: Box::new(Ty::String {
+                attr: TyAttr::default(),
+            }),
+            value: Box::new(Ty::Int {
+                attr: TyAttr::default(),
+            }),
+            attr: TyAttr::default(),
         });
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
@@ -425,14 +458,28 @@ mod tests {
             name: "Person".to_string(),
             description: Some("A person".to_string()),
             fields: vec![
-                ("name".to_string(), Ty::String, None),
-                ("age".to_string(), Ty::Int, Some("Age in years".to_string())),
+                (
+                    "name".to_string(),
+                    Ty::String {
+                        attr: TyAttr::default(),
+                    },
+                    None,
+                ),
+                (
+                    "age".to_string(),
+                    Ty::Int {
+                        attr: TyAttr::default(),
+                    },
+                    Some("Age in years".to_string()),
+                ),
             ],
         };
 
-        let content =
-            OutputFormatContent::new(Ty::Class(baml_type::TypeName::local("Person".into())))
-                .with_class(cls);
+        let content = OutputFormatContent::new(Ty::Class(
+            baml_type::TypeName::local("Person".into()),
+            TyAttr::default(),
+        ))
+        .with_class(cls);
 
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
@@ -455,14 +502,28 @@ mod tests {
             name: "Point".to_string(),
             description: None,
             fields: vec![
-                ("x".to_string(), Ty::Int, None),
-                ("y".to_string(), Ty::Int, None),
+                (
+                    "x".to_string(),
+                    Ty::Int {
+                        attr: TyAttr::default(),
+                    },
+                    None,
+                ),
+                (
+                    "y".to_string(),
+                    Ty::Int {
+                        attr: TyAttr::default(),
+                    },
+                    None,
+                ),
             ],
         };
 
-        let content =
-            OutputFormatContent::new(Ty::Class(baml_type::TypeName::local("Point".into())))
-                .with_class(cls);
+        let content = OutputFormatContent::new(Ty::Class(
+            baml_type::TypeName::local("Point".into()),
+            TyAttr::default(),
+        ))
+        .with_class(cls);
 
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
@@ -489,9 +550,11 @@ mod tests {
             ],
         };
 
-        let content =
-            OutputFormatContent::new(Ty::Enum(baml_type::TypeName::local("Color".into())))
-                .with_enum(enm);
+        let content = OutputFormatContent::new(Ty::Enum(
+            baml_type::TypeName::local("Color".into()),
+            TyAttr::default(),
+        ))
+        .with_enum(enm);
 
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
@@ -507,7 +570,20 @@ mod tests {
 
     #[test]
     fn test_render_union() {
-        let content = OutputFormatContent::new(Ty::Union(vec![Ty::String, Ty::Int, Ty::Bool]));
+        let content = OutputFormatContent::new(Ty::Union(
+            vec![
+                Ty::String {
+                    attr: TyAttr::default(),
+                },
+                Ty::Int {
+                    attr: TyAttr::default(),
+                },
+                Ty::Bool {
+                    attr: TyAttr::default(),
+                },
+            ],
+            TyAttr::default(),
+        ));
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
             rendered,
@@ -517,7 +593,17 @@ mod tests {
 
     #[test]
     fn test_render_with_custom_or_splitter() {
-        let content = OutputFormatContent::new(Ty::Union(vec![Ty::String, Ty::Int]));
+        let content = OutputFormatContent::new(Ty::Union(
+            vec![
+                Ty::String {
+                    attr: TyAttr::default(),
+                },
+                Ty::Int {
+                    attr: TyAttr::default(),
+                },
+            ],
+            TyAttr::default(),
+        ));
         let options = RenderOptions {
             or_splitter: RenderSetting::Always(" | ".to_string()),
             ..Default::default()
@@ -531,8 +617,10 @@ mod tests {
 
     #[test]
     fn test_render_literal_string() {
-        let content =
-            OutputFormatContent::new(Ty::Literal(LiteralValue::String("hello".to_string())));
+        let content = OutputFormatContent::new(Ty::Literal(
+            LiteralValue::String("hello".to_string()),
+            TyAttr::default(),
+        ));
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
             rendered,
@@ -542,7 +630,8 @@ mod tests {
 
     #[test]
     fn test_render_literal_int() {
-        let content = OutputFormatContent::new(Ty::Literal(LiteralValue::Int(42)));
+        let content =
+            OutputFormatContent::new(Ty::Literal(LiteralValue::Int(42), TyAttr::default()));
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
             rendered,
@@ -552,7 +641,8 @@ mod tests {
 
     #[test]
     fn test_render_literal_bool() {
-        let content = OutputFormatContent::new(Ty::Literal(LiteralValue::Bool(true)));
+        let content =
+            OutputFormatContent::new(Ty::Literal(LiteralValue::Bool(true), TyAttr::default()));
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
             rendered,

--- a/scripts/jj-unresolved
+++ b/scripts/jj-unresolved
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+owner="boundaryml"
+repo="baml"
+pr="3194"
+
+gh api graphql -F owner="$owner" -F repo="$repo" -F pr="$pr" -f query='
+query($owner:String!, $repo:String!, $pr:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          comments(first: 100) {
+            nodes { author { login } body url createdAt }
+          }
+        }
+      }
+    }
+  }
+}
+' | jq -r '
+  def indent(s):
+    (s
+      | gsub("\r"; "")
+      | split("\n")
+      | map(if . == "" then "" else "    " + . end)
+      | join("\n")
+    );
+
+  def divider:
+    ("-" * 80);
+
+  .data.repository.pullRequest.reviewThreads.nodes
+  | map(select(.isResolved == false))
+  | sort_by(.path, (.line // .originalLine // 0))
+  | .[]
+  | (
+      "FILE: " + (.path // "?") + ":" + (((.line // .originalLine) // 0) | tostring)
+      + (if .isOutdated then "  [outdated]" else "" end)
+      + "  [unresolved]"
+      + "\n"
+      + (
+          .comments.nodes
+          | map(
+              "  COMMENT:"
+              + "\n  AUTHOR: " + (.author.login // "?")
+              + "\n  TIME: " + (.createdAt // "")
+              + "\n  URL: " + (.url // "")
+              + "\n\n"
+              + indent(.body // "")
+              + "\n"
+            )
+          | join("\n")
+        )
+      + "\n" + divider + "\n"
+    )
+'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Core types now carry compact per-type attribute metadata throughout the system, enabling richer annotations and improved diagnostics.
* **New Exports**
  * Attribute and SAP types (type/field attribute enums and helpers) are publicly exposed for downstream use.
* **Public API**
  * Small surface changes: class field metadata and an event payload wrapper were added to public types.
* **Tests / Bug Fixes**
  * Tests and metadata constructors updated to use the new attribute-bearing types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->