### PR TITLE
add streaming fields to openai req builder

### DIFF
--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -54,10 +54,11 @@ pub(crate) trait LlmRequestBuilder {
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
+        stream: bool,
     ) -> Result<RawHttpRequest, BuildRequestError> {
         let url = self.build_url(client)?;
         let headers = self.build_headers(client);
-        let body = self.build_body(client, prompt)?;
+        let body = self.build_body(client, prompt, stream)?;
         Ok(RawHttpRequest {
             method: "POST".to_string(),
             url,
@@ -87,6 +88,7 @@ pub(crate) trait LlmRequestBuilder {
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
+        _stream: bool,
     ) -> Result<String, BuildRequestError> {
         let mut body = serde_json::Map::new();
         if let Some(model) = get_string_option(client, "model") {
@@ -128,6 +130,7 @@ pub(crate) trait LlmRequestBuilder {
 pub(crate) fn build_request(
     client: &LlmPrimitiveClient,
     prompt: bex_vm_types::PromptAst,
+    stream: bool,
 ) -> Result<builtin_types::owned::HttpRequest, BuildRequestError> {
     let provider = LlmProvider::from_str(&client.provider)
         .map_err(|_| BuildRequestError::UnsupportedLlmProvider(client.provider.clone()))?;
@@ -138,12 +141,14 @@ pub(crate) fn build_request(
         | LlmProvider::AzureOpenAi
         | LlmProvider::Ollama
         | LlmProvider::OpenRouter => {
-            openai::OpenAiBuilder::new(&provider).build_request(client, prompt)?
+            openai::OpenAiBuilder::new(&provider).build_request(client, prompt, stream)?
         }
         LlmProvider::OpenAiResponses => {
-            openai::OpenAiResponsesBuilder::new(&provider).build_request(client, prompt)?
+            openai::OpenAiResponsesBuilder::new(&provider).build_request(client, prompt, stream)?
         }
-        LlmProvider::Anthropic => anthropic::AnthropicBuilder.build_request(client, prompt)?,
+        LlmProvider::Anthropic => {
+            anthropic::AnthropicBuilder.build_request(client, prompt, stream)?
+        }
         LlmProvider::GoogleAi
         | LlmProvider::VertexAi
         | LlmProvider::AwsBedrock
@@ -304,7 +309,7 @@ mod tests {
     fn test_unsupported_provider() {
         let client = make_client("unknown-provider", vec![]);
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt);
+        let result = build_request(&client, prompt, false);
         assert!(result.is_err());
         assert!(
             result
@@ -332,7 +337,7 @@ mod tests {
         let system_text = "Given the receipt below:\n\n```\ntest@email.com\n```\n\nAnswer in JSON using this schema:\n{\n  items: [\n    {\n      name: string,\n      description: string or null,\n      quantity: int,\n      price: float,\n    }\n  ],\n  total_cost: float or null,\n  venue: \"barisa\" or \"ox_burger\",\n}";
         let prompt = Arc::new(PromptAst::Vec(vec![msg("system", system_text)]));
 
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
 
         // Verify envelope
         assert_eq!(result.method, "POST");
@@ -383,7 +388,7 @@ mod tests {
             msg("user", "Write a nice short story about Dr. Pepper"),
         ]));
 
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
 
         assert_eq!(result.url, "https://api.openai.com/v1/chat/completions");
 
@@ -418,7 +423,7 @@ mod tests {
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
         let prompt = msg("user", "Hello world");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert!(body["messages"][0]["content"].is_array());
         assert_eq!(body["messages"][0]["content"][0]["type"], "text");
@@ -435,7 +440,7 @@ mod tests {
             )],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         assert_eq!(result.url, "https://custom.api.com/chat/completions");
     }
 
@@ -449,7 +454,7 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert_eq!(body["temperature"], 0.7);
     }
@@ -468,7 +473,7 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert!(body.get("api_key").is_none());
         assert!(body.get("base_url").is_none());
@@ -500,7 +505,7 @@ mod tests {
             msg("user", "Write a nice short story about Dr. Pepper"),
         ]));
 
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
 
         // Verify envelope
         assert_eq!(result.method, "POST");
@@ -547,7 +552,7 @@ mod tests {
             ],
         );
         let prompt = msg("user", "Hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert!(body.get("system").is_none());
         assert_eq!(body["messages"].as_array().unwrap().len(), 1);
@@ -595,7 +600,7 @@ mod tests {
         );
 
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
 
         assert_eq!(
             result.headers.get("anthropic-beta").unwrap(),
@@ -617,7 +622,7 @@ mod tests {
             )],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         assert_eq!(
             result.headers.get("anthropic-version").unwrap(),
             "2024-01-01"
@@ -628,7 +633,7 @@ mod tests {
     fn test_anthropic_default_version() {
         let client = make_client("anthropic", vec![]);
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         assert_eq!(
             result.headers.get("anthropic-version").unwrap(),
             "2023-06-01"
@@ -648,7 +653,7 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert_eq!(body["max_tokens"], 1000);
     }
@@ -667,7 +672,7 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         assert_eq!(result.url, "https://api.openai.com/v1/responses");
         assert_eq!(
             result.headers.get("authorization").unwrap(),
@@ -682,7 +687,7 @@ mod tests {
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert!(
             body.get("input").is_some(),
@@ -701,7 +706,7 @@ mod tests {
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert_eq!(
             body,
@@ -727,7 +732,7 @@ mod tests {
             msg("user", "hello"),
             msg("assistant", "hi there"),
         ]));
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(body["input"][1]["content"][0]["type"], "output_text");
@@ -743,7 +748,7 @@ mod tests {
             msg("system", "You are helpful."),
             msg("user", "Hi"),
         ]));
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert_eq!(body["input"][0]["role"], "system");
         assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
@@ -760,7 +765,7 @@ mod tests {
             )],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         assert_eq!(result.url, "https://custom.api.com/v1/responses");
     }
 
@@ -774,7 +779,7 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt).unwrap();
+        let result = build_request(&client, prompt, false).unwrap();
         let body = parse_body(&result);
         assert_eq!(body["temperature"], 0.5);
     }

--- a/baml_language/crates/sys_llm/src/build_request/openai/chat_completions.rs
+++ b/baml_language/crates/sys_llm/src/build_request/openai/chat_completions.rs
@@ -93,10 +93,18 @@ impl LlmRequestBuilder for OpenAiBuilder<'_> {
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
+        stream: bool,
     ) -> Result<String, BuildRequestError> {
         let mut body = serde_json::Map::new();
         if let Some(model) = get_string_option(client, "model") {
             body.insert("model".to_string(), serde_json::Value::String(model));
+        }
+        if stream {
+            body.insert("stream".to_string(), serde_json::Value::Bool(true));
+            body.insert(
+                "stream_options".to_string(),
+                serde_json::json!({ "include_usage": true }),
+            );
         }
         body.extend(self.build_prompt_body(client, prompt)?);
         self.forward_options(client, &mut body);
@@ -836,7 +844,7 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk".into())),
             ],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         let body = parse_body(&result.body);
         assert_eq!(body["max_tokens"], 4096);
     }
@@ -855,7 +863,7 @@ mod tests {
                 ("max_tokens", BexExternalValue::Int(1000)),
             ],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         let body = parse_body(&result.body);
         assert_eq!(body["max_tokens"], 1000);
     }
@@ -874,7 +882,7 @@ mod tests {
                 ("max_completion_tokens", BexExternalValue::Int(2000)),
             ],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         let body = parse_body(&result.body);
         assert!(body.get("max_tokens").is_none());
         assert_eq!(body["max_completion_tokens"], 2000);
@@ -886,7 +894,7 @@ mod tests {
             "openai",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         let body = parse_body(&result.body);
         assert!(body.get("max_tokens").is_none());
     }
@@ -894,7 +902,7 @@ mod tests {
     #[test]
     fn openai_no_model_when_absent() {
         let client = make_client("openai", vec![]);
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         let body = parse_body(&result.body);
         assert!(body.get("model").is_none());
     }
@@ -908,7 +916,7 @@ mod tests {
                 ("resource_name", BexExternalValue::String("res".into())),
             ],
         );
-        let err = build_request(&client, msg("user", "hi")).unwrap_err();
+        let err = build_request(&client, msg("user", "hi"), false).unwrap_err();
         assert!(err.to_string().contains("api_version"));
     }
 
@@ -919,7 +927,7 @@ mod tests {
     #[test]
     fn openai_generic_requires_base_url() {
         let client = make_client("openai-generic", vec![]);
-        let err = build_request(&client, msg("user", "hi")).unwrap_err();
+        let err = build_request(&client, msg("user", "hi"), false).unwrap_err();
         assert!(err.to_string().contains("base_url"));
     }
 
@@ -936,7 +944,7 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk-custom".into())),
             ],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         assert_eq!(result.url, "https://my-llm.example.com/v1/chat/completions");
         assert_eq!(
             result.headers.get("authorization").unwrap(),
@@ -953,7 +961,7 @@ mod tests {
             "ollama",
             vec![("model", BexExternalValue::String("llama3".into()))],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         assert_eq!(result.url, "http://localhost:11434/v1/chat/completions");
         let body = parse_body(&result.body);
         assert_eq!(body["model"], "llama3");
@@ -971,7 +979,7 @@ mod tests {
                 ("model", BexExternalValue::String("llama3".into())),
             ],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         assert_eq!(result.url, "http://remote:11434/v1/chat/completions");
     }
 
@@ -981,7 +989,7 @@ mod tests {
             "ollama",
             vec![("model", BexExternalValue::String("llama3".into()))],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         assert!(result.headers.get("authorization").is_none());
         assert!(result.headers.get("api-key").is_none());
     }
@@ -995,7 +1003,7 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk-or-test".into())),
             ],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         assert_eq!(result.url, "https://openrouter.ai/api/v1/chat/completions");
         assert_eq!(
             result.headers.get("authorization").unwrap(),
@@ -1015,9 +1023,33 @@ mod tests {
                 ("max_tokens", BexExternalValue::Int(500)),
             ],
         );
-        let result = build_request(&client, msg("user", "hi")).unwrap();
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
         let body = parse_body(&result.body);
         assert_eq!(body["temperature"], 0.3);
         assert_eq!(body["max_tokens"], 500);
+    }
+
+    #[test]
+    fn stream_true_sets_stream_and_stream_options() {
+        let client = make_client(
+            "openai",
+            vec![("model", BexExternalValue::String("gpt-4o".into()))],
+        );
+        let result = build_request(&client, msg("user", "hi"), true).unwrap();
+        let body = parse_body(&result.body);
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn stream_false_omits_stream_fields() {
+        let client = make_client(
+            "openai",
+            vec![("model", BexExternalValue::String("gpt-4o".into()))],
+        );
+        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let body = parse_body(&result.body);
+        assert!(body.get("stream").is_none());
+        assert!(body.get("stream_options").is_none());
     }
 }

