### PR TITLE
baml-language: add TyAttr to enum/class defs

### DIFF
--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -207,6 +207,7 @@ pub fn compile_files(
             description: None,
             alias: None,
             type_tag,
+            ty_attr: baml_type::TyAttr::default(),
         });
         class_type_tag_counter += 1;
         let class_obj_idx = program.add_object(class_obj);
@@ -271,6 +272,7 @@ pub fn compile_files(
                     description: class.description.value().cloned(),
                     alias: class.alias.value().cloned(),
                     type_tag,
+                    ty_attr: class.ty_attr.clone(),
                 });
                 class_type_tag_counter += 1;
                 let class_obj_idx = program.add_object(class_obj);
@@ -316,6 +318,7 @@ pub fn compile_files(
                     variants,
                     description: None, // HIR Enum doesn't carry description
                     alias: enum_def.alias.value().cloned(),
+                    ty_attr: enum_def.ty_attr.clone(),
                 });
                 let enum_obj_idx = program.add_object(enum_obj);
                 enum_object_indices.insert(enum_name.clone(), enum_obj_idx);
@@ -349,6 +352,7 @@ pub fn compile_files(
             variants,
             description: None,
             alias: None,
+            ty_attr: baml_type::TyAttr::default(),
         });
         let enum_obj_idx = program.add_object(enum_obj);
         enum_object_indices.insert(builtin_enum.path.to_string(), enum_obj_idx);

--- a/baml_language/crates/baml_compiler_hir/src/item_tree.rs
+++ b/baml_language/crates/baml_compiler_hir/src/item_tree.rs
@@ -6,7 +6,7 @@
 
 use std::ops::Index;
 
-use baml_base::Name;
+use baml_base::{Name, TyAttr};
 use indexmap::IndexMap;
 use rowan::TextRange;
 use rustc_hash::FxHashMap;
@@ -238,6 +238,8 @@ pub struct Class {
     pub alias: Attribute<String>,
     /// @@description("text") - documentation for the class
     pub description: Attribute<String>,
+    /// Class-level type attribute (e.g., from @@stream.done).
+    pub ty_attr: TyAttr,
     // Note: Generic parameters are queried separately via generic_params()
     // for incrementality - changes to generics don't invalidate ItemTree
 }
@@ -266,6 +268,8 @@ pub struct Enum {
     // Block attributes (@@alias)
     /// @@alias("name") - alternative name for serialization
     pub alias: Attribute<String>,
+    /// Enum-level type attribute.
+    pub ty_attr: TyAttr,
     // Note: Generic parameters are queried separately via generic_params()
 }
 

--- a/baml_language/crates/baml_compiler_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_hir/src/lib.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use baml_base::{FileId, Name, SourceFile, Span};
+use baml_base::{FileId, Name, SourceFile, Span, TyAttr};
 use baml_compiler_diagnostics::{HirDiagnostic, NameError};
 use baml_compiler_parser::syntax_tree;
 use baml_compiler_syntax::SyntaxNode;
@@ -2188,6 +2188,7 @@ pub(crate) fn lower_class(node: &SyntaxNode, ctx: &mut LoweringContext) -> Optio
         is_dynamic: class_is_dynamic,
         alias: class_alias,
         description: class_description,
+        ty_attr: TyAttr::default(),
     })
 }
 
@@ -2422,6 +2423,7 @@ pub(crate) fn lower_enum(node: &SyntaxNode, ctx: &mut LoweringContext) -> Option
         name,
         variants,
         alias: enum_alias,
+        ty_attr: TyAttr::default(),
     })
 }
 

--- a/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
@@ -136,6 +136,7 @@ fn lower_class(
         is_dynamic: attr_to_bool(&class.is_dynamic),
         description: attr_to_option(&class.description),
         alias: attr_to_option(&class.alias),
+        ty_attr: class.ty_attr.clone(),
     }
 }
 
@@ -156,6 +157,7 @@ fn lower_enum(enum_def: &baml_compiler_hir::Enum) -> VirEnum {
         variants,
         description: None, // HIR Enum has no @@description
         alias: attr_to_option(&enum_def.alias),
+        ty_attr: enum_def.ty_attr.clone(),
     }
 }
 

--- a/baml_language/crates/baml_type/src/defs.rs
+++ b/baml_language/crates/baml_type/src/defs.rs
@@ -3,7 +3,7 @@
 //! These types represent classes, enums, functions, and type aliases as they
 //! appear in the compiled schema.
 
-use baml_base::Name;
+use baml_base::{Name, TyAttr};
 
 use crate::{FieldAttr, Ty};
 
@@ -24,6 +24,7 @@ pub struct ClassDef {
     pub is_dynamic: bool,
     pub description: Option<String>,
     pub alias: Option<String>,
+    pub ty_attr: TyAttr,
 }
 
 /// A field within a class.
@@ -44,6 +45,7 @@ pub struct EnumDef {
     pub variants: Vec<EnumVariantDef>,
     pub description: Option<String>,
     pub alias: Option<String>,
+    pub ty_attr: TyAttr,
 }
 
 /// A variant within an enum.

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -479,6 +479,7 @@ mod tests {
             description: None,
             alias: None,
             type_tag: 100,
+            ty_attr: baml_type::TyAttr::default(),
         }));
 
         // Allocate an instance of that class
@@ -529,6 +530,7 @@ mod tests {
             ],
             description: None,
             alias: None,
+            ty_attr: baml_type::TyAttr::default(),
         }));
 
         // Allocate a variant (Color::Green = index 1)

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -417,6 +417,9 @@ pub struct Class {
     /// Type tag for this class, used by `TypeTag` instruction for jump table dispatch.
     /// Assigned during codegen as `CLASS_BASE + class_index`.
     pub type_tag: i64,
+
+    /// Class-level type attribute (e.g., from @@stream.done).
+    pub ty_attr: baml_type::TyAttr,
 }
 
 impl std::fmt::Display for Class {
@@ -464,6 +467,9 @@ pub struct Enum {
 
     /// Enum-level serialization alias.
     pub alias: Option<String>,
+
+    /// Enum-level type attribute.
+    pub ty_attr: baml_type::TyAttr,
 }
 
 impl std::fmt::Display for Enum {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Compiler pipeline now consistently preserves type attributes for class and enum definitions across stages.
* **New Features**
  * Type attributes are exposed to runtime representations of classes and enums, improving attribute visibility and downstream tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->