### PR TITLE
Fern Vertex AI Claude docs

### DIFF
--- a/fern/03-reference/baml/clients/providers/vertex.mdx
+++ b/fern/03-reference/baml/clients/providers/vertex.mdx
@@ -516,6 +516,32 @@ client<llm> MyClient {
 }
 ```
 
+  <Accordion title="Gemini Thinking Configuration">
+  
+  For Gemini models (2.5-pro and later), you can enable thinking mode using `thinkingConfig`:
+
+  ```baml BAML
+  client<llm> GeminiThinking {
+    provider vertex-ai
+    options {
+      model gemini-2.5-pro
+      project_id my-project-id
+      location us-central1
+      generationConfig {
+        thinkingConfig {
+          thinkingBudget 1024
+          includeThoughts true
+        }
+      }
+    }
+  }
+  ```
+
+  <Warning>
+    **`thinkingConfig` is only for Gemini models.** For Claude models on Vertex AI, use the `thinking` parameter instead. See [Extended Thinking for Claude on Vertex AI](#extended-thinking-for-claude-on-vertex-ai).
+  </Warning>
+  </Accordion>
+
 </ParamField>
 
 For all other options, see the [official Vertex AI documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/start/quickstarts/quickstart-multimodal).
@@ -529,21 +555,80 @@ Meta, use your project endpoint as the `base_url` in BAML:
 client<llm> VertexLlama {
   provider vertex-ai
   options {
-    base_url "https://${LOCATION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/endpoints/"
+    base_url "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/endpoints/"
     location us-central1
   }
 }
 ```
 
-For anthropic  
+### Anthropic Claude Models on Vertex AI
+
+For Anthropic Claude models, you can use the simplified configuration with `location` and `project_id`:
 
 ```baml
 client<llm> VertexClaudeSonnet {
   provider vertex-ai
   options {
-    model "claude-sonnet-4"
-    anthropic_version "${ANTHROPIC_VERSION}"
-    base_url "https://${LOCATION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/publishers/anthropic/models"
+    model "claude-sonnet-4-5@20250929"
+    location us-east5
+    project_id my-project-id
+    anthropic_version "vertex-2023-10-16"
+    credentials env.GOOGLE_APPLICATION_CREDENTIALS
   }
 }
 ```
+
+<Note>
+  **Claude Model Names on Vertex AI**: Use the format `model-name@version` (e.g., `claude-sonnet-4-5@20250929`).
+  Available models include `claude-sonnet-4`, `claude-opus-4`, `claude-sonnet-4-5`, `claude-opus-4-5`, `claude-sonnet-4-6`, and `claude-opus-4-6`.
+  Check [Google Cloud's Claude documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude) for the latest model names and regional availability.
+</Note>
+
+Alternatively, you can use a custom `base_url` with environment variables:
+
+```baml
+client<llm> VertexClaudeWithBaseUrl {
+  provider vertex-ai
+  options {
+    model "claude-sonnet-4-5@20250929"
+    anthropic_version "vertex-2023-10-16"
+    base_url env.VERTEX_CLAUDE_BASE_URL
+  }
+}
+```
+
+Where `VERTEX_CLAUDE_BASE_URL` would be set to something like:
+```bash
+VERTEX_CLAUDE_BASE_URL="https://us-east5-aiplatform.googleapis.com/v1/projects/your-project-id/locations/us-east5/publishers/anthropic/models"
+```
+
+<Warning>
+  When using a custom `base_url`, do NOT include the model name at the end. BAML will automatically append `/{model}:rawPredict` (or `:streamRawPredict` for streaming) to the base URL.
+</Warning>
+
+### Extended Thinking for Claude on Vertex AI
+
+To enable extended thinking for Claude models on Vertex AI, use the `thinking` parameter:
+
+```baml
+client<llm> VertexClaudeThinking {
+  provider vertex-ai
+  options {
+    model "claude-sonnet-4-5@20250929"
+    location us-east5
+    project_id my-project-id
+    anthropic_version "vertex-2023-10-16"
+    credentials env.GOOGLE_APPLICATION_CREDENTIALS
+    max_tokens 4096
+    thinking {
+      type "enabled"
+      budget_tokens 2048
+    }
+  }
+}
+```
+
+<Note>
+  Extended thinking is available on Claude Sonnet 4.5+, Claude Opus 4.5+, and later models.
+  For Claude Opus 4.6, Anthropic recommends using adaptive thinking (`type: "adaptive"`) with an `effort` parameter instead of manual mode.
+</Note>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number] (Addresses user feedback regarding Vertex AI Claude configuration and documentation inaccuracies.)

## Changes
Please describe the changes proposed in this pull request

This PR updates the Vertex AI provider documentation (`fern/03-reference/baml/clients/providers/vertex.mdx`) to:
- Correct `base_url` examples for Claude models, clarifying the use of `location` and `project_id` or full `env.VAR_NAME` for the URL.
- Add a warning that `base_url` should not include the model name.
- Clarify that `thinkingConfig { includeThoughts: true }` is exclusive to Gemini models.
- Document how to enable extended thinking for Claude models using the `thinking` parameter.
- Add notes on the expected `model-name@version` format for Claude models on Vertex AI.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (Reviewed the updated documentation for clarity and accuracy.)
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

These changes directly address user-reported issues regarding 404 errors with Claude models on Vertex AI due to incorrect `base_url` configurations and confusion around `thinkingConfig` and model naming conventions.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1772778808608209?thread_ts=1772778808.608209&cid=C09F3QMJE9G)

<p><a href="https://cursor.com/agents/bc-ef543eb4-3d73-537f-a1b7-e0897848184f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef543eb4-3d73-537f-a1b7-e0897848184f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->