### PR TITLE
Bep activity Slack thread

### DIFF
--- a/typescript/apps/beps/convex/_generated/api.d.ts
+++ b/typescript/apps/beps/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as issues from "../issues.js";
 import type * as lib_prompts from "../lib/prompts.js";
 import type * as migrations from "../migrations.js";
 import type * as presence from "../presence.js";
+import type * as slack from "../slack.js";
 import type * as users from "../users.js";
 
 import type {
@@ -39,6 +40,7 @@ declare const fullApi: ApiFromModules<{
   "lib/prompts": typeof lib_prompts;
   migrations: typeof migrations;
   presence: typeof presence;
+  slack: typeof slack;
   users: typeof users;
 }>;
 

--- a/typescript/apps/beps/convex/beps.ts
+++ b/typescript/apps/beps/convex/beps.ts
@@ -129,6 +129,19 @@ export const getById = internalQuery({
   },
 });
 
+// Internal mutation to store Slack thread timestamp
+export const storeSlackThreadTs = internalMutation({
+  args: {
+    bepId: v.id("beps"),
+    slackThreadTs: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.bepId, {
+      slackThreadTs: args.slackThreadTs,
+    });
+  },
+});
+
 // Internal query to get version by ID with editor name
 export const getVersionById = internalQuery({
   args: { id: v.id("bepVersions") },

--- a/typescript/apps/beps/convex/beps.ts
+++ b/typescript/apps/beps/convex/beps.ts
@@ -1,4 +1,4 @@
-import { query, mutation, internalQuery } from "./_generated/server";
+import { query, mutation, internalQuery, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { bepStatus } from "./schema";
 import { internal } from "./_generated/api";
@@ -257,6 +257,11 @@ export const create = mutation({
       createdAt: now,
     });
 
+    // Notify Slack about the new BEP
+    await ctx.scheduler.runAfter(0, internal.slack.notifyBepCreated, {
+      bepId,
+    });
+
     return { bepId, number: bepNumber };
   },
 });
@@ -393,6 +398,12 @@ export const update = mutation({
         previousVersionId: latestVersion._id,
       });
     }
+
+    // Notify Slack about the new version
+    await ctx.scheduler.runAfter(0, internal.slack.notifyBepVersionCreated, {
+      bepId: args.id,
+      versionId: newVersionId,
+    });
   },
 });
 
@@ -407,12 +418,11 @@ export const updateStatus = mutation({
       updatedAt: Date.now(),
     });
 
-    // TODO: Trigger Slack notification
-    // await ctx.scheduler.runAfter(0, internal.notifications.sendSlack, {
-    //   type: "status_change",
-    //   bepId: args.id,
-    //   newStatus: args.status,
-    // });
+    // Notify Slack about the status change
+    await ctx.scheduler.runAfter(0, internal.slack.notifyStatusChanged, {
+      bepId: args.id,
+      newStatus: args.status,
+    });
   },
 });
 
@@ -664,6 +674,12 @@ export const importVersion = mutation({
           previousVersionId: latestVersion._id,
         });
       }
+
+      // 7a. Notify Slack about the new version
+      await ctx.scheduler.runAfter(0, internal.slack.notifyBepVersionCreated, {
+        bepId: args.bepId,
+        versionId,
+      });
 
       return {
         versionId,

--- a/typescript/apps/beps/convex/comments.ts
+++ b/typescript/apps/beps/convex/comments.ts
@@ -1,6 +1,7 @@
 import { query, mutation, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 import { commentType } from "./schema";
+import { internal } from "./_generated/api";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // QUERIES
@@ -292,6 +293,12 @@ export const add = mutation({
       resolved: false,
       createdAt: now,
       updatedAt: now,
+    });
+
+    // Notify Slack about the new comment
+    await ctx.scheduler.runAfter(0, internal.slack.notifyCommentAdded, {
+      bepId: args.bepId,
+      commentId,
     });
 
     return commentId;

--- a/typescript/apps/beps/convex/schema.ts
+++ b/typescript/apps/beps/convex/schema.ts
@@ -73,6 +73,9 @@ export default defineSchema({
     createdAt: v.number(),
     updatedAt: v.number(),
     supersededBy: v.optional(v.id("beps")),
+
+    // Slack integration - thread_ts for #beps channel notifications
+    slackThreadTs: v.optional(v.string()),
   })
     .index("by_number", ["number"])
     .index("by_status", ["status"])

--- a/typescript/apps/beps/convex/slack.ts
+++ b/typescript/apps/beps/convex/slack.ts
@@ -1,0 +1,385 @@
+"use node";
+
+import { v } from "convex/values";
+import { internalAction, internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+const SLACK_CHANNEL = "#beps";
+
+interface SlackBlock {
+  type: string;
+  text?: {
+    type: string;
+    text: string;
+    emoji?: boolean;
+  };
+  fields?: Array<{
+    type: string;
+    text: string;
+  }>;
+  elements?: Array<{
+    type: string;
+    text: string;
+    url?: string;
+  }>;
+}
+
+interface SlackPostResponse {
+  ok: boolean;
+  ts?: string;
+  error?: string;
+}
+
+async function postToSlack(
+  blocks: SlackBlock[],
+  text: string,
+  threadTs?: string
+): Promise<SlackPostResponse> {
+  const token = process.env.SLACK_BOUNDARY_BOT_TOKEN;
+
+  if (!token) {
+    console.warn("SLACK_BOUNDARY_BOT_TOKEN not configured - skipping Slack notification");
+    return { ok: false, error: "SLACK_BOUNDARY_BOT_TOKEN not configured" };
+  }
+
+  const payload: Record<string, unknown> = {
+    channel: SLACK_CHANNEL,
+    blocks,
+    text,
+  };
+
+  if (threadTs) {
+    payload.thread_ts = threadTs;
+  }
+
+  try {
+    const response = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const result = (await response.json()) as SlackPostResponse;
+
+    if (!result.ok) {
+      console.error("Slack API error:", result.error);
+    }
+
+    return result;
+  } catch (error) {
+    console.error("Failed to post to Slack:", error);
+    return { ok: false, error: String(error) };
+  }
+}
+
+function getBepUrl(bepNumber: number): string {
+  const baseUrl = process.env.NEXT_PUBLIC_CONVEX_URL
+    ? process.env.NEXT_PUBLIC_CONVEX_URL.replace(".convex.cloud", ".vercel.app")
+    : "https://beps.boundaryml.com";
+  return `${baseUrl}/beps/${bepNumber}`;
+}
+
+function getStatusEmoji(status: string): string {
+  switch (status) {
+    case "draft":
+      return "📝";
+    case "proposed":
+      return "📋";
+    case "accepted":
+      return "✅";
+    case "implemented":
+      return "🚀";
+    case "rejected":
+      return "❌";
+    case "superseded":
+      return "🔄";
+    default:
+      return "📄";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// INTERNAL MUTATION: Store Slack thread timestamp
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const storeSlackThreadTs = internalMutation({
+  args: {
+    bepId: v.id("beps"),
+    slackThreadTs: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.bepId, {
+      slackThreadTs: args.slackThreadTs,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// INTERNAL ACTIONS: Slack notifications
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Notify Slack when a new BEP is created.
+ * Creates a new thread in #beps and stores the thread_ts.
+ */
+export const notifyBepCreated = internalAction({
+  args: {
+    bepId: v.id("beps"),
+  },
+  handler: async (ctx, args) => {
+    const bep = await ctx.runQuery(internal.beps.getById, { id: args.bepId });
+    if (!bep) {
+      console.error("BEP not found for Slack notification:", args.bepId);
+      return;
+    }
+
+    const shepherds: string[] = [];
+    for (const shepherdId of bep.shepherds) {
+      const user = await ctx.runQuery(internal.users.getById, { id: shepherdId });
+      if (user) {
+        shepherds.push(user.name);
+      }
+    }
+
+    const bepUrl = getBepUrl(bep.number);
+    const statusEmoji = getStatusEmoji(bep.status);
+
+    const blocks: SlackBlock[] = [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: `🆕 New BEP Created: BEP-${bep.number}`,
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*<${bepUrl}|${bep.title}>*`,
+        },
+      },
+      {
+        type: "section",
+        fields: [
+          {
+            type: "mrkdwn",
+            text: `*Status:* ${statusEmoji} ${bep.status}`,
+          },
+          {
+            type: "mrkdwn",
+            text: `*Shepherds:* ${shepherds.length > 0 ? shepherds.join(", ") : "None assigned"}`,
+          },
+        ],
+      },
+    ];
+
+    if (bep.content) {
+      const preview = bep.content.substring(0, 300) + (bep.content.length > 300 ? "..." : "");
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `_${preview}_`,
+        },
+      });
+    }
+
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${bepUrl}|View BEP-${bep.number} →>`,
+      },
+    });
+
+    const result = await postToSlack(
+      blocks,
+      `New BEP Created: BEP-${bep.number} - ${bep.title}`
+    );
+
+    if (result.ok && result.ts) {
+      await ctx.runMutation(internal.slack.storeSlackThreadTs, {
+        bepId: args.bepId,
+        slackThreadTs: result.ts,
+      });
+    }
+  },
+});
+
+/**
+ * Notify Slack when a BEP is updated with a new version.
+ * Replies to the existing thread if one exists.
+ */
+export const notifyBepVersionCreated = internalAction({
+  args: {
+    bepId: v.id("beps"),
+    versionId: v.id("bepVersions"),
+  },
+  handler: async (ctx, args) => {
+    const bep = await ctx.runQuery(internal.beps.getById, { id: args.bepId });
+    if (!bep) {
+      console.error("BEP not found for Slack notification:", args.bepId);
+      return;
+    }
+
+    const version = await ctx.runQuery(internal.beps.getVersionById, {
+      id: args.versionId,
+    });
+    if (!version) {
+      console.error("Version not found for Slack notification:", args.versionId);
+      return;
+    }
+
+    const bepUrl = getBepUrl(bep.number);
+
+    const blocks: SlackBlock[] = [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `📝 *Version ${version.version}* published for <${bepUrl}|BEP-${bep.number}>`,
+        },
+      },
+      {
+        type: "section",
+        fields: [
+          {
+            type: "mrkdwn",
+            text: `*Edited by:* ${version.editedByName}`,
+          },
+          {
+            type: "mrkdwn",
+            text: `*Note:* ${version.editNote || "No description"}`,
+          },
+        ],
+      },
+    ];
+
+    const result = await postToSlack(
+      blocks,
+      `BEP-${bep.number} updated to version ${version.version}`,
+      bep.slackThreadTs
+    );
+
+    if (!bep.slackThreadTs && result.ok && result.ts) {
+      await ctx.runMutation(internal.slack.storeSlackThreadTs, {
+        bepId: args.bepId,
+        slackThreadTs: result.ts,
+      });
+    }
+  },
+});
+
+/**
+ * Notify Slack when a comment is added to a BEP.
+ * Replies to the existing thread if one exists.
+ */
+export const notifyCommentAdded = internalAction({
+  args: {
+    bepId: v.id("beps"),
+    commentId: v.id("comments"),
+  },
+  handler: async (ctx, args) => {
+    const bep = await ctx.runQuery(internal.beps.getById, { id: args.bepId });
+    if (!bep) {
+      console.error("BEP not found for Slack notification:", args.bepId);
+      return;
+    }
+
+    const comment = await ctx.runQuery(internal.comments.getById, {
+      id: args.commentId,
+    });
+    if (!comment) {
+      console.error("Comment not found for Slack notification:", args.commentId);
+      return;
+    }
+
+    const bepUrl = getBepUrl(bep.number);
+
+    const typeEmoji = {
+      discussion: "💬",
+      concern: "⚠️",
+      question: "❓",
+    }[comment.type] || "💬";
+
+    const blocks: SlackBlock[] = [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `${typeEmoji} *${comment.authorName}* ${comment.parentId ? "replied to a comment" : `added a ${comment.type}`} on <${bepUrl}|BEP-${bep.number}>`,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `> ${comment.content.substring(0, 500)}${comment.content.length > 500 ? "..." : ""}`,
+        },
+      },
+    ];
+
+    const result = await postToSlack(
+      blocks,
+      `${comment.authorName} commented on BEP-${bep.number}`,
+      bep.slackThreadTs
+    );
+
+    if (!bep.slackThreadTs && result.ok && result.ts) {
+      await ctx.runMutation(internal.slack.storeSlackThreadTs, {
+        bepId: args.bepId,
+        slackThreadTs: result.ts,
+      });
+    }
+  },
+});
+
+/**
+ * Notify Slack when a BEP's status changes.
+ * Replies to the existing thread if one exists.
+ */
+export const notifyStatusChanged = internalAction({
+  args: {
+    bepId: v.id("beps"),
+    newStatus: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const bep = await ctx.runQuery(internal.beps.getById, { id: args.bepId });
+    if (!bep) {
+      console.error("BEP not found for Slack notification:", args.bepId);
+      return;
+    }
+
+    const bepUrl = getBepUrl(bep.number);
+    const statusEmoji = getStatusEmoji(args.newStatus);
+
+    const blocks: SlackBlock[] = [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `${statusEmoji} <${bepUrl}|BEP-${bep.number}> status changed to *${args.newStatus}*`,
+        },
+      },
+    ];
+
+    const result = await postToSlack(
+      blocks,
+      `BEP-${bep.number} status changed to ${args.newStatus}`,
+      bep.slackThreadTs
+    );
+
+    if (!bep.slackThreadTs && result.ok && result.ts) {
+      await ctx.runMutation(internal.slack.storeSlackThreadTs, {
+        bepId: args.bepId,
+        slackThreadTs: result.ts,
+      });
+    }
+  },
+});
+

--- a/typescript/apps/beps/convex/slack.ts
+++ b/typescript/apps/beps/convex/slack.ts
@@ -1,7 +1,7 @@
 "use node";
 
 import { v } from "convex/values";
-import { internalAction, internalMutation } from "./_generated/server";
+import { internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 
 const SLACK_CHANNEL = "#beps";
@@ -102,22 +102,6 @@ function getStatusEmoji(status: string): string {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// INTERNAL MUTATION: Store Slack thread timestamp
-// ─────────────────────────────────────────────────────────────────────────────
-
-export const storeSlackThreadTs = internalMutation({
-  args: {
-    bepId: v.id("beps"),
-    slackThreadTs: v.string(),
-  },
-  handler: async (ctx, args) => {
-    await ctx.db.patch(args.bepId, {
-      slackThreadTs: args.slackThreadTs,
-    });
-  },
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
 // INTERNAL ACTIONS: Slack notifications
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -203,7 +187,7 @@ export const notifyBepCreated = internalAction({
     );
 
     if (result.ok && result.ts) {
-      await ctx.runMutation(internal.slack.storeSlackThreadTs, {
+      await ctx.runMutation(internal.beps.storeSlackThreadTs, {
         bepId: args.bepId,
         slackThreadTs: result.ts,
       });
@@ -267,7 +251,7 @@ export const notifyBepVersionCreated = internalAction({
     );
 
     if (!bep.slackThreadTs && result.ok && result.ts) {
-      await ctx.runMutation(internal.slack.storeSlackThreadTs, {
+      await ctx.runMutation(internal.beps.storeSlackThreadTs, {
         bepId: args.bepId,
         slackThreadTs: result.ts,
       });
@@ -331,7 +315,7 @@ export const notifyCommentAdded = internalAction({
     );
 
     if (!bep.slackThreadTs && result.ok && result.ts) {
-      await ctx.runMutation(internal.slack.storeSlackThreadTs, {
+      await ctx.runMutation(internal.beps.storeSlackThreadTs, {
         bepId: args.bepId,
         slackThreadTs: result.ts,
       });
@@ -375,7 +359,7 @@ export const notifyStatusChanged = internalAction({
     );
 
     if (!bep.slackThreadTs && result.ok && result.ts) {
-      await ctx.runMutation(internal.slack.storeSlackThreadTs, {
+      await ctx.runMutation(internal.beps.storeSlackThreadTs, {
         bepId: args.bepId,
         slackThreadTs: result.ts,
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #

## Changes
Please describe the changes proposed in this pull request

This PR implements Slack notifications for BEP (Boundary Enhancement Proposal) activity, ensuring all updates and comments for a given BEP are posted within a single, dedicated thread in the `#beps` channel.

-   **New `slack.ts` module:** Handles posting messages to Slack, creating new threads, and replying to existing threads.
-   **Schema update:** Added `slackThreadTs` to the `beps` table to store the Slack thread timestamp, ensuring all related notifications for a BEP go into the same thread.
-   **Integration with BEP lifecycle:**
    -   `beps.create`: Notifies when a new BEP is created, starting a new Slack thread.
    -   `beps.update` (for new versions), `beps.importVersion`: Notifies when a new BEP version is published.
    -   `beps.updateStatus`: Notifies when a BEP's status changes.
    -   `comments.add`: Notifies when a new comment is added to a BEP.
All notifications for a specific BEP are posted as replies within its dedicated Slack thread.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [ ] Manual testing performed (Requires `SLACK_BOUNDARY_BOT_TOKEN` to be configured)
- [x] Tested in local development environment (Compilation and type checks passed)

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [ ] I have read and followed the contributing guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

To enable Slack notifications, the `SLACK_BOUNDARY_BOT_TOKEN` environment variable must be configured in Convex. Notifications will gracefully fail if the token is not set.

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1773359991171989?thread_ts=1773359991.171989&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-518410a1-9ddc-51ef-9103-2f32d0c4c363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-518410a1-9ddc-51ef-9103-2f32d0c4c363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications now automatically post when BEPs are created, versions are created, comments are added, and when BEP status changes.
  * Notifications are organized in threaded conversations for improved context and organization in Slack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->