### PR TITLE
baml-language: fix type alias resolution in compiler2

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -13,7 +13,7 @@
 //! NOT recurse into it — lambda bodies are separate scopes with their own
 //! `infer_scope_types` Salsa query.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use baml_base::Name;
 use baml_compiler2_ast::{Expr, ExprBody, ExprId, PatId, Stmt, StmtId, TypeExpr};
@@ -333,13 +333,26 @@ impl<'db> TypeInferenceBuilder<'db> {
                 type_name
                     .as_ref()
                     .and_then(|n| {
-                        self.package_items.lookup_type(&[n.clone()]).map(|def| {
-                            Ty::Class(crate::lower_type_expr::qualify_def(
-                                self.context.db(),
-                                def,
-                                n,
-                            ))
-                        })
+                        self.package_items
+                            .lookup_type(&[n.clone()])
+                            .map(|def| match def {
+                                Definition::Class(_) => Ty::Class(
+                                    crate::lower_type_expr::qualify_def(self.context.db(), def, n),
+                                ),
+                                Definition::TypeAlias(_) => {
+                                    let alias_ty =
+                                        Ty::TypeAlias(crate::lower_type_expr::qualify_def(
+                                            self.context.db(),
+                                            def,
+                                            n,
+                                        ));
+                                    match self.resolve_alias(&alias_ty) {
+                                        Ty::Class(qn) => Ty::Class(qn.clone()),
+                                        _ => Ty::Unknown,
+                                    }
+                                }
+                                _ => Ty::Unknown,
+                            })
                     })
                     .unwrap_or(Ty::Unknown)
             }
@@ -465,15 +478,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                     self.infer_expr(expr_id, body)
                 }
             }
-            // Object: if expected is Class(name), check fields
+            // Object: if expected is Class(name) or alias to a class, check fields
             Expr::Object { fields, .. } => {
-                if let Ty::Class(_) = expected {
+                let resolved = self.resolve_alias(expected).clone();
+                if let Ty::Class(_) = &resolved {
                     for (_field_name, field_expr) in fields {
                         self.infer_expr(*field_expr, body);
                     }
-                    let ty = expected.clone();
-                    self.record_expr_type(expr_id, ty.clone());
-                    ty
+                    self.record_expr_type(expr_id, resolved.clone());
+                    resolved
                 } else {
                     self.infer_expr(expr_id, body)
                 }
@@ -1073,6 +1086,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
                 Some(out)
             }
+            Ty::TypeAlias(_) => {
+                let resolved = self.resolve_alias(ty);
+                if std::ptr::eq(resolved, ty) {
+                    None
+                } else {
+                    self.required_match_cases(resolved)
+                }
+            }
             Ty::Never => Some(BTreeSet::new()),
             _ => None,
         }
@@ -1424,8 +1445,16 @@ impl<'db> TypeInferenceBuilder<'db> {
             Ty::Union(parts) => parts
                 .iter()
                 .any(|part| self.ty_matches_throw_fact(part, throw_fact)),
-            Ty::Class(qn) | Ty::Enum(qn) | Ty::TypeAlias(qn) => {
+            Ty::Class(qn) | Ty::Enum(qn) => {
                 throw_fact == qn.name.as_str() || throw_fact == qn.to_string()
+            }
+            Ty::TypeAlias(_) => {
+                let resolved = self.resolve_alias(ty);
+                if std::ptr::eq(resolved, ty) {
+                    false
+                } else {
+                    self.ty_matches_throw_fact(resolved, throw_fact)
+                }
             }
             Ty::EnumVariant(qn, variant) => {
                 throw_fact == format!("{}.{}", qn.name, variant) || throw_fact == qn.name.as_str()
@@ -2047,6 +2076,21 @@ impl<'db> TypeInferenceBuilder<'db> {
                     Ty::Unknown
                 }
             }
+            Ty::TypeAlias(_) => {
+                let resolved = self.resolve_alias(base_ty).clone();
+                if resolved == *base_ty {
+                    self.context.report_simple(
+                        TirTypeError::UnresolvedMember {
+                            base_type: base_ty.clone(),
+                            member: member.clone(),
+                        },
+                        at,
+                    );
+                    Ty::Unknown
+                } else {
+                    self.resolve_member(&resolved, member, at)
+                }
+            }
             Ty::Unknown => {
                 // Base type unknown — can't resolve member, but don't emit error
                 // (the base type error was already reported upstream)
@@ -2104,11 +2148,46 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // Drill through Optional to resolve the member on the inner type
                 self.try_resolve_member_on_ty(inner, member)
             }
+            Ty::TypeAlias(_) => {
+                let resolved = self.resolve_alias(ty);
+                if std::ptr::eq(resolved, ty) {
+                    None
+                } else {
+                    self.try_resolve_member_on_ty(resolved, member)
+                }
+            }
             Ty::Unknown => {
                 // Unknown propagates — treat as if the field exists with Unknown type
                 Some(Ty::Unknown)
             }
             _ => None,
+        }
+    }
+
+    /// Resolve a type through aliases to its underlying non-alias type.
+    /// Follows alias chains (A -> B -> C -> Class).
+    /// Returns the input type unchanged if it's not an alias or the alias is unknown.
+    /// Handles recursive aliases by returning the alias type for self-referential chains.
+    fn resolve_alias<'a>(&'a self, ty: &'a Ty) -> &'a Ty {
+        self.resolve_alias_impl(ty, &mut HashSet::new())
+    }
+
+    fn resolve_alias_impl<'a>(
+        &'a self,
+        ty: &'a Ty,
+        seen: &mut HashSet<crate::ty::QualifiedTypeName>,
+    ) -> &'a Ty {
+        match ty {
+            Ty::TypeAlias(qn) => {
+                if !seen.insert(qn.clone()) {
+                    return ty; // cycle — return as-is
+                }
+                match self.aliases.get(qn) {
+                    Some(target) => self.resolve_alias_impl(target, seen),
+                    None => ty,
+                }
+            }
+            _ => ty,
         }
     }
 

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -471,10 +471,6 @@ pub fn compile_files(
                     }
                     baml_compiler_hir::FunctionBody::Expr(_, _) => {
                         // Run type inference
-                        // Note: type_aliases is not passed here, so exhaustiveness
-                        // checking for type aliases won't work. This is acceptable
-                        // since codegen is for runtime execution, and type errors
-                        // should be caught in the TIR phase.
                         let inference = baml_compiler_tir::infer_function(
                             db,
                             &signature,
@@ -482,7 +478,7 @@ pub fn compile_files(
                             &body,
                             Some(typing_context.clone()),
                             Some(class_field_types.clone()),
-                            None, // type_aliases - not needed for codegen
+                            Some(type_aliases.clone()),
                             Some(enum_variant_names.clone()), // enum_variants - needed for enum variant detection
                             *func_loc,
                         );

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -217,6 +217,27 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
         )
     }
 
+    /// Resolve a type name through type aliases to find the underlying class name.
+    /// If the name is a type alias to a class, returns the class name.
+    /// Otherwise returns the original name unchanged.
+    fn resolve_class_name_through_aliases(&self, name: &str) -> String {
+        let mut current = Name::new(name);
+        let mut seen = std::collections::HashSet::new();
+        loop {
+            if !seen.insert(current.clone()) {
+                break; // cycle — return as-is
+            }
+            match self.type_aliases.get(&current) {
+                Some(baml_compiler_tir::Ty::Class(qn, _)) => return qn.name.to_string(),
+                Some(baml_compiler_tir::Ty::TypeAlias(qn, _)) => {
+                    current = qn.name.clone();
+                }
+                _ => break,
+            }
+        }
+        name.to_string()
+    }
+
     // ========================================================================
     // Visualization Helpers
     // ========================================================================
@@ -798,7 +819,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                         .collect();
 
                     let kind = if let Some(name) = type_name {
-                        AggregateKind::Class(name.to_string())
+                        AggregateKind::Class(self.resolve_class_name_through_aliases(name.as_str()))
                     } else {
                         AggregateKind::Class("Anonymous".to_string())
                     };
@@ -825,7 +846,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
                     let class_name = type_name
                         .as_ref()
-                        .map(std::string::ToString::to_string)
+                        .map(|n| self.resolve_class_name_through_aliases(n.as_str()))
                         .unwrap_or_else(|| "Anonymous".to_string());
 
                     // Get class fields and invert to get field_index -> field_name
@@ -2438,7 +2459,8 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
     /// Get field index for a type and field name.
     fn field_index_for_type_and_name(&self, ty: &Ty, field: &Name) -> usize {
-        let class_name = Self::class_name_from_ty(ty);
+        let class_name =
+            Self::class_name_from_ty(ty).map(|name| self.resolve_class_name_through_aliases(&name));
 
         if let Some(ref class_name) = class_name {
             if let Some(fields) = self.class_fields.get(class_name) {

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -4633,10 +4633,41 @@ fn infer_field_access(
     // First, try class field lookup for named types
     let found_field = match base {
         Ty::TypeAlias(fqn, _) => {
-            let key = fqn.display_name();
-            ctx.lookup(field)
-                .or(ctx.lookup_class_field(&key, field))
-                .cloned()
+            // Resolve the alias to its underlying type and look up the field there.
+            let mut current_name = fqn.name.clone();
+            let mut seen = std::collections::HashSet::new();
+            let mut result: Option<Ty> = None;
+            while seen.insert(current_name.clone()) {
+                match ctx.lookup_type_alias(&current_name) {
+                    Some(Ty::Class(class_fqn, _)) => {
+                        let key = class_fqn.display_name();
+                        let method_qn = QualifiedName {
+                            namespace: class_fqn.namespace.clone(),
+                            name: QualifiedName::local_method_from_str(
+                                class_fqn.name.as_str(),
+                                field.as_str(),
+                            ),
+                        };
+                        let method_lookup_name = method_qn.display_name();
+                        if let Some(method_ty) = ctx.lookup(&method_lookup_name).cloned() {
+                            if let Some(expr_id) = expr_id {
+                                ctx.set_expr_resolution(
+                                    expr_id,
+                                    ResolvedValue::Function(method_qn),
+                                );
+                            }
+                            return method_ty;
+                        }
+                        result = ctx.lookup_class_field(&key, field).cloned();
+                        break;
+                    }
+                    Some(Ty::TypeAlias(next_fqn, _)) => {
+                        current_name = next_fqn.name.clone();
+                    }
+                    _ => break,
+                }
+            }
+            result
         }
         Ty::Class(fqn, _) => {
             // First try to find a method using a class-qualified name in the same

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__06_codegen.snap
@@ -4215,317 +4215,363 @@ function MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: b
     load_const MatchSuccess
     cmp_op instanceof
     pop_jump_if_false L23
-    jump L24
+    jump L23
 
   L23:
     load_var r
-    load_const MatchFailure
-    cmp_op instanceof
-    pop_jump_if_false L24
+    jump_table [L24, L24, L24, L24, L24, L24], default L24
 
   L24:
     load_var r
-    pop 1
-    load_const false
+    type_tag
+    load_const 0
+    cmp_op ==
     pop_jump_if_false L25
+    load_var r
+    load_const 0
+    cmp_op >
+    pop_jump_if_false L25
+    jump L26
 
   L25:
     load_var r
-    jump_table [L26, L26, L26, L26, L26, L26], default L26
+    type_tag
+    load_const 0
+    cmp_op ==
+    pop_jump_if_false L26
+    load_var r
+    load_const 0
+    cmp_op <
+    pop_jump_if_false L26
 
   L26:
     load_var r
     type_tag
     load_const 0
     cmp_op ==
-    pop_jump_if_false L27
+    pop_jump_if_false L42
     load_var r
+    store_var n
+    load_var n
     load_const 0
     cmp_op >
     pop_jump_if_false L27
     jump L28
 
   L27:
-    load_var r
-    type_tag
-    load_const 0
-    cmp_op ==
-    pop_jump_if_false L28
-    load_var r
-    load_const 0
-    cmp_op <
-    pop_jump_if_false L28
+    load_const false
+    jump L29
 
   L28:
-    load_var r
-    type_tag
-    load_const 0
-    cmp_op ==
-    pop_jump_if_false L44
-    load_var r
-    store_var n
-    load_var n
-    load_const 0
-    cmp_op >
-    pop_jump_if_false L29
-    jump L30
-
-  L29:
-    load_const false
-    jump L31
-
-  L30:
     load_var n
     load_const 100
     cmp_op <
 
-  L31:
-    pop_jump_if_false L32
-    jump L33
+  L29:
+    pop_jump_if_false L30
+    jump L31
 
-  L32:
+  L30:
     load_const false
-    jump L34
+    jump L32
 
-  L33:
+  L31:
     load_var n
     load_const 42
     cmp_op !=
 
-  L34:
-    pop_jump_if_false L35
-    jump L36
+  L32:
+    pop_jump_if_false L33
+    jump L34
 
-  L35:
+  L33:
     load_const false
-    jump L37
+    jump L35
 
-  L36:
+  L34:
     load_var n
     load_const 13
     cmp_op !=
 
-  L37:
-    pop_jump_if_false L38
-    jump L39
+  L35:
+    pop_jump_if_false L36
+    jump L37
 
-  L38:
+  L36:
     load_const false
-    jump L40
+    jump L38
 
-  L39:
+  L37:
     load_var n
     load_const 7
     cmp_op !=
 
-  L40:
-    pop_jump_if_false L41
-    jump L42
+  L38:
+    pop_jump_if_false L39
+    jump L40
 
-  L41:
+  L39:
     load_const false
-    jump L43
+    jump L41
 
-  L42:
+  L40:
     load_var n
     load_const 99
     cmp_op !=
 
-  L43:
-    pop_jump_if_false L44
+  L41:
+    pop_jump_if_false L42
 
-  L44:
+  L42:
     load_var r
     copy 0
     load_const 0
     cmp_op ==
-    pop_jump_if_false L45
+    pop_jump_if_false L43
     pop 1
 
-  L45:
+  L43:
     copy 0
     load_const 1
     cmp_op ==
-    pop_jump_if_false L46
+    pop_jump_if_false L44
     pop 1
 
-  L46:
+  L44:
     pop 1
     load_var r
-    jump_table [L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47, L47], default L47
+    jump_table [L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45, L45], default L45
 
-  L47:
+  L45:
     load_var r
     discriminant
     copy 0
     load_const MatchStatus.Active
     cmp_op ==
+    pop_jump_if_false L46
+    pop 1
+
+  L46:
+    copy 0
+    load_const MatchStatus.Inactive
+    cmp_op ==
+    pop_jump_if_false L47
+    pop 1
+
+  L47:
+    pop 1
+    load_var r
+    copy 0
+    load_const 0
+    cmp_op ==
     pop_jump_if_false L48
     pop 1
 
   L48:
-    copy 0
-    load_const MatchStatus.Inactive
-    cmp_op ==
-    pop_jump_if_false L49
     pop 1
+    jump L51
+    load_var b
+    pop_jump_if_false L49
+    jump L50
 
   L49:
-    pop 1
-    load_var r
-    copy 0
-    load_const 0
-    cmp_op ==
-    pop_jump_if_false L50
-    pop 1
-
-  L50:
-    pop 1
-    jump L53
-    load_var b
-    pop_jump_if_false L51
-    jump L52
-
-  L51:
     load_const "this is the false branch also very long"
     store_var result
-    jump L53
+    jump L51
 
-  L52:
+  L50:
     load_const "this is the true branch with a very long string"
     store_var result
 
-  L53:
+  L51:
     load_var r
     type_tag
     load_const 0
     cmp_op ==
-    pop_jump_if_false L66
+    pop_jump_if_false L64
     load_var r
     store_var n
     load_var n
     load_const 0
     cmp_op >
-    pop_jump_if_false L54
-    jump L55
+    pop_jump_if_false L52
+    jump L53
+
+  L52:
+    load_const false
+    jump L54
+
+  L53:
+    load_var n
+    load_const 100
+    cmp_op <
 
   L54:
-    load_const false
+    pop_jump_if_false L55
     jump L56
 
   L55:
-    load_var n
-    load_const 100
-    cmp_op <
+    load_const false
+    jump L57
 
   L56:
-    pop_jump_if_false L57
-    jump L58
-
-  L57:
-    load_const false
-    jump L59
-
-  L58:
     load_var n
     load_const 42
     cmp_op !=
 
-  L59:
-    pop_jump_if_false L60
-    jump L61
+  L57:
+    pop_jump_if_false L58
+    jump L59
 
-  L60:
+  L58:
     load_const false
-    jump L62
+    jump L60
 
-  L61:
+  L59:
     load_var n
     load_const 13
     cmp_op !=
 
-  L62:
-    pop_jump_if_false L63
-    jump L64
+  L60:
+    pop_jump_if_false L61
+    jump L62
 
-  L63:
+  L61:
     load_const false
-    jump L65
+    jump L63
 
-  L64:
+  L62:
     load_var n
     load_const 7
     cmp_op !=
 
-  L65:
-    pop_jump_if_false L66
+  L63:
+    pop_jump_if_false L64
 
-  L66:
+  L64:
     load_var r
     type_tag
     load_const 0
     cmp_op ==
-    pop_jump_if_false L79
+    pop_jump_if_false L77
     load_var r
     store_var n
     load_var n
     load_const 0
     cmp_op >
-    pop_jump_if_false L67
-    jump L68
+    pop_jump_if_false L65
+    jump L66
 
-  L67:
+  L65:
     load_const false
-    jump L69
+    jump L67
 
-  L68:
+  L66:
     load_var n
     load_const 100
     cmp_op <
 
-  L69:
-    pop_jump_if_false L70
-    jump L71
+  L67:
+    pop_jump_if_false L68
+    jump L69
 
-  L70:
+  L68:
     load_const false
-    jump L72
+    jump L70
 
-  L71:
+  L69:
     load_var n
     load_const 42
     cmp_op !=
 
-  L72:
-    pop_jump_if_false L73
-    jump L74
+  L70:
+    pop_jump_if_false L71
+    jump L72
 
-  L73:
+  L71:
     load_const false
-    jump L75
+    jump L73
 
-  L74:
+  L72:
     load_var n
     load_const 13
     cmp_op !=
 
-  L75:
-    pop_jump_if_false L76
-    jump L77
+  L73:
+    pop_jump_if_false L74
+    jump L75
 
-  L76:
+  L74:
     load_const false
-    jump L78
+    jump L76
 
-  L77:
+  L75:
     load_var n
     load_const 7
     cmp_op !=
 
+  L76:
+    pop_jump_if_false L77
+
+  L77:
+    load_var r
+    load_const 1
+    bin_op +
+    copy 0
+    load_const 0
+    cmp_op ==
+    pop_jump_if_false L78
+    pop 1
+
   L78:
+    pop 1
+    load_var r
+    load_var r
+    bin_op *
+    load_var b
+    load_var b
+    bin_op *
+    bin_op +
+    load_var r
+    load_var b
+    bin_op *
+    bin_op +
+    load_var r
+    bin_op +
+    load_var b
+    bin_op +
+    load_var r
+    load_var r
+    bin_op *
+    load_var r
+    bin_op *
+    bin_op +
+    load_var b
+    load_var b
+    bin_op *
+    load_var b
+    bin_op *
+    bin_op +
+    load_var r
+    load_var b
+    bin_op *
+    load_var r
+    bin_op *
+    bin_op +
+    load_var b
+    load_var r
+    bin_op *
+    load_var b
+    bin_op *
+    bin_op +
+    copy 0
+    load_const 0
+    cmp_op ==
     pop_jump_if_false L79
+    pop 1
 
   L79:
+    pop 1
     load_var r
     load_const 1
     bin_op +
@@ -4538,44 +4584,6 @@ function MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: b
   L80:
     pop 1
     load_var r
-    load_var r
-    bin_op *
-    load_var b
-    load_var b
-    bin_op *
-    bin_op +
-    load_var r
-    load_var b
-    bin_op *
-    bin_op +
-    load_var r
-    bin_op +
-    load_var b
-    bin_op +
-    load_var r
-    load_var r
-    bin_op *
-    load_var r
-    bin_op *
-    bin_op +
-    load_var b
-    load_var b
-    bin_op *
-    load_var b
-    bin_op *
-    bin_op +
-    load_var r
-    load_var b
-    bin_op *
-    load_var r
-    bin_op *
-    bin_op +
-    load_var b
-    load_var r
-    bin_op *
-    load_var b
-    bin_op *
-    bin_op +
     copy 0
     load_const 0
     cmp_op ==
@@ -4585,8 +4593,6 @@ function MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: b
   L81:
     pop 1
     load_var r
-    load_const 1
-    bin_op +
     copy 0
     load_const 0
     cmp_op ==
@@ -4595,151 +4601,129 @@ function MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: b
 
   L82:
     pop 1
-    load_var r
-    copy 0
-    load_const 0
+    jump L83
+    load_var b
+    load_const true
     cmp_op ==
     pop_jump_if_false L83
-    pop 1
+    jump L83
 
   L83:
-    pop 1
     load_var r
     copy 0
     load_const 0
     cmp_op ==
     pop_jump_if_false L84
     pop 1
+    jump L89
 
   L84:
-    pop 1
-    jump L85
-    load_var b
-    load_const true
-    cmp_op ==
-    pop_jump_if_false L85
-    jump L85
-
-  L85:
-    load_var r
-    copy 0
-    load_const 0
-    cmp_op ==
-    pop_jump_if_false L86
-    pop 1
-    jump L91
-
-  L86:
     copy 0
     load_const 1
     cmp_op ==
-    pop_jump_if_false L87
+    pop_jump_if_false L85
     pop 1
 
-  L87:
+  L85:
     pop 1
-    jump L96
+    jump L94
     load_var r
     load_const MatchSuccess
     cmp_op instanceof
+    pop_jump_if_false L86
+    jump L87
+
+  L86:
+    jump L94
+
+  L87:
+    load_var b
+    load_const true
+    cmp_op ==
     pop_jump_if_false L88
-    jump L89
+    jump L94
 
   L88:
-    load_var r
-    load_const MatchFailure
-    cmp_op instanceof
-    pop_jump_if_false L96
-    jump L96
+    jump L94
 
   L89:
     load_var b
     load_const true
     cmp_op ==
     pop_jump_if_false L90
-    jump L96
+    jump L91
 
   L90:
-    jump L96
+    jump L94
 
   L91:
-    load_var b
-    load_const true
-    cmp_op ==
-    pop_jump_if_false L92
-    jump L93
-
-  L92:
-    jump L96
-
-  L93:
     load_var r
     discriminant
     copy 0
     load_const MatchStatus.Active
     cmp_op ==
-    pop_jump_if_false L94
+    pop_jump_if_false L92
+    pop 1
+
+  L92:
+    copy 0
+    load_const MatchStatus.Inactive
+    cmp_op ==
+    pop_jump_if_false L93
+    pop 1
+
+  L93:
     pop 1
 
   L94:
+    load_var r
     copy 0
-    load_const MatchStatus.Inactive
+    load_const 0
     cmp_op ==
     pop_jump_if_false L95
     pop 1
 
   L95:
     pop 1
+    jump L98
+    load_var b
+    pop_jump_if_false L98
+    load_var r
+    discriminant
+    copy 0
+    load_const MatchStatus.Active
+    cmp_op ==
+    pop_jump_if_false L96
+    pop 1
 
   L96:
-    load_var r
     copy 0
-    load_const 0
+    load_const MatchStatus.Inactive
     cmp_op ==
     pop_jump_if_false L97
     pop 1
 
   L97:
     pop 1
-    jump L100
-    load_var b
-    pop_jump_if_false L100
-    load_var r
-    discriminant
-    copy 0
-    load_const MatchStatus.Active
-    cmp_op ==
-    pop_jump_if_false L98
-    pop 1
 
   L98:
-    copy 0
-    load_const MatchStatus.Inactive
-    cmp_op ==
-    pop_jump_if_false L99
-    pop 1
-
-  L99:
-    pop 1
-
-  L100:
     load_var r
     copy 0
     load_const 0
     cmp_op ==
-    pop_jump_if_false L101
+    pop_jump_if_false L99
     pop 1
-    jump L102
+    jump L100
 
-  L101:
+  L99:
     pop 1
     load_const "other"
-    jump L103
+    jump L101
 
-  L102:
+  L100:
     load_const "zero"
 
-  L103:
+  L101:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -66,20 +66,9 @@ function DeeplyNestedLiterals(x: 200 | 201 | 204) -> string {
     pop 1
 
   L1:
-    copy 0
-    load_const 204
-    cmp_op ==
-    pop_jump_if_false L2
     pop 1
-
-  L2:
-    pop 1
-    jump L3
     load_const "all success codes"
     return
-
-  L3:
-    unreachable
 }
 
 function DuplicateBoolLiteral(b: bool) -> string {
@@ -188,10 +177,6 @@ function DuplicateStringLiteral(role: "user" | "assistant" | "system") -> string
     jump L3
 
   L2:
-    load_var role
-    load_const "system"
-    cmp_op ==
-    pop_jump_if_false L6
     load_const "system"
     jump L6
 
@@ -296,29 +281,18 @@ function ExhaustiveAliasOfLiterals(code: 200 | 201) -> string {
     cmp_op ==
     pop_jump_if_false L0
     pop 1
-    jump L2
+    jump L1
 
   L0:
-    copy 0
-    load_const 201
-    cmp_op ==
-    pop_jump_if_false L1
     pop 1
+    load_const "created"
+    jump L2
 
   L1:
-    pop 1
-    jump L4
-    load_const "created"
-    jump L3
-
-  L2:
     load_const "ok"
 
-  L3:
+  L2:
     return
-
-  L4:
-    unreachable
 }
 
 function ExhaustiveBool(b: bool) -> string {
@@ -347,10 +321,6 @@ function ExhaustiveClassPlusLiteral(x: Success | 200) -> string {
     jump L1
 
   L0:
-    load_var x
-    load_const 200
-    cmp_op ==
-    pop_jump_if_false L2
     load_const "http ok"
     jump L2
 
@@ -370,10 +340,6 @@ function ExhaustiveCustomBool(b: true | false) -> string {
     jump L1
 
   L0:
-    load_var b
-    load_const false
-    cmp_op ==
-    pop_jump_if_false L2
     load_const "no"
     jump L2
 
@@ -399,10 +365,6 @@ function ExhaustiveDoubleMaybe(dm: Success | Failure??) -> string {
     jump L2
 
   L1:
-    load_var dm
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
     load_const "nothing"
     jump L4
 
@@ -481,12 +443,6 @@ function ExhaustiveEnumWithTypedPattern(s: Status) -> string {
 }
 
 function ExhaustiveFalseType(f: false) -> string {
-    load_var f
-    load_const false
-    cmp_op ==
-    pop_jump_if_false L0
-
-  L0:
     load_const "always false"
     return
 }
@@ -498,7 +454,7 @@ function ExhaustiveIntLiterals(code: 200 | 201 | 204) -> string {
     cmp_op ==
     pop_jump_if_false L0
     pop 1
-    jump L4
+    jump L3
 
   L0:
     copy 0
@@ -506,33 +462,22 @@ function ExhaustiveIntLiterals(code: 200 | 201 | 204) -> string {
     cmp_op ==
     pop_jump_if_false L1
     pop 1
-    jump L3
+    jump L2
 
   L1:
-    copy 0
-    load_const 204
-    cmp_op ==
-    pop_jump_if_false L2
     pop 1
+    load_const "No Content"
+    jump L4
 
   L2:
-    pop 1
-    jump L6
-    load_const "No Content"
-    jump L5
+    load_const "Created"
+    jump L4
 
   L3:
-    load_const "Created"
-    jump L5
-
-  L4:
     load_const "OK"
 
-  L5:
+  L4:
     return
-
-  L6:
-    unreachable
 }
 
 function ExhaustiveLiteralWithBaseType(x: int) -> string {
@@ -568,10 +513,6 @@ function ExhaustiveMixedLiterals(x: 200 | "success" | true) -> string {
     jump L2
 
   L1:
-    load_var x
-    load_const true
-    cmp_op ==
-    pop_jump_if_false L4
     load_const "boolean true"
     jump L4
 
@@ -675,10 +616,6 @@ function ExhaustiveOptionalSingleton(code: 200?) -> string {
     jump L1
 
   L0:
-    load_var code
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
     load_const "no code"
     jump L2
 
@@ -691,20 +628,9 @@ function ExhaustiveOptionalSingleton(code: 200?) -> string {
 
 function ExhaustiveSingletonInt(code: 200) -> string {
     load_var code
-    copy 0
-    load_const 200
-    cmp_op ==
-    pop_jump_if_false L0
     pop 1
-
-  L0:
-    pop 1
-    jump L1
     load_const "OK"
     return
-
-  L1:
-    unreachable
 }
 
 function ExhaustiveStringLiterals(role: "user" | "assistant" | "system") -> string {
@@ -722,10 +648,6 @@ function ExhaustiveStringLiterals(role: "user" | "assistant" | "system") -> stri
     jump L2
 
   L1:
-    load_var role
-    load_const "system"
-    cmp_op ==
-    pop_jump_if_false L4
     load_const "System"
     jump L4
 
@@ -741,12 +663,6 @@ function ExhaustiveStringLiterals(role: "user" | "assistant" | "system") -> stri
 }
 
 function ExhaustiveTrueType(t: true) -> string {
-    load_var t
-    load_const true
-    cmp_op ==
-    pop_jump_if_false L0
-
-  L0:
     load_const "always true"
     return
 }
@@ -759,10 +675,6 @@ function ExhaustiveTypeAlias(r: Success | Failure) -> string {
     jump L1
 
   L0:
-    load_var r
-    load_const Failure
-    cmp_op instanceof
-    pop_jump_if_false L2
     load_var r
     load_field .reason
     jump L2
@@ -944,7 +856,7 @@ function IntLiteralUnionPattern(code: 200 | 201 | 204) -> string {
     cmp_op ==
     pop_jump_if_false L0
     pop 1
-    jump L3
+    jump L2
 
   L0:
     copy 0
@@ -952,29 +864,18 @@ function IntLiteralUnionPattern(code: 200 | 201 | 204) -> string {
     cmp_op ==
     pop_jump_if_false L1
     pop 1
-    jump L3
+    jump L2
 
   L1:
-    copy 0
-    load_const 204
-    cmp_op ==
-    pop_jump_if_false L2
     pop 1
+    load_const "no content"
+    jump L3
 
   L2:
-    pop 1
-    jump L5
-    load_const "no content"
-    jump L4
-
-  L3:
     load_const "success with body"
 
-  L4:
+  L3:
     return
-
-  L5:
-    unreachable
 }
 
 function JumpTableClassTypeTag(pet: Cat | Dog | Bird | Fish) -> string {
@@ -1557,10 +1458,6 @@ function NestedTypeAlias(mr: Success | Failure?) -> string {
     jump L2
 
   L1:
-    load_var mr
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
     load_const "nothing"
     jump L4
 
@@ -1585,10 +1482,6 @@ function NestedTypeBindings(r: Success | Failure) -> int {
     jump L1
 
   L0:
-    load_var r
-    load_const Failure
-    cmp_op instanceof
-    pop_jump_if_false L2
     load_const 1
     jump L2
 
@@ -2014,10 +1907,6 @@ function OverlappingTypedPatterns(r: Success | Failure) -> string {
     jump L1
 
   L0:
-    load_var r
-    pop 1
-    load_const false
-    pop_jump_if_false L2
     load_const "covers failure only (success already handled)"
     jump L2
 
@@ -2036,10 +1925,6 @@ function OverlappingWithBindings(r: Success | Failure) -> string {
     jump L1
 
   L0:
-    load_var r
-    pop 1
-    load_const false
-    pop_jump_if_false L2
     load_const "remaining"
     jump L2
 
@@ -2088,10 +1973,6 @@ function PartialUnionPlusCatchAll(r: Success | Failure | Pending) -> string {
     jump L1
 
   L0:
-    load_var r
-    load_const Pending
-    cmp_op instanceof
-    pop_jump_if_false L2
     load_const "pending"
     jump L2
 
@@ -2136,10 +2017,6 @@ function StringLiteralUnionPattern(role: "user" | "assistant" | "system") -> str
     jump L2
 
   L1:
-    load_var role
-    load_const "system"
-    cmp_op ==
-    pop_jump_if_false L3
     load_const "system"
     jump L3
 
@@ -2229,12 +2106,6 @@ function ThreeLevelNestedMatch(x: int, y: int, z: int) -> string {
 }
 
 function UnionPatternCoversAll(r: Success | Failure) -> string {
-    load_var r
-    pop 1
-    load_const false
-    pop_jump_if_false L0
-
-  L0:
     load_const "covered"
     return
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -159,6 +159,128 @@ fn resolve_type_alias_query() {
     insta::assert_snapshot!(render_tir(&db, file), @"type user.MyStr = string");
 }
 
+// ── Type alias struct literal regression tests ─────────────────────────────
+
+#[test]
+fn class_struct_literal() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "class Foo { x int }\nfunction f() -> Foo { return Foo { x: 1 }; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    class user.Foo {
+      x: int
+    }
+    function user.f() -> user.Foo {
+      { : never
+        return Foo { x: 1 } : user.Foo
+      }
+    }
+    ");
+}
+
+#[test]
+fn type_alias_struct_literal() {
+    // Regression test: type alias used in struct literal should resolve
+    // the alias and type-check fields against the underlying class.
+    //
+    // BUG: Currently `Bar { x: 1 }` is typed as `user.Bar` by creating a
+    // fake Ty::Class with the alias name. This "works" superficially but
+    // field access will fail (see type_alias_struct_literal_field_access).
+    // After fix: the struct literal should resolve through the alias to
+    // produce Ty::Class(user.Foo).
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "class Foo { x int }\ntype Bar = Foo\nfunction f() -> Bar { return Bar { x: 1 }; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    class user.Foo {
+      x: int
+    }
+    type user.Bar = user.Foo
+    function user.f() -> user.Bar {
+      { : never
+        return Bar { x: 1 } : user.Foo
+      }
+    }
+    ");
+}
+
+#[test]
+fn type_alias_struct_literal_field_access() {
+    // Field access through a type-alias-constructed struct literal.
+    //
+    // BUG: `v.x` fails with "unresolved member: user.Bar.x" because the
+    // struct literal was typed as a fake class "Bar" which has no fields.
+    // After fix: `v.x` should resolve to `int`.
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "class Foo { x int }\ntype Bar = Foo\nfunction f() -> int { let v = Bar { x: 1 }; return v.x; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    class user.Foo {
+      x: int
+    }
+    type user.Bar = user.Foo
+    function user.f() -> int {
+      { : never
+        let v = Bar { x: 1 } : user.Foo
+        return v.x : int
+      }
+    }
+    ");
+}
+
+#[test]
+fn type_alias_check_expr_path() {
+    // When the expected type is a TypeAlias (from return type annotation),
+    // check_expr should resolve through the alias for field checking.
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "class Foo { x int }\ntype Bar = Foo\nfunction f() -> Bar { return Foo { x: 1 }; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    class user.Foo {
+      x: int
+    }
+    type user.Bar = user.Foo
+    function user.f() -> user.Bar {
+      { : never
+        return Foo { x: 1 } : user.Foo
+      }
+    }
+    ");
+}
+
+#[test]
+fn type_alias_member_access_on_param() {
+    // Field access on a parameter typed with an alias.
+    //
+    // BUG: `v.x` fails with "unresolved member: user.Bar.x" because
+    // resolve_member has no TypeAlias arm.
+    // After fix: `v.x` should resolve to `int`.
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "class Foo { x int }\ntype Bar = Foo\nfunction f(v: Bar) -> int { return v.x; }",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @r"
+    class user.Foo {
+      x: int
+    }
+    type user.Bar = user.Foo
+    function user.f(v: user.Bar) -> int {
+      { : never
+        return v.x : int
+      }
+    }
+    ");
+}
+
 #[test]
 fn two_functions_independent() {
     let mut db = make_db();

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -118,181 +118,169 @@ function http_status(code: int) -> string {
 }
 
 function score(input: User | ErrorInfo, threshold: int) -> Report {
-  45   0     load_var 1              (input)
-       1     load_const 0            (User)
-       2     cmp_op instanceof       
-       3     pop_jump_if_false +2    (to 5)
-       4     jump +9                 (to 13)
-       5     load_var 1              (input)
-       6     load_const 1            (ErrorInfo)
-       7     cmp_op instanceof       
-       8     pop_jump_if_false +8    (to 16)
+  45   0     load_var 1             (input)
+       1     load_const 0           (User)
+       2     cmp_op instanceof      
+       3     pop_jump_if_false +2   (to 5)
+       4     jump +5                (to 9)
 
-  47   9     load_var 1              (input)
-       10    load_field 1            (message)
-       11    store_var 3             (name)
-       12    jump +4                 (to 16)
+  47   5     load_var 1             (input)
+       6     load_field 1           (message)
+       7     store_var 3            (name)
+       8     jump +4                (to 12)
 
-  46   13    load_var 1              (input)
-       14    load_field 0            (name)
-       15    store_var 3             (name)
+  46   9     load_var 1             (input)
+       10    load_field 0           (name)
+       11    store_var 3            (name)
 
-  50   16    load_var 1              (input)
-       17    load_const 0            (User)
-       18    cmp_op instanceof       
-       19    pop_jump_if_false +2    (to 21)
-       20    jump +10                (to 30)
-       21    load_var 1              (input)
-       22    load_const 1            (ErrorInfo)
-       23    cmp_op instanceof       
-       24    pop_jump_if_false +9    (to 33)
+  50   12    load_var 1             (input)
+       13    load_const 0           (User)
+       14    cmp_op instanceof      
+       15    pop_jump_if_false +2   (to 17)
+       16    jump +6                (to 22)
 
-  52   25    load_var 1              (input)
-       26    load_field 0            (code)
-       27    unary_op -              
-       28    store_var 4             (age)
-       29    jump +4                 (to 33)
+  52   17    load_var 1             (input)
+       18    load_field 0           (code)
+       19    unary_op -             
+       20    store_var 4            (age)
+       21    jump +4                (to 25)
 
-  51   30    load_var 1              (input)
-       31    load_field 1            (age)
-       32    store_var 4             (age)
+  51   22    load_var 1             (input)
+       23    load_field 1           (age)
+       24    store_var 4            (age)
 
-  55   33    load_var 1              (input)
-       34    load_const 0            (User)
-       35    cmp_op instanceof       
-       36    pop_jump_if_false +2    (to 38)
-       37    jump +8                 (to 45)
-       38    load_var 1              (input)
-       39    load_const 1            (ErrorInfo)
-       40    cmp_op instanceof       
-       41    pop_jump_if_false +19   (to 60)
+  55   25    load_var 1             (input)
+       26    load_const 0           (User)
+       27    cmp_op instanceof      
+       28    pop_jump_if_false +2   (to 30)
+       29    jump +4                (to 33)
 
-  62   42    load_const 2            (0)
-       43    store_var 5             (role_score)
-       44    jump +16                (to 60)
+  62   30    load_const 1           (0)
+       31    store_var 5            (role_score)
+       32    jump +16               (to 48)
 
-  56   45    load_var 1              (input)
-       46    load_field 2            (role)
-       47    discriminant            
-       48    jump_table 0, +96       ([to 58, to 55, to 52, to 49], default to 144)
+  56   33    load_var 1             (input)
+       34    load_field 2           (role)
+       35    discriminant           
+       36    jump_table 0, +96      ([to 46, to 43, to 40, to 37], default to 132)
 
-  60   49    load_const 3            (1)
-       50    store_var 5             (role_score)
-       51    jump +9                 (to 60)
+  60   37    load_const 2           (1)
+       38    store_var 5            (role_score)
+       39    jump +9                (to 48)
 
-  59   52    load_const 4            (2)
-       53    store_var 5             (role_score)
-       54    jump +6                 (to 60)
+  59   40    load_const 3           (2)
+       41    store_var 5            (role_score)
+       42    jump +6                (to 48)
 
-  58   55    load_const 5            (5)
-       56    store_var 5             (role_score)
-       57    jump +3                 (to 60)
+  58   43    load_const 4           (5)
+       44    store_var 5            (role_score)
+       45    jump +3                (to 48)
 
-  57   58    load_const 6            (10)
-       59    store_var 5             (role_score)
+  57   46    load_const 5           (10)
+       47    store_var 5            (role_score)
 
-  65   60    load_var 4              (age)
-       61    load_const 4            (2)
-       62    bin_op *                
-       63    load_const 6            (10)
-       64    bin_op +                
-       65    store_var 6             (base)
+  65   48    load_var 4             (age)
+       49    load_const 3           (2)
+       50    bin_op *               
+       51    load_const 5           (10)
+       52    bin_op +               
+       53    store_var 6            (base)
 
-  66   66    load_var 6              (base)
-       67    load_const 7            (100)
-       68    cmp_op >                
-       69    pop_jump_if_false +2    (to 71)
-       70    jump +12                (to 82)
+  66   54    load_var 6             (base)
+       55    load_const 6           (100)
+       56    cmp_op >               
+       57    pop_jump_if_false +2   (to 59)
+       58    jump +12               (to 70)
 
-  68   71    load_var 6              (base)
-       72    load_const 2            (0)
-       73    cmp_op <                
-       74    pop_jump_if_false +2    (to 76)
-       75    jump +4                 (to 79)
+  68   59    load_var 6             (base)
+       60    load_const 1           (0)
+       61    cmp_op <               
+       62    pop_jump_if_false +2   (to 64)
+       63    jump +4                (to 67)
 
-  70   76    load_var 6              (base)
-       77    store_var 7             (capped)
-       78    jump +6                 (to 84)
+  70   64    load_var 6             (base)
+       65    store_var 7            (capped)
+       66    jump +6                (to 72)
 
-  68   79    load_const 2            (0)
-       80    store_var 7             (capped)
-       81    jump +3                 (to 84)
+  68   67    load_const 1           (0)
+       68    store_var 7            (capped)
+       69    jump +3                (to 72)
 
-  66   82    load_const 7            (100)
-       83    store_var 7             (capped)
+  66   70    load_const 6           (100)
+       71    store_var 7            (capped)
 
-  73   84    load_var 7              (capped)
-       85    load_const 4            (2)
-       86    bin_op %                
-       87    load_const 2            (0)
-       88    cmp_op ==               
-       89    pop_jump_if_false +2    (to 91)
-       90    jump +4                 (to 94)
-       91    load_const 2            (0)
-       92    store_var 8             (bonus)
-       93    jump +3                 (to 96)
-       94    load_const 5            (5)
-       95    store_var 8             (bonus)
+  73   72    load_var 7             (capped)
+       73    load_const 3           (2)
+       74    bin_op %               
+       75    load_const 1           (0)
+       76    cmp_op ==              
+       77    pop_jump_if_false +2   (to 79)
+       78    jump +4                (to 82)
+       79    load_const 1           (0)
+       80    store_var 8            (bonus)
+       81    jump +3                (to 84)
+       82    load_const 4           (5)
+       83    store_var 8            (bonus)
 
-  74   96    load_var 7              (capped)
-       97    load_var 5              (role_score)
-       98    bin_op *                
-       99    load_var 8              (bonus)
-       100   bin_op +                
-       101   store_var 9             (total)
+  74   84    load_var 7             (capped)
+       85    load_var 5             (role_score)
+       86    bin_op *               
+       87    load_var 8             (bonus)
+       88    bin_op +               
+       89    store_var 9            (total)
 
-  76   102   load_var 9              (total)
-       103   load_var 2              (threshold)
-       104   cmp_op >                
-       105   store_var 11            (_50)
-       106   load_var 11             (_50)
-       107   load_const 8            (true)
-       108   cmp_op ==               
-       109   pop_jump_if_false +2    (to 111)
-       110   jump +4                 (to 114)
+  76   90    load_var 9             (total)
+       91    load_var 2             (threshold)
+       92    cmp_op >               
+       93    store_var 11           (_50)
+       94    load_var 11            (_50)
+       95    load_const 7           (true)
+       96    cmp_op ==              
+       97    pop_jump_if_false +2   (to 99)
+       98    jump +4                (to 102)
 
-  78   111   load_const 9            (" [LOW]")
-       112   store_var 10            (suffix)
-       113   jump +3                 (to 116)
+  78   99    load_const 8           (" [LOW]")
+       100   store_var 10           (suffix)
+       101   jump +3                (to 104)
 
-  77   114   load_const 10           (" [HIGH]")
-       115   store_var 10            (suffix)
+  77   102   load_const 9           (" [HIGH]")
+       103   store_var 10           (suffix)
 
-  82   116   load_var 6              (base)
-       117   load_var 7              (capped)
-       118   load_var 9              (total)
-       119   alloc_array 3           
-       120   store_var 12            (scores)
+  82   104   load_var 6             (base)
+       105   load_var 7             (capped)
+       106   load_var 9             (total)
+       107   alloc_array 3          
+       108   store_var 12           (scores)
 
-  83   121   load_var 12             (scores)
-       122   load_const 2            (0)
-       123   load_var 9              (total)
-       124   store_array_element     
+  83   109   load_var 12            (scores)
+       110   load_const 1           (0)
+       111   load_var 9             (total)
+       112   store_array_element    
 
-  88   125   alloc_instance 12       (Report)
-       126   copy 0                  
+  88   113   alloc_instance 12      (Report)
+       114   copy 0                 
 
-  84   127   load_var 12             (scores)
-       128   load_const 2            (0)
-       129   load_array_element      
-       130   store_field 0           (score)
-       131   copy 0                  
+  84   115   load_var 12            (scores)
+       116   load_const 1           (0)
+       117   load_array_element     
+       118   store_field 0          (score)
+       119   copy 0                 
 
-  80   132   load_var 3              (name)
-       133   load_var 10             (suffix)
-       134   bin_op +                
-       135   store_field 1           (label)
-       136   copy 0                  
+  80   120   load_var 3             (name)
+       121   load_var 10            (suffix)
+       122   bin_op +               
+       123   store_field 1          (label)
+       124   copy 0                 
 
-  86   137   load_var 6              (base)
-       138   load_var 5              (role_score)
-       139   load_const 11           ("base")
-       140   load_const 12           ("role")
-       141   alloc_map 2             
-       142   store_field 2           (breakdown)
+  86   125   load_var 6             (base)
+       126   load_var 5             (role_score)
+       127   load_const 10          ("base")
+       128   load_const 11          ("role")
+       129   alloc_map 2            
+       130   store_field 2          (breakdown)
 
-  88   143   return                  
-       144   unreachable             
+  88   131   return                 
+       132   unreachable            
 }
 
 function stream_User.promote(self: stream_User, bonus: int) -> Report {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -123,202 +123,190 @@ function http_status(code: int) -> string {
 }
 
 function score(input: User | ErrorInfo, threshold: int) -> Report {
-  45   0     load_var 1              (input)
-       1     load_const 0            (User)
-       2     cmp_op instanceof       
-       3     pop_jump_if_false +2    (to 5)
-       4     jump +11                (to 15)
-       5     load_var 1              (input)
-       6     load_const 1            (ErrorInfo)
-       7     cmp_op instanceof       
-       8     pop_jump_if_false +12   (to 20)
+  45   0     load_var 1             (input)
+       1     load_const 0           (User)
+       2     cmp_op instanceof      
+       3     pop_jump_if_false +2   (to 5)
+       4     jump +7                (to 11)
 
-  47   9     load_var 1              (input)
-       10    store_var 5             (e)
-       11    load_var 5              (e)
-       12    load_field 1            (message)
-       13    store_var 3             (name)
-       14    jump +6                 (to 20)
+  47   5     load_var 1             (input)
+       6     store_var 5            (e)
+       7     load_var 5             (e)
+       8     load_field 1           (message)
+       9     store_var 3            (name)
+       10    jump +6                (to 16)
 
-  46   15    load_var 1              (input)
-       16    store_var 4             (u)
-       17    load_var 4              (u)
-       18    load_field 0            (name)
-       19    store_var 3             (name)
+  46   11    load_var 1             (input)
+       12    store_var 4            (u)
+       13    load_var 4             (u)
+       14    load_field 0           (name)
+       15    store_var 3            (name)
 
-  50   20    load_var 1              (input)
-       21    load_const 0            (User)
-       22    cmp_op instanceof       
-       23    pop_jump_if_false +2    (to 25)
-       24    jump +12                (to 36)
-       25    load_var 1              (input)
-       26    load_const 1            (ErrorInfo)
-       27    cmp_op instanceof       
-       28    pop_jump_if_false +13   (to 41)
+  50   16    load_var 1             (input)
+       17    load_const 0           (User)
+       18    cmp_op instanceof      
+       19    pop_jump_if_false +2   (to 21)
+       20    jump +8                (to 28)
 
-  52   29    load_var 1              (input)
-       30    store_var 8             (e)
-       31    load_var 8              (e)
-       32    load_field 0            (code)
-       33    unary_op -              
-       34    store_var 6             (age)
-       35    jump +6                 (to 41)
+  52   21    load_var 1             (input)
+       22    store_var 8            (e)
+       23    load_var 8             (e)
+       24    load_field 0           (code)
+       25    unary_op -             
+       26    store_var 6            (age)
+       27    jump +6                (to 33)
 
-  51   36    load_var 1              (input)
-       37    store_var 7             (u)
-       38    load_var 7              (u)
-       39    load_field 1            (age)
-       40    store_var 6             (age)
+  51   28    load_var 1             (input)
+       29    store_var 7            (u)
+       30    load_var 7             (u)
+       31    load_field 1           (age)
+       32    store_var 6            (age)
 
-  55   41    load_var 1              (input)
-       42    load_const 0            (User)
-       43    cmp_op instanceof       
-       44    pop_jump_if_false +2    (to 46)
-       45    jump +10                (to 55)
-       46    load_var 1              (input)
-       47    load_const 1            (ErrorInfo)
-       48    cmp_op instanceof       
-       49    pop_jump_if_false +23   (to 72)
+  55   33    load_var 1             (input)
+       34    load_const 0           (User)
+       35    cmp_op instanceof      
+       36    pop_jump_if_false +2   (to 38)
+       37    jump +6                (to 43)
 
-  62   50    load_var 1              (input)
-       51    store_var 11            (e)
-       52    load_const 2            (0)
-       53    store_var 9             (role_score)
-       54    jump +18                (to 72)
+  62   38    load_var 1             (input)
+       39    store_var 11           (e)
+       40    load_const 1           (0)
+       41    store_var 9            (role_score)
+       42    jump +18               (to 60)
 
-  56   55    load_var 1              (input)
-       56    store_var 10            (u)
-       57    load_var 10             (u)
-       58    load_field 2            (role)
-       59    discriminant            
-       60    jump_table 0, +102      ([to 70, to 67, to 64, to 61], default to 162)
+  56   43    load_var 1             (input)
+       44    store_var 10           (u)
+       45    load_var 10            (u)
+       46    load_field 2           (role)
+       47    discriminant           
+       48    jump_table 0, +102     ([to 58, to 55, to 52, to 49], default to 150)
 
-  60   61    load_const 3            (1)
-       62    store_var 9             (role_score)
-       63    jump +9                 (to 72)
+  60   49    load_const 2           (1)
+       50    store_var 9            (role_score)
+       51    jump +9                (to 60)
 
-  59   64    load_const 4            (2)
-       65    store_var 9             (role_score)
-       66    jump +6                 (to 72)
+  59   52    load_const 3           (2)
+       53    store_var 9            (role_score)
+       54    jump +6                (to 60)
 
-  58   67    load_const 5            (5)
-       68    store_var 9             (role_score)
-       69    jump +3                 (to 72)
+  58   55    load_const 4           (5)
+       56    store_var 9            (role_score)
+       57    jump +3                (to 60)
 
-  57   70    load_const 6            (10)
-       71    store_var 9             (role_score)
+  57   58    load_const 5           (10)
+       59    store_var 9            (role_score)
 
-  65   72    load_var 6              (age)
-       73    load_const 4            (2)
-       74    bin_op *                
-       75    load_const 6            (10)
-       76    bin_op +                
-       77    store_var 12            (base)
+  65   60    load_var 6             (age)
+       61    load_const 3           (2)
+       62    bin_op *               
+       63    load_const 5           (10)
+       64    bin_op +               
+       65    store_var 12           (base)
 
-  66   78    load_var 12             (base)
-       79    load_const 7            (100)
-       80    cmp_op >                
-       81    pop_jump_if_false +2    (to 83)
-       82    jump +12                (to 94)
+  66   66    load_var 12            (base)
+       67    load_const 6           (100)
+       68    cmp_op >               
+       69    pop_jump_if_false +2   (to 71)
+       70    jump +12               (to 82)
 
-  68   83    load_var 12             (base)
-       84    load_const 2            (0)
-       85    cmp_op <                
-       86    pop_jump_if_false +2    (to 88)
-       87    jump +4                 (to 91)
+  68   71    load_var 12            (base)
+       72    load_const 1           (0)
+       73    cmp_op <               
+       74    pop_jump_if_false +2   (to 76)
+       75    jump +4                (to 79)
 
-  70   88    load_var 12             (base)
-       89    store_var 13            (capped)
-       90    jump +6                 (to 96)
+  70   76    load_var 12            (base)
+       77    store_var 13           (capped)
+       78    jump +6                (to 84)
 
-  68   91    load_const 2            (0)
-       92    store_var 13            (capped)
-       93    jump +3                 (to 96)
+  68   79    load_const 1           (0)
+       80    store_var 13           (capped)
+       81    jump +3                (to 84)
 
-  66   94    load_const 7            (100)
-       95    store_var 13            (capped)
+  66   82    load_const 6           (100)
+       83    store_var 13           (capped)
 
-  73   96    load_var 13             (capped)
-       97    load_const 4            (2)
-       98    bin_op %                
-       99    load_const 2            (0)
-       100   cmp_op ==               
-       101   pop_jump_if_false +2    (to 103)
-       102   jump +4                 (to 106)
-       103   load_const 2            (0)
-       104   store_var 14            (bonus)
-       105   jump +3                 (to 108)
-       106   load_const 5            (5)
-       107   store_var 14            (bonus)
+  73   84    load_var 13            (capped)
+       85    load_const 3           (2)
+       86    bin_op %               
+       87    load_const 1           (0)
+       88    cmp_op ==              
+       89    pop_jump_if_false +2   (to 91)
+       90    jump +4                (to 94)
+       91    load_const 1           (0)
+       92    store_var 14           (bonus)
+       93    jump +3                (to 96)
+       94    load_const 4           (5)
+       95    store_var 14           (bonus)
 
-  74   108   load_var 13             (capped)
-       109   load_var 9              (role_score)
-       110   bin_op *                
-       111   load_var 14             (bonus)
-       112   bin_op +                
-       113   store_var 15            (total)
+  74   96    load_var 13            (capped)
+       97    load_var 9             (role_score)
+       98    bin_op *               
+       99    load_var 14            (bonus)
+       100   bin_op +               
+       101   store_var 15           (total)
 
-  76   114   load_var 15             (total)
-       115   load_var 2              (threshold)
-       116   cmp_op >                
-       117   store_var 17            (_50)
-       118   load_var 17             (_50)
-       119   load_const 8            (true)
-       120   cmp_op ==               
-       121   pop_jump_if_false +2    (to 123)
-       122   jump +4                 (to 126)
+  76   102   load_var 15            (total)
+       103   load_var 2             (threshold)
+       104   cmp_op >               
+       105   store_var 17           (_50)
+       106   load_var 17            (_50)
+       107   load_const 7           (true)
+       108   cmp_op ==              
+       109   pop_jump_if_false +2   (to 111)
+       110   jump +4                (to 114)
 
-  78   123   load_const 9            (" [LOW]")
-       124   store_var 16            (suffix)
-       125   jump +3                 (to 128)
+  78   111   load_const 8           (" [LOW]")
+       112   store_var 16           (suffix)
+       113   jump +3                (to 116)
 
-  77   126   load_const 10           (" [HIGH]")
-       127   store_var 16            (suffix)
+  77   114   load_const 9           (" [HIGH]")
+       115   store_var 16           (suffix)
 
-  80   128   load_var 3              (name)
-       129   load_var 16             (suffix)
-       130   bin_op +                
-       131   store_var 18            (label)
+  80   116   load_var 3             (name)
+       117   load_var 16            (suffix)
+       118   bin_op +               
+       119   store_var 18           (label)
 
-  82   132   load_var 12             (base)
-       133   load_var 13             (capped)
-       134   load_var 15             (total)
-       135   alloc_array 3           
-       136   store_var 19            (scores)
+  82   120   load_var 12            (base)
+       121   load_var 13            (capped)
+       122   load_var 15            (total)
+       123   alloc_array 3          
+       124   store_var 19           (scores)
 
-  83   137   load_var 19             (scores)
-       138   load_const 2            (0)
-       139   load_var 15             (total)
-       140   store_array_element     
+  83   125   load_var 19            (scores)
+       126   load_const 1           (0)
+       127   load_var 15            (total)
+       128   store_array_element    
 
-  84   141   load_var 19             (scores)
-       142   load_const 2            (0)
-       143   load_array_element      
-       144   store_var 20            (top)
+  84   129   load_var 19            (scores)
+       130   load_const 1           (0)
+       131   load_array_element     
+       132   store_var 20           (top)
 
-  86   145   load_var 12             (base)
-       146   load_var 9              (role_score)
-       147   load_const 11           ("base")
-       148   load_const 12           ("role")
-       149   alloc_map 2             
-       150   store_var 21            (breakdown)
+  86   133   load_var 12            (base)
+       134   load_var 9             (role_score)
+       135   load_const 10          ("base")
+       136   load_const 11          ("role")
+       137   alloc_map 2            
+       138   store_var 21           (breakdown)
 
-  88   151   alloc_instance 12       (Report)
-       152   copy 0                  
+  88   139   alloc_instance 12      (Report)
+       140   copy 0                 
 
-  89   153   load_var 20             (top)
-       154   store_field 0           (score)
-       155   copy 0                  
+  89   141   load_var 20            (top)
+       142   store_field 0          (score)
+       143   copy 0                 
 
-  90   156   load_var 18             (label)
-       157   store_field 1           (label)
-       158   copy 0                  
+  90   144   load_var 18            (label)
+       145   store_field 1          (label)
+       146   copy 0                 
 
-  91   159   load_var 21             (breakdown)
-       160   store_field 2           (breakdown)
+  91   147   load_var 21            (breakdown)
+       148   store_field 2          (breakdown)
 
-  88   161   return                  
-       162   unreachable             
+  88   149   return                 
+       150   unreachable            
 }
 
 function stream_User.promote(self: stream_User, bonus: int) -> Report {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -138,10 +138,6 @@ function score(input: User | ErrorInfo, threshold: int) -> Report {
 
   L0:
     load_var input
-    load_const ErrorInfo
-    cmp_op instanceof
-    pop_jump_if_false L2
-    load_var input
     load_field .message
     store_var name
     jump L2
@@ -159,10 +155,6 @@ function score(input: User | ErrorInfo, threshold: int) -> Report {
     jump L4
 
   L3:
-    load_var input
-    load_const ErrorInfo
-    cmp_op instanceof
-    pop_jump_if_false L5
     load_var input
     load_field .code
     unary_op -
@@ -182,10 +174,6 @@ function score(input: User | ErrorInfo, threshold: int) -> Report {
     jump L7
 
   L6:
-    load_var input
-    load_const ErrorInfo
-    cmp_op instanceof
-    pop_jump_if_false L12
     load_const 0
     store_var role_score
     jump L12

--- a/baml_language/crates/baml_tests/tests/match_types.rs
+++ b/baml_language/crates/baml_tests/tests/match_types.rs
@@ -103,10 +103,6 @@ async fn match_typed_pattern_second_arm() {
         jump L1
 
       L0:
-        load_var result
-        load_const Failure
-        cmp_op instanceof
-        pop_jump_if_false L2
         load_const "failure: "
         load_var result
         load_field .reason
@@ -172,10 +168,6 @@ async fn match_typed_pattern_with_field_access() {
         jump L1
 
       L0:
-        load_var shape
-        load_const Circle
-        cmp_op instanceof
-        pop_jump_if_false L2
         load_var shape
         load_field .radius
         jump L2

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__alias_in_return_type_annotation.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__alias_in_return_type_annotation.snap
@@ -1,0 +1,11 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> Foo {
+    alloc_instance Foo
+    copy 0
+    load_const 5
+    store_field .x
+    return
+}

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__alias_multi_field_access.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__alias_multi_field_access.snap
@@ -1,0 +1,20 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> int {
+    alloc_instance Pair
+    copy 0
+    load_const 3
+    store_field .a
+    copy 0
+    load_const 4
+    store_field .b
+    store_var p
+    load_var p
+    load_field .a
+    load_var p
+    load_field .b
+    bin_op +
+    return
+}

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__alias_param_field_access.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__alias_param_field_access.snap
@@ -1,0 +1,24 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> int {
+    alloc_instance Pair
+    copy 0
+    load_const 3
+    store_field .a
+    copy 0
+    load_const 4
+    store_field .b
+    call sum
+    return
+}
+
+function sum(p: Pair) -> int {
+    load_var p
+    load_field .a
+    load_var p
+    load_field .b
+    bin_op +
+    return
+}

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__chained_alias_field_access.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__chained_alias_field_access.snap
@@ -1,0 +1,20 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> int {
+    alloc_instance Point
+    copy 0
+    load_const 10
+    store_field .x
+    copy 0
+    load_const 20
+    store_field .y
+    store_var p
+    load_var p
+    load_field .x
+    load_var p
+    load_field .y
+    bin_op +
+    return
+}

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__chained_alias_struct_literal.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__chained_alias_struct_literal.snap
@@ -1,0 +1,11 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> Foo {
+    alloc_instance Foo
+    copy 0
+    load_const 42
+    store_field .x
+    return
+}

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__field_access_through_alias.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__field_access_through_alias.snap
@@ -1,0 +1,12 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> int {
+    alloc_instance Foo
+    copy 0
+    load_const 7
+    store_field .x
+    load_field .x
+    return
+}

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__mir_alias_aggregate_resolution.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__mir_alias_aggregate_resolution.snap
@@ -1,0 +1,26 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> int {
+    alloc_instance Coord
+    copy 0
+    load_const 1
+    store_field .x
+    copy 0
+    load_const 2
+    store_field .y
+    copy 0
+    load_const 3
+    store_field .z
+    store_var c
+    load_var c
+    load_field .x
+    load_var c
+    load_field .y
+    bin_op +
+    load_var c
+    load_field .z
+    bin_op +
+    return
+}

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__mir_chained_alias_aggregate_resolution.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__mir_chained_alias_aggregate_resolution.snap
@@ -1,0 +1,26 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> int {
+    alloc_instance RGB
+    copy 0
+    load_const 10
+    store_field .r
+    copy 0
+    load_const 20
+    store_field .g
+    copy 0
+    load_const 30
+    store_field .b
+    store_var c
+    load_var c
+    load_field .r
+    load_var c
+    load_field .g
+    bin_op +
+    load_var c
+    load_field .b
+    bin_op +
+    return
+}

--- a/baml_language/crates/baml_tests/tests/snapshots/type_aliases__struct_literal_through_alias.snap
+++ b/baml_language/crates/baml_tests/tests/snapshots/type_aliases__struct_literal_through_alias.snap
@@ -1,0 +1,11 @@
+---
+source: crates/baml_tests/tests/type_aliases.rs
+expression: output.bytecode
+---
+function main() -> Foo {
+    alloc_instance Foo
+    copy 0
+    load_const 1
+    store_field .x
+    return
+}

--- a/baml_language/crates/baml_tests/tests/type_aliases.rs
+++ b/baml_language/crates/baml_tests/tests/type_aliases.rs
@@ -1,0 +1,227 @@
+//! Tests for type alias usage in struct literals, field access, and related contexts.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+use indexmap::indexmap;
+
+// ============================================================================
+// Struct literal construction through aliases
+// ============================================================================
+
+#[tokio::test]
+async fn struct_literal_through_alias() {
+    let output = baml_test!(
+        "
+        class Foo { x int }
+        type Bar = Foo;
+
+        function main() -> Bar {
+            let v = Bar { x: 1 };
+            v
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::instance(
+            "Foo",
+            indexmap! {
+                "x" => BexExternalValue::Int(1),
+            }
+        ))
+    );
+}
+
+#[tokio::test]
+async fn chained_alias_struct_literal() {
+    let output = baml_test!(
+        "
+        class Foo { x int }
+        type A = B;
+        type B = Foo;
+
+        function main() -> Foo {
+            let v = A { x: 42 };
+            v
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::instance(
+            "Foo",
+            indexmap! {
+                "x" => BexExternalValue::Int(42),
+            }
+        ))
+    );
+}
+
+#[tokio::test]
+async fn field_access_through_alias() {
+    let output = baml_test!(
+        "
+        class Foo { x int }
+        type Bar = Foo;
+
+        function main() -> int {
+            let v = Bar { x: 7 };
+            v.x
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+
+    assert_eq!(output.result, Ok(BexExternalValue::Int(7)));
+}
+
+#[tokio::test]
+async fn alias_in_return_type_annotation() {
+    let output = baml_test!(
+        "
+        class Foo { x int }
+        type Bar = Foo;
+
+        function main() -> Bar {
+            Foo { x: 5 }
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::instance(
+            "Foo",
+            indexmap! {
+                "x" => BexExternalValue::Int(5),
+            }
+        ))
+    );
+}
+
+// ============================================================================
+// Field access through aliases (old TIR regression)
+// ============================================================================
+
+/// Regression: old TIR `infer_field_access` used the alias name to look up
+/// class fields, which failed because fields are stored under the real class
+/// name. Fixed by resolving through the alias chain before field lookup.
+#[tokio::test]
+async fn chained_alias_field_access() {
+    let output = baml_test!(
+        "
+        class Point { x int  y int }
+        type A = B;
+        type B = Point;
+
+        function main() -> int {
+            let p = A { x: 10, y: 20 };
+            p.x + p.y
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+    assert_eq!(output.result, Ok(BexExternalValue::Int(30)));
+}
+
+/// Regression: field access on a local variable whose type is inferred from
+/// an alias-constructed struct literal.  The old TIR needed to resolve the
+/// alias to find the underlying class for field lookup.
+#[tokio::test]
+async fn alias_multi_field_access() {
+    let output = baml_test!(
+        "
+        class Pair { a int  b int }
+        type MyPair = Pair;
+
+        function main() -> int {
+            let p = MyPair { a: 3, b: 4 };
+            p.a + p.b
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+    assert_eq!(output.result, Ok(BexExternalValue::Int(7)));
+}
+
+/// Regression: alias-typed parameter field access.  The emit phase was not
+/// passing type_aliases to infer_function, so alias-typed parameters were
+/// not recognized and their fields could not be accessed.
+#[tokio::test]
+async fn alias_param_field_access() {
+    let output = baml_test!(
+        "
+        class Pair { a int  b int }
+        type MyPair = Pair;
+
+        function main() -> int {
+            sum(MyPair { a: 3, b: 4 })
+        }
+
+        function sum(p: MyPair) -> int {
+            p.a + p.b
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+    assert_eq!(output.result, Ok(BexExternalValue::Int(7)));
+}
+
+// ============================================================================
+// MIR lowering regression — alias name resolved to class name for emit
+// ============================================================================
+
+/// Regression: MIR lowering passed the alias name ("Bar") to
+/// `AggregateKind::Class`, causing `emit.rs` to panic with
+/// "undefined class: Bar".  Fixed by resolving through `type_aliases`
+/// before creating the aggregate.
+#[tokio::test]
+async fn mir_alias_aggregate_resolution() {
+    let output = baml_test!(
+        "
+        class Coord { x int  y int  z int }
+        type Vec3 = Coord;
+
+        function main() -> int {
+            let c = Vec3 { x: 1, y: 2, z: 3 };
+            c.x + c.y + c.z
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+    assert_eq!(output.result, Ok(BexExternalValue::Int(6)));
+}
+
+/// Regression: chained aliases through MIR — both alias hops must resolve
+/// to the real class name for the emitter.
+#[tokio::test]
+async fn mir_chained_alias_aggregate_resolution() {
+    let output = baml_test!(
+        "
+        class RGB { r int  g int  b int }
+        type Color = RGB;
+        type Shade = Color;
+
+        function main() -> int {
+            let c = Shade { r: 10, g: 20, b: 30 };
+            c.r + c.g + c.b
+        }
+    "
+    );
+
+    insta::assert_snapshot!(output.bytecode);
+    assert_eq!(output.result, Ok(BexExternalValue::Int(60)));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced type-alias resolution across compilation phases so struct literals, field access, returns, and codegen correctly follow chained aliases.

* **Bug Fixes**
  * Fixed member and method lookup through chained type aliases and added cycle protection.
  * Reduced redundant runtime type checks in some pattern-match branches.

* **Tests**
  * Added extensive regression tests covering alias chains, struct literals, field access, and related codegen paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->