### PR TITLE
baml-language: add TyAttr to HIR types

### DIFF
--- a/baml_language/crates/baml_compiler_hir/src/item_tree.rs
+++ b/baml_language/crates/baml_compiler_hir/src/item_tree.rs
@@ -6,7 +6,7 @@
 
 use std::ops::Index;
 
-use baml_base::{Name, TyAttr};
+use baml_base::{FieldAttr, Name, TyAttr};
 use indexmap::IndexMap;
 use rowan::TextRange;
 use rustc_hash::FxHashMap;
@@ -257,6 +257,8 @@ pub struct Field {
     pub description: Attribute<String>,
     /// @skip - exclude field from serialization
     pub skip: Attribute<()>,
+    /// Field attributes for streaming (e.g., from @sap.*)
+    pub field_attr: FieldAttr,
 }
 
 /// An enum definition.

--- a/baml_language/crates/baml_compiler_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_hir/src/lib.rs
@@ -431,7 +431,7 @@ fn function_signature_with_source_map<'db>(
             Arc::new(FunctionSignature {
                 name: func_name,
                 params: vec![],
-                return_type: TypeRef::Path(path::Path::new(vec![
+                return_type: TypeRef::path(path::Path::new(vec![
                     Name::new("baml"),
                     Name::new("llm"),
                     Name::new("PrimitiveClient"),
@@ -448,7 +448,7 @@ fn function_signature_with_source_map<'db>(
             item_tree::CompilerGenerated::LlmCall { base_name } => (base_name.clone(), None),
             item_tree::CompilerGenerated::LlmRenderPrompt { base_name } => (
                 base_name.clone(),
-                Some(TypeRef::Path(path::Path::new(vec![
+                Some(TypeRef::path(path::Path::new(vec![
                     Name::new("baml"),
                     Name::new("llm"),
                     Name::new("PromptAst"),
@@ -456,7 +456,7 @@ fn function_signature_with_source_map<'db>(
             ),
             item_tree::CompilerGenerated::LlmBuildRequest { base_name } => (
                 base_name.clone(),
-                Some(TypeRef::Path(path::Path::new(vec![
+                Some(TypeRef::path(path::Path::new(vec![
                     Name::new("baml"),
                     Name::new("http"),
                     Name::new("Request"),
@@ -483,7 +483,7 @@ fn function_signature_with_source_map<'db>(
                 Arc::new(FunctionSignature {
                     name: base_name.clone(),
                     params: vec![],
-                    return_type: TypeRef::Unknown,
+                    return_type: TypeRef::unknown(),
                     throws: None,
                 }),
                 SignatureSourceMap::default(),
@@ -513,7 +513,7 @@ fn function_signature_with_source_map<'db>(
         Arc::new(FunctionSignature {
             name: func.name.clone(),
             params: vec![],
-            return_type: TypeRef::Unknown,
+            return_type: TypeRef::unknown(),
             throws: None,
         }),
         SignatureSourceMap::default(),
@@ -577,7 +577,7 @@ fn lower_method_signature(
                     type_node
                         .as_ref()
                         .map(TypeRef::from_ast)
-                        .unwrap_or(TypeRef::Unknown)
+                        .unwrap_or_else(TypeRef::unknown)
                 };
 
                 // Store the spans in the source map
@@ -597,7 +597,7 @@ fn lower_method_signature(
     let return_type = return_type_node
         .as_ref()
         .map(TypeRef::from_ast)
-        .unwrap_or(TypeRef::Unknown);
+        .unwrap_or_else(TypeRef::unknown);
 
     // Store return type span in source map
     if let Some(span) = return_type_node.map(|t| t.text_range()) {
@@ -2085,7 +2085,7 @@ pub(crate) fn lower_class(node: &SyntaxNode, ctx: &mut LoweringContext) -> Optio
             let type_ref = field_node
                 .ty()
                 .map(|t| TypeRef::from_ast(&t))
-                .unwrap_or(TypeRef::Unknown);
+                .unwrap_or_else(TypeRef::unknown);
 
             fields.push(crate::Field {
                 name: field_name,
@@ -2093,6 +2093,7 @@ pub(crate) fn lower_class(node: &SyntaxNode, ctx: &mut LoweringContext) -> Optio
                 alias: field_alias,
                 description: field_description,
                 skip: field_skip,
+                field_attr: baml_base::FieldAttr::default(),
             });
         }
     }
@@ -2541,7 +2542,7 @@ pub(crate) fn lower_type_alias(node: &SyntaxNode) -> Option<TypeAlias> {
     let type_ref = alias
         .ty()
         .map(|t| TypeRef::from_ast(&t))
-        .unwrap_or(TypeRef::Unknown);
+        .unwrap_or_else(TypeRef::unknown);
 
     Some(TypeAlias { name, type_ref })
 }
@@ -3157,9 +3158,9 @@ fn check_duplicate(
 /// Extract the base type name from a `TypeRef`, unwrapping Optional, List, etc.
 fn get_base_type_name(type_ref: &TypeRef) -> Option<String> {
     match type_ref {
-        TypeRef::Path(path) => path.last_segment().map(std::string::ToString::to_string),
-        TypeRef::Optional(inner) => get_base_type_name(inner),
-        TypeRef::List(inner) => get_base_type_name(inner),
+        TypeRef::Path(path, _) => path.last_segment().map(std::string::ToString::to_string),
+        TypeRef::Optional(inner, _) => get_base_type_name(inner),
+        TypeRef::List(inner, _) => get_base_type_name(inner),
         TypeRef::Generic { base, .. } => get_base_type_name(base),
         _ => None,
     }

--- a/baml_language/crates/baml_compiler_hir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_hir/src/pretty.rs
@@ -495,28 +495,28 @@ pub fn type_ref_to_str(ty: &TypeRef) -> String {
 /// - `((int) -> string)?` vs `(int) -> string?`
 fn type_ref_to_str_impl(ty: &TypeRef, wrap: bool) -> String {
     match ty {
-        TypeRef::Path(path) => path
+        TypeRef::Path(path, _) => path
             .segments
             .iter()
             .map(std::string::ToString::to_string)
             .collect::<Vec<_>>()
             .join("."),
-        TypeRef::Int => "int".to_string(),
-        TypeRef::Float => "float".to_string(),
-        TypeRef::String => "string".to_string(),
-        TypeRef::Bool => "bool".to_string(),
-        TypeRef::Null => "null".to_string(),
-        TypeRef::Media(kind) => kind.to_string(),
-        TypeRef::Optional(inner) => format!("{}?", type_ref_to_str_impl(inner, true)),
-        TypeRef::List(inner) => format!("{}[]", type_ref_to_str_impl(inner, true)),
-        TypeRef::Map { key, value } => {
+        TypeRef::Int { .. } => "int".to_string(),
+        TypeRef::Float { .. } => "float".to_string(),
+        TypeRef::String { .. } => "string".to_string(),
+        TypeRef::Bool { .. } => "bool".to_string(),
+        TypeRef::Null { .. } => "null".to_string(),
+        TypeRef::Media(kind, _) => kind.to_string(),
+        TypeRef::Optional(inner, _) => format!("{}?", type_ref_to_str_impl(inner, true)),
+        TypeRef::List(inner, _) => format!("{}[]", type_ref_to_str_impl(inner, true)),
+        TypeRef::Map { key, value, .. } => {
             format!(
                 "map<{}, {}>",
                 type_ref_to_str_impl(key, false),
                 type_ref_to_str_impl(value, false)
             )
         }
-        TypeRef::Union(types) => {
+        TypeRef::Union(types, _) => {
             let inner = types
                 .iter()
                 .map(|t| type_ref_to_str_impl(t, false))
@@ -524,11 +524,11 @@ fn type_ref_to_str_impl(ty: &TypeRef, wrap: bool) -> String {
                 .join(" | ");
             if wrap { format!("({inner})") } else { inner }
         }
-        TypeRef::StringLiteral(s) => format!("\"{s}\""),
-        TypeRef::IntLiteral(n) => n.to_string(),
-        TypeRef::FloatLiteral(f) => f.clone(),
-        TypeRef::BoolLiteral(b) => b.to_string(),
-        TypeRef::Generic { base, args } => {
+        TypeRef::StringLiteral(s, _) => format!("\"{s}\""),
+        TypeRef::IntLiteral(n, _) => n.to_string(),
+        TypeRef::FloatLiteral(f, _) => f.clone(),
+        TypeRef::BoolLiteral(b, _) => b.to_string(),
+        TypeRef::Generic { base, args, .. } => {
             let args_str = args
                 .iter()
                 .map(|t| type_ref_to_str_impl(t, false))
@@ -536,8 +536,8 @@ fn type_ref_to_str_impl(ty: &TypeRef, wrap: bool) -> String {
                 .join(", ");
             format!("{}<{}>", type_ref_to_str_impl(base, false), args_str)
         }
-        TypeRef::TypeParam(name) => name.to_string(),
-        TypeRef::Function { params, ret } => {
+        TypeRef::TypeParam(name, _) => name.to_string(),
+        TypeRef::Function { params, ret, .. } => {
             let params_str = params
                 .iter()
                 .map(|p| {
@@ -553,10 +553,10 @@ fn type_ref_to_str_impl(ty: &TypeRef, wrap: bool) -> String {
             let inner = format!("({}) -> {}", params_str, type_ref_to_str_impl(ret, false));
             if wrap { format!("({inner})") } else { inner }
         }
-        TypeRef::Error => "<error>".to_string(),
-        TypeRef::Unknown => "<unknown>".to_string(),
-        TypeRef::BuiltinUnknown => "unknown".to_string(),
-        TypeRef::Never => "never".to_string(),
-        TypeRef::Type => "type".to_string(),
+        TypeRef::Error { .. } => "<error>".to_string(),
+        TypeRef::Unknown { .. } => "<unknown>".to_string(),
+        TypeRef::BuiltinUnknown { .. } => "unknown".to_string(),
+        TypeRef::Never { .. } => "never".to_string(),
+        TypeRef::Type { .. } => "type".to_string(),
     }
 }

--- a/baml_language/crates/baml_compiler_hir/src/signature.rs
+++ b/baml_language/crates/baml_compiler_hir/src/signature.rs
@@ -58,7 +58,7 @@ impl FunctionSignature {
                     let type_ref = type_node
                         .as_ref()
                         .map(TypeRef::from_ast)
-                        .unwrap_or(TypeRef::Unknown);
+                        .unwrap_or_else(TypeRef::unknown);
 
                     // Store the spans in the source map
                     source_map.push_param_span(Some(param_node.syntax().text_range()));
@@ -77,7 +77,7 @@ impl FunctionSignature {
         let return_type = return_type_node
             .as_ref()
             .map(TypeRef::from_ast)
-            .unwrap_or(TypeRef::Unknown);
+            .unwrap_or_else(TypeRef::unknown);
 
         // Store return type span in source map
         if let Some(span) = return_type_node.map(|t| t.text_range()) {
@@ -141,7 +141,7 @@ impl TemplateStringSignature {
                     let type_ref = type_node
                         .as_ref()
                         .map(TypeRef::from_ast)
-                        .unwrap_or(TypeRef::Unknown);
+                        .unwrap_or_else(TypeRef::unknown);
 
                     // Store the spans in the source map
                     source_map.push_param_span(Some(param_node.syntax().text_range()));

--- a/baml_language/crates/baml_compiler_hir/src/type_ref.rs
+++ b/baml_language/crates/baml_compiler_hir/src/type_ref.rs
@@ -3,8 +3,8 @@
 //! These are type references before name resolution.
 //! `TypeRef` -> Ty happens during THIR construction.
 
-use baml_base::Name;
-use baml_compiler_syntax::TypePostFixModifier;
+use baml_base::{Name, TyAttr};
+use baml_compiler_syntax::ast::TypePostFixModifier;
 use rowan::ast::AstNode;
 
 use crate::path::Path;
@@ -36,41 +36,58 @@ impl FunctionTypeParamRef {
     }
 }
 
-/// A type reference before name resolution.
+/// A type reference before name resolution — with type-level attributes on every variant.
+///
+/// Every variant carries a `TyAttr` (or trailing `TyAttr` for tuple variants),
+/// matching the convention used by `baml_type::Ty` and `baml_compiler_tir::Ty`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypeRef {
+    // --- Named types ---
     /// Named type (with path for future module support).
     /// Examples:
-    ///   `Path::single("User`") -> User
-    ///   `Path::new`(`["users", "User"]`) -> `users::User` (future)
-    Path(Path),
+    ///   `Path::single("User")` -> User
+    ///   `Path::new(["users", "User"])` -> `users::User` (future)
+    Path(Path, TyAttr),
 
-    /// Primitive types (no resolution needed).
-    Int,
-    Float,
-    String,
-    Bool,
-    Null,
+    // --- Primitives ---
+    Int {
+        attr: TyAttr,
+    },
+    Float {
+        attr: TyAttr,
+    },
+    String {
+        attr: TyAttr,
+    },
+    Bool {
+        attr: TyAttr,
+    },
+    Null {
+        attr: TyAttr,
+    },
 
-    Media(baml_base::MediaKind),
+    // --- Media ---
+    Media(baml_base::MediaKind, TyAttr),
 
-    /// Type constructors.
-    Optional(Box<TypeRef>),
-    List(Box<TypeRef>),
+    // --- Type constructors ---
+    Optional(Box<TypeRef>, TyAttr),
+    List(Box<TypeRef>, TyAttr),
     Map {
         key: Box<TypeRef>,
         value: Box<TypeRef>,
+        attr: TyAttr,
     },
-    Union(Vec<TypeRef>),
+    Union(Vec<TypeRef>, TyAttr),
 
-    /// Literal types in unions.
-    StringLiteral(String),
-    IntLiteral(i64),
+    // --- Literals ---
+    StringLiteral(String, TyAttr),
+    IntLiteral(i64, TyAttr),
     /// Float literal stored as string to avoid f64's lack of Eq/Hash.
-    FloatLiteral(String),
+    FloatLiteral(String, TyAttr),
     /// Boolean literal for pattern matching (true/false as types).
-    BoolLiteral(bool),
+    BoolLiteral(bool, TyAttr),
 
+    // --- Function types ---
     /// Function type: `(x: int, y: int) -> bool` or `(int, int) -> bool`.
     ///
     /// Parameter names are optional and for documentation only - they do not
@@ -78,61 +95,206 @@ pub enum TypeRef {
     Function {
         params: Vec<FunctionTypeParamRef>,
         ret: Box<TypeRef>,
+        attr: TyAttr,
     },
 
+    // --- Future ---
     /// Future: Generic type application.
     /// Example: Result<User, string>
     #[allow(dead_code)]
     Generic {
         base: Box<TypeRef>,
         args: Vec<TypeRef>,
+        attr: TyAttr,
     },
-
     /// Future: Type parameter reference.
     /// Example: T in `function<T>(x: T) -> T`
     #[allow(dead_code)]
-    TypeParam(Name),
+    TypeParam(Name, TyAttr),
 
+    // --- Sentinels ---
     /// Error sentinel.
-    Error,
-
+    Error {
+        attr: TyAttr,
+    },
     /// Unknown/inferred (internal use for error recovery).
-    Unknown,
-
+    Unknown {
+        attr: TyAttr,
+    },
     /// The `unknown` type keyword - accepts any value.
     /// Used in builtin functions like `render_prompt(args: map<string, unknown>)`.
     /// Maps to `Ty::BuiltinUnknown` in TIR.
-    BuiltinUnknown,
-
+    BuiltinUnknown {
+        attr: TyAttr,
+    },
     /// The bottom type — uninhabited (no values).
     /// Maps to `tir::Ty::Never` during lowering.
-    Never,
-
+    Never {
+        attr: TyAttr,
+    },
     /// The `type` type keyword — the meta-type for type values.
     /// Used in type annotations like `let t: type = ...`.
     /// Maps to `tir::Ty::Type` during lowering.
-    Type,
+    Type {
+        attr: TyAttr,
+    },
 }
 
 impl TypeRef {
+    // --- TyAttr accessors ---
+
+    /// Get the `TyAttr` for this type reference.
+    pub fn attr(&self) -> &TyAttr {
+        match self {
+            TypeRef::Int { attr }
+            | TypeRef::Float { attr }
+            | TypeRef::String { attr }
+            | TypeRef::Bool { attr }
+            | TypeRef::Null { attr }
+            | TypeRef::Error { attr }
+            | TypeRef::Unknown { attr }
+            | TypeRef::BuiltinUnknown { attr }
+            | TypeRef::Never { attr }
+            | TypeRef::Type { attr }
+            | TypeRef::Map { attr, .. }
+            | TypeRef::Function { attr, .. }
+            | TypeRef::Generic { attr, .. } => attr,
+            TypeRef::Path(_, attr)
+            | TypeRef::Media(_, attr)
+            | TypeRef::Optional(_, attr)
+            | TypeRef::List(_, attr)
+            | TypeRef::Union(_, attr)
+            | TypeRef::StringLiteral(_, attr)
+            | TypeRef::IntLiteral(_, attr)
+            | TypeRef::FloatLiteral(_, attr)
+            | TypeRef::BoolLiteral(_, attr)
+            | TypeRef::TypeParam(_, attr) => attr,
+        }
+    }
+
+    /// Replace the `TyAttr` on this type reference, returning a new `TypeRef`.
+    /// Short-circuits if the attr is default.
+    #[must_use]
+    pub fn with_attr(self, attr: TyAttr) -> Self {
+        if attr.is_default() {
+            return self;
+        }
+        match self {
+            TypeRef::Int { .. } => TypeRef::Int { attr },
+            TypeRef::Float { .. } => TypeRef::Float { attr },
+            TypeRef::String { .. } => TypeRef::String { attr },
+            TypeRef::Bool { .. } => TypeRef::Bool { attr },
+            TypeRef::Null { .. } => TypeRef::Null { attr },
+            TypeRef::Error { .. } => TypeRef::Error { attr },
+            TypeRef::Unknown { .. } => TypeRef::Unknown { attr },
+            TypeRef::BuiltinUnknown { .. } => TypeRef::BuiltinUnknown { attr },
+            TypeRef::Never { .. } => TypeRef::Never { attr },
+            TypeRef::Type { .. } => TypeRef::Type { attr },
+            TypeRef::Path(p, _) => TypeRef::Path(p, attr),
+            TypeRef::Media(kind, _) => TypeRef::Media(kind, attr),
+            TypeRef::Optional(inner, _) => TypeRef::Optional(inner, attr),
+            TypeRef::List(inner, _) => TypeRef::List(inner, attr),
+            TypeRef::Union(members, _) => TypeRef::Union(members, attr),
+            TypeRef::StringLiteral(s, _) => TypeRef::StringLiteral(s, attr),
+            TypeRef::IntLiteral(i, _) => TypeRef::IntLiteral(i, attr),
+            TypeRef::FloatLiteral(f, _) => TypeRef::FloatLiteral(f, attr),
+            TypeRef::BoolLiteral(b, _) => TypeRef::BoolLiteral(b, attr),
+            TypeRef::TypeParam(n, _) => TypeRef::TypeParam(n, attr),
+            TypeRef::Map { key, value, .. } => TypeRef::Map { key, value, attr },
+            TypeRef::Function { params, ret, .. } => TypeRef::Function { params, ret, attr },
+            TypeRef::Generic { base, args, .. } => TypeRef::Generic { base, args, attr },
+        }
+    }
+
+    // ── Convenience constructors (default attr) ──
+
+    pub fn int() -> Self {
+        TypeRef::Int {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn float() -> Self {
+        TypeRef::Float {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn string() -> Self {
+        TypeRef::String {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn bool_() -> Self {
+        TypeRef::Bool {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn null() -> Self {
+        TypeRef::Null {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn never() -> Self {
+        TypeRef::Never {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn error() -> Self {
+        TypeRef::Error {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn unknown() -> Self {
+        TypeRef::Unknown {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn builtin_unknown() -> Self {
+        TypeRef::BuiltinUnknown {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn type_() -> Self {
+        TypeRef::Type {
+            attr: TyAttr::default(),
+        }
+    }
+    pub fn media(kind: baml_base::MediaKind) -> Self {
+        TypeRef::Media(kind, TyAttr::default())
+    }
+    pub fn path(p: Path) -> Self {
+        TypeRef::Path(p, TyAttr::default())
+    }
+    pub fn string_literal(s: String) -> Self {
+        TypeRef::StringLiteral(s, TyAttr::default())
+    }
+    pub fn int_literal(i: i64) -> Self {
+        TypeRef::IntLiteral(i, TyAttr::default())
+    }
+    pub fn float_literal(f: String) -> Self {
+        TypeRef::FloatLiteral(f, TyAttr::default())
+    }
+    pub fn bool_literal(b: bool) -> Self {
+        TypeRef::BoolLiteral(b, TyAttr::default())
+    }
+
     /// Create a simple named type reference.
     pub fn named(name: Name) -> Self {
-        TypeRef::Path(Path::single(name))
+        Self::path(Path::single(name))
     }
 
     /// Create an optional type.
     pub fn optional(inner: TypeRef) -> Self {
-        TypeRef::Optional(Box::new(inner))
+        TypeRef::Optional(Box::new(inner), TyAttr::default())
     }
 
     /// Create a list type.
     pub fn list(inner: TypeRef) -> Self {
-        TypeRef::List(Box::new(inner))
+        TypeRef::List(Box::new(inner), TyAttr::default())
     }
 
     /// Create a union type.
     pub fn union(types: Vec<TypeRef>) -> Self {
-        TypeRef::Union(types)
+        TypeRef::Union(types, TyAttr::default())
     }
 
     /// Create a `TypeRef` from an AST `TypeExpr` node.
@@ -150,9 +312,8 @@ impl TypeRef {
         if type_expr.is_union() {
             let member_parts = type_expr.union_member_parts();
             let members: Vec<TypeRef> = member_parts.iter().map(Self::from_union_member).collect();
-            return TypeRef::Union(members);
+            return Self::union(members);
         }
-
         // Handle function types like `(x: int, y: int) -> bool`
         if type_expr.is_function_type() {
             let params = type_expr
@@ -163,17 +324,18 @@ impl TypeRef {
                     let ty = p
                         .ty()
                         .map(|t| Self::from_ast(&t))
-                        .unwrap_or(TypeRef::Unknown);
+                        .unwrap_or_else(Self::unknown);
                     FunctionTypeParamRef { name, ty }
                 })
                 .collect();
             let ret = type_expr
                 .function_return_type()
                 .map(|t| Self::from_ast(&t))
-                .unwrap_or(TypeRef::Unknown);
+                .unwrap_or_else(Self::unknown);
             return TypeRef::Function {
                 params,
                 ret: Box::new(ret),
+                attr: TyAttr::default(),
             };
         }
 
@@ -196,7 +358,7 @@ impl TypeRef {
                     .map(|t| Self::from_ast(&t))
                     .collect();
                 if !members.is_empty() {
-                    return TypeRef::Union(members);
+                    return Self::union(members);
                 }
             }
         }
@@ -208,17 +370,17 @@ impl TypeRef {
     fn from_ast_base_type(type_expr: &baml_compiler_syntax::ast::TypeExpr) -> Self {
         // Check for string literal types like `"user"`
         if let Some(s) = type_expr.string_literal() {
-            return TypeRef::StringLiteral(s);
+            return Self::string_literal(s);
         }
 
         // Check for integer literal types like `200`
         if let Some(i) = type_expr.integer_literal() {
-            return TypeRef::IntLiteral(i);
+            return Self::int_literal(i);
         }
 
         // Check for boolean literal types
         if let Some(b) = type_expr.bool_literal() {
-            return TypeRef::BoolLiteral(b);
+            return Self::bool_literal(b);
         }
 
         // Check for map type with type args
@@ -231,6 +393,7 @@ impl TypeRef {
                     return TypeRef::Map {
                         key: Box::new(key),
                         value: Box::new(value),
+                        attr: TyAttr::default(),
                     };
                 }
             }
@@ -239,7 +402,7 @@ impl TypeRef {
             return Self::from_type_name(&name);
         }
 
-        TypeRef::Unknown
+        Self::unknown()
     }
 
     /// Parse a union member from its structured parts (tokens and child nodes).
@@ -248,9 +411,8 @@ impl TypeRef {
     fn from_union_member(parts: &baml_compiler_syntax::ast::UnionMemberParts) -> Self {
         // Check for parenthesized type first (e.g., `(int | string)` in `A | (int | string)`)
         if let Some(type_expr) = parts.type_expr() {
-            let inner = Self::from_ast(&type_expr);
-            // Apply array and optional modifiers from tokens
-            return Self::apply_modifiers(inner, &parts.postfix_modifiers());
+            let base = Self::from_ast(&type_expr);
+            return Self::apply_modifiers(base, &parts.postfix_modifiers());
         }
 
         // Check for FUNCTION_TYPE_PARAM child (new parser structure for parenthesized types)
@@ -263,21 +425,21 @@ impl TypeRef {
             {
                 if let Some(type_expr) = baml_compiler_syntax::ast::TypeExpr::cast(inner_type_expr)
                 {
-                    let inner = Self::from_ast(&type_expr);
-                    return Self::apply_modifiers(inner, &parts.postfix_modifiers());
+                    let base = Self::from_ast(&type_expr);
+                    return Self::apply_modifiers(base, &parts.postfix_modifiers());
                 }
             }
         }
 
         // Check for string literal (e.g., `"user"` in `"user" | "admin"`)
         if let Some(s) = parts.string_literal() {
-            let base = TypeRef::StringLiteral(s);
+            let base = Self::string_literal(s);
             return Self::apply_modifiers(base, &parts.postfix_modifiers());
         }
 
         // Check for integer literal (e.g., `200` in `200 | 201`)
         if let Some(i) = parts.integer_literal() {
-            let base = TypeRef::IntLiteral(i);
+            let base = Self::int_literal(i);
             return Self::apply_modifiers(base, &parts.postfix_modifiers());
         }
 
@@ -298,6 +460,7 @@ impl TypeRef {
                         let base = TypeRef::Map {
                             key: Box::new(key),
                             value: Box::new(value),
+                            attr: TyAttr::default(),
                         };
                         return Self::apply_modifiers(base, &parts.postfix_modifiers());
                     }
@@ -306,14 +469,14 @@ impl TypeRef {
 
             // Check for boolean literals
             let base = match name.as_str() {
-                "true" => TypeRef::BoolLiteral(true),
-                "false" => TypeRef::BoolLiteral(false),
+                "true" => Self::bool_literal(true),
+                "false" => Self::bool_literal(false),
                 _ => Self::from_type_name(&name),
             };
             return Self::apply_modifiers(base, &parts.postfix_modifiers());
         }
 
-        TypeRef::Unknown
+        Self::unknown()
     }
 
     /// Apply postfix modifiers (`[]` and `?`) to a base type, innermost first.
@@ -322,10 +485,10 @@ impl TypeRef {
         for modifier in modifiers {
             match modifier {
                 TypePostFixModifier::Optional => {
-                    result = TypeRef::Optional(Box::new(result));
+                    result = Self::optional(result);
                 }
                 TypePostFixModifier::Array => {
-                    result = TypeRef::List(Box::new(result));
+                    result = Self::list(result);
                 }
             }
         }
@@ -338,24 +501,24 @@ impl TypeRef {
         // This ensures that `Unknown` is treated as a user-defined type name,
         // not as the `unknown` builtin keyword.
         match name {
-            "int" => TypeRef::Int,
-            "float" => TypeRef::Float,
-            "string" => TypeRef::String,
-            "bool" => TypeRef::Bool,
-            "null" => TypeRef::Null,
-            "unknown" => TypeRef::BuiltinUnknown,
-            "never" => TypeRef::Never,
-            "type" => TypeRef::Type,
-            "image" => TypeRef::Media(baml_base::MediaKind::Image),
-            "audio" => TypeRef::Media(baml_base::MediaKind::Audio),
-            "video" => TypeRef::Media(baml_base::MediaKind::Video),
-            "pdf" => TypeRef::Media(baml_base::MediaKind::Pdf),
+            "int" => Self::int(),
+            "float" => Self::float(),
+            "string" => Self::string(),
+            "bool" => Self::bool_(),
+            "null" => Self::null(),
+            "unknown" => Self::builtin_unknown(),
+            "never" => Self::never(),
+            "type" => Self::type_(),
+            "image" => Self::media(baml_base::MediaKind::Image),
+            "audio" => Self::media(baml_base::MediaKind::Audio),
+            "video" => Self::media(baml_base::MediaKind::Video),
+            "pdf" => Self::media(baml_base::MediaKind::Pdf),
             _ => {
                 if name.contains('.') {
                     let segments: Vec<Name> = name.split('.').map(Name::new).collect();
-                    TypeRef::Path(Path::new(segments))
+                    Self::path(Path::new(segments))
                 } else {
-                    TypeRef::Path(Path::single(Name::new(name)))
+                    Self::path(Path::single(Name::new(name)))
                 }
             }
         }

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -2497,7 +2497,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                             })
                             .collect();
 
-                        // Phase 3: Re-check arguments with expected types (bidirectional checking)
+                        // Re-check arguments with expected types (bidirectional checking)
                         // This allows empty maps/arrays to pick up their expected types
                         let arg_types_with_spans: Vec<(Ty, Option<ErrorLocation>)> = args
                             .iter()
@@ -3504,24 +3504,24 @@ fn lower_throws_to_facts(
 
     let mut facts = BTreeSet::new();
     match type_ref {
-        TypeRef::Int => {
+        TypeRef::Int { .. } => {
             facts.insert("int".into());
         }
-        TypeRef::Float => {
+        TypeRef::Float { .. } => {
             facts.insert("float".into());
         }
-        TypeRef::String => {
+        TypeRef::String { .. } => {
             facts.insert("string".into());
         }
-        TypeRef::Bool => {
+        TypeRef::Bool { .. } => {
             facts.insert("bool".into());
         }
-        TypeRef::Null => {
+        TypeRef::Null { .. } => {
             facts.insert("null".into());
         }
-        TypeRef::Never => {}
+        TypeRef::Never { .. } => {}
 
-        TypeRef::Path(path) => match path.segments.len() {
+        TypeRef::Path(path, _) => match path.segments.len() {
             1 => {
                 let name = &path.segments[0];
                 if enum_names.contains_key(name) {
@@ -3559,7 +3559,7 @@ fn lower_throws_to_facts(
             }
         },
 
-        TypeRef::Union(members) => {
+        TypeRef::Union(members, _) => {
             for m in members {
                 facts.extend(lower_throws_to_facts(
                     m,
@@ -3570,7 +3570,7 @@ fn lower_throws_to_facts(
             }
         }
 
-        TypeRef::Optional(inner) => {
+        TypeRef::Optional(inner, _) => {
             facts.insert("null".into());
             facts.extend(lower_throws_to_facts(
                 inner,
@@ -3580,16 +3580,16 @@ fn lower_throws_to_facts(
             ));
         }
 
-        TypeRef::StringLiteral(_) => {
+        TypeRef::StringLiteral(..) => {
             facts.insert("string".into());
         }
-        TypeRef::IntLiteral(_) => {
+        TypeRef::IntLiteral(..) => {
             facts.insert("int".into());
         }
-        TypeRef::FloatLiteral(_) => {
+        TypeRef::FloatLiteral(..) => {
             facts.insert("float".into());
         }
-        TypeRef::BoolLiteral(_) => {
+        TypeRef::BoolLiteral(..) => {
             facts.insert("bool".into());
         }
 
@@ -4229,8 +4229,8 @@ fn validate_catch_binding_type(
     if let Pattern::TypedBinding { ty, .. } = pattern {
         use baml_compiler_hir::TypeRef;
         let banned_name = match ty {
-            TypeRef::BuiltinUnknown => Some("unknown"),
-            TypeRef::Path(path)
+            TypeRef::BuiltinUnknown { .. } => Some("unknown"),
+            TypeRef::Path(path, _)
                 if path.is_simple()
                     && path.first_segment().map(baml_base::Name::as_str) == Some("any") =>
             {

--- a/baml_language/crates/baml_compiler_tir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lower.rs
@@ -87,22 +87,20 @@ impl<'a> TypeLoweringContextResolved<'a> {
         self.type_alias_names.contains(name)
     }
 
-    fn unknown_type_error(&mut self, name: &Name) -> Ty {
+    fn unknown_type_error(&mut self, name: &Name, attr: TyAttr) -> Ty {
         self.errors.push(TypeError::UnknownType {
             name: name.to_string(),
             location: self.current_location(),
         });
-        Ty::Error {
-            attr: TyAttr::default(),
-        }
+        Ty::Error { attr }
     }
 
-    fn resolve_name(&self, name: &Name) -> Option<Ty> {
+    fn resolve_name(&self, name: &Name, attr: &TyAttr) -> Option<Ty> {
         if let Some(qn) = self.class_names.get(name) {
-            return Some(Ty::Class(qn.clone(), TyAttr::default()));
+            return Some(Ty::Class(qn.clone(), attr.clone()));
         }
         if let Some(qn) = self.enum_names.get(name) {
-            return Some(Ty::Enum(qn.clone(), TyAttr::default()));
+            return Some(Ty::Enum(qn.clone(), attr.clone()));
         }
         None
     }
@@ -115,44 +113,34 @@ fn lower_type_ref_resolved_with_ctx(
 ) -> Ty {
     match type_ref {
         // Primitives
-        TypeRef::Int => Ty::Int {
-            attr: TyAttr::default(),
-        },
-        TypeRef::Float => Ty::Float {
-            attr: TyAttr::default(),
-        },
-        TypeRef::String => Ty::String {
-            attr: TyAttr::default(),
-        },
-        TypeRef::Bool => Ty::Bool {
-            attr: TyAttr::default(),
-        },
-        TypeRef::Null => Ty::Null {
-            attr: TyAttr::default(),
-        },
+        TypeRef::Int { attr } => Ty::Int { attr: attr.clone() },
+        TypeRef::Float { attr } => Ty::Float { attr: attr.clone() },
+        TypeRef::String { attr } => Ty::String { attr: attr.clone() },
+        TypeRef::Bool { attr } => Ty::Bool { attr: attr.clone() },
+        TypeRef::Null { attr } => Ty::Null { attr: attr.clone() },
 
         // Media types
-        TypeRef::Media(kind) => Ty::Media(*kind, TyAttr::default()),
+        TypeRef::Media(kind, attr) => Ty::Media(*kind, attr.clone()),
 
         // Named type via path
-        TypeRef::Path(path) => lower_path_type_resolved_with_ctx(ctx, path),
+        TypeRef::Path(path, attr) => lower_path_type_resolved_with_ctx(ctx, path, attr.clone()),
 
         // Type constructors - track path for error location
-        TypeRef::Optional(inner) => {
+        TypeRef::Optional(inner, attr) => {
             ctx.current_path.push(0); // Optional inner is at index 0
             let inner_ty = lower_type_ref_resolved_with_ctx(ctx, inner);
             ctx.current_path.pop();
-            Ty::Optional(Box::new(inner_ty), TyAttr::default())
+            Ty::Optional(Box::new(inner_ty), attr.clone())
         }
 
-        TypeRef::List(inner) => {
+        TypeRef::List(inner, attr) => {
             ctx.current_path.push(0); // List element is at index 0
             let inner_ty = lower_type_ref_resolved_with_ctx(ctx, inner);
             ctx.current_path.pop();
-            Ty::List(Box::new(inner_ty), TyAttr::default())
+            Ty::List(Box::new(inner_ty), attr.clone())
         }
 
-        TypeRef::Map { key, value } => {
+        TypeRef::Map { key, value, attr } => {
             ctx.current_path.push(0); // Map key is at index 0
             let key_ty = lower_type_ref_resolved_with_ctx(ctx, key);
             ctx.current_path.pop();
@@ -164,11 +152,11 @@ fn lower_type_ref_resolved_with_ctx(
             Ty::Map {
                 key: Box::new(key_ty),
                 value: Box::new(value_ty),
-                attr: TyAttr::default(),
+                attr: attr.clone(),
             }
         }
 
-        TypeRef::Union(types) => {
+        TypeRef::Union(types, attr) => {
             let tys: Vec<Ty> = types
                 .iter()
                 .enumerate()
@@ -179,18 +167,18 @@ fn lower_type_ref_resolved_with_ctx(
                     ty
                 })
                 .collect();
-            normalize_union(tys)
+            normalize_union(tys, attr.clone())
         }
 
-        TypeRef::StringLiteral(s) => {
-            Ty::Literal(LiteralValue::String(s.clone()), TyAttr::default())
+        TypeRef::StringLiteral(s, attr) => {
+            Ty::Literal(LiteralValue::String(s.clone()), attr.clone())
         }
-        TypeRef::IntLiteral(i) => Ty::Literal(LiteralValue::Int(*i), TyAttr::default()),
-        TypeRef::FloatLiteral(f) => Ty::Literal(LiteralValue::Float(f.clone()), TyAttr::default()),
-        TypeRef::BoolLiteral(b) => Ty::Literal(LiteralValue::Bool(*b), TyAttr::default()),
+        TypeRef::IntLiteral(i, attr) => Ty::Literal(LiteralValue::Int(*i), attr.clone()),
+        TypeRef::FloatLiteral(f, attr) => Ty::Literal(LiteralValue::Float(f.clone()), attr.clone()),
+        TypeRef::BoolLiteral(b, attr) => Ty::Literal(LiteralValue::Bool(*b), attr.clone()),
 
         // Function types: (x: int, y: int) -> bool
-        TypeRef::Function { params, ret } => {
+        TypeRef::Function { params, ret, attr } => {
             let param_tys: Vec<(Option<Name>, Ty)> = params
                 .iter()
                 .enumerate()
@@ -207,40 +195,26 @@ fn lower_type_ref_resolved_with_ctx(
             Ty::Function {
                 params: param_tys,
                 ret: Box::new(ret_ty),
-                attr: TyAttr::default(),
+                attr: attr.clone(),
             }
         }
 
         // Generics - not yet supported
-        TypeRef::Generic { .. } => Ty::Unknown {
-            attr: TyAttr::default(),
-        },
-        TypeRef::TypeParam(_) => Ty::Unknown {
-            attr: TyAttr::default(),
-        },
+        TypeRef::Generic { attr, .. } => Ty::Unknown { attr: attr.clone() },
+        TypeRef::TypeParam(_, attr) => Ty::Unknown { attr: attr.clone() },
 
         // Error/Unknown
-        TypeRef::Error => Ty::Error {
-            attr: TyAttr::default(),
-        },
-        TypeRef::Unknown => Ty::Unknown {
-            attr: TyAttr::default(),
-        },
+        TypeRef::Error { attr } => Ty::Error { attr: attr.clone() },
+        TypeRef::Unknown { attr } => Ty::Unknown { attr: attr.clone() },
 
         // BuiltinUnknown - the `unknown` type keyword for builtin functions
-        TypeRef::BuiltinUnknown => Ty::BuiltinUnknown {
-            attr: TyAttr::default(),
-        },
+        TypeRef::BuiltinUnknown { attr } => Ty::BuiltinUnknown { attr: attr.clone() },
 
         // Never - the bottom type
-        TypeRef::Never => Ty::Never {
-            attr: TyAttr::default(),
-        },
+        TypeRef::Never { attr } => Ty::Never { attr: attr.clone() },
 
         // Type - the `type` keyword for the meta-type
-        TypeRef::Type => Ty::Type {
-            attr: TyAttr::default(),
-        },
+        TypeRef::Type { attr } => Ty::Type { attr: attr.clone() },
     }
 }
 
@@ -248,58 +222,44 @@ fn lower_type_ref_resolved_with_ctx(
 fn lower_path_type_resolved_with_ctx(
     ctx: &mut TypeLoweringContextResolved<'_>,
     path: &baml_compiler_hir::Path,
+    attr: TyAttr,
 ) -> Ty {
     match path.segments.len() {
         1 => {
             let name = &path.segments[0];
             match name.as_str() {
                 // Primitive type names
-                "int" => Ty::Int {
-                    attr: TyAttr::default(),
-                },
-                "float" => Ty::Float {
-                    attr: TyAttr::default(),
-                },
-                "string" => Ty::String {
-                    attr: TyAttr::default(),
-                },
-                "bool" => Ty::Bool {
-                    attr: TyAttr::default(),
-                },
-                "null" => Ty::Null {
-                    attr: TyAttr::default(),
-                },
-                "image" => Ty::Media(baml_base::MediaKind::Image, TyAttr::default()),
-                "audio" => Ty::Media(baml_base::MediaKind::Audio, TyAttr::default()),
-                "video" => Ty::Media(baml_base::MediaKind::Video, TyAttr::default()),
-                "pdf" => Ty::Media(baml_base::MediaKind::Pdf, TyAttr::default()),
+                "int" => Ty::Int { attr },
+                "float" => Ty::Float { attr },
+                "string" => Ty::String { attr },
+                "bool" => Ty::Bool { attr },
+                "null" => Ty::Null { attr },
+                "image" => Ty::Media(baml_base::MediaKind::Image, attr),
+                "audio" => Ty::Media(baml_base::MediaKind::Audio, attr),
+                "video" => Ty::Media(baml_base::MediaKind::Video, attr),
+                "pdf" => Ty::Media(baml_base::MediaKind::Pdf, attr),
                 // map with wrong arity - the arity error is already reported by HIR,
                 // so we don't report an unknown type error here
-                "map" => Ty::Error {
-                    attr: TyAttr::default(),
-                },
+                "map" => Ty::Error { attr },
                 // User-defined type - resolve to Class/Enum or validate
                 _ => {
                     use baml_compiler_hir::QualifiedName;
 
                     // Skip validation for complex type expressions
                     if !is_simple_type_name(name.as_str()) {
-                        return Ty::TypeAlias(
-                            QualifiedName::local(name.clone()),
-                            TyAttr::default(),
-                        );
+                        return Ty::TypeAlias(QualifiedName::local(name.clone()), attr);
                     }
 
                     // Try to resolve to Class/Enum
-                    if let Some(resolved) = ctx.resolve_name(name) {
+                    if let Some(resolved) = ctx.resolve_name(name, &attr) {
                         return resolved;
                     }
 
                     // Check if it's a type alias
                     if ctx.is_type_alias_name(name) {
-                        Ty::TypeAlias(QualifiedName::local(name.clone()), TyAttr::default())
+                        Ty::TypeAlias(QualifiedName::local(name.clone()), attr)
                     } else {
-                        ctx.unknown_type_error(name)
+                        ctx.unknown_type_error(name, attr)
                     }
                 }
             }
@@ -316,18 +276,18 @@ fn lower_path_type_resolved_with_ctx(
             let name = Name::new(&full_path);
 
             if !is_simple_type_name(&full_path) {
-                return Ty::TypeAlias(QualifiedName::local(name), TyAttr::default());
+                return Ty::TypeAlias(QualifiedName::local(name), attr);
             }
 
             // Resolve as class/enum (builtin types like "baml.http.Request" are in class_names)
-            if let Some(resolved) = ctx.resolve_name(&name) {
+            if let Some(resolved) = ctx.resolve_name(&name, &attr) {
                 return resolved;
             }
 
             if ctx.is_type_alias_name(&name) {
-                Ty::TypeAlias(QualifiedName::local(name), TyAttr::default())
+                Ty::TypeAlias(QualifiedName::local(name), attr)
             } else {
-                ctx.unknown_type_error(&name)
+                ctx.unknown_type_error(&name, attr)
             }
         }
     }
@@ -357,7 +317,7 @@ fn is_simple_type_name(name: &str) -> bool {
 /// Uses `TyAttr::default()` for the output union because this is only called during
 /// type lowering from `TypeRef` syntax nodes, which construct fresh types rather than
 /// transforming existing ones — there is no source `TyAttr` to preserve.
-fn normalize_union(types: Vec<Ty>) -> Ty {
+fn normalize_union(types: Vec<Ty>, attr: TyAttr) -> Ty {
     let mut normalized = Vec::new();
 
     for ty in types {
@@ -381,11 +341,9 @@ fn normalize_union(types: Vec<Ty>) -> Ty {
 
     // Simplify
     match normalized.len() {
-        0 => Ty::Unknown {
-            attr: TyAttr::default(),
-        }, // Empty union becomes Unknown (could be Never in a more complete type system)
+        0 => Ty::Unknown { attr }, // Empty union becomes Unknown (could be Never in a more complete type system)
         1 => normalized.pop().unwrap(),
-        _ => Ty::Union(normalized, TyAttr::default()),
+        _ => Ty::Union(normalized, attr),
     }
 }
 
@@ -399,23 +357,26 @@ mod tests {
 
     #[test]
     fn test_normalize_union_empty() {
-        let result = normalize_union(vec![]);
+        let result = normalize_union(vec![], d());
         assert_eq!(result, Ty::Unknown { attr: d() });
     }
 
     #[test]
     fn test_normalize_union_single() {
-        let result = normalize_union(vec![Ty::Int { attr: d() }]);
+        let result = normalize_union(vec![Ty::Int { attr: d() }], d());
         assert_eq!(result, Ty::Int { attr: d() });
     }
 
     #[test]
     fn test_normalize_union_removes_duplicates() {
-        let result = normalize_union(vec![
-            Ty::Int { attr: d() },
-            Ty::String { attr: d() },
-            Ty::Int { attr: d() },
-        ]);
+        let result = normalize_union(
+            vec![
+                Ty::Int { attr: d() },
+                Ty::String { attr: d() },
+                Ty::Int { attr: d() },
+            ],
+            d(),
+        );
         assert_eq!(
             result,
             Ty::Union(vec![Ty::Int { attr: d() }, Ty::String { attr: d() }], d())
@@ -425,7 +386,7 @@ mod tests {
     #[test]
     fn test_normalize_union_flattens() {
         let inner = Ty::Union(vec![Ty::Int { attr: d() }, Ty::Float { attr: d() }], d());
-        let result = normalize_union(vec![inner, Ty::String { attr: d() }]);
+        let result = normalize_union(vec![inner, Ty::String { attr: d() }], d());
         assert_eq!(
             result,
             Ty::Union(

--- a/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use baml_base::{FieldAttr, Name, Span};
+use baml_base::{Name, Span};
 use baml_compiler_hir::{
     self, Attribute, FunctionBody, ItemId, file_item_tree, file_items, function_body,
     function_signature,
@@ -125,7 +125,7 @@ fn lower_class(
                 description: attr_to_option(&field.description),
                 alias: attr_to_option(&field.alias),
                 skip: attr_to_bool(&field.skip),
-                field_attr: FieldAttr::default(),
+                field_attr: field.field_attr.clone(),
             }
         })
         .collect();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Types now uniformly carry per-type attribute metadata throughout the compiler, improving attribute propagation and display consistency.
  * Constructors and pattern handling updated so type representations consistently include attribute payloads.
  * Defaulting to unknown types is now lazy to avoid unnecessary work.
  * Field entries expose new streaming-related field attributes, enabling richer field-level metadata to be preserved and surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->