### PR TITLE
remove instanceof from the language

### DIFF
--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -170,6 +170,9 @@ pub enum DiagnosticId {
 
     // VIR lowering errors (E0089)
     LoweringError,
+
+    // Removed feature errors (E0098)
+    InstanceofRemoved,
 }
 
 impl DiagnosticId {
@@ -296,6 +299,9 @@ impl DiagnosticId {
 
             // VIR lowering errors
             DiagnosticId::LoweringError => "E0089",
+
+            // Removed feature errors
+            DiagnosticId::InstanceofRemoved => "E0098",
         }
     }
 }
@@ -558,6 +564,7 @@ mod tests {
             DiagnosticId::UnexpectedToken,
             DiagnosticId::DuplicateName,
             DiagnosticId::LoweringError,
+            DiagnosticId::InstanceofRemoved,
         ];
 
         for id in ids {

--- a/baml_language/crates/baml_compiler_diagnostics/src/errors/type_error.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/errors/type_error.rs
@@ -258,4 +258,7 @@ pub enum TypeError<C: ErrorContext> {
         unused_types: Vec<String>,
         location: C::Location,
     },
+
+    /// `instanceof` operator is no longer supported; use `match` instead.
+    InstanceofRemoved { location: C::Location },
 }

--- a/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
@@ -511,6 +511,12 @@ impl<C: ErrorContext> TypeError<C> {
                 format!("Type `{type_name}` is not allowed in catch bindings"),
             )
             .with_primary_span(loc_fn(location)),
+
+            TypeError::InstanceofRemoved { location } => Diagnostic::error(
+                DiagnosticId::InstanceofRemoved,
+                "`instanceof` is no longer supported. Use a `match` expression for type checking instead.".to_string(),
+            )
+            .with_primary_span(loc_fn(location)),
         };
         diag.with_phase(DiagnosticPhase::Type)
     }

--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -1625,7 +1625,6 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             BinOp::BitXor => Instruction::BinOp(VmBinOp::BitXor),
             BinOp::Shl => Instruction::BinOp(VmBinOp::Shl),
             BinOp::Shr => Instruction::BinOp(VmBinOp::Shr),
-            BinOp::Instanceof => Instruction::CmpOp(CmpOp::InstanceOf),
         }
     }
 

--- a/baml_language/crates/baml_compiler_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler_mir/src/ir.rs
@@ -568,9 +568,6 @@ pub enum BinOp {
     BitXor,
     Shl,
     Shr,
-
-    // Type checking
-    Instanceof,
 }
 
 impl fmt::Display for BinOp {
@@ -592,7 +589,6 @@ impl fmt::Display for BinOp {
             BinOp::BitXor => "^",
             BinOp::Shl => "<<",
             BinOp::Shr => ">>",
-            BinOp::Instanceof => "instanceof",
         };
         write!(f, "{s}")
     }

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -22,7 +22,7 @@ use baml_compiler_tir::{ResolvedValue, TypeResolutionContext};
 use baml_compiler_vir::{
     AssignOp, BinaryOp, CatchClauseKind, Expr, ExprBody, ExprId, Literal, PatId, Pattern, UnaryOp,
 };
