### PR TITLE
Fix/streaming parser off by one

### DIFF
--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
@@ -171,43 +171,24 @@ mod tests {
         }
     }
 
-    // Tests for the off-by-one fix in should_close_unescaped_string.
+    // Regression tests for the off-by-one fix in should_close_unescaped_string.
     // When the iterator exhausts without finding a structural delimiter, the
     // counter must account for the last consumed character to prevent the outer
-    // loop from re-processing it (which causes character duplication).
-
-    #[test]
-    fn test_partial_unquoted_value_no_char_duplication() {
-        // InObjectValue: unquoted string "hello" as a value, stream ends mid-token.
-        // Without the fix, the last char would be duplicated (e.g. "helloo").
-        let opts = ParseOptions::default();
-        let vals = parse(r#"{"key": hello"#, &opts).unwrap();
-        match &vals[0].0 {
-            Value::Object(fields, _) => {
-                assert_eq!(fields.len(), 1);
-                let (key, val) = &fields[0];
-                assert_eq!(key.as_str(), "key");
-                match val {
-                    Value::String(s, cmplt) => {
-                        assert_eq!(s.as_str(), "hello", "Value should be 'hello' without duplicated chars");
-                        assert_eq!(cmplt, &CompletionState::Incomplete);
-                    }
-                    _ => panic!("Expected string value, got: {val:?}"),
-                }
-            }
-            _ => panic!("Expected object"),
-        }
-    }
+    // loop from re-processing it. These tests fail without the fix.
+    //
+    // Note: The InObjectValue branch has the same bug but it only manifests
+    // during streaming (multiple parse() calls on successive chunks), not in
+    // single-pass parsing, so it cannot be tested at this level.
 
     #[test]
     fn test_partial_unquoted_key_no_char_duplication() {
-        // InObjectKey: unquoted key, stream ends before ':' is found.
-        // Without the fix, the last char of the key would be duplicated.
+        // InObjectKey: unquoted key "mykey", stream ends before ':' is found.
+        // Without the fix, the off-by-one causes the last char to be
+        // re-processed, creating a spurious key-value pair.
         let opts = ParseOptions::default();
         let vals = parse(r#"{mykey"#, &opts).unwrap();
         match &vals[0].0 {
             Value::Object(fields, _) => {
-                // Key should be captured without duplication
                 assert_eq!(fields.len(), 0, "No complete key-value pair yet");
             }
             _ => panic!("Expected object"),
@@ -217,7 +198,7 @@ mod tests {
     #[test]
     fn test_partial_unquoted_toplevel_no_char_duplication() {
         // InNothing: unquoted string at top level, stream ends without '{' or '['.
-        // Without the fix, the last char would be duplicated.
+        // Without the fix, the off-by-one corrupts parsing so no value is produced.
         let opts = ParseOptions::default();
         let vals = parse("foobar", &opts).unwrap();
         match &vals[0].0 {
@@ -225,35 +206,6 @@ mod tests {
                 assert_eq!(s.as_str(), "foobar", "Top-level string should be 'foobar' without duplicated chars");
             }
             _ => panic!("Expected string, got: {:?}", vals[0].0),
-        }
-    }
-
-    #[test]
-    fn test_partial_object_value_multifield_no_corruption() {
-        // Simulates the production bug: an object with multiple string fields
-        // where an unquoted value ends at stream boundary. The field name
-        // "therapeutic_approach" was being corrupted to "therapeutic_apeutic_approach".
-        let opts = ParseOptions::default();
-        let vals = parse(
-            r#"{"situation_analysis": "done", "therapeutic_approach": planning"#,
-            &opts,
-        ).unwrap();
-        match &vals[0].0 {
-            Value::Object(fields, _) => {
-                assert_eq!(fields.len(), 2);
-                let (key1, _) = &fields[0];
-                let (key2, val2) = &fields[1];
-                assert_eq!(key1.as_str(), "situation_analysis");
-                assert_eq!(key2.as_str(), "therapeutic_approach");
-                match val2 {
-                    Value::String(s, cmplt) => {
-                        assert_eq!(s.as_str(), "planning", "Value should be 'planning' without duplicated chars");
-                        assert_eq!(cmplt, &CompletionState::Incomplete);
-                    }
-                    _ => panic!("Expected string value, got: {val2:?}"),
-                }
-            }
-            _ => panic!("Expected object"),
         }
     }
 }

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
@@ -170,4 +170,90 @@ mod tests {
             _ => panic!("Expected object"),
         }
     }
+
+    // Tests for the off-by-one fix in should_close_unescaped_string.
+    // When the iterator exhausts without finding a structural delimiter, the
+    // counter must account for the last consumed character to prevent the outer
+    // loop from re-processing it (which causes character duplication).
+
+    #[test]
+    fn test_partial_unquoted_value_no_char_duplication() {
+        // InObjectValue: unquoted string "hello" as a value, stream ends mid-token.
+        // Without the fix, the last char would be duplicated (e.g. "helloo").
+        let opts = ParseOptions::default();
+        let vals = parse(r#"{"key": hello"#, &opts).unwrap();
+        match &vals[0].0 {
+            Value::Object(fields, _) => {
+                assert_eq!(fields.len(), 1);
+                let (key, val) = &fields[0];
+                assert_eq!(key.as_str(), "key");
+                match val {
+                    Value::String(s, cmplt) => {
+                        assert_eq!(s.as_str(), "hello", "Value should be 'hello' without duplicated chars");
+                        assert_eq!(cmplt, &CompletionState::Incomplete);
+                    }
+                    _ => panic!("Expected string value, got: {val:?}"),
+                }
+            }
+            _ => panic!("Expected object"),
+        }
+    }
+
+    #[test]
+    fn test_partial_unquoted_key_no_char_duplication() {
+        // InObjectKey: unquoted key, stream ends before ':' is found.
+        // Without the fix, the last char of the key would be duplicated.
+        let opts = ParseOptions::default();
+        let vals = parse(r#"{mykey"#, &opts).unwrap();
+        match &vals[0].0 {
+            Value::Object(fields, _) => {
+                // Key should be captured without duplication
+                assert_eq!(fields.len(), 0, "No complete key-value pair yet");
+            }
+            _ => panic!("Expected object"),
+        }
+    }
+
+    #[test]
+    fn test_partial_unquoted_toplevel_no_char_duplication() {
+        // InNothing: unquoted string at top level, stream ends without '{' or '['.
+        // Without the fix, the last char would be duplicated.
+        let opts = ParseOptions::default();
+        let vals = parse("foobar", &opts).unwrap();
+        match &vals[0].0 {
+            Value::String(s, _) => {
+                assert_eq!(s.as_str(), "foobar", "Top-level string should be 'foobar' without duplicated chars");
+            }
+            _ => panic!("Expected string, got: {:?}", vals[0].0),
+        }
+    }
+
+    #[test]
+    fn test_partial_object_value_multifield_no_corruption() {
+        // Simulates the production bug: an object with multiple string fields
+        // where an unquoted value ends at stream boundary. The field name
+        // "therapeutic_approach" was being corrupted to "therapeutic_apeutic_approach".
+        let opts = ParseOptions::default();
+        let vals = parse(
+            r#"{"situation_analysis": "done", "therapeutic_approach": planning"#,
+            &opts,
+        ).unwrap();
+        match &vals[0].0 {
+            Value::Object(fields, _) => {
+                assert_eq!(fields.len(), 2);
+                let (key1, _) = &fields[0];
+                let (key2, val2) = &fields[1];
+                assert_eq!(key1.as_str(), "situation_analysis");
+                assert_eq!(key2.as_str(), "therapeutic_approach");
+                match val2 {
+                    Value::String(s, cmplt) => {
+                        assert_eq!(s.as_str(), "planning", "Value should be 'planning' without duplicated chars");
+                        assert_eq!(cmplt, &CompletionState::Incomplete);
+                    }
+                    _ => panic!("Expected string value, got: {val2:?}"),
+                }
+            }
+            _ => panic!("Expected object"),
+        }
+    }
 }

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
@@ -202,8 +202,9 @@ mod tests {
         let opts = ParseOptions::default();
         let vals = parse("foobar", &opts).unwrap();
         match &vals[0].0 {
-            Value::String(s, _) => {
+            Value::String(s, cmplt) => {
                 assert_eq!(s.as_str(), "foobar", "Top-level string should be 'foobar' without duplicated chars");
+                assert_eq!(cmplt, &CompletionState::Incomplete);
             }
             _ => panic!("Expected string, got: {:?}", vals[0].0),
         }

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
@@ -203,7 +203,11 @@ mod tests {
         let vals = parse("foobar", &opts).unwrap();
         match &vals[0].0 {
             Value::String(s, cmplt) => {
-                assert_eq!(s.as_str(), "foobar", "Top-level string should be 'foobar' without duplicated chars");
+                assert_eq!(
+                    s.as_str(),
+                    "foobar",
+                    "Top-level string should be 'foobar' without duplicated chars"
+                );
                 assert_eq!(cmplt, &CompletionState::Incomplete);
             }
             _ => panic!("Expected string, got: {:?}", vals[0].0),

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -909,3 +909,46 @@ enum CloseStringResult {
     Close(usize, CompletionState),
     Continue,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use baml_types::CompletionState;
+
+    /// Test the InObjectValue branch of should_close_unescaped_string directly.
+    ///
+    /// The off-by-one bug on this branch only manifests during streaming (multiple
+    /// parse() calls on successive chunks), not in single-pass parsing. Testing
+    /// through the public parse() API cannot catch it because the re-processed
+    /// character gets absorbed harmlessly. So we test the private function directly
+    /// by setting up the collection stack to simulate being inside an object value.
+    #[test]
+    fn test_should_close_unescaped_string_in_object_value_exhausted() {
+        let mut state = JsonParseState::new();
+        // Set up stack: Object with one key but no value yet (InObjectValue),
+        // then an UnquotedString being accumulated on top.
+        state.collection_stack.push((
+            JsonCollection::Object(
+                vec!["key".to_string()],
+                vec![],
+                CompletionState::Incomplete,
+            ),
+            Default::default(),
+        ));
+        state.collection_stack.push((
+            JsonCollection::UnquotedString("hello".to_string(), CompletionState::Incomplete),
+            Default::default(),
+        ));
+
+        // Remaining chars: "world" — no ',' or '}' to trigger Complete
+        let remaining: Vec<(usize, char)> =
+            vec![(0, 'w'), (1, 'o'), (2, 'r'), (3, 'l'), (4, 'd')];
+        let result = state.should_close_unescaped_string(remaining.into_iter().peekable());
+
+        // counter should be 5 (last idx=4, +1), not 4
+        assert_eq!(
+            result,
+            CloseStringResult::Close(5, CompletionState::Incomplete)
+        );
+    }
+}

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -222,6 +222,7 @@ impl JsonParseState {
                         }
                     }
                 }
+                counter += 1; // Match InArray: account for the last consumed character
                 CloseStringResult::Close(counter, CompletionState::Incomplete)
             }
             Pos::Unknown => CloseStringResult::Continue,
@@ -237,6 +238,7 @@ impl JsonParseState {
                         }
                     }
                 }
+                counter += 1; // Match InArray: account for the last consumed character
                 CloseStringResult::Close(counter, CompletionState::Incomplete)
             }
             Pos::InObjectValue => {
@@ -352,6 +354,7 @@ impl JsonParseState {
                         }
                     }
                 }
+                counter += 1; // Match InArray: account for the last consumed character
                 CloseStringResult::Close(counter, CompletionState::Incomplete)
             }
             Pos::InArray => {

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -18,6 +18,10 @@ struct StringQuoteTracking {
     unescaped_quote_count: usize,
 }
 
+/// Incremental JSON parser state machine that assembles JSON values from a
+/// stream of characters. Handles malformed JSON commonly produced by LLMs,
+/// including unquoted strings, single-quoted strings, trailing commas, and
+/// unterminated structures.
 #[derive(Debug)]
 pub struct JsonParseState {
     /// The stack of Json collection values being assembled.
@@ -35,6 +39,9 @@ pub struct JsonParseState {
     string_quote_tracking: StringQuoteTracking,
 }
 
+/// The position context of the current unquoted string relative to its
+/// enclosing collection. Used by `should_close_unescaped_string` to determine
+/// which delimiters terminate the string.
 #[derive(Clone, Debug)]
 enum Pos {
     InNothing,     // 0
@@ -45,6 +52,7 @@ enum Pos {
 }
 
 impl JsonParseState {
+    /// Creates a new empty parser state with no collections on the stack.
     pub fn new() -> Self {
         JsonParseState {
             collection_stack: vec![],
@@ -126,6 +134,8 @@ impl JsonParseState {
         }
     }
 
+    /// Appends a character to the current string-like collection on top of the stack.
+    /// Returns `Ok(0)` on success (no additional characters to skip).
     fn consume(&mut self, token: char) -> Result<usize> {
         // First check if we're in a QuotedString and need to update tracking
         // (done before getting mutable borrow to avoid borrow checker conflict)
@@ -166,6 +176,8 @@ impl JsonParseState {
         Ok(0)
     }
 
+    /// Returns `true` if the current unquoted string on the stack represents a
+    /// complete JSON literal (`true`, `false`, `null`, or a valid number).
     fn is_string_complete(&self) -> bool {
         let Some((JsonCollection::UnquotedString(v, _), _)) = self.collection_stack.last() else {
             return false;
@@ -184,6 +196,18 @@ impl JsonParseState {
         }
     }
 
+    /// Determines whether the current unquoted string should be closed based on
+    /// upcoming characters. Consumes characters from `next` looking for a
+    /// structural delimiter appropriate to the string's context (`:` for object
+    /// keys, `,`/`}` for object values, `,`/`]` for arrays, `{`/`[` for
+    /// top-level). Returns the number of characters consumed so the caller can
+    /// advance the outer iterator accordingly.
+    ///
+    /// When the iterator is exhausted without finding a delimiter (stream
+    /// incomplete), returns `Close(counter, Incomplete)` where `counter` is the
+    /// number of characters consumed. The `counter += 1` before each such return
+    /// accounts for the last character yielded by the iterator — without it, the
+    /// outer loop would re-process that character, causing duplication.
     fn should_close_unescaped_string(
         &mut self,
         mut next: Peekable<impl Iterator<Item = (usize, char)>>,
@@ -376,6 +400,9 @@ impl JsonParseState {
         }
     }
 
+    /// Determines whether a quoted string (double-quoted, single-quoted, or
+    /// backtick) should be closed at the current position by peeking at
+    /// upcoming characters and checking for structural delimiters.
     fn should_close_string(
         &mut self,
         mut next: Peekable<impl Iterator<Item = (usize, char)>>,
@@ -493,6 +520,9 @@ impl JsonParseState {
         }
     }
 
+    /// Processes a single character token in the context of the current parser
+    /// state. Returns the number of additional characters consumed from `next`
+    /// that the caller should skip in the outer iteration loop.
     pub fn process_token(
         &mut self,
         token: char,
@@ -733,7 +763,9 @@ impl JsonParseState {
         }
     }
 
-    // Returns the number of increments to skip after processing the token
+    /// Attempts to start parsing a new JSON value from the given token character.
+    /// Pushes the appropriate collection type onto the stack and returns the
+    /// number of additional characters consumed from `next`.
     fn find_any_starting_value(
         &mut self,
         token: char,
@@ -870,6 +902,8 @@ impl JsonParseState {
     }
 }
 
+/// Result of `should_close_unescaped_string`: either close the string with a
+/// character count and completion state, or continue accumulating characters.
 #[derive(Debug, PartialEq)]
 enum CloseStringResult {
     Close(usize, CompletionState),

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -912,8 +912,9 @@ enum CloseStringResult {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use baml_types::CompletionState;
+
+    use super::*;
 
     /// Test the InObjectValue branch of should_close_unescaped_string directly.
     ///
@@ -928,11 +929,7 @@ mod tests {
         // Set up stack: Object with one key but no value yet (InObjectValue),
         // then an UnquotedString being accumulated on top.
         state.collection_stack.push((
-            JsonCollection::Object(
-                vec!["key".to_string()],
-                vec![],
-                CompletionState::Incomplete,
-            ),
+            JsonCollection::Object(vec!["key".to_string()], vec![], CompletionState::Incomplete),
             Default::default(),
         ));
         state.collection_stack.push((
@@ -941,8 +938,7 @@ mod tests {
         ));
 
         // Remaining chars: "world" — no ',' or '}' to trigger Complete
-        let remaining: Vec<(usize, char)> =
-            vec![(0, 'w'), (1, 'o'), (2, 'r'), (3, 'l'), (4, 'd')];
+        let remaining: Vec<(usize, char)> = vec![(0, 'w'), (1, 'o'), (2, 'r'), (3, 'l'), (4, 'd')];
         let result = state.should_close_unescaped_string(remaining.into_iter().peekable());
 
         // counter should be 5 (last idx=4, +1), not 4


### PR DESCRIPTION
Updated version of https://github.com/BoundaryML/baml/pull/3137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced incremental JSON parser to better build values from character streams and handle malformed inputs (unquoted/single-quoted strings, trailing commas, unterminated structures).

* **Bug Fixes**
  * Fixed an off-by-one string-parsing bug that could duplicate incomplete values or keys when the input ends mid-token.

* **Tests**
  * Added regression tests covering partial/unquoted strings and stream-end cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->