### PR TITLE
Recursive SpannedTypeExpr for precise type-error diagnostics

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -84,12 +84,96 @@ pub struct FunctionTypeParam {
     pub ty: TypeExpr,
 }
 
+/// Recursive spanned type expression kind — mirrors `TypeExpr` but children
+/// are `SpannedTypeExpr` so every sub-expression carries its own source span.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpannedTypeExprKind {
+    Path(Vec<Name>),
+    Int,
+    Float,
+    String,
+    Bool,
+    Null,
+    Never,
+    Media(baml_base::MediaKind),
+    Optional(Box<SpannedTypeExpr>),
+    List(Box<SpannedTypeExpr>),
+    Map {
+        key: Box<SpannedTypeExpr>,
+        value: Box<SpannedTypeExpr>,
+    },
+    Union(Vec<SpannedTypeExpr>),
+    Literal(baml_base::Literal),
+    Function {
+        params: Vec<SpannedFunctionTypeParam>,
+        ret: Box<SpannedTypeExpr>,
+    },
+    BuiltinUnknown,
+    Type,
+    Rust,
+    Error,
+    Unknown,
+}
+
+/// A parameter in a spanned function type expression.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpannedFunctionTypeParam {
+    pub name: Option<Name>,
+    pub ty: SpannedTypeExpr,
+}
+
 /// A type expression with its source span — used in item definitions
 /// where we need both the type data and the source location.
+///
+/// Recursive: children are also `SpannedTypeExpr`, so every sub-expression
+/// (e.g. each union member) carries its own span for precise diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpannedTypeExpr {
-    pub expr: TypeExpr,
+    pub kind: SpannedTypeExprKind,
     pub span: TextRange,
+}
+
+impl SpannedTypeExpr {
+    /// Recursively strip spans to produce a span-free `TypeExpr` for Salsa queries.
+    pub fn to_type_expr(&self) -> TypeExpr {
+        match &self.kind {
+            SpannedTypeExprKind::Path(segments) => TypeExpr::Path(segments.clone()),
+            SpannedTypeExprKind::Int => TypeExpr::Int,
+            SpannedTypeExprKind::Float => TypeExpr::Float,
+            SpannedTypeExprKind::String => TypeExpr::String,
+            SpannedTypeExprKind::Bool => TypeExpr::Bool,
+            SpannedTypeExprKind::Null => TypeExpr::Null,
+            SpannedTypeExprKind::Never => TypeExpr::Never,
+            SpannedTypeExprKind::Media(kind) => TypeExpr::Media(*kind),
+            SpannedTypeExprKind::Optional(inner) => {
+                TypeExpr::Optional(Box::new(inner.to_type_expr()))
+            }
+            SpannedTypeExprKind::List(inner) => TypeExpr::List(Box::new(inner.to_type_expr())),
+            SpannedTypeExprKind::Map { key, value } => TypeExpr::Map {
+                key: Box::new(key.to_type_expr()),
+                value: Box::new(value.to_type_expr()),
+            },
+            SpannedTypeExprKind::Union(members) => {
+                TypeExpr::Union(members.iter().map(SpannedTypeExpr::to_type_expr).collect())
+            }
+            SpannedTypeExprKind::Literal(lit) => TypeExpr::Literal(lit.clone()),
+            SpannedTypeExprKind::Function { params, ret } => TypeExpr::Function {
+                params: params
+                    .iter()
+                    .map(|p| FunctionTypeParam {
+                        name: p.name.clone(),
+                        ty: p.ty.to_type_expr(),
+                    })
+                    .collect(),
+                ret: Box::new(ret.to_type_expr()),
+            },
+            SpannedTypeExprKind::BuiltinUnknown => TypeExpr::BuiltinUnknown,
+            SpannedTypeExprKind::Type => TypeExpr::Type,
+            SpannedTypeExprKind::Rust => TypeExpr::Rust,
+            SpannedTypeExprKind::Error => TypeExpr::Error,
+            SpannedTypeExprKind::Unknown => TypeExpr::Unknown,
+        }
+    }
 }
 
 // ── Expression Bodies ───────────────────────────────────────────

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -214,6 +214,9 @@ pub struct AstSourceMap {
     pub pattern_spans: Arena<TextRange>,
     pub match_arm_spans: Arena<TextRange>,
     pub type_annotation_spans: Arena<TextRange>,
+    /// Parallel to `type_annotation_spans` — full `SpannedTypeExpr` tree for
+    /// per-node diagnostics (e.g. underline only the bad union member).
+    pub type_annotation_spanned_exprs: Vec<SpannedTypeExpr>,
     pub catch_arm_spans: Arena<TextRange>,
 }
 
@@ -225,6 +228,7 @@ impl AstSourceMap {
             pattern_spans: Arena::new(),
             match_arm_spans: Arena::new(),
             type_annotation_spans: Arena::new(),
+            type_annotation_spanned_exprs: Vec::new(),
             catch_arm_spans: Arena::new(),
         }
     }
@@ -270,6 +274,12 @@ impl AstSourceMap {
             .nth(raw as usize)
             .map(|(_, &span)| span)
             .unwrap_or_default()
+    }
+
+    /// Look up the full `SpannedTypeExpr` for a type annotation (for per-node diagnostics).
+    pub fn type_annotation_spanned(&self, id: TypeAnnotId) -> Option<&SpannedTypeExpr> {
+        let raw: u32 = id.into_raw().into_u32();
+        self.type_annotation_spanned_exprs.get(raw as usize)
     }
 
     /// Look up the source span of a catch arm by its `CatchArmId`.
@@ -398,7 +408,7 @@ pub enum Stmt {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Pattern {
     Binding(Name),
-    TypedBinding { name: Name, ty: TypeExpr },
+    TypedBinding { name: Name, ty: SpannedTypeExpr },
     Literal(Literal),
     Null,
     EnumVariant { enum_name: Name, variant: Name },

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -336,7 +336,7 @@ class Media {
             .expect("expected _data field");
 
         match &field.type_expr {
-            Some(spanned) => match &spanned.expr {
+            Some(spanned) => match spanned.to_type_expr() {
                 TypeExpr::Rust => {}
                 other => panic!("expected TypeExpr::Rust, got {other:?}"),
             },
@@ -446,7 +446,11 @@ class Media {
             assert!(data_field.is_some(), "expected _data field");
             assert!(
                 matches!(
-                    data_field.unwrap().type_expr.as_ref().map(|te| &te.expr),
+                    data_field
+                        .unwrap()
+                        .type_expr
+                        .as_ref()
+                        .map(super::ast::SpannedTypeExpr::to_type_expr),
                     Some(TypeExpr::Rust)
                 ),
                 "_data field should have TypeExpr::Rust"
@@ -467,10 +471,10 @@ function f() -> int throws never {
         let throws = func
             .throws
             .expect("expected throws clause to be lowered into FunctionDef.throws");
+        let throws_te = throws.to_type_expr();
         assert!(
-            matches!(throws.expr, TypeExpr::Never),
-            "expected throws type to lower as TypeExpr::Never, got {:?}",
-            throws.expr
+            matches!(throws_te, TypeExpr::Never),
+            "expected throws type to lower as TypeExpr::Never, got {throws_te:?}"
         );
     }
 

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -23,7 +23,7 @@ mod tests {
     use baml_compiler_syntax::{SyntaxKind, SyntaxNode};
 
     use crate::{
-        ast::{BuiltinKind, Expr, FunctionBodyDef, Item, Stmt, TypeExpr},
+        ast::{BuiltinKind, Expr, FunctionBodyDef, Item, SpannedTypeExprKind, Stmt, TypeExpr},
         lower_cst::lower_file,
     };
 
@@ -471,10 +471,32 @@ function f() -> int throws never {
         let throws = func
             .throws
             .expect("expected throws clause to be lowered into FunctionDef.throws");
-        let throws_te = throws.to_type_expr();
-        assert!(
-            matches!(throws_te, TypeExpr::Never),
-            "expected throws type to lower as TypeExpr::Never, got {throws_te:?}"
+        match throws.to_type_expr() {
+            TypeExpr::Never => {}
+            other => panic!("expected throws type to lower as TypeExpr::Never, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_container_type_has_distinct_spans_per_level() {
+        let source = "function f(x: int[][]) -> int { return 0 }";
+        let items = parse_and_lower(source);
+        let func = first_function(items);
+        let param = func.params.first().expect("one param");
+        let te = param.type_expr.as_ref().expect("param has type annotation");
+        // int[][] lowers to List(List(Int)); outer and inner List should have distinct spans.
+        let SpannedTypeExprKind::List(inner) = &te.kind else {
+            panic!("expected outer List, got {:?}", te.kind);
+        };
+        let SpannedTypeExprKind::List(inner_inner) = &inner.kind else {
+            panic!("expected inner List, got {:?}", inner.kind);
+        };
+        let SpannedTypeExprKind::Int = &inner_inner.kind else {
+            panic!("expected Int, got {:?}", inner_inner.kind);
+        };
+        assert_ne!(
+            te.span, inner.span,
+            "nested container levels should have distinct spans for precise diagnostics"
         );
     }
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -17,8 +17,7 @@ use crate::{
     ast::{
         BuiltinKind, ClientDef, ConfigItemDef, EnumDef, FieldDef, FunctionBodyDef, FunctionDef,
         GeneratorDef, Interpolation, Item, LlmBodyDef, Param, RawAttribute, RawAttributeArg,
-        RawPrompt, RetryPolicyDef, SpannedTypeExpr, TemplateStringDef, TestDef, TypeAliasDef,
-        VariantDef,
+        RawPrompt, RetryPolicyDef, TemplateStringDef, TestDef, TypeAliasDef, VariantDef,
     },
     lower_expr_body, lower_type_expr,
 };
@@ -102,18 +101,14 @@ fn lower_function(node: &SyntaxNode) -> Option<FunctionDef> {
         .map(|pl| lower_params(&pl))
         .unwrap_or_default();
 
-    let return_type = func.return_type().map(|te| SpannedTypeExpr {
-        expr: lower_type_expr::lower_type_expr_node(&te),
-        span: te.syntax().text_range(),
-    });
+    let return_type = func
+        .return_type()
+        .map(|te| lower_type_expr::lower_type_expr_node(&te));
 
     let throws = func
         .throws_clause()
         .and_then(|tc| tc.type_expr())
-        .map(|te| SpannedTypeExpr {
-            expr: lower_type_expr::lower_type_expr_node(&te),
-            span: te.syntax().text_range(),
-        });
+        .map(|te| lower_type_expr::lower_type_expr_node(&te));
 
     let body = if let Some(llm) = func.llm_body() {
         Some(FunctionBodyDef::Llm(lower_llm_body(&llm)))
@@ -182,10 +177,9 @@ fn lower_param(param: &ast::Parameter) -> Option<Param> {
     let name_token = param.name()?;
     Some(Param {
         name: Name::new(name_token.text()),
-        type_expr: param.ty().map(|te| SpannedTypeExpr {
-            expr: lower_type_expr::lower_type_expr_node(&te),
-            span: te.syntax().text_range(),
-        }),
+        type_expr: param
+            .ty()
+            .map(|te| lower_type_expr::lower_type_expr_node(&te)),
         span: param.syntax().text_range(),
         name_span: name_token.text_range(),
     })
@@ -268,10 +262,7 @@ fn lower_class(node: &SyntaxNode) -> Option<crate::ast::ClassDef> {
             let fname = f.name()?;
             Some(FieldDef {
                 name: Name::new(fname.text()),
-                type_expr: f.ty().map(|te| SpannedTypeExpr {
-                    expr: lower_type_expr::lower_type_expr_node(&te),
-                    span: te.syntax().text_range(),
-                }),
+                type_expr: f.ty().map(|te| lower_type_expr::lower_type_expr_node(&te)),
                 attributes: lower_field_attributes(&f),
                 span: f.syntax().text_range(),
                 name_span: fname.text_range(),
@@ -357,10 +348,9 @@ fn lower_type_alias(node: &SyntaxNode) -> Option<TypeAliasDef> {
 
     Some(TypeAliasDef {
         name: Name::new(name_token.text()),
-        type_expr: alias.ty().map(|te| SpannedTypeExpr {
-            expr: lower_type_expr::lower_type_expr_node(&te),
-            span: te.syntax().text_range(),
-        }),
+        type_expr: alias
+            .ty()
+            .map(|te| lower_type_expr::lower_type_expr_node(&te)),
         span: node.text_range(),
         name_span: name_token.text_range(),
     })

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -105,9 +105,10 @@ impl LoweringContext {
         id
     }
 
-    fn alloc_type_annot(&mut self, ty: TypeExpr, range: TextRange) -> TypeAnnotId {
-        let id = self.type_annotations.alloc(ty);
-        self.source_map.type_annotation_spans.alloc(range);
+    fn alloc_type_annot(&mut self, spanned: crate::ast::SpannedTypeExpr) -> TypeAnnotId {
+        let id = self.type_annotations.alloc(spanned.to_type_expr());
+        self.source_map.type_annotation_spans.alloc(spanned.span);
+        self.source_map.type_annotation_spanned_exprs.push(spanned);
         id
     }
 
@@ -585,10 +586,8 @@ impl LoweringContext {
                         if let Some(type_expr) =
                             baml_compiler_syntax::ast::TypeExpr::cast(child.clone())
                         {
-                            let span = child.text_range();
                             let spanned = crate::lower_type_expr::lower_type_expr_node(&type_expr);
-                            scrutinee_type =
-                                Some(self.alloc_type_annot(spanned.to_type_expr(), span));
+                            scrutinee_type = Some(self.alloc_type_annot(spanned));
                         }
                     }
                     _ => {
@@ -781,11 +780,15 @@ impl LoweringContext {
                                 // After `name:`, we expect the type to be a node child (TYPE_EXPR),
                                 // but sometimes parser emits it as a WORD token directly.
                                 // Treat it as a named type.
-                                let pat = Pattern::TypedBinding {
-                                    name,
-                                    ty: crate::ast::TypeExpr::Path(vec![Name::new(&text)]),
+                                let span = token.text_range();
+                                let ty = crate::ast::SpannedTypeExpr {
+                                    kind: crate::ast::SpannedTypeExprKind::Path(vec![Name::new(
+                                        &text,
+                                    )]),
+                                    span,
                                 };
-                                elements.push(self.alloc_pattern(pat, token.text_range()));
+                                let pat = Pattern::TypedBinding { name, ty };
+                                elements.push(self.alloc_pattern(pat, span));
                                 continue;
                             }
 
@@ -895,10 +898,7 @@ impl LoweringContext {
                                 {
                                     let spanned =
                                         crate::lower_type_expr::lower_type_expr_node(&type_expr);
-                                    let pat = Pattern::TypedBinding {
-                                        name,
-                                        ty: spanned.to_type_expr(),
-                                    };
+                                    let pat = Pattern::TypedBinding { name, ty: spanned };
                                     elements.push(self.alloc_pattern(pat, child.text_range()));
                                 }
                             }
@@ -1751,11 +1751,9 @@ impl LoweringContext {
                             if let Some(type_expr) =
                                 baml_compiler_syntax::ast::TypeExpr::cast(child.clone())
                             {
-                                let span = child.text_range();
                                 let spanned =
                                     crate::lower_type_expr::lower_type_expr_node(&type_expr);
-                                type_annotation =
-                                    Some(self.alloc_type_annot(spanned.to_type_expr(), span));
+                                type_annotation = Some(self.alloc_type_annot(spanned));
                                 seen_colon = false;
                             }
                         } else if pattern_id.is_none() {

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -586,8 +586,9 @@ impl LoweringContext {
                             baml_compiler_syntax::ast::TypeExpr::cast(child.clone())
                         {
                             let span = child.text_range();
-                            let ty = crate::lower_type_expr::lower_type_expr_node(&type_expr);
-                            scrutinee_type = Some(self.alloc_type_annot(ty, span));
+                            let spanned = crate::lower_type_expr::lower_type_expr_node(&type_expr);
+                            scrutinee_type =
+                                Some(self.alloc_type_annot(spanned.to_type_expr(), span));
                         }
                     }
                     _ => {
@@ -892,9 +893,12 @@ impl LoweringContext {
                                 if let Some(type_expr) =
                                     baml_compiler_syntax::ast::TypeExpr::cast(child.clone())
                                 {
-                                    let ty =
+                                    let spanned =
                                         crate::lower_type_expr::lower_type_expr_node(&type_expr);
-                                    let pat = Pattern::TypedBinding { name, ty };
+                                    let pat = Pattern::TypedBinding {
+                                        name,
+                                        ty: spanned.to_type_expr(),
+                                    };
                                     elements.push(self.alloc_pattern(pat, child.text_range()));
                                 }
                             }
@@ -1748,8 +1752,10 @@ impl LoweringContext {
                                 baml_compiler_syntax::ast::TypeExpr::cast(child.clone())
                             {
                                 let span = child.text_range();
-                                let ty = crate::lower_type_expr::lower_type_expr_node(&type_expr);
-                                type_annotation = Some(self.alloc_type_annot(ty, span));
+                                let spanned =
+                                    crate::lower_type_expr::lower_type_expr_node(&type_expr);
+                                type_annotation =
+                                    Some(self.alloc_type_annot(spanned.to_type_expr(), span));
                                 seen_colon = false;
                             }
                         } else if pattern_id.is_none() {

--- a/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
@@ -1,109 +1,124 @@
-//! CST `TypeExpr` node → `ast::TypeExpr` recursive enum.
+//! CST `TypeExpr` node → `ast::SpannedTypeExpr` recursive lowering.
 //!
-//! Adapts the logic from `TypeRef::from_ast()` in `baml_compiler_hir/src/type_ref.rs`.
-//! The output is the same recursive structure but as `ast::TypeExpr` instead of `TypeRef`.
+//! Produces a recursive `SpannedTypeExpr` where every sub-expression carries
+//! its own `TextRange`. A span-free `TypeExpr` can be obtained via
+//! `SpannedTypeExpr::to_type_expr()`.
 
 use baml_base::Name;
 use baml_compiler_syntax::{FunctionTypeParam, ast::TypeExpr as CstTypeExpr};
 use rowan::ast::AstNode;
 
-use crate::ast::{FunctionTypeParam as AstFunctionTypeParam, TypeExpr};
+use crate::ast::{SpannedFunctionTypeParam, SpannedTypeExpr, SpannedTypeExprKind};
 
-/// Convert a CST `TypeExpr` node to our `ast::TypeExpr` recursive enum.
-pub(crate) fn lower_type_expr_node(type_expr: &CstTypeExpr) -> TypeExpr {
-    // Handle optional modifier (outermost)
-    // For `int[]?`, optional wraps the array
+/// Convert a CST `TypeExpr` node to a recursive `SpannedTypeExpr`.
+pub(crate) fn lower_type_expr_node(type_expr: &CstTypeExpr) -> SpannedTypeExpr {
+    let span = type_expr.trimmed_text_range();
+
     if type_expr.is_optional() {
         let inner = lower_without_optional(type_expr);
-        return TypeExpr::Optional(Box::new(inner));
+        return SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Optional(Box::new(inner)),
+            span,
+        };
     }
 
     lower_without_optional(type_expr)
 }
 
-/// Parse a `TypeExpr` assuming the optional modifier has been handled.
-fn lower_without_optional(type_expr: &CstTypeExpr) -> TypeExpr {
-    // Handle union FIRST (top-level PIPE separators)
-    // For `int[] | string[]`, this is a union of arrays, not an array of unions
+fn lower_without_optional(type_expr: &CstTypeExpr) -> SpannedTypeExpr {
+    let span = type_expr.trimmed_text_range();
+
     if type_expr.is_union() {
         let member_parts = type_expr.union_member_parts();
-        let members: Vec<TypeExpr> = member_parts.iter().map(lower_union_member).collect();
-        return TypeExpr::Union(members);
+        let members: Vec<SpannedTypeExpr> = member_parts.iter().map(lower_union_member).collect();
+        return SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Union(members),
+            span,
+        };
     }
 
-    // Handle array modifier
     if type_expr.is_array() {
         let element = lower_array_element(type_expr);
-        return TypeExpr::List(Box::new(element));
+        return SpannedTypeExpr {
+            kind: SpannedTypeExprKind::List(Box::new(element)),
+            span,
+        };
     }
 
     lower_base(type_expr)
 }
 
-/// Get the element type for an array `TypeExpr`.
-fn lower_array_element(type_expr: &CstTypeExpr) -> TypeExpr {
-    // For parenthesized arrays like `(int | string)[]`, the element is the inner TypeExpr
+fn lower_array_element(type_expr: &CstTypeExpr) -> SpannedTypeExpr {
     if let Some(inner) = type_expr.inner_type_expr() {
         return lower_type_expr_node(&inner);
     }
 
-    // For non-parenthesized arrays like `int[]`, `string[][]`:
-    // Use array_depth() to count nesting levels and lower_base_type() for the base.
-    // For `int[][]`: depth=2, base=Int -> element is List(Int) i.e. `int[]`
-    // For `int[]`: depth=1, base=Int -> element is Int
     let depth = type_expr.array_depth();
     let base = lower_base_type(type_expr);
 
-    // Wrap base type in (depth-1) List layers to get the element type
     let mut result = base;
     for _ in 0..depth.saturating_sub(1) {
-        result = TypeExpr::List(Box::new(result));
+        let s = result.span;
+        result = SpannedTypeExpr {
+            kind: SpannedTypeExprKind::List(Box::new(result)),
+            span: s,
+        };
     }
     result
 }
 
-/// Parse the base type (no optional, array, or union modifiers).
-fn lower_base(type_expr: &CstTypeExpr) -> TypeExpr {
-    // Handle function types like `(x: int, y: int) -> bool`
+fn lower_base(type_expr: &CstTypeExpr) -> SpannedTypeExpr {
+    let span = type_expr.trimmed_text_range();
+
     if type_expr.is_function_type() {
         let params = type_expr
             .function_type_params()
             .iter()
             .map(|p| {
                 let name = p.name().map(|s| Name::new(&s));
-                let ty = p
-                    .ty()
-                    .map(|t| lower_type_expr_node(&t))
-                    .unwrap_or(TypeExpr::Unknown);
-                AstFunctionTypeParam { name, ty }
+                let ty =
+                    p.ty()
+                        .map(|t| lower_type_expr_node(&t))
+                        .unwrap_or_else(|| SpannedTypeExpr {
+                            kind: SpannedTypeExprKind::Unknown,
+                            span,
+                        });
+                SpannedFunctionTypeParam { name, ty }
             })
             .collect();
         let ret = type_expr
             .function_return_type()
             .map(|t| lower_type_expr_node(&t))
-            .unwrap_or(TypeExpr::Unknown);
-        return TypeExpr::Function {
-            params,
-            ret: Box::new(ret),
+            .unwrap_or_else(|| SpannedTypeExpr {
+                kind: SpannedTypeExprKind::Unknown,
+                span,
+            });
+        return SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Function {
+                params,
+                ret: Box::new(ret),
+            },
+            span,
         };
     }
 
-    // Handle parenthesized types like `(int | string)`
     if let Some(inner) = type_expr.inner_type_expr() {
         return lower_type_expr_node(&inner);
     }
 
-    // Handle parenthesized unions: `(A | B)` where the union is inside parens
     if type_expr.is_parenthesized() && !type_expr.is_function_type() {
         let params = type_expr.function_type_params();
         if params.len() > 1 {
-            let members: Vec<TypeExpr> = params
+            let members: Vec<SpannedTypeExpr> = params
                 .iter()
                 .filter_map(FunctionTypeParam::ty)
                 .map(|t| lower_type_expr_node(&t))
                 .collect();
             if !members.is_empty() {
-                return TypeExpr::Union(members);
+                return SpannedTypeExpr {
+                    kind: SpannedTypeExprKind::Union(members),
+                    span,
+                };
             }
         }
     }
@@ -111,54 +126,70 @@ fn lower_base(type_expr: &CstTypeExpr) -> TypeExpr {
     lower_base_type(type_expr)
 }
 
-/// Parse a base type (no modifiers, not a union).
-fn lower_base_type(type_expr: &CstTypeExpr) -> TypeExpr {
+fn lower_base_type(type_expr: &CstTypeExpr) -> SpannedTypeExpr {
+    let span = type_expr.trimmed_text_range();
+
     if let Some(s) = type_expr.string_literal() {
-        return TypeExpr::Literal(baml_base::Literal::String(s));
+        return SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Literal(baml_base::Literal::String(s)),
+            span,
+        };
     }
 
     if let Some(i) = type_expr.integer_literal() {
-        return TypeExpr::Literal(baml_base::Literal::Int(i));
+        return SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Literal(baml_base::Literal::Int(i)),
+            span,
+        };
     }
 
     if let Some(f) = type_expr.float_literal() {
-        return TypeExpr::Literal(baml_base::Literal::Float(f));
+        return SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Literal(baml_base::Literal::Float(f)),
+            span,
+        };
     }
 
     if let Some(b) = type_expr.bool_literal() {
-        return TypeExpr::Literal(baml_base::Literal::Bool(b));
+        return SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Literal(baml_base::Literal::Bool(b)),
+            span,
+        };
     }
 
-    // Check for map type with type args
     if let Some(name) = type_expr.dotted_name() {
         if name == "map" {
             let args = type_expr.type_arg_exprs();
             if args.len() == 2 {
                 let key = lower_type_expr_node(&args[0]);
                 let value = lower_type_expr_node(&args[1]);
-                return TypeExpr::Map {
-                    key: Box::new(key),
-                    value: Box::new(value),
+                return SpannedTypeExpr {
+                    kind: SpannedTypeExprKind::Map {
+                        key: Box::new(key),
+                        value: Box::new(value),
+                    },
+                    span,
                 };
             }
         }
 
-        // Named type (primitive or user-defined)
-        return lower_from_type_name(&name);
+        return lower_from_type_name(&name, span);
     }
 
-    TypeExpr::Unknown
+    SpannedTypeExpr {
+        kind: SpannedTypeExprKind::Unknown,
+        span,
+    }
 }
 
-/// Parse a union member from its structured parts.
-fn lower_union_member(parts: &baml_compiler_syntax::ast::UnionMemberParts) -> TypeExpr {
-    // Check for parenthesized type first (e.g., `(int | string)` in `A | (int | string)`)
+fn lower_union_member(parts: &baml_compiler_syntax::ast::UnionMemberParts) -> SpannedTypeExpr {
+    let span = parts.text_range();
+
     if let Some(type_expr) = parts.type_expr() {
         let inner = lower_type_expr_node(&type_expr);
-        return apply_modifiers_from_parts(inner, parts);
+        return apply_modifiers_from_parts(inner, parts, span);
     }
 
-    // Check for FUNCTION_TYPE_PARAM child (new parser structure for parenthesized types)
     if let Some(func_param) = parts.function_type_param() {
         if let Some(inner_type_expr) = func_param
             .children()
@@ -166,27 +197,35 @@ fn lower_union_member(parts: &baml_compiler_syntax::ast::UnionMemberParts) -> Ty
         {
             if let Some(type_expr) = baml_compiler_syntax::ast::TypeExpr::cast(inner_type_expr) {
                 let inner = lower_type_expr_node(&type_expr);
-                return apply_modifiers_from_parts(inner, parts);
+                return apply_modifiers_from_parts(inner, parts, span);
             }
         }
     }
 
     if let Some(s) = parts.string_literal() {
-        let base = TypeExpr::Literal(baml_base::Literal::String(s));
-        return apply_modifiers_from_parts(base, parts);
+        let base = SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Literal(baml_base::Literal::String(s)),
+            span,
+        };
+        return apply_modifiers_from_parts(base, parts, span);
     }
 
     if let Some(i) = parts.integer_literal() {
-        let base = TypeExpr::Literal(baml_base::Literal::Int(i));
-        return apply_modifiers_from_parts(base, parts);
+        let base = SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Literal(baml_base::Literal::Int(i)),
+            span,
+        };
+        return apply_modifiers_from_parts(base, parts, span);
     }
 
     if let Some(f) = parts.float_literal() {
-        let base = TypeExpr::Literal(baml_base::Literal::Float(f));
-        return apply_modifiers_from_parts(base, parts);
+        let base = SpannedTypeExpr {
+            kind: SpannedTypeExprKind::Literal(baml_base::Literal::Float(f)),
+            span,
+        };
+        return apply_modifiers_from_parts(base, parts, span);
     }
 
-    // Check for named/primitive type or map type
     if let Some(name) = parts.dotted_name() {
         if name == "map" {
             if let Some(type_args_node) = parts.type_args() {
@@ -199,69 +238,86 @@ fn lower_union_member(parts: &baml_compiler_syntax::ast::UnionMemberParts) -> Ty
                 if type_arg_exprs.len() == 2 {
                     let key = lower_type_expr_node(&type_arg_exprs[0]);
                     let value = lower_type_expr_node(&type_arg_exprs[1]);
-                    let base = TypeExpr::Map {
-                        key: Box::new(key),
-                        value: Box::new(value),
+                    let base = SpannedTypeExpr {
+                        kind: SpannedTypeExprKind::Map {
+                            key: Box::new(key),
+                            value: Box::new(value),
+                        },
+                        span,
                     };
-                    return apply_modifiers_from_parts(base, parts);
+                    return apply_modifiers_from_parts(base, parts, span);
                 }
             }
         }
 
         let base = match name.as_str() {
-            "true" => TypeExpr::Literal(baml_base::Literal::Bool(true)),
-            "false" => TypeExpr::Literal(baml_base::Literal::Bool(false)),
-            _ => lower_from_type_name(&name),
+            "true" => SpannedTypeExpr {
+                kind: SpannedTypeExprKind::Literal(baml_base::Literal::Bool(true)),
+                span,
+            },
+            "false" => SpannedTypeExpr {
+                kind: SpannedTypeExprKind::Literal(baml_base::Literal::Bool(false)),
+                span,
+            },
+            _ => lower_from_type_name(&name, span),
         };
-        return apply_modifiers_from_parts(base, parts);
+        return apply_modifiers_from_parts(base, parts, span);
     }
 
-    TypeExpr::Unknown
+    SpannedTypeExpr {
+        kind: SpannedTypeExprKind::Unknown,
+        span,
+    }
 }
 
-/// Apply array and optional modifiers from `UnionMemberParts` to a base type.
 fn apply_modifiers_from_parts(
-    base: TypeExpr,
+    base: SpannedTypeExpr,
     parts: &baml_compiler_syntax::ast::UnionMemberParts,
-) -> TypeExpr {
+    outer_span: text_size::TextRange,
+) -> SpannedTypeExpr {
     let mut result = base;
     for modifier in parts.postfix_modifiers() {
         match modifier {
             baml_compiler_syntax::ast::TypePostFixModifier::Optional => {
-                result = TypeExpr::Optional(Box::new(result));
+                result = SpannedTypeExpr {
+                    kind: SpannedTypeExprKind::Optional(Box::new(result)),
+                    span: outer_span,
+                };
             }
             baml_compiler_syntax::ast::TypePostFixModifier::Array => {
-                result = TypeExpr::List(Box::new(result));
+                result = SpannedTypeExpr {
+                    kind: SpannedTypeExprKind::List(Box::new(result)),
+                    span: outer_span,
+                };
             }
         }
     }
-
     result
 }
 
-/// Create a `TypeExpr` from a type name string (primitive or user-defined).
-fn lower_from_type_name(name: &str) -> TypeExpr {
-    match name {
-        "int" => TypeExpr::Int,
-        "float" => TypeExpr::Float,
-        "string" => TypeExpr::String,
-        "bool" => TypeExpr::Bool,
-        "null" => TypeExpr::Null,
-        "never" => TypeExpr::Never,
-        "unknown" => TypeExpr::BuiltinUnknown,
-        "type" => TypeExpr::Type,
-        "$rust_type" => TypeExpr::Rust,
-        "image" => TypeExpr::Media(baml_base::MediaKind::Image),
-        "audio" => TypeExpr::Media(baml_base::MediaKind::Audio),
-        "video" => TypeExpr::Media(baml_base::MediaKind::Video),
-        "pdf" => TypeExpr::Media(baml_base::MediaKind::Pdf),
+fn lower_from_type_name(name: &str, span: text_size::TextRange) -> SpannedTypeExpr {
+    let kind = match name {
+        "int" => SpannedTypeExprKind::Int,
+        "float" => SpannedTypeExprKind::Float,
+        "string" => SpannedTypeExprKind::String,
+        "bool" => SpannedTypeExprKind::Bool,
+        "null" => SpannedTypeExprKind::Null,
+        "never" => SpannedTypeExprKind::Never,
+        "unknown" => SpannedTypeExprKind::BuiltinUnknown,
+        "type" => SpannedTypeExprKind::Type,
+        "$rust_type" => SpannedTypeExprKind::Rust,
+        "image" => SpannedTypeExprKind::Media(baml_base::MediaKind::Image),
+        "audio" => SpannedTypeExprKind::Media(baml_base::MediaKind::Audio),
+        "video" => SpannedTypeExprKind::Media(baml_base::MediaKind::Video),
+        "pdf" => SpannedTypeExprKind::Media(baml_base::MediaKind::Pdf),
         _ => {
             if name.contains('.') {
                 let segments: Vec<Name> = name.split('.').map(Name::new).collect();
-                TypeExpr::Path(segments)
+                SpannedTypeExprKind::Path(segments)
             } else {
-                TypeExpr::Path(vec![Name::new(name)])
+                SpannedTypeExprKind::Path(vec![Name::new(name)])
             }
         }
-    }
+    };
+    SpannedTypeExpr { kind, span }
 }

--- a/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
@@ -7,6 +7,7 @@
 use baml_base::Name;
 use baml_compiler_syntax::{FunctionTypeParam, ast::TypeExpr as CstTypeExpr};
 use rowan::ast::AstNode;
+use text_size::{TextRange, TextSize};
 
 use crate::ast::{SpannedFunctionTypeParam, SpannedTypeExpr, SpannedTypeExprKind};
 
@@ -39,9 +40,11 @@ fn lower_without_optional(type_expr: &CstTypeExpr) -> SpannedTypeExpr {
 
     if type_expr.is_array() {
         let element = lower_array_element(type_expr);
+        let wrapper_span =
+            TextRange::new(element.span.end(), element.span.end() + TextSize::from(1));
         return SpannedTypeExpr {
             kind: SpannedTypeExprKind::List(Box::new(element)),
-            span,
+            span: wrapper_span,
         };
     }
 
@@ -55,13 +58,20 @@ fn lower_array_element(type_expr: &CstTypeExpr) -> SpannedTypeExpr {
 
     let depth = type_expr.array_depth();
     let base = lower_base_type(type_expr);
+    let full_span = type_expr.trimmed_text_range();
 
     let mut result = base;
-    for _ in 0..depth.saturating_sub(1) {
-        let s = result.span;
+    let n_wrappers = depth.saturating_sub(1);
+    for i in 0..n_wrappers {
+        let is_outermost = i == n_wrappers - 1;
+        let span = if is_outermost {
+            full_span
+        } else {
+            TextRange::new(result.span.end(), result.span.end() + TextSize::from(1))
+        };
         result = SpannedTypeExpr {
             kind: SpannedTypeExprKind::List(Box::new(result)),
-            span: s,
+            span,
         };
     }
     result
@@ -273,29 +283,26 @@ fn lower_union_member(parts: &baml_compiler_syntax::ast::UnionMemberParts) -> Sp
 fn apply_modifiers_from_parts(
     base: SpannedTypeExpr,
     parts: &baml_compiler_syntax::ast::UnionMemberParts,
-    outer_span: text_size::TextRange,
+    _outer_span: TextRange,
 ) -> SpannedTypeExpr {
     let mut result = base;
     for modifier in parts.postfix_modifiers() {
-        match modifier {
-            baml_compiler_syntax::ast::TypePostFixModifier::Optional => {
-                result = SpannedTypeExpr {
-                    kind: SpannedTypeExprKind::Optional(Box::new(result)),
-                    span: outer_span,
-                };
-            }
-            baml_compiler_syntax::ast::TypePostFixModifier::Array => {
-                result = SpannedTypeExpr {
-                    kind: SpannedTypeExprKind::List(Box::new(result)),
-                    span: outer_span,
-                };
-            }
-        }
+        let span = TextRange::new(result.span.end(), result.span.end() + TextSize::from(1));
+        result = match modifier {
+            baml_compiler_syntax::ast::TypePostFixModifier::Optional => SpannedTypeExpr {
+                kind: SpannedTypeExprKind::Optional(Box::new(result)),
+                span,
+            },
+            baml_compiler_syntax::ast::TypePostFixModifier::Array => SpannedTypeExpr {
+                kind: SpannedTypeExprKind::List(Box::new(result)),
+                span,
+            },
+        };
     }
     result
 }
 
-fn lower_from_type_name(name: &str, span: text_size::TextRange) -> SpannedTypeExpr {
+fn lower_from_type_name(name: &str, span: TextRange) -> SpannedTypeExpr {
     let kind = match name {
         "int" => SpannedTypeExprKind::Int,
         "float" => SpannedTypeExprKind::Float,

--- a/baml_language/crates/baml_compiler2_hir/src/signature.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/signature.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use baml_compiler2_ast::TypeExpr;
+use baml_compiler2_ast::{SpannedTypeExpr, TypeExpr};
 use text_size::TextRange;
 
 use crate::loc::FunctionLoc;
@@ -33,14 +33,23 @@ pub struct FunctionSignature {
 /// Kept separate from `FunctionSignature` so that whitespace-only source
 /// changes only invalidate `function_signature_source_map`, not
 /// `function_signature`.
+///
+/// Stores recursive `SpannedTypeExpr` trees so each sub-expression (e.g.
+/// individual union members) carries its own span for precise diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignatureSourceMap {
     /// One span per parameter, parallel to `FunctionSignature::params`.
     pub param_spans: Vec<TextRange>,
+    /// Recursive spanned type expression trees for parameter types.
+    pub param_type_exprs: Vec<Option<SpannedTypeExpr>>,
     /// Span of the return type annotation, if present.
     pub return_type_span: Option<TextRange>,
+    /// Recursive spanned return type tree, if present.
+    pub return_type_expr: Option<SpannedTypeExpr>,
     /// Span of the throws type annotation, if present.
     pub throws_type_span: Option<TextRange>,
+    /// Recursive spanned throws type tree, if present.
+    pub throws_type_expr: Option<SpannedTypeExpr>,
 }
 
 /// Shared implementation — reads from the `ItemTree` (full AST data),
@@ -53,7 +62,7 @@ fn function_signature_with_source_map<'db>(
     let item_tree = crate::file_item_tree(db, file);
     let func_data = &item_tree[function.id(db)];
 
-    // Build semantic signature — strip spans, keep TypeExpr
+    // Build semantic signature — strip spans via to_type_expr()
     let params: Vec<_> = func_data
         .params
         .iter()
@@ -61,26 +70,36 @@ fn function_signature_with_source_map<'db>(
             let type_expr = p
                 .type_expr
                 .as_ref()
-                .map(|te| te.expr.clone())
+                .map(SpannedTypeExpr::to_type_expr)
                 .unwrap_or(TypeExpr::Unknown);
             (p.name.clone(), type_expr)
         })
         .collect();
 
-    let return_type = func_data.return_type.as_ref().map(|te| te.expr.clone());
+    let return_type = func_data
+        .return_type
+        .as_ref()
+        .map(SpannedTypeExpr::to_type_expr);
 
     let sig = Arc::new(FunctionSignature {
         name: func_data.name.clone(),
         params,
         return_type,
-        throws: func_data.throws.as_ref().map(|te| te.expr.clone()),
+        throws: func_data.throws.as_ref().map(SpannedTypeExpr::to_type_expr),
     });
 
-    // Build source map — spans only (separate for early-cutoff)
+    // Build source map — spans + recursive SpannedTypeExpr trees
     let source_map = SignatureSourceMap {
         param_spans: func_data.params.iter().map(|p| p.span).collect(),
+        param_type_exprs: func_data
+            .params
+            .iter()
+            .map(|p| p.type_expr.clone())
+            .collect(),
         return_type_span: func_data.return_type.as_ref().map(|te| te.span),
+        return_type_expr: func_data.return_type.clone(),
         throws_type_span: func_data.throws.as_ref().map(|te| te.span),
+        throws_type_expr: func_data.throws.clone(),
     };
 
     (sig, source_map)

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -16,7 +16,7 @@
 use std::collections::{BTreeSet, HashMap};
 
 use baml_base::Name;
-use baml_compiler2_ast::{Expr, ExprBody, ExprId, PatId, Stmt, StmtId, TypeExpr};
+use baml_compiler2_ast::{AstSourceMap, Expr, ExprBody, ExprId, PatId, Stmt, StmtId, TypeExpr};
 use baml_compiler2_hir::{
     contributions::Definition,
     package::{PackageId, PackageItems},
@@ -81,6 +81,8 @@ pub struct TypeInferenceBuilder<'db> {
     declared_return_ty: Option<Ty>,
     /// Source span of the return type annotation (for precise diagnostics).
     return_type_span: Option<TextRange>,
+    /// Body source map (when in function scope) for per-node type annotation diagnostics.
+    body_source_map: Option<AstSourceMap>,
     /// Local variable bindings: name → inferred type (flow-sensitive, updated
     /// by narrowing and assignments).
     locals: FxHashMap<Name, Ty>,
@@ -118,6 +120,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             scope,
             declared_return_ty: None,
             return_type_span: None,
+            body_source_map: None,
             locals: FxHashMap::default(),
             declared_types: FxHashMap::default(),
             aliases,
@@ -145,6 +148,11 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// Set the source span of the return type annotation.
     pub fn set_return_type_span(&mut self, span: TextRange) {
         self.return_type_span = Some(span);
+    }
+
+    /// Set the body source map (for precise type-annotation diagnostics in let etc.).
+    pub fn set_body_source_map(&mut self, source_map: Option<AstSourceMap>) {
+        self.body_source_map = source_map;
     }
 
     /// Report a type error at a raw source span (for type annotations).
@@ -573,14 +581,40 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let mut ann_ty_for_decl: Option<Ty> = None;
                 let init_ty = if let Some(init) = initializer {
                     if let Some(ann_idx) = type_annotation {
-                        let mut diags = Vec::new();
-                        let ann_ty = crate::lower_type_expr::lower_type_expr(
-                            self.context.db(),
-                            &body.type_annotations[*ann_idx],
-                            self.package_items,
-                            &mut diags,
-                        );
-                        for diag in diags {
+                        let (ann_ty, fallback_diags) = if let Some(ref sm) = self.body_source_map {
+                            if let Some(spanned) = sm.type_annotation_spanned(*ann_idx) {
+                                let mut spanned_diags = Vec::new();
+                                let ty = crate::lower_type_expr::lower_spanned_type_expr(
+                                    self.context.db(),
+                                    spanned,
+                                    self.package_items,
+                                    &mut spanned_diags,
+                                );
+                                for (diag, span) in spanned_diags {
+                                    self.context.report_at_span(diag, span);
+                                }
+                                (ty, Vec::new())
+                            } else {
+                                let mut diags = Vec::new();
+                                let ty = crate::lower_type_expr::lower_type_expr(
+                                    self.context.db(),
+                                    &body.type_annotations[*ann_idx],
+                                    self.package_items,
+                                    &mut diags,
+                                );
+                                (ty, diags)
+                            }
+                        } else {
+                            let mut diags = Vec::new();
+                            let ty = crate::lower_type_expr::lower_type_expr(
+                                self.context.db(),
+                                &body.type_annotations[*ann_idx],
+                                self.package_items,
+                                &mut diags,
+                            );
+                            (ty, diags)
+                        };
+                        for diag in fallback_diags {
                             self.context.report_at_type_annot(diag, *ann_idx);
                         }
                         let ty = self.check_expr(*init, body, &ann_ty);
@@ -930,7 +964,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             let binding_name = match &body.patterns[clause.binding] {
                 baml_compiler2_ast::Pattern::Binding(name) => Some(name.clone()),
                 baml_compiler2_ast::Pattern::TypedBinding { name, ty } => {
-                    if let Some(banned) = crate::throw_inference::is_banned_catch_binding_type(ty) {
+                    if let Some(banned) =
+                        crate::throw_inference::is_banned_catch_binding_type(&ty.to_type_expr())
+                    {
                         self.context.report_simple(
                             TirTypeError::InvalidCatchBindingType {
                                 type_name: banned.to_string(),
@@ -1211,7 +1247,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
             baml_compiler2_ast::Pattern::TypedBinding { ty, .. } => {
-                self.lower_pattern_type_expr(ty, at_expr)
+                self.lower_pattern_type_expr(&ty.to_type_expr(), at_expr)
             }
             baml_compiler2_ast::Pattern::Literal(lit) => {
                 Ty::Literal(lit.clone(), crate::ty::Freshness::Regular)
@@ -1369,7 +1405,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
             baml_compiler2_ast::Pattern::TypedBinding { ty, .. } => {
-                let lowered = self.lower_pattern_type_expr(ty, at_expr);
+                let lowered = self.lower_pattern_type_expr(&ty.to_type_expr(), at_expr);
                 if self.ty_matches_throw_fact(&lowered, throw_fact) {
                     PatternMatchStrength::DefiniteMatch
                 } else if throw_fact == "unknown" {

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -79,6 +79,8 @@ pub struct TypeInferenceBuilder<'db> {
     scope: ScopeId<'db>,
     /// Declared return type for the function (used to check return statements).
     declared_return_ty: Option<Ty>,
+    /// Source span of the return type annotation (for precise diagnostics).
+    return_type_span: Option<TextRange>,
     /// Local variable bindings: name → inferred type (flow-sensitive, updated
     /// by narrowing and assignments).
     locals: FxHashMap<Name, Ty>,
@@ -115,6 +117,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             package_id,
             scope,
             declared_return_ty: None,
+            return_type_span: None,
             locals: FxHashMap::default(),
             declared_types: FxHashMap::default(),
             aliases,
@@ -137,6 +140,11 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// Set the declared return type (for return statement checking).
     pub fn set_return_type(&mut self, ty: Ty) {
         self.declared_return_ty = Some(ty);
+    }
+
+    /// Set the source span of the return type annotation.
+    pub fn set_return_type_span(&mut self, span: TextRange) {
+        self.return_type_span = Some(span);
     }
 
     /// Report a type error at a raw source span (for type annotations).
@@ -396,14 +404,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 } else if let Some(tail) = tail_expr {
                     self.check_expr(*tail, body, expected)
                 } else if !matches!(expected, Ty::Unknown | Ty::Void) {
-                    // No tail expression, no divergence — block falls through
-                    // without producing a value. Report missing return.
-                    self.context.report_simple(
-                        TirTypeError::MissingReturn {
-                            expected: expected.clone(),
-                        },
-                        expr_id,
-                    );
+                    let error = TirTypeError::MissingReturn {
+                        expected: expected.clone(),
+                    };
+                    if let Some(span) = self.return_type_span {
+                        self.context.report_at_span(error, span);
+                    } else {
+                        self.context.report_simple(error, expr_id);
+                    }
                     expected.clone()
                 } else {
                     Ty::Void
@@ -2127,19 +2135,19 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let item_tree = baml_compiler2_hir::file_item_tree(self.context.db(), file);
                 let class_data = &item_tree[class_loc.id(self.context.db())];
                 for field in &class_data.fields {
-                    let mut diags = Vec::new();
                     let field_ty = field
                         .type_expr
                         .as_ref()
                         .map(|te| {
-                            let ty = crate::lower_type_expr::lower_type_expr(
+                            let mut spanned_diags = Vec::new();
+                            let ty = crate::lower_type_expr::lower_spanned_type_expr(
                                 self.context.db(),
-                                &te.expr,
+                                te,
                                 self.package_items,
-                                &mut diags,
+                                &mut spanned_diags,
                             );
-                            for diag in diags.drain(..) {
-                                self.context.report_at_span(diag, te.span);
+                            for (diag, span) in spanned_diags {
+                                self.context.report_at_span(diag, span);
                             }
                             ty
                         })
@@ -2338,7 +2346,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .map(|te| {
                         crate::generics::lower_type_expr_with_generics(
                             db,
-                            &te.expr,
+                            &te.to_type_expr(),
                             self.package_items,
                             &bindings,
                             &mut diags,

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -1006,25 +1006,25 @@ impl<'db> TypeInferenceBuilder<'db> {
     pub fn check_throws_contract(
         &mut self,
         body: &ExprBody,
-        declared_throws: Option<&TypeExpr>,
+        declared_throws: Option<&baml_compiler2_ast::SpannedTypeExpr>,
         throws_span: Option<TextRange>,
         fallback_span: TextRange,
     ) {
-        let Some(declared_expr) = declared_throws else {
+        let Some(declared_spanned) = declared_throws else {
             return;
         };
 
         let mut diags = Vec::new();
-        let declared_ty = crate::lower_type_expr::lower_type_expr(
+        let declared_ty = crate::lower_type_expr::lower_spanned_type_expr(
             self.context.db(),
-            declared_expr,
+            declared_spanned,
             self.package_items,
             &mut diags,
         );
-        let span = throws_span.unwrap_or(fallback_span);
-        for diag in diags {
+        for (diag, span) in diags {
             self.context.report_at_span(diag, span);
         }
+        let span = throws_span.unwrap_or(fallback_span);
 
         let declared = crate::throw_inference::throw_facts_from_ty(&declared_ty);
         let effective = self.collect_effective_throws(body);
@@ -2135,21 +2135,19 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let item_tree = baml_compiler2_hir::file_item_tree(self.context.db(), file);
                 let class_data = &item_tree[class_loc.id(self.context.db())];
                 for field in &class_data.fields {
+                    // Don't report diagnostics here — check_file() already reports
+                    // class-field type errors once via resolve_class_fields.
                     let field_ty = field
                         .type_expr
                         .as_ref()
                         .map(|te| {
-                            let mut spanned_diags = Vec::new();
-                            let ty = crate::lower_type_expr::lower_spanned_type_expr(
+                            let mut diags = Vec::new();
+                            crate::lower_type_expr::lower_spanned_type_expr(
                                 self.context.db(),
                                 te,
                                 self.package_items,
-                                &mut spanned_diags,
-                            );
-                            for (diag, span) in spanned_diags {
-                                self.context.report_at_span(diag, span);
-                            }
-                            ty
+                                &mut diags,
+                            )
                         })
                         .unwrap_or(Ty::Unknown);
                     result.insert(field.name.clone(), field_ty);

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -140,7 +140,7 @@ impl fmt::Display for TirTypeError {
                 write!(f, "operator `{op:?}` cannot be applied to `{operand}`")
             }
             TirTypeError::UnresolvedType { name } => {
-                write!(f, "unresolved type: {name}")
+                write!(f, "unresolved type: `{name}`")
             }
             TirTypeError::ArgumentCountMismatch { expected, got } => {
                 write!(f, "expected {expected} argument(s), got {got}")

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -154,33 +154,32 @@ pub fn infer_scope_types<'db>(
                     let sig = baml_compiler2_hir::signature::function_signature(db, func_loc);
 
                     if let FunctionBody::Expr(expr_body) = body.as_ref() {
-                        // Get declared return type
-                        let mut diags = Vec::new();
-                        let return_ty = sig
-                            .return_type
-                            .as_ref()
-                            .map(|te| {
-                                crate::lower_type_expr::lower_type_expr(
-                                    db, te, pkg_items, &mut diags,
-                                )
-                            })
-                            .unwrap_or(Ty::Unknown);
+                        let sig_sm = baml_compiler2_hir::signature::function_signature_source_map(
+                            db, func_loc,
+                        );
 
-                        // Report unresolved type diagnostics for return type
-                        if !diags.is_empty() {
-                            let sig_sm =
-                                baml_compiler2_hir::signature::function_signature_source_map(
-                                    db, func_loc,
-                                );
-                            if let Some(ret_span) = sig_sm.return_type_span {
-                                for diag in diags.drain(..) {
-                                    builder.report_at_span(diag, ret_span);
-                                }
+                        // Get declared return type — use spanned version for precise diagnostics
+                        let return_ty = if let Some(ret_spanned) = &sig_sm.return_type_expr {
+                            let mut diags = Vec::new();
+                            let ty = crate::lower_type_expr::lower_spanned_type_expr(
+                                db,
+                                ret_spanned,
+                                pkg_items,
+                                &mut diags,
+                            );
+                            for (diag, span) in diags {
+                                builder.report_at_span(diag, span);
                             }
-                        }
+                            ty
+                        } else {
+                            Ty::Unknown
+                        };
 
                         // Set declared return type for return statement checking
                         builder.set_return_type(return_ty.clone());
+                        if let Some(span) = sig_sm.return_type_span {
+                            builder.set_return_type_span(span);
+                        }
 
                         // Determine enclosing class name for `self` parameter resolution
                         let enclosing_class_name: Option<Name> =
@@ -194,18 +193,13 @@ pub fn infer_scope_types<'db>(
                             });
 
                         // Add parameter bindings as locals
-                        let sig_sm = baml_compiler2_hir::signature::function_signature_source_map(
-                            db, func_loc,
-                        );
                         for (i, (param_name, param_te)) in sig.params.iter().enumerate() {
                             let param_ty = if param_name.as_str() == "self"
                                 && matches!(param_te, baml_compiler2_ast::TypeExpr::Unknown)
                             {
-                                // `self` parameter with no type annotation — infer from enclosing class
                                 enclosing_class_name
                                     .as_ref()
                                     .and_then(|cn| {
-                                        // Look up the class to get its definition's package
                                         pkg_items.lookup_type(&[cn.clone()]).map(|def| {
                                             Ty::Class(crate::lower_type_expr::qualify_def(
                                                 db, def, cn,
@@ -213,6 +207,19 @@ pub fn infer_scope_types<'db>(
                                         })
                                     })
                                     .unwrap_or(Ty::Unknown)
+                            } else if let Some(Some(param_spanned)) = sig_sm.param_type_exprs.get(i)
+                            {
+                                let mut param_diags = Vec::new();
+                                let ty = crate::lower_type_expr::lower_spanned_type_expr(
+                                    db,
+                                    param_spanned,
+                                    pkg_items,
+                                    &mut param_diags,
+                                );
+                                for (diag, span) in param_diags {
+                                    builder.report_at_span(diag, span);
+                                }
+                                ty
                             } else {
                                 let mut param_diags = Vec::new();
                                 let ty = crate::lower_type_expr::lower_type_expr(
@@ -433,12 +440,10 @@ pub fn resolve_class_fields<'db>(
                 .as_ref()
                 .map(|te| {
                     let mut diags = Vec::new();
-                    let ty = crate::lower_type_expr::lower_type_expr(
-                        db, &te.expr, pkg_items, &mut diags,
+                    let ty = crate::lower_type_expr::lower_spanned_type_expr(
+                        db, te, pkg_items, &mut diags,
                     );
-                    for d in diags {
-                        all_diags.push((d, te.span));
-                    }
+                    all_diags.extend(diags);
                     ty
                 })
                 .unwrap_or(Ty::Unknown);
@@ -473,10 +478,8 @@ pub fn resolve_type_alias<'db>(
         .as_ref()
         .map(|te| {
             let mut diags = Vec::new();
-            let ty = crate::lower_type_expr::lower_type_expr(db, &te.expr, pkg_items, &mut diags);
-            for d in diags {
-                all_diags.push((d, te.span));
-            }
+            let ty = crate::lower_type_expr::lower_spanned_type_expr(db, te, pkg_items, &mut diags);
+            all_diags.extend(diags);
             ty
         })
         .unwrap_or(Ty::Unknown);

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -248,7 +248,7 @@ pub fn infer_scope_types<'db>(
                         // Validate declared `throws` against effective escaping throws.
                         builder.check_throws_contract(
                             expr_body,
-                            sig.throws.as_ref(),
+                            sig_sm.throws_type_expr.as_ref(),
                             sig_sm.throws_type_span,
                             func_data.span,
                         );

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -157,6 +157,9 @@ pub fn infer_scope_types<'db>(
                         let sig_sm = baml_compiler2_hir::signature::function_signature_source_map(
                             db, func_loc,
                         );
+                        builder.set_body_source_map(
+                            baml_compiler2_hir::body::function_body_source_map(db, func_loc),
+                        );
 
                         // Get declared return type — use spanned version for precise diagnostics
                         let return_ty = if let Some(ret_spanned) = &sig_sm.return_type_expr {

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -1,7 +1,8 @@
 //! `TypeExpr → Ty` lowering using package-level name resolution.
 
-use baml_compiler2_ast::TypeExpr;
+use baml_compiler2_ast::{SpannedTypeExpr, SpannedTypeExprKind, TypeExpr};
 use baml_compiler2_hir::{contributions::Definition, package::PackageItems};
+use text_size::TextRange;
 
 use crate::{
     infer_context::TirTypeError,
@@ -116,4 +117,99 @@ pub fn qualify_def(
     let file = def.file(db);
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
     qualify(pkg_info.package.as_str(), name)
+}
+
+/// Resolve a recursive `SpannedTypeExpr` to a `Ty`, collecting errors with
+/// per-node spans. Each error is paired with the `TextRange` of the specific
+/// sub-expression that caused it (e.g. just the `sring` part of `sring | image`).
+pub fn lower_spanned_type_expr(
+    db: &dyn crate::Db,
+    spanned: &SpannedTypeExpr,
+    package_items: &PackageItems<'_>,
+    diagnostics: &mut Vec<(TirTypeError, TextRange)>,
+) -> Ty {
+    match &spanned.kind {
+        SpannedTypeExprKind::Path(segments) => {
+            let names: Vec<baml_base::Name> = segments.clone();
+            if let Some(def) = package_items.lookup_type(&names) {
+                let short = segments.last().expect("non-empty path");
+                match def {
+                    Definition::Class(_) => Ty::Class(qualify_def(db, def, short)),
+                    Definition::Enum(_) => Ty::Enum(qualify_def(db, def, short)),
+                    Definition::TypeAlias(_) => Ty::TypeAlias(qualify_def(db, def, short)),
+                    _ => Ty::Unknown,
+                }
+            } else {
+                let name = segments
+                    .iter()
+                    .map(|n| n.as_str())
+                    .collect::<Vec<_>>()
+                    .join(".");
+                diagnostics.push((
+                    TirTypeError::UnresolvedType {
+                        name: baml_base::Name::new(&name),
+                    },
+                    spanned.span,
+                ));
+                Ty::Unknown
+            }
+        }
+        SpannedTypeExprKind::Int => Ty::Primitive(PrimitiveType::Int),
+        SpannedTypeExprKind::Float => Ty::Primitive(PrimitiveType::Float),
+        SpannedTypeExprKind::String => Ty::Primitive(PrimitiveType::String),
+        SpannedTypeExprKind::Bool => Ty::Primitive(PrimitiveType::Bool),
+        SpannedTypeExprKind::Null => Ty::Primitive(PrimitiveType::Null),
+        SpannedTypeExprKind::Never => Ty::Never,
+        SpannedTypeExprKind::Media(kind) => Ty::Primitive(match kind {
+            baml_base::MediaKind::Image => PrimitiveType::Image,
+            baml_base::MediaKind::Audio => PrimitiveType::Audio,
+            baml_base::MediaKind::Video => PrimitiveType::Video,
+            baml_base::MediaKind::Pdf => PrimitiveType::Pdf,
+            baml_base::MediaKind::Generic => return Ty::Unknown,
+        }),
+        SpannedTypeExprKind::Optional(inner) => Ty::Optional(Box::new(lower_spanned_type_expr(
+            db,
+            inner,
+            package_items,
+            diagnostics,
+        ))),
+        SpannedTypeExprKind::List(inner) => Ty::List(Box::new(lower_spanned_type_expr(
+            db,
+            inner,
+            package_items,
+            diagnostics,
+        ))),
+        SpannedTypeExprKind::Map { key, value } => Ty::Map(
+            Box::new(lower_spanned_type_expr(db, key, package_items, diagnostics)),
+            Box::new(lower_spanned_type_expr(
+                db,
+                value,
+                package_items,
+                diagnostics,
+            )),
+        ),
+        SpannedTypeExprKind::Union(members) => Ty::Union(
+            members
+                .iter()
+                .map(|m| lower_spanned_type_expr(db, m, package_items, diagnostics))
+                .collect(),
+        ),
+        SpannedTypeExprKind::Function { params, ret } => Ty::Function {
+            params: params
+                .iter()
+                .map(|p| {
+                    (
+                        p.name.clone(),
+                        lower_spanned_type_expr(db, &p.ty, package_items, diagnostics),
+                    )
+                })
+                .collect(),
+            ret: Box::new(lower_spanned_type_expr(db, ret, package_items, diagnostics)),
+        },
+        SpannedTypeExprKind::Literal(lit) => Ty::Literal(lit.clone(), Freshness::Regular),
+        SpannedTypeExprKind::BuiltinUnknown => Ty::BuiltinUnknown,
+        SpannedTypeExprKind::Error | SpannedTypeExprKind::Unknown => Ty::Unknown,
+        SpannedTypeExprKind::Type => Ty::Unknown,
+        SpannedTypeExprKind::Rust => Ty::RustType,
+    }
 }

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -258,6 +258,28 @@ impl UnionMemberParts {
             .find(|t| t.kind() == SyntaxKind::FLOAT_LITERAL)
             .map(|t| t.text().to_string())
     }
+
+    /// Compute the text range covering all tokens and child nodes in this member.
+    pub fn text_range(&self) -> rowan::TextRange {
+        let mut start = None::<rowan::TextSize>;
+        let mut end = None::<rowan::TextSize>;
+
+        for t in &self.tokens {
+            let r = t.text_range();
+            start = Some(start.map_or(r.start(), |s: rowan::TextSize| s.min(r.start())));
+            end = Some(end.map_or(r.end(), |e: rowan::TextSize| e.max(r.end())));
+        }
+        for n in &self.child_nodes {
+            let r = n.text_range();
+            start = Some(start.map_or(r.start(), |s: rowan::TextSize| s.min(r.start())));
+            end = Some(end.map_or(r.end(), |e: rowan::TextSize| e.max(r.end())));
+        }
+
+        match (start, end) {
+            (Some(s), Some(e)) => rowan::TextRange::new(s, e),
+            _ => rowan::TextRange::default(),
+        }
+    }
 }
 
 impl Default for UnionMemberParts {
@@ -590,6 +612,34 @@ impl TypeExpr {
     /// This is useful for error reporting and span creation.
     pub fn text_range(&self) -> rowan::TextRange {
         self.syntax.text_range()
+    }
+
+    /// Get the text range excluding leading/trailing trivia (whitespace/comments).
+    ///
+    /// Rowan attaches trivia to the node's first/last tokens, so
+    /// `syntax().text_range()` can include surrounding whitespace.
+    /// This method finds the first and last non-trivia tokens to produce
+    /// a tight range covering only the meaningful syntax.
+    pub fn trimmed_text_range(&self) -> rowan::TextRange {
+        let mut start = None::<rowan::TextSize>;
+        let mut end = None::<rowan::TextSize>;
+
+        for element in self.syntax.descendants_with_tokens() {
+            if let rowan::NodeOrToken::Token(token) = element {
+                if !token.kind().is_trivia() {
+                    let r = token.text_range();
+                    if start.is_none() {
+                        start = Some(r.start());
+                    }
+                    end = Some(r.end());
+                }
+            }
+        }
+
+        match (start, end) {
+            (Some(s), Some(e)) => rowan::TextRange::new(s, e),
+            _ => self.syntax.text_range(),
+        }
     }
 
     /// Check if this is a function type: `(x: int, y: int) -> bool` or `(int) -> bool`.

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -183,6 +183,27 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
                 }
             }
         }
+
+        // Check throws type — use lower_spanned_type_expr for per-node spans.
+        if let Some(throws_spanned) = &func_data.throws {
+            type_errors_spanned.clear();
+            baml_compiler2_tir::lower_type_expr::lower_spanned_type_expr(
+                db,
+                throws_spanned,
+                &pkg_items,
+                &mut type_errors_spanned,
+            );
+            for (error, span) in type_errors_spanned.drain(..) {
+                diagnostics.push(
+                    Diagnostic::error(tir_type_error_to_diagnostic_id(&error), error.to_string())
+                        .with_primary_span(Span {
+                            file_id,
+                            range: span,
+                        })
+                        .with_phase(DiagnosticPhase::Type),
+                );
+            }
+        }
     }
 
     // Deduplicate: multiple steps can produce the same diagnostic (e.g. scope

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -136,62 +136,50 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
             continue;
         }
 
-        let sig = baml_compiler2_hir::signature::function_signature(db, func_loc);
-        let mut type_errors = Vec::new();
+        let mut type_errors_spanned = Vec::new();
 
-        // Check return type — use the span from the item tree's SpannedTypeExpr.
-        if let Some(ret_te) = &sig.return_type {
-            baml_compiler2_tir::lower_type_expr::lower_type_expr(
+        // Check return type — use lower_spanned_type_expr for per-node spans.
+        if let Some(ret_spanned) = &func_data.return_type {
+            baml_compiler2_tir::lower_type_expr::lower_spanned_type_expr(
                 db,
-                ret_te,
+                ret_spanned,
                 &pkg_items,
-                &mut type_errors,
+                &mut type_errors_spanned,
             );
-            if !type_errors.is_empty() {
-                if let Some(ret_spanned) = &func_data.return_type {
-                    for error in type_errors.drain(..) {
-                        diagnostics.push(
-                            Diagnostic::error(
-                                tir_type_error_to_diagnostic_id(&error),
-                                error.to_string(),
-                            )
-                            .with_primary_span(Span {
-                                file_id,
-                                range: ret_spanned.span,
-                            })
-                            .with_phase(DiagnosticPhase::Type),
-                        );
-                    }
-                }
+            for (error, span) in type_errors_spanned.drain(..) {
+                diagnostics.push(
+                    Diagnostic::error(tir_type_error_to_diagnostic_id(&error), error.to_string())
+                        .with_primary_span(Span {
+                            file_id,
+                            range: span,
+                        })
+                        .with_phase(DiagnosticPhase::Type),
+                );
             }
         }
 
-        // Check parameter types — use the type_expr span, not the whole param span.
-        for (i, (_name, te)) in sig.params.iter().enumerate() {
-            type_errors.clear();
-            baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                db,
-                te,
-                &pkg_items,
-                &mut type_errors,
-            );
-            if !type_errors.is_empty() {
-                if let Some(param) = func_data.params.get(i) {
-                    if let Some(type_spanned) = &param.type_expr {
-                        for error in type_errors.drain(..) {
-                            diagnostics.push(
-                                Diagnostic::error(
-                                    tir_type_error_to_diagnostic_id(&error),
-                                    error.to_string(),
-                                )
-                                .with_primary_span(Span {
-                                    file_id,
-                                    range: type_spanned.span,
-                                })
-                                .with_phase(DiagnosticPhase::Type),
-                            );
-                        }
-                    }
+        // Check parameter types — use lower_spanned_type_expr for per-node spans.
+        for param in &func_data.params {
+            if let Some(type_spanned) = &param.type_expr {
+                type_errors_spanned.clear();
+                baml_compiler2_tir::lower_type_expr::lower_spanned_type_expr(
+                    db,
+                    type_spanned,
+                    &pkg_items,
+                    &mut type_errors_spanned,
+                );
+                for (error, span) in type_errors_spanned.drain(..) {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            tir_type_error_to_diagnostic_id(&error),
+                            error.to_string(),
+                        )
+                        .with_primary_span(Span {
+                            file_id,
+                            range: span,
+                        })
+                        .with_phase(DiagnosticPhase::Type),
+                    );
                 }
             }
         }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -96,7 +96,7 @@ pub(crate) mod support {
         match pat {
             Pattern::Binding(n) => n.to_string(),
             Pattern::TypedBinding { name, ty } => {
-                format!("{name}: {}", type_expr_to_string(ty))
+                format!("{name}: {}", type_expr_to_string(&ty.to_type_expr()))
             }
             Pattern::Literal(lit) => lit.to_string(),
             Pattern::Null => "null".into(),
@@ -347,7 +347,7 @@ pub(crate) mod support {
                 let pat_name = match &body.patterns[*pattern] {
                     Pattern::Binding(n) => n.to_string(),
                     Pattern::TypedBinding { name, ty } => {
-                        format!("{name}: {}", type_expr_to_string(ty))
+                        format!("{name}: {}", type_expr_to_string(&ty.to_type_expr()))
                     }
                     other => format!("{other:?}"),
                 };

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
@@ -108,6 +108,47 @@ fn unknown_type_in_throws() {
     ");
 }
 
+// ── 3A-2b. UnknownType on let-binding annotation ──────────────────────────
+// Quick test: see how let x: BadType = ... is diagnosed (span precision).
+
+#[test]
+fn unknown_type_in_let_binding() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "function f() -> int { let x: Nonexistent = 1; return x; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    function user.f() -> int {
+      { : never
+        let x = 1 : 1
+        return x : 1
+      }
+      !! 29..40: unresolved type: `Nonexistent`
+    }
+    ");
+}
+
+#[test]
+fn unknown_type_in_let_binding_union() {
+    // Bug check: without SpannedTypeExpr in body we get one span per type annotation (whole "int | sring").
+    // With per-node spans we'd get the diagnostic only on "sring". Snapshot shows actual span.
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "function f() -> int { let x: int | sring = 1; return x; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    function user.f() -> int {
+      { : never
+        let x = 1 : 1
+        return x : 1
+      }
+      !! 35..40: unresolved type: `sring`
+    }
+    ");
+}
+
 // ── 3A-3. UnresolvedName diagnostic ──────────────────────────────────────
 
 #[test]

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
@@ -72,6 +72,42 @@ fn unknown_type_in_return() {
     ");
 }
 
+#[test]
+fn unknown_type_in_union_return() {
+    // Precise diagnostic: only the bad union member is underlined, not the whole type.
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "function f() -> int | sring | bool { return 0; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    function user.f() -> int | unknown | bool {
+      { : never
+        return 0 : 0
+      }
+      !! 22..27: unresolved type: `sring`
+    }
+    ");
+}
+
+#[test]
+fn unknown_type_in_throws() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "function f() -> int throws MissingType { return 0; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    function user.f() -> int throws unknown {
+      { : never
+        return 0 : 0
+      }
+      !! 27..38: unresolved type: `MissingType`
+      ?? 27..38: extraneous throws declaration: unknown
+    }
+    ");
+}
+
 // ── 3A-3. UnresolvedName diagnostic ──────────────────────────────────────
 
 #[test]

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
@@ -53,7 +53,7 @@ fn unknown_type_in_param() {
       { : never
         return 0 : 0
       }
-      !! 11..25: unresolved type: Nonexistent
+      !! 14..25: unresolved type: `Nonexistent`
     }
     ");
 }
@@ -67,7 +67,7 @@ fn unknown_type_in_return() {
       { : never
         return 0 : 0
       }
-      !! 15..28: unresolved type: DoesNotExist
+      !! 16..28: unresolved type: `DoesNotExist`
     }
     ");
 }
@@ -206,7 +206,7 @@ fn missing_return() {
       { : int
         let x = 1 : 1 -> int
       }
-      !! 19..34: missing return: expected `int`
+      !! 16..19: missing return: expected `int`
     }
     ");
 }
@@ -220,7 +220,7 @@ fn block_ending_in_stmt() {
       { : string
         let x = "hello" : "hello" -> string
       }
-      !! 22..43: missing return: expected `string`
+      !! 16..22: missing return: expected `string`
     }
     "#);
 }

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -639,7 +639,7 @@ fn pat_desc(pat_id: baml_compiler2_ast::PatId, body: &baml_compiler2_ast::ExprBo
     match pat {
         Pattern::Binding(n) => n.to_string(),
         Pattern::TypedBinding { name, ty } => {
-            format!("{name}: {}", hir2_type_expr_to_string(ty))
+            format!("{name}: {}", hir2_spanned_type_expr_to_string(ty))
         }
         Pattern::Literal(lit) => lit.to_string(),
         Pattern::Null => "null".into(),
@@ -1906,7 +1906,7 @@ impl CompilerRunner {
             match pat {
                 Pattern::Binding(n) => n.to_string(),
                 Pattern::TypedBinding { name, ty } => {
-                    format!("{name}: {}", hir2_type_expr_to_string(ty))
+                    format!("{name}: {}", hir2_spanned_type_expr_to_string(ty))
                 }
                 Pattern::Literal(lit) => lit.to_string(),
                 Pattern::Null => "null".into(),
@@ -2298,7 +2298,7 @@ impl CompilerRunner {
                             let pat_name = match &body.patterns[*pattern] {
                                 Pattern::Binding(n) => n.to_string(),
                                 Pattern::TypedBinding { name, ty } => {
-                                    format!("{name}: {}", hir2_type_expr_to_string(ty))
+                                    format!("{name}: {}", hir2_spanned_type_expr_to_string(ty))
                                 }
                                 other => format!("{other:?}"),
                             };

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -1569,7 +1569,7 @@ impl CompilerRunner {
                                         format!(
                                             "{}: {}",
                                             p.name.as_str(),
-                                            hir2_type_expr_to_string(&te.expr)
+                                            hir2_type_expr_to_string(&te.to_type_expr())
                                         )
                                     })
                                     .unwrap_or_else(|| p.name.as_str().to_string())
@@ -1578,7 +1578,7 @@ impl CompilerRunner {
                         let ret_str = f
                             .return_type
                             .as_ref()
-                            .map(|te| hir2_type_expr_to_string(&te.expr))
+                            .map(|te| hir2_type_expr_to_string(&te.to_type_expr()))
                             .unwrap_or_else(|| "?".to_string());
                         let body_kind = match &f.body {
                             Some(FunctionBodyDef::Expr(_, _)) => "expr",
@@ -1597,7 +1597,7 @@ impl CompilerRunner {
                                 detail.push(format!(
                                     "  param {}: {}",
                                     p.name,
-                                    hir2_type_expr_to_string(&te.expr)
+                                    hir2_type_expr_to_string(&te.to_type_expr())
                                 ));
                             }
                         }
@@ -1698,7 +1698,7 @@ impl CompilerRunner {
                             let ty_str = field
                                 .type_expr
                                 .as_ref()
-                                .map(|te| hir2_type_expr_to_string(&te.expr))
+                                .map(|te| hir2_type_expr_to_string(&te.to_type_expr()))
                                 .unwrap_or_else(|| "?".to_string());
                             detail.push(format!("    {}: {}", field.name, ty_str));
                         }
@@ -1755,7 +1755,7 @@ impl CompilerRunner {
                     let ty_str = ta
                         .type_expr
                         .as_ref()
-                        .map(|te| hir2_type_expr_to_string(&te.expr))
+                        .map(|te| hir2_type_expr_to_string(&te.to_type_expr()))
                         .unwrap_or_else(|| "?".to_string());
                     let mut detail = vec![format!("type {}", ta.name), format!("  = {}", ty_str)];
                     let errors = item_errors(ta.name.as_str());
@@ -2849,7 +2849,7 @@ impl CompilerRunner {
                         let raw = ta
                             .type_expr
                             .as_ref()
-                            .map(|te| hir2_type_expr_to_string(&te.expr))
+                            .map(|te| hir2_type_expr_to_string(&te.to_type_expr()))
                             .unwrap_or_else(|| "?".to_string());
                         detail.push(plain(format!("  = {raw} (unresolved)")));
                         format!("= {raw}")

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -73,6 +73,11 @@ fn hir2_type_expr_to_string(ty: &baml_compiler2_ast::TypeExpr) -> String {
     }
 }
 
+/// Format compiler2 `SpannedTypeExpr` for display (strips spans).
+fn hir2_spanned_type_expr_to_string(ty: &baml_compiler2_ast::SpannedTypeExpr) -> String {
+    hir2_type_expr_to_string(&ty.to_type_expr())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum CompilerPhase {
     Lexer,
@@ -1569,7 +1574,7 @@ impl CompilerRunner {
                                         format!(
                                             "{}: {}",
                                             p.name.as_str(),
-                                            hir2_type_expr_to_string(&te.to_type_expr())
+                                            hir2_spanned_type_expr_to_string(te)
                                         )
                                     })
                                     .unwrap_or_else(|| p.name.as_str().to_string())
@@ -1578,7 +1583,7 @@ impl CompilerRunner {
                         let ret_str = f
                             .return_type
                             .as_ref()
-                            .map(|te| hir2_type_expr_to_string(&te.to_type_expr()))
+                            .map(hir2_spanned_type_expr_to_string)
                             .unwrap_or_else(|| "?".to_string());
                         let body_kind = match &f.body {
                             Some(FunctionBodyDef::Expr(_, _)) => "expr",
@@ -1597,7 +1602,7 @@ impl CompilerRunner {
                                 detail.push(format!(
                                     "  param {}: {}",
                                     p.name,
-                                    hir2_type_expr_to_string(&te.to_type_expr())
+                                    hir2_spanned_type_expr_to_string(te)
                                 ));
                             }
                         }
@@ -1698,7 +1703,7 @@ impl CompilerRunner {
                             let ty_str = field
                                 .type_expr
                                 .as_ref()
-                                .map(|te| hir2_type_expr_to_string(&te.to_type_expr()))
+                                .map(hir2_spanned_type_expr_to_string)
                                 .unwrap_or_else(|| "?".to_string());
                             detail.push(format!("    {}: {}", field.name, ty_str));
                         }
@@ -1755,7 +1760,7 @@ impl CompilerRunner {
                     let ty_str = ta
                         .type_expr
                         .as_ref()
-                        .map(|te| hir2_type_expr_to_string(&te.to_type_expr()))
+                        .map(hir2_spanned_type_expr_to_string)
                         .unwrap_or_else(|| "?".to_string());
                     let mut detail = vec![format!("type {}", ta.name), format!("  = {}", ty_str)];
                     let errors = item_errors(ta.name.as_str());
@@ -2849,7 +2854,7 @@ impl CompilerRunner {
                         let raw = ta
                             .type_expr
                             .as_ref()
-                            .map(|te| hir2_type_expr_to_string(&te.to_type_expr()))
+                            .map(hir2_spanned_type_expr_to_string)
                             .unwrap_or_else(|| "?".to_string());
                         detail.push(plain(format!("  = {raw} (unresolved)")));
                         format!("= {raw}")


### PR DESCRIPTION
Before this change, type expressions were stored as a single TypeExpr plus one span, so diagnostics (e.g. "unresolved type") pointed at the whole annotation. Now every sub-expression has its own span, so we can highlight only the part that's wrong.

## Examples of impact

- **Union with one bad member:** For `x: int | sring | bool`, we now underline only `sring` (e.g. 14..20) with "unresolved type: `sring`" instead of the whole `int | sring | bool`.

- **Bad return type:** For `function f() -> DoesNotExist { ... }`, the error is on `DoesNotExist` (e.g. 16..28), not the entire `-> DoesNotExist`.

- **Missing return:** For a function declared `-> int` with no return, the "missing return" diagnostic is on the return type annotation `: int` (e.g. 16..19), not the block body, so it's clear which function is wrong.

- **Parameter type:** For `fn f(x: Nonexistent)`, the diagnostic targets the `Nonexistent` token (e.g. 11..25), not the whole parameter.

## What changed

- **AST:** SpannedTypeExpr is recursive (SpannedTypeExprKind with spanned children). Add `to_type_expr()` for span-free TypeExpr.
- **CST→AST:** Type lowering produces SpannedTypeExpr with per-node `trimmed_text_range()`; lower_cst uses it directly.
- **HIR:** SignatureSourceMap stores full SpannedTypeExpr trees for params, return, and throws.
- **TIR:** Add `lower_spanned_type_expr()`, report `(TirTypeError, span)` per node; use for return/param/field/alias. Report "missing return" on return-type span via `return_type_span`.
- **LSP:** check uses `lower_spanned_type_expr` for precise spans.
- **Syntax:** `UnionMemberParts::text_range()`, `TypeExpr::trimmed_text_range()`.
- **Tests and tools_onionskin** updated; UnresolvedType message uses backticks.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Type annotations now record and preserve precise per-subexpression spans for richer source mapping.

* **Bug Fixes**
  * Diagnostics for return, parameter, throws and other type errors now report exact sub-expression locations and use improved code-formatted type names.
  * Many tooling paths updated to emit span-aware diagnostics for clearer error placement.

* **Tests**
  * Added and updated tests for unknown types and span-accurate diagnostics (union, throws, let bindings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->