-use baml_type::{Ty, TyAttr, TypeName};
+use baml_type::{Ty, TyAttr};
 
 use crate::{
     AggregateKind, BinOp, BlockId, Constant, Local, MirFunction, Operand, Place, Rvalue,
@@ -1765,29 +1765,6 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
         dest: Place,
         body: &ExprBody,
     ) {
-        // Special case: instanceof operator - RHS is a type name, not a value
-        if op == BinaryOp::Instanceof {
-            let lhs_operand = self.lower_to_operand(lhs, body);
-
-            // Extract the type name from RHS (should be a Var or single-segment Path)
-            let type_name = match body.expr(rhs) {
-                Expr::Var(name) => name.clone(),
-                Expr::Path(segments) if segments.len() == 1 => segments[0].clone(),
-                _ => panic!("instanceof RHS must be a simple type name"),
-            };
-
-            // Constructed from the type name in the instanceof expression, not transformed
-            // from an existing typed value, so default attr is correct.
-            self.builder.assign(
-                dest,
-                Rvalue::IsType {
-                    operand: lhs_operand,
-                    ty: Ty::TypeAlias(TypeName::local(type_name), baml_type::TyAttr::default()),
-                },
-            );
-            return;
-        }
-
         let lhs_operand = self.lower_to_operand(lhs, body);
         let rhs_operand = self.lower_to_operand(rhs, body);
 
@@ -1822,7 +1799,6 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             // These are handled separately as short-circuit
             BinaryOp::And => BinOp::BitAnd,
             BinaryOp::Or => BinOp::BitOr,
-            BinaryOp::Instanceof => BinOp::Instanceof,
         }
     }
 

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -2360,12 +2360,9 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
         }
 
         Expr::Binary { lhs, op, rhs } => {
-            // Special case: instanceof operator - RHS is a type reference, not an expression
             if *op == baml_compiler_hir::BinaryOp::Instanceof {
-                let _lhs_ty = infer_expr(ctx, *lhs, body);
-                // For instanceof, don't try to resolve RHS as a variable.
-                // The RHS is a type name and will be resolved at runtime.
-                // Just return bool since instanceof always returns a boolean.
+                ctx.push_error(TypeError::InstanceofRemoved { location });
+                // Return bool to avoid cascading errors
                 Ty::Bool { attr: d() }
             } else {
                 let lhs_ty = infer_expr(ctx, *lhs, body);
@@ -2845,7 +2842,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
             // Condition: accept any type (truthiness check), not just bool
             infer_expr(ctx, *condition, body);
 
-            // Apply true-branch narrowing (instanceof + null checks + truthiness)
+            // Apply true-branch narrowing (null checks + truthiness)
             let true_narrowings = extract_condition_narrowing(ctx, *condition, body, true);
             let then_ty = if !true_narrowings.is_empty() {
                 ctx.push_scope();
@@ -3185,7 +3182,7 @@ fn check_expr_with_info_location(
             // Condition: accept any type (truthiness check), not just bool
             infer_expr(ctx, *condition, body);
 
-            // Apply true-branch narrowing (instanceof + null checks + truthiness)
+            // Apply true-branch narrowing (null checks + truthiness)
             let true_narrowings = extract_condition_narrowing(ctx, *condition, body, true);
             let then_ty = if !true_narrowings.is_empty() {
                 ctx.push_scope();
@@ -4384,8 +4381,7 @@ fn infer_binary_op(
     location: ErrorLocation,
 ) -> Ty {
     use baml_compiler_hir::BinaryOp::{
-        Add, And, BitAnd, BitOr, BitXor, Div, Eq, Ge, Gt, Instanceof, Le, Lt, Mod, Mul, Ne, Or,
-        Shl, Shr, Sub,
+        Add, And, BitAnd, BitOr, BitXor, Div, Eq, Ge, Gt, Le, Lt, Mod, Mul, Ne, Or, Shl, Shr, Sub,
     };
 
     use crate::types::LiteralValue;
@@ -4520,8 +4516,10 @@ fn infer_binary_op(
             }
         }
 
-        // Type checking operations
-        Instanceof => Ty::Bool { attr: d() },
+        // deprecated instanceof is rejected before reaching infer_binary_op
+        baml_compiler_hir::BinaryOp::Instanceof => {
+            unreachable!("instanceof rejected by type checker")
+        }
     }
 }
 

--- a/baml_language/crates/baml_compiler_tir/src/narrowing.rs
+++ b/baml_language/crates/baml_compiler_tir/src/narrowing.rs
@@ -4,7 +4,7 @@
 //! - **Divergence detection**: Determining whether a block/statement always exits
 //!   via `return`/`break`/`continue` (used to enable narrowing after early returns).
 //! - **Condition narrowing**: Extracting type narrowing implications from conditions
-//!   (`x == null`, `x instanceof Foo`, `x.type == "literal"`, `!cond`, truthiness).
+//!   (`x == null`, `x.type == "literal"`, `!cond`, truthiness).
 //! - **Early-return narrowing**: Applying the negation of an if-condition to code
 //!   after the if, when the if-body definitely diverges.
 
@@ -59,50 +59,6 @@ fn remove_null(ty: &Ty) -> Ty {
     }
 }
 
-/// Get the simple name of a named type (Class, Enum, or `TypeAlias`).
-fn named_type_name(ty: &Ty) -> Option<&Name> {
-    match ty {
-        Ty::Class(qn, _) | Ty::Enum(qn, _) | Ty::TypeAlias(qn, _) => Some(&qn.name),
-        _ => None,
-    }
-}
-
-/// Check if two types refer to the same named type, even if one is `TypeAlias`
-/// and the other is Class/Enum (since instanceof returns `TypeAlias`).
-fn same_named_type(a: &Ty, b: &Ty) -> bool {
-    if a == b {
-        return true;
-    }
-    match (named_type_name(a), named_type_name(b)) {
-        (Some(a_name), Some(b_name)) => a_name == b_name,
-        _ => false,
-    }
-}
-
-/// Remove a specific type from a union (for instanceof false-branch narrowing).
-fn remove_type_from(ty: &Ty, to_remove: &Ty) -> Ty {
-    match ty {
-        Ty::Union(members, union_attr) => {
-            let remaining: Vec<Ty> = members
-                .iter()
-                .filter(|m| !same_named_type(m, to_remove))
-                .cloned()
-                .collect();
-            match remaining.len() {
-                0 => Ty::Unknown {
-                    attr: union_attr.clone(),
-                },
-                1 => remaining.into_iter().next().unwrap(),
-                _ => Ty::Union(remaining, union_attr.clone()),
-            }
-        }
-        Ty::Optional(inner, opt_attr) if same_named_type(inner.as_ref(), to_remove) => Ty::Null {
-            attr: opt_attr.clone(),
-        },
-        _ => ty.clone(),
-    }
-}
-
 /// Look up a field on a single union member type without emitting errors.
 /// Returns `Some(field_type)` if the member has that field, None otherwise.
 pub(crate) fn infer_union_member_field(
@@ -124,46 +80,6 @@ pub(crate) fn infer_union_member_field(
 }
 
 // ── Narrowing extraction ────────────────────────────────────────────────
-
-/// Extract instanceof narrowing info from a condition expression.
-///
-/// If the condition is `x instanceof Foo`, returns `Some((x, Foo_type))`.
-/// Otherwise returns `None`.
-fn extract_instanceof_narrowing(
-    _ctx: &TypeContext<'_>,
-    condition: ExprId,
-    body: &ExprBody,
-) -> Option<(Name, Ty)> {
-    use baml_compiler_hir::Expr;
-
-    let expr = &body.exprs[condition];
-
-    // Check if this is an instanceof expression
-    if let Expr::Binary { op, lhs, rhs } = expr {
-        if *op == baml_compiler_hir::BinaryOp::Instanceof {
-            // LHS should be a simple path (variable name)
-            if let Expr::Path(segments) = &body.exprs[*lhs] {
-                if segments.len() == 1 {
-                    let var_name = segments[0].clone();
-
-                    // RHS should be a simple path (type name)
-                    if let Expr::Path(type_segments) = &body.exprs[*rhs] {
-                        if type_segments.len() == 1 {
-                            use baml_compiler_hir::QualifiedName;
-                            let type_name = type_segments[0].clone();
-                            return Some((
-                                var_name,
-                                Ty::TypeAlias(QualifiedName::local(type_name), TyAttr::default()),
-                            ));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}
 
 /// Check if a binary comparison involves null on one side and a variable on the other.
 /// Returns (`variable_name`, `variable_type`) if matched.
@@ -309,7 +225,6 @@ fn extract_discriminated_union_narrowing(
 /// Supports:
 /// - `x == null` / `x != null` → null narrowing
 /// - `x.field == "literal"` → discriminated union narrowing
-/// - `x instanceof Foo` → instanceof narrowing
 /// - `!cond` → flips the branch
 /// - Simple variable truthiness (`if (x)` where x is nullable)
 pub(crate) fn extract_condition_narrowing(
@@ -365,29 +280,6 @@ pub(crate) fn extract_condition_narrowing(
                 } else {
                     extract_discriminated_union_narrowing(ctx, *lhs, *rhs, body, !when_true)
                         .unwrap_or_default()
-                }
-            }
-
-            // `x instanceof Foo`
-            BinaryOp::Instanceof => {
-                if when_true {
-                    extract_instanceof_narrowing(ctx, condition, body)
-                        .into_iter()
-                        .collect()
-                } else {
-                    // When false: remove Foo from x's type
-                    if let Some((var_name, instanceof_ty)) =
-                        extract_instanceof_narrowing(ctx, condition, body)
-                    {
-                        if let Some(var_ty) = ctx.lookup(&var_name) {
-                            let narrowed = remove_type_from(var_ty, &instanceof_ty);
-                            vec![(var_name, narrowed)]
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        vec![]
-                    }
                 }
             }
 

--- a/baml_language/crates/baml_compiler_tir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_tir/src/pretty.rs
@@ -914,6 +914,10 @@ pub fn short_display(error: &TirTypeError) -> String {
                 )
             }
         }
+        TypeError::InstanceofRemoved { .. } => {
+            "`instanceof` is no longer supported. Use a `match` expression for type checking instead."
+                .to_string()
+        }
     }
 }
 

--- a/baml_language/crates/baml_compiler_vir/src/control_flow.rs
+++ b/baml_language/crates/baml_compiler_vir/src/control_flow.rs
@@ -813,7 +813,6 @@ fn render_expr_compact(body: &ExprBody, id: ExprId) -> String {
                 BinaryOp::BitXor => "^",
                 BinaryOp::Shl => "<<",
                 BinaryOp::Shr => ">>",
-                BinaryOp::Instanceof => "instanceof",
             };
             format!(
                 "{} {} {}",

--- a/baml_language/crates/baml_compiler_vir/src/expr.rs
+++ b/baml_language/crates/baml_compiler_vir/src/expr.rs
@@ -353,9 +353,6 @@ pub enum BinaryOp {
     BitXor,
     Shl,
     Shr,
-
-    // Type checking
-    Instanceof,
 }
 
 /// Unary operators.
@@ -424,7 +421,10 @@ impl From<baml_compiler_hir::BinaryOp> for BinaryOp {
             baml_compiler_hir::BinaryOp::BitXor => BinaryOp::BitXor,
             baml_compiler_hir::BinaryOp::Shl => BinaryOp::Shl,
             baml_compiler_hir::BinaryOp::Shr => BinaryOp::Shr,
-            baml_compiler_hir::BinaryOp::Instanceof => BinaryOp::Instanceof,
+            // deprecated instanceof is rejected at the TIR level; it should never reach VIR.
+            baml_compiler_hir::BinaryOp::Instanceof => {
+                unreachable!("instanceof rejected by type checker")
+            }
         }
     }
 }

--- a/baml_language/crates/baml_compiler_vir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_vir/src/pretty.rs
@@ -202,7 +202,6 @@ impl<'a> PrettyPrinter<'a> {
                     BinaryOp::BitXor => "^",
                     BinaryOp::Shl => "<<",
                     BinaryOp::Shr => ">>",
-                    BinaryOp::Instanceof => "instanceof",
                 };
                 writeln!(self.output, "({op_str}) : {ty}").unwrap();
                 self.print_expr(*lhs, level + 1);

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/expr/early_return_narrowing.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/expr/early_return_narrowing.baml
@@ -91,4 +91,39 @@ function test_diverging_if_with_plain_else(x: int?) -> int {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// Error: `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     ╭─[ expr_early_return_narrowing.baml:62:9 ]
+//     │
+//  62 │     if (x instanceof NarrowBar) {
+//     │         ───────────┬──────────  
+//     │                    ╰──────────── `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     │ 
+//     │ Note: Error code: E0098
+// ────╯
+// Error: Type `NarrowFoo | NarrowBar` has no field `field`
+//     ╭─[ expr_early_return_narrowing.baml:66:12 ]
+//     │
+//  66 │     return x.field;
+//     │            ───┬───  
+//     │               ╰───── Type `NarrowFoo | NarrowBar` has no field `field`
+//     │ 
+//     │ Note: Error code: E0007
+// ────╯
+// Error: `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     ╭─[ expr_early_return_narrowing.baml:31:9 ]
+//     │
+//  31 │     if (x instanceof NarrowBar) {
+//     │         ───────────┬──────────  
+//     │                    ╰──────────── `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     │ 
+//     │ Note: Error code: E0098
+// ────╯
+// Error: Type `NarrowFoo | NarrowBar` has no field `field`
+//     ╭─[ expr_early_return_narrowing.baml:35:12 ]
+//     │
+//  35 │     return x.field;
+//     │            ───┬───  
+//     │               ╰───── Type `NarrowFoo | NarrowBar` has no field `field`
+//     │ 
+//     │ Note: Error code: E0007
+// ────╯

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/expr/instanceof_narrowing.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/expr/instanceof_narrowing.baml
@@ -43,4 +43,75 @@ function test_multiple_classes(x: Foo | Bar | Baz) -> string {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// Error: `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     ╭─[ expr_instanceof_narrowing.baml:11:9 ]
+//     │
+//  11 │     if (x instanceof Foo) {
+//     │         ────────┬───────  
+//     │                 ╰───────── `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     │ 
+//     │ Note: Error code: E0098
+// ────╯
+// Error: Type `Foo | Bar` has no field `field`
+//     ╭─[ expr_instanceof_narrowing.baml:13:16 ]
+//     │
+//  13 │         return x.field;
+//     │                ───┬───  
+//     │                   ╰───── Type `Foo | Bar` has no field `field`
+//     │ 
+//     │ Note: Error code: E0007
+// ────╯
+// Error: `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     ╭─[ expr_instanceof_narrowing.baml:35:9 ]
+//     │
+//  35 │     if (x instanceof Foo) {
+//     │         ────────┬───────  
+//     │                 ╰───────── `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     │ 
+//     │ Note: Error code: E0098
+// ────╯
+// Error: Type `Foo | Bar | Baz` has no field `field`
+//     ╭─[ expr_instanceof_narrowing.baml:36:16 ]
+//     │
+//  36 │         return x.field;
+//     │                ───┬───  
+//     │                   ╰───── Type `Foo | Bar | Baz` has no field `field`
+//     │ 
+//     │ Note: Error code: E0007
+// ────╯
+// Error: `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     ╭─[ expr_instanceof_narrowing.baml:37:16 ]
+//     │
+//  37 │     } else if (x instanceof Baz) {
+//     │                ────────┬───────  
+//     │                        ╰───────── `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     │ 
+//     │ Note: Error code: E0098
+// ────╯
+// Error: Type `Foo | Bar | Baz` has no field `field`
+//     ╭─[ expr_instanceof_narrowing.baml:38:16 ]
+//     │
+//  38 │         return x.field;
+//     │                ───┬───  
+//     │                   ╰───── Type `Foo | Bar | Baz` has no field `field`
+//     │ 
+//     │ Note: Error code: E0007
+// ────╯
+// Error: `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     ╭─[ expr_instanceof_narrowing.baml:22:9 ]
+//     │
+//  22 │     if (x instanceof Foo) {
+//     │         ────────┬───────  
+//     │                 ╰───────── `instanceof` is no longer supported. Use a `match` expression for type checking instead.
+//     │ 
+//     │ Note: Error code: E0098
+// ────╯
+// Error: Type `Foo | null` has no field `field`
+//     ╭─[ expr_instanceof_narrowing.baml:23:16 ]
+//     │
+//  23 │         return x.field;
+//     │                ───┬───  
+//     │                   ╰───── Type `Foo | null` has no field `field`
+//     │ 
+//     │ Note: Error code: E0007
+// ────╯

--- a/baml_language/crates/baml_tests/tests/instanceof.rs
+++ b/baml_language/crates/baml_tests/tests/instanceof.rs
@@ -1,9 +1,10 @@
 //! Tests that the `instanceof` operator produces a compile error
 //! suggesting `match` instead.
 
+use std::path::Path;
+
 use baml_compiler_diagnostics::Severity;
 use baml_project::ProjectDatabase;
-use std::path::Path;
 
 fn get_errors(source: &str) -> Vec<String> {
     let mut db = ProjectDatabase::new();

--- a/baml_language/crates/baml_tests/tests/instanceof.rs
+++ b/baml_language/crates/baml_tests/tests/instanceof.rs
@@ -1,75 +1,48 @@
-//! Unified tests for instanceof operator and narrowing.
+//! Tests that the `instanceof` operator produces a compile error
+//! suggesting `match` instead.
 
-use baml_tests::baml_test;
-use bex_engine::BexExternalValue;
+use baml_compiler_diagnostics::Severity;
+use baml_project::ProjectDatabase;
+use std::path::Path;
 
-#[tokio::test]
-async fn instance_of_returns_true() {
-    let output = baml_test!(
+fn get_errors(source: &str) -> Vec<String> {
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(Path::new("."));
+    db.add_file("test.baml", source);
+
+    let project = db.get_project().expect("project must be set");
+    let all_files = db.get_source_files();
+    let diagnostics = baml_project::collect_diagnostics(&db, project, &all_files);
+    diagnostics
+        .iter()
+        .filter(|d| matches!(d.severity, Severity::Error))
+        .map(|d| d.message.clone())
+        .collect()
+}
+
+#[test]
+fn instanceof_produces_error() {
+    let errors = get_errors(
         "
         class StopTool {
-            action \"stop\"
+            action string
         }
 
         function main() -> bool {
             let t = StopTool { action: \"stop\" };
             t instanceof StopTool
         }
-    "
+    ",
     );
 
-    insta::assert_snapshot!(output.bytecode, @r#"
-    function main() -> bool {
-        alloc_instance StopTool
-        copy 0
-        load_const "stop"
-        store_field .action
-        load_const StopTool
-        cmp_op instanceof
-        return
-    }
-    "#);
-
-    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+    assert_eq!(errors.len(), 1);
+    assert!(errors[0].contains("instanceof"));
+    assert!(errors[0].contains("match"));
 }
 
-#[tokio::test]
-async fn instance_of_returns_false() {
-    let output = baml_test!(
-        "
-        class StopTool {
-            action \"stop\"
-        }
-
-        class StartTool {
-            action \"start\"
-        }
-
-        function main() -> bool {
-            let t = StopTool { action: \"stop\" };
-            t instanceof StartTool
-        }
-    "
-    );
-
-    insta::assert_snapshot!(output.bytecode, @r#"
-    function main() -> bool {
-        alloc_instance StopTool
-        copy 0
-        load_const "stop"
-        store_field .action
-        load_const StartTool
-        cmp_op instanceof
-        return
-    }
-    "#);
-
-    assert_eq!(output.result, Ok(BexExternalValue::Bool(false)));
-}
-
-#[tokio::test]
-async fn instanceof_narrowing_true_branch() {
-    let output = baml_test!(
+#[test]
+fn instanceof_in_if_produces_error() {
+    let errors = get_errors(
         "
         class Foo {
             field string
@@ -80,175 +53,16 @@ async fn instanceof_narrowing_true_branch() {
         }
 
         function main() -> string {
-            let x = Foo { field: \"test value\" };
+            let x = Foo { field: \"test\" };
             if (x instanceof Foo) {
                 return x.field;
             } else {
                 return \"not foo\";
             }
         }
-    "
+    ",
     );
 
-    insta::assert_snapshot!(output.bytecode, @r#"
-    function main() -> string {
-        alloc_instance Foo
-        copy 0
-        load_const "test value"
-        store_field .field
-        store_var x
-        load_var x
-        load_const Foo
-        cmp_op instanceof
-        pop_jump_if_false L0
-        jump L1
-
-      L0:
-        load_const "not foo"
-        return
-
-      L1:
-        load_var x
-        load_field .0
-        return
-    }
-    "#);
-
-    assert_eq!(
-        output.result,
-        Ok(BexExternalValue::String("test value".to_string()))
-    );
-}
-
-#[tokio::test]
-async fn instanceof_narrowing_false_branch() {
-    let output = baml_test!(
-        "
-        class Foo {
-            field string
-        }
-
-        class Bar {
-            other int
-        }
-
-        function main() -> string {
-            let x = Bar { other: 42 };
-            if (x instanceof Foo) {
-                return \"is foo\";
-            } else {
-                return \"not foo\";
-            }
-        }
-    "
-    );
-
-    insta::assert_snapshot!(output.bytecode, @r#"
-    function main() -> string {
-        alloc_instance Bar
-        copy 0
-        load_const 42
-        store_field .other
-        load_const Foo
-        cmp_op instanceof
-        pop_jump_if_false L0
-        jump L1
-
-      L0:
-        load_const "not foo"
-        return
-
-      L1:
-        load_const "is foo"
-        return
-    }
-    "#);
-
-    assert_eq!(
-        output.result,
-        Ok(BexExternalValue::String("not foo".to_string()))
-    );
-}
-
-#[tokio::test]
-async fn instanceof_chained_checks() {
-    let output = baml_test!(
-        "
-        class A {
-            a_field string
-        }
-
-        class B {
-            b_field string
-        }
-
-        class C {
-            c_field string
-        }
-
-        function main() -> string {
-            let x = B { b_field: \"b value\" };
-            if (x instanceof A) {
-                return \"is A\";
-            } else if (x instanceof B) {
-                return x.b_field;
-            } else if (x instanceof C) {
-                return \"is C\";
-            } else {
-                return \"unknown\";
-            }
-        }
-    "
-    );
-
-    insta::assert_snapshot!(output.bytecode, @r#"
-    function main() -> string {
-        alloc_instance B
-        copy 0
-        load_const "b value"
-        store_field .b_field
-        store_var x
-        load_var x
-        load_const A
-        cmp_op instanceof
-        pop_jump_if_false L0
-        jump L5
-
-      L0:
-        load_var x
-        load_const B
-        cmp_op instanceof
-        pop_jump_if_false L1
-        jump L4
-
-      L1:
-        load_var x
-        load_const C
-        cmp_op instanceof
-        pop_jump_if_false L2
-        jump L3
-
-      L2:
-        load_const "unknown"
-        return
-
-      L3:
-        load_const "is C"
-        return
-
-      L4:
-        load_var x
-        load_field .0
-        return
-
-      L5:
-        load_const "is A"
-        return
-    }
-    "#);
-
-    assert_eq!(
-        output.result,
-        Ok(BexExternalValue::String("b value".to_string()))
-    );
+    assert!(!errors.is_empty());
+    assert!(errors.iter().any(|e| e.contains("instanceof")));
 }


### PR DESCRIPTION
Removes instanceof from the language and adds a diagnostic that suggests using match instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The `instanceof` operator has been removed. Use `match` expressions for type checks; the compiler now reports error E0098 when `instanceof` is used.
* **Tests**
  * Test expectations updated to assert compile-time diagnostics for `instanceof` (reflecting the new error) instead of runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->