--- a/baml_language/crates/sys_llm/src/build_request/openai/responses.rs
+++ b/baml_language/crates/sys_llm/src/build_request/openai/responses.rs
@@ -87,6 +87,27 @@ impl LlmRequestBuilder for OpenAiResponsesBuilder<'_> {
         headers
     }
 
+    fn build_body(
+        &self,
+        client: &LlmPrimitiveClient,
+        prompt: bex_vm_types::PromptAst,
+        stream: bool,
+    ) -> Result<String, BuildRequestError> {
+        let mut body = serde_json::Map::new();
+        if let Some(model) = get_string_option(client, "model") {
+            body.insert("model".to_string(), serde_json::Value::String(model));
+        }
+        if stream {
+            body.insert("stream".to_string(), serde_json::Value::Bool(true));
+        }
+        body.extend(self.build_prompt_body(client, prompt)?);
+        self.forward_options(client, &mut body);
+        serde_json::to_string(&body).map_err(|e| BuildRequestError::InvalidOption {
+            key: "body".into(),
+            reason: e.to_string(),
+        })
+    }
+
     fn build_prompt_body(
         &self,
         client: &LlmPrimitiveClient,
@@ -591,5 +612,34 @@ mod tests {
             .build_url(&client)
             .unwrap();
         assert_eq!(url, "https://custom.api.com/v1/responses");
+    }
+
+    #[test]
+    fn stream_true_sets_stream() {
+        let client = make_client(
+            "openai-responses",
+            vec![("model", BexExternalValue::String("gpt-4o".into()))],
+        );
+        let builder = OpenAiResponsesBuilder::new(&LlmProvider::OpenAiResponses);
+        let body_str = builder
+            .build_body(&client, msg("user", "hi"), true)
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+        assert_eq!(body["stream"], true);
+        assert!(body.get("stream_options").is_none());
+    }
+
+    #[test]
+    fn stream_false_omits_stream() {
+        let client = make_client(
+            "openai-responses",
+            vec![("model", BexExternalValue::String("gpt-4o".into()))],
+        );
+        let builder = OpenAiResponsesBuilder::new(&LlmProvider::OpenAiResponses);
+        let body_str = builder
+            .build_body(&client, msg("user", "hi"), false)
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+        assert!(body.get("stream").is_none());
     }
 }

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -89,7 +89,8 @@ pub fn execute_build_request_from_owned(
     client: &builtin_types::owned::LlmPrimitiveClient,
     prompt: bex_vm_types::PromptAst,
 ) -> Result<builtin_types::owned::HttpRequest, LlmOpError> {
-    build_request::build_request(client, prompt).map_err(|e| LlmOpError::Other(e.to_string()))
+    build_request::build_request(client, prompt, false)
+        .map_err(|e| LlmOpError::Other(e.to_string()))
 }
 
 /// Parse an LLM response and extract the return value given already-extracted owned types.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming support for LLM requests across OpenAI and Anthropic providers, enabling incremental response processing instead of waiting for complete responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->