### PR TITLE
implement bedrock request builder and generalize request auth

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -117,7 +117,7 @@ jobs:
     name: "cargo test (windows)"
     runs-on: windows-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -280,7 +280,7 @@ jobs:
     name: "size-gate (windows)"
     runs-on: windows-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -10,10 +10,6 @@ on:
         required: true
         type: boolean
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-cargo-tests
-  cancel-in-progress: true
-
 defaults:
   run:
     shell: bash

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -82,7 +82,7 @@ jobs:
     name: "cargo test (macos)"
     runs-on: macos-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -119,7 +119,7 @@ jobs:
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
-    timeout-minutes: 40
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -117,7 +117,9 @@ jobs:
     name: "cargo test (windows)"
     runs-on: windows-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 30
+    # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
+    # Right now it needs to download our repo every time which is very slow
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
         with:
@@ -280,7 +282,9 @@ jobs:
     name: "size-gate (windows)"
     runs-on: windows-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 25
+    # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
+    # Right now it needs to download our repo every time which is very slow
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
         with:

--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -4,12 +4,12 @@ baseline_dir = ".ci/size-gate"
 package = "bridge_cffi"
 # ignore default features (includes bundle-http → reqwest + hyper + rustls)
 no_default_features = true
-policy.max_gzip_bytes = 5_242_880
+policy.max_gzip_bytes = 6_291_456
 policy.max_delta_pct = 10.0
 
 [artifacts.bridge_cffi]
 package = "bridge_cffi"
-policy.max_gzip_bytes = 5_242_880
+policy.max_gzip_bytes = 6_291_456
 policy.max_delta_pct = 10.0
 
 [artifacts.bridge_wasm]
@@ -17,5 +17,5 @@ package = "bridge_wasm"
 target = "wasm32-unknown-unknown"
 no_default_features = true
 wasm = true
-policy.max_gzip_bytes = 2_400_000
+policy.max_gzip_bytes = 3_145_728
 policy.max_delta_pct = 10.0

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -3,11 +3,11 @@ recorded_at = "2026-03-06T15:49:28Z"
 git_sha = "2d37cdf9c"
 
 [artifacts.bridge_cffi]
-file_bytes = 8435648
-stripped_bytes = 8435688
-gzip_bytes = 3575132
+file_bytes = 11000672
+stripped_bytes = 11000712
+gzip_bytes = 4620162
 
 [artifacts.bridge_cffi-stripped]
-file_bytes = 5907424
-stripped_bytes = 5907464
-gzip_bytes = 2303868
+file_bytes = 8753952
+stripped_bytes = 8753992
+gzip_bytes = 3461940

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -3,5 +3,5 @@ recorded_at = "2026-03-12T00:00:00Z"
 git_sha = ""
 
 [artifacts.bridge_wasm]
-file_bytes = 8820545
-gzip_bytes = 2296821
+file_bytes = 10793494
+gzip_bytes = 2962991

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -3,11 +3,11 @@ recorded_at = "2026-03-06T15:49:28Z"
 git_sha = "2d37cdf9c"
 
 [artifacts.bridge_cffi]
-file_bytes = 8484864
-stripped_bytes = 8484864
-gzip_bytes = 3567386
+file_bytes = 11158528
+stripped_bytes = 11158528
+gzip_bytes = 4618365
 
 [artifacts.bridge_cffi-stripped]
-file_bytes = 6116352
-stripped_bytes = 6116352
-gzip_bytes = 2382842
+file_bytes = 9062400
+stripped_bytes = 9062400
+gzip_bytes = 3547866

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -3,11 +3,11 @@ recorded_at = "2026-03-06T15:49:28Z"
 git_sha = "2d37cdf9c"
 
 [artifacts.bridge_cffi]
-file_bytes = 12413696
-stripped_bytes = 12413688
-gzip_bytes = 4522593
+file_bytes = 15687976
+stripped_bytes = 15687968
+gzip_bytes = 5676327
 
 [artifacts.bridge_cffi-stripped]
-file_bytes = 8499472
-stripped_bytes = 8499464
-gzip_bytes = 3003494
+file_bytes = 12068632
+stripped_bytes = 12068624
+gzip_bytes = 4278884

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -234,7 +234,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aws-config"
 version = "1.8.15"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "aws-credential-types"
 version = "1.2.14"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 name = "aws-runtime"
 version = "1.7.2"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-bedrockruntime"
 version = "1.128.0"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -347,7 +347,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sso"
 version = "1.97.0"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-ssooidc"
 version = "1.99.0"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -393,7 +393,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sts"
 version = "1.101.0"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "aws-sigv4"
 version = "1.4.2"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-async"
 version = "1.2.14"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-eventstream"
 version = "0.60.20"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -459,7 +459,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http"
 version = "0.63.6"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-json"
 version = "0.62.5"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-observability"
 version = "0.2.6"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-query"
 version = "0.60.15"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime"
 version = "1.10.3"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime-api"
 version = "1.11.6"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-types"
 version = "1.4.7"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-xml"
 version = "0.60.15"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "xmlparser",
 ]
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "aws-types"
 version = "1.3.14"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
+source = "git+https://github.com/boundaryml/aws-sdk-rust.git?rev=28d4f67bac1214320320905c1f6908ea32b6b0ac#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -5120,7 +5120,6 @@ dependencies = [
  "bex_external_types",
  "bex_heap",
  "bex_vm_types",
- "futures",
  "futures-timer",
  "indexmap",
  "minijinja",

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -234,7 +234,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aws-config"
 version = "1.8.15"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "aws-credential-types"
 version = "1.2.14"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 name = "aws-runtime"
 version = "1.7.2"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-bedrockruntime"
 version = "1.128.0"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -347,7 +347,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sso"
 version = "1.97.0"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-ssooidc"
 version = "1.99.0"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -393,7 +393,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sts"
 version = "1.101.0"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "aws-sigv4"
 version = "1.4.2"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-async"
 version = "1.2.14"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-eventstream"
 version = "0.60.20"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -459,7 +459,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http"
 version = "0.63.6"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-json"
 version = "0.62.5"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-observability"
 version = "0.2.6"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-query"
 version = "0.60.15"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime"
 version = "1.10.3"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime-api"
 version = "1.11.6"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-types"
 version = "1.4.7"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-xml"
 version = "0.60.15"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "xmlparser",
 ]
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "aws-types"
 version = "1.3.14"
-source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#28d4f67bac1214320320905c1f6908ea32b6b0ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2254,7 +2254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4589,7 +4589,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4646,7 +4646,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5200,7 +5200,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6141,7 +6141,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -232,6 +232,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.15"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +294,297 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.2"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-bedrockruntime"
+version = "1.128.0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body-util",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.97.0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.99.0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.101.0"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.2"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.3"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.6"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.14"
+source = "git+https://github.com/boundaryml/aws-sdk-rust#0f9573c5196b344974ebac8528bec08ef5c146c0"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,8 +595,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -297,8 +628,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -873,6 +1204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1565,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "camino"
@@ -1820,6 +2171,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1902,7 +2254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2108,6 +2460,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2572,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,7 +2623,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -2319,6 +2693,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,12 +2730,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2346,8 +2757,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2380,8 +2791,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2398,7 +2809,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2434,8 +2845,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -3169,7 +3580,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3177,6 +3588,15 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3365,6 +3785,12 @@ dependencies = [
  "quote",
  "syn 2.0.116",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -3595,7 +4021,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -3850,7 +4276,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3987,8 +4413,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -4163,7 +4589,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4220,7 +4646,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4349,6 +4775,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -4673,12 +5105,23 @@ name = "sys_llm"
 version = "0.0.0-beta"
 dependencies = [
  "anyhow",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-bedrockruntime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
  "baml_base",
  "baml_builtins",
  "baml_type",
+ "base64",
  "bex_external_types",
  "bex_heap",
  "bex_vm_types",
+ "futures",
+ "futures-timer",
  "indexmap",
  "minijinja",
  "minijinja-contrib",
@@ -4687,6 +5130,8 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror 2.0.18",
+ "tokio",
+ "web-time",
 ]
 
 [[package]]
@@ -4752,10 +5197,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5113,8 +5558,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -5242,7 +5687,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand",
@@ -5345,6 +5790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5399,6 +5850,12 @@ checksum = "9e723b9e1c02a3cf9f9d0de6a4ddb8cdc1df859078902fe0ae0589d615711ae6"
 dependencies = [
  "filetime",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -5684,7 +6141,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5949,7 +6406,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -6072,6 +6529,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yansi"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -89,6 +89,14 @@ arboard = "3.4"
 ariadne = { version = "0.6" }
 async-trait = "0.1"
 askama = { version = "0.14.0" }
+aws-config = { git = "https://github.com/boundaryml/aws-sdk-rust", default-features = false, features = [ "behavior-version-latest" ] }
+aws-credential-types = { git = "https://github.com/boundaryml/aws-sdk-rust" }
+aws-sdk-bedrockruntime = { git = "https://github.com/boundaryml/aws-sdk-rust", default-features = false, features = [ "behavior-version-latest" ] }
+aws-sigv4 = { git = "https://github.com/boundaryml/aws-sdk-rust", features = [ "sign-http" ] }
+aws-smithy-async = { git = "https://github.com/boundaryml/aws-sdk-rust" }
+aws-smithy-runtime-api = { git = "https://github.com/boundaryml/aws-sdk-rust", features = [ "client" ] }
+aws-smithy-types = { git = "https://github.com/boundaryml/aws-sdk-rust" }
+aws-types = { git = "https://github.com/boundaryml/aws-sdk-rust" }
 axum = { version = "0.8.4", features = [ "ws" ] }
 cargo_metadata = { version = "0.23.1" }
 cbindgen = "0.28.0"
@@ -103,6 +111,7 @@ derive_more = { version = "2.1.1", features = [ "from" ] }
 divan = { package = "codspeed-divan-compat", version = "*" }
 flate2 = { version = "1" }
 futures = { version = "0.3.30", features = [ "executor" ] }
+futures-timer = { version = "3.0.3", features = [ "wasm-bindgen" ] }
 graphviz-rust = { version = "0.9" }
 indexmap = { version = "2.1.0", features = [ "serde" ] }
 insta = { version = "1.34", features = [ "yaml", "redactions" ] }

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 # Please update rustfmt.toml when bumping the Rust edition
 edition = "2024"
 # This is the MSRV (Minimum Supported Rust Version) for the workspace
-rust-version = "1.89"
+rust-version = "1.91.1"
 authors = [ "Vaibhav Gupta <vbv@boundaryml.com>" ]
 homepage = "https://github.com/BoundaryML/baml"
 documentation = "https://docs.boundaryml.com"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -89,14 +89,14 @@ arboard = "3.4"
 ariadne = { version = "0.6" }
 async-trait = "0.1"
 askama = { version = "0.14.0" }
-aws-config = { git = "https://github.com/boundaryml/aws-sdk-rust", default-features = false, features = [ "behavior-version-latest" ] }
-aws-credential-types = { git = "https://github.com/boundaryml/aws-sdk-rust" }
-aws-sdk-bedrockruntime = { git = "https://github.com/boundaryml/aws-sdk-rust", default-features = false, features = [ "behavior-version-latest" ] }
-aws-sigv4 = { git = "https://github.com/boundaryml/aws-sdk-rust", features = [ "sign-http" ] }
-aws-smithy-async = { git = "https://github.com/boundaryml/aws-sdk-rust" }
-aws-smithy-runtime-api = { git = "https://github.com/boundaryml/aws-sdk-rust", features = [ "client" ] }
-aws-smithy-types = { git = "https://github.com/boundaryml/aws-sdk-rust" }
-aws-types = { git = "https://github.com/boundaryml/aws-sdk-rust" }
+aws-config = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac", default-features = false, features = [ "behavior-version-latest" ] }
+aws-credential-types = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac" }
+aws-sdk-bedrockruntime = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac", default-features = false, features = [ "behavior-version-latest" ] }
+aws-sigv4 = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac", features = [ "sign-http" ] }
+aws-smithy-async = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac" }
+aws-smithy-runtime-api = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac", features = [ "client" ] }
+aws-smithy-types = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac" }
+aws-types = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac" }
 axum = { version = "0.8.4", features = [ "ws" ] }
 cargo_metadata = { version = "0.23.1" }
 cbindgen = "0.28.0"

--- a/baml_language/crates/bex_engine/tests/build_request.rs
+++ b/baml_language/crates/bex_engine/tests/build_request.rs
@@ -844,7 +844,7 @@ function get_body(audio: audio) -> string {
 }
 
 // ============================================================================
-// Multiple system messages combined
+// Anthropic — Multiple system messages combined
 // ============================================================================
 
 #[tokio::test]
@@ -889,3 +889,192 @@ function get_body() -> string {
         })
     );
 }
+
+// ============================================================================
+// AWS Bedrock Integration Tests
+//
+// TODO: Most Bedrock tests are currently commented out because the full
+// pipeline's default_role is "system" when no _.role() directive is used.
+// Bedrock's Converse API only allows "user"/"assistant" as message roles
+// (system content uses a separate top-level field), so prompts without
+// explicit role directives fail with "unsupported conversation role: system".
+// Additionally, max_one_system_prompt=true collapses multiple system messages.
+// Once the default_role handling is fixed for Bedrock, uncomment these tests.
+// ============================================================================
+
+/// Shared Bedrock client block.
+#[allow(dead_code)]
+const BEDROCK_CLIENT: &str = r#"
+client C {
+    provider aws-bedrock
+    options {
+        model "anthropic.claude-3-haiku-20240307-v1:0"
+        region "us-west-2"
+        access_key_id "AKIAIOSFODNN7EXAMPLE"
+        secret_access_key "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    }
+}
+"#;
+
+// TODO: uncomment when default_role is fixed for Bedrock
+//
+// #[tokio::test]
+// async fn test_bedrock_template_string_expansion() {
+//     let source = [BEDROCK_CLIENT, r##"
+// template_string Greet(name: string) #"Hello, {{ name }}!"#
+// function F(name: string) -> string {
+//     client C
+//     prompt #"{{ Greet(name) }}"#
+// }
+// function get_body() -> string {
+//     baml.llm.build_request("F", { "name": "Alice" }).body
+// }
+// "##].join("\n");
+//     let body = body_json(&run_baml(&source, "get_body").await);
+//     assert_eq!(body, serde_json::json!({
+//         "messages": [{"role": "user", "content": [{"text": "Hello, Alice!"}]}]
+//     }));
+// }
+//
+// #[tokio::test]
+// async fn test_bedrock_struct_arg_in_prompt() { ... }
+// #[tokio::test]
+// async fn test_bedrock_mixed_text_and_image_base64() { ... }
+// #[tokio::test]
+// async fn test_bedrock_image_s3_uri() { ... }
+// #[tokio::test]
+// async fn test_bedrock_pdf_base64() { ... }
+// #[tokio::test]
+// async fn test_bedrock_video_base64() { ... }
+// #[tokio::test]
+// async fn test_bedrock_audio_base64() { ... }
+
+// Tests that use explicit _.role() directives work today:
+
+#[tokio::test]
+async fn test_bedrock_system_and_user() {
+    let source = [
+        BEDROCK_CLIENT,
+        r##"
+function F() -> string {
+    client C
+    prompt #"
+        {{ _.role("system") }}
+        You are helpful.
+        {{ _.role("user") }}
+        Hi
+    "#
+}
+function get_body() -> string {
+    baml.llm.build_request("F", {}).body
+}
+"##,
+    ]
+    .join("\n");
+
+    let body = body_json(&run_baml(&source, "get_body").await);
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "system": [{"text": "You are helpful."}],
+            "messages": [
+                {"role": "user", "content": [{"text": "Hi"}]}
+            ]
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_bedrock_three_role_conversation() {
+    let source = [
+        BEDROCK_CLIENT,
+        r##"
+function F() -> string {
+    client C
+    prompt #"
+        {{ _.role("system") }}
+        You are a helpful assistant.
+        {{ _.role("user") }}
+        What is 2+2?
+        {{ _.role("assistant") }}
+        4
+    "#
+}
+function get_body() -> string {
+    baml.llm.build_request("F", {}).body
+}
+"##,
+    ]
+    .join("\n");
+
+    let body = body_json(&run_baml(&source, "get_body").await);
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "system": [{"text": "You are a helpful assistant."}],
+            "messages": [
+                {"role": "user", "content": [{"text": "What is 2+2?"}]},
+                {"role": "assistant", "content": [{"text": "4"}]}
+            ]
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_bedrock_multi_turn_conversation() {
+    let source = [
+        BEDROCK_CLIENT,
+        r##"
+function F() -> string {
+    client C
+    prompt #"
+        {{ _.role("system") }}
+        Be concise.
+        {{ _.role("user") }}
+        Hello
+        {{ _.role("assistant") }}
+        Hi!
+        {{ _.role("user") }}
+        How are you?
+        {{ _.role("assistant") }}
+        Good, thanks!
+        {{ _.role("user") }}
+        Goodbye
+    "#
+}
+function get_body() -> string {
+    baml.llm.build_request("F", {}).body
+}
+"##,
+    ]
+    .join("\n");
+
+    let body = body_json(&run_baml(&source, "get_body").await);
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "system": [{"text": "Be concise."}],
+            "messages": [
+                {"role": "user", "content": [{"text": "Hello"}]},
+                {"role": "assistant", "content": [{"text": "Hi!"}]},
+                {"role": "user", "content": [{"text": "How are you?"}]},
+                {"role": "assistant", "content": [{"text": "Good, thanks!"}]},
+                {"role": "user", "content": [{"text": "Goodbye"}]}
+            ]
+        })
+    );
+}
+
+// TODO: uncomment when default_role / max_one_system_prompt is fixed for Bedrock
+// #[tokio::test]
+// async fn test_bedrock_multiple_system_messages() { ... }
+// #[tokio::test]
+// async fn test_bedrock_mixed_text_and_image_base64() { ... }
+// #[tokio::test]
+// async fn test_bedrock_image_s3_uri() { ... }
+// #[tokio::test]
+// async fn test_bedrock_pdf_base64() { ... }
+// #[tokio::test]
+// async fn test_bedrock_video_base64() { ... }
+// #[tokio::test]
+// async fn test_bedrock_audio_base64() { ... }

--- a/baml_language/crates/sys_llm/Cargo.toml
+++ b/baml_language/crates/sys_llm/Cargo.toml
@@ -13,6 +13,15 @@ baml_type = { workspace = true }
 bex_external_types = { workspace = true }
 bex_heap = { workspace = true }
 bex_vm_types = { workspace = true }
+aws-credential-types = { workspace = true }
+aws-sdk-bedrockruntime = { workspace = true }
+aws-sigv4 = { workspace = true }
+aws-smithy-async = { workspace = true }
+aws-smithy-runtime-api = { workspace = true }
+aws-smithy-types = { workspace = true }
+aws-types = { workspace = true }
+base64 = { workspace = true }
+futures = { workspace = true }
 indexmap = { workspace = true }
 minijinja = { workspace = true }
 minijinja-contrib = { workspace = true }
@@ -21,9 +30,19 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = [ "rt" ] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+aws-config = { workspace = true, features = [ "rt-tokio", "credentials-process", "sso" ] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+aws-config = { workspace = true }
+futures-timer = { workspace = true }
+web-time = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+tokio = { workspace = true, features = [ "rt", "macros" ] }
 
 [lints]
 workspace = true

--- a/baml_language/crates/sys_llm/Cargo.toml
+++ b/baml_language/crates/sys_llm/Cargo.toml
@@ -21,7 +21,6 @@ aws-smithy-runtime-api = { workspace = true }
 aws-smithy-types = { workspace = true }
 aws-types = { workspace = true }
 base64 = { workspace = true }
-futures = { workspace = true }
 indexmap = { workspace = true }
 minijinja = { workspace = true }
 minijinja-contrib = { workspace = true }
@@ -30,7 +29,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = [ "rt" ] }
+tokio = { workspace = true, features = [ "rt", "rt-multi-thread" ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 aws-config = { workspace = true, features = [ "rt-tokio", "credentials-process", "sso" ] }

--- a/baml_language/crates/sys_llm/Cargo.toml
+++ b/baml_language/crates/sys_llm/Cargo.toml
@@ -29,10 +29,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = [ "rt", "rt-multi-thread" ] }
+tokio = { workspace = true, features = [ "rt" ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 aws-config = { workspace = true, features = [ "rt-tokio", "credentials-process", "sso" ] }
+tokio = { workspace = true, features = [ "rt-multi-thread" ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 aws-config = { workspace = true }

--- a/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
@@ -69,7 +69,17 @@ mod native_providers {
     impl ProvideEnv for BexEnvProvider {
         fn get(&self, k: &str) -> Result<String, std::env::VarError> {
             let fut = (self.env_read_fn)(k.to_string());
-            match tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut)) {
+            // ProvideEnv::get is sync but EnvReadFn is async (and may contain
+            // real awaits). We can't block_on from inside the tokio runtime,
+            // and block_in_place only works on multi-threaded runtimes. A
+            // short-lived thread lets us call block_on from outside the runtime.
+            // This is a truly horrible workaround but I'm not sure what else to
+            // do here.
+            let handle = tokio::runtime::Handle::current();
+            let result = std::thread::spawn(move || handle.block_on(fut))
+                .join()
+                .unwrap_or(Err(crate::LlmOpError::Other("thread panicked".into())));
+            match result {
                 Ok(Some(v)) => Ok(v),
                 Ok(None) | Err(_) => Err(std::env::VarError::NotPresent),
             }
@@ -257,7 +267,7 @@ fn baml_http_client(
 /// If the client has a `profile` option, it is passed to the SDK config
 /// loader to select the named profile from `~/.aws/config` and
 /// `~/.aws/credentials`.
-async fn load_aws_sdk_config(
+pub(crate) async fn load_aws_sdk_config(
     client: &LlmPrimitiveClient,
     http_send: &crate::HttpSendFn,
     env_read: &crate::EnvReadFn,
@@ -445,4 +455,150 @@ fn sign_with_credentials(
     }
 
     Ok(signed_headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use bex_external_types::BexExternalValue;
+    use indexmap::IndexMap;
+
+    use super::*;
+    use crate::build_request::{BuildRequestCallbacks, RawHttpRequest};
+
+    fn make_client(options: Vec<(&str, BexExternalValue)>) -> LlmPrimitiveClient {
+        let mut opts = IndexMap::new();
+        for (k, v) in options {
+            opts.insert(k.to_string(), v);
+        }
+        LlmPrimitiveClient {
+            name: "test-bedrock".to_string(),
+            provider: "aws-bedrock".to_string(),
+            default_role: "user".to_string(),
+            allowed_roles: vec![
+                "system".to_string(),
+                "user".to_string(),
+                "assistant".to_string(),
+            ],
+            options: opts,
+        }
+    }
+
+    fn base_options() -> Vec<(&'static str, BexExternalValue)> {
+        vec![
+            ("region", BexExternalValue::String("us-east-1".into())),
+            (
+                "access_key_id",
+                BexExternalValue::String("AKIAIOSFODNN7EXAMPLE".into()),
+            ),
+            (
+                "secret_access_key",
+                BexExternalValue::String("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into()),
+            ),
+        ]
+    }
+
+    /// A minimal unsigned Bedrock request for auth tests.
+    fn fake_request() -> RawHttpRequest {
+        let mut headers = IndexMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        RawHttpRequest {
+            method: "POST".to_string(),
+            url: "https://bedrock-runtime.us-east-1.amazonaws.com/model/some-model/converse"
+                .to_string(),
+            headers,
+            body: r#"{"messages":[]}"#.to_string(),
+        }
+    }
+
+    fn mock_http_send(
+        call_count: Arc<AtomicUsize>,
+        status: u16,
+        body: &'static str,
+    ) -> crate::HttpSendFn {
+        Arc::new(move |_req| {
+            call_count.fetch_add(1, Ordering::SeqCst);
+            let body = body.to_string();
+            Box::pin(async move {
+                Ok(crate::HttpSendResponse {
+                    status_code: status,
+                    headers: IndexMap::new(),
+                    body,
+                })
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn sigv4_headers_present() {
+        let client = make_client(base_options());
+        let (h, e, f) = crate::build_request::stub_callbacks();
+        let callbacks = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let result = BedrockAuth
+            .authorize(fake_request(), &client, &callbacks)
+            .await
+            .unwrap();
+        assert!(result.headers.contains_key("authorization"));
+        assert!(result.headers.contains_key("x-amz-date"));
+    }
+
+    #[tokio::test]
+    async fn fails_without_explicit_credentials() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let send_fn = mock_http_send(call_count, 404, "");
+        let (e, f) = crate::build_request::noop_env_fs_callbacks();
+        let client = make_client(vec![]);
+        let callbacks = BuildRequestCallbacks {
+            http_send: &send_fn,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let result = BedrockAuth
+            .authorize(fake_request(), &client, &callbacks)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn http_send_invoked_during_credential_resolution() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let send_fn = mock_http_send(call_count.clone(), 404, "");
+        let (e, f) = crate::build_request::noop_env_fs_callbacks();
+        let client = make_client(vec![]);
+        let callbacks = BuildRequestCallbacks {
+            http_send: &send_fn,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let _result = BedrockAuth
+            .authorize(fake_request(), &client, &callbacks)
+            .await;
+        assert!(call_count.load(Ordering::SeqCst) > 0);
+    }
+
+    #[tokio::test]
+    async fn http_send_not_invoked_with_explicit_credentials() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let send_fn = mock_http_send(call_count.clone(), 200, "");
+        let client = make_client(base_options());
+        let (_, e, f) = crate::build_request::stub_callbacks();
+        let callbacks = BuildRequestCallbacks {
+            http_send: &send_fn,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let result = BedrockAuth
+            .authorize(fake_request(), &client, &callbacks)
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+    }
 }

--- a/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
@@ -1,5 +1,6 @@
 //! AWS Bedrock request authorization: credential resolution + `SigV4` signing.
 
+#[allow(clippy::disallowed_types)]
 use std::time::SystemTime;
 
 use aws_credential_types::{Credentials, provider::ProvideCredentials};

--- a/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
@@ -39,10 +39,8 @@ fn now() -> SystemTime {
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let offset = web_time::SystemTime::now()
-            .duration_since(web_time::UNIX_EPOCH)
-            .unwrap();
-        std::time::UNIX_EPOCH + offset
+        use aws_smithy_async::time::TimeSource;
+        crate::wasm::BrowserTime.now()
     }
 }
 
@@ -71,7 +69,7 @@ mod native_providers {
     impl ProvideEnv for BexEnvProvider {
         fn get(&self, k: &str) -> Result<String, std::env::VarError> {
             let fut = (self.env_read_fn)(k.to_string());
-            match futures::executor::block_on(fut) {
+            match tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut)) {
                 Ok(Some(v)) => Ok(v),
                 Ok(None) | Err(_) => Err(std::env::VarError::NotPresent),
             }
@@ -110,7 +108,7 @@ mod native_providers {
             _path: &std::path::Path,
             _contents: &[u8],
         ) -> std::pin::Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + '_>> {
-            unreachable!()
+            Box::pin(async { Err(std::io::Error::other("not implemented")) })
         }
     }
 }

--- a/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
@@ -1,0 +1,448 @@
+//! AWS Bedrock request authorization: credential resolution + `SigV4` signing.
+
+use std::time::SystemTime;
+
+use aws_credential_types::{Credentials, provider::ProvideCredentials};
+use aws_sigv4::{
+    http_request::{SignableBody, SignableRequest, SigningSettings, sign},
+    sign::v4,
+};
+use aws_smithy_runtime_api::{
+    client::{
+        http::{HttpConnectorFuture, SharedHttpConnector},
+        result::ConnectorError,
+    },
+    http as smithy_http,
+};
+use aws_smithy_types::body::SdkBody;
+use bex_heap::builtin_types::owned::LlmPrimitiveClient;
+use indexmap::IndexMap;
+
+use super::LlmRequestAuthorizer;
+use crate::build_request::{
+    BuildRequestCallbacks, BuildRequestError, RawHttpRequest, get_string_option,
+};
+
+// ---------------------------------------------------------------------------
+// Platform helpers
+// ---------------------------------------------------------------------------
+
+/// Platform-aware `SystemTime::now()`.
+///
+/// On WASM, `std::time::SystemTime::now()` panics — use `web_time` instead.
+fn now() -> SystemTime {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        SystemTime::now()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let offset = web_time::SystemTime::now()
+            .duration_since(web_time::UNIX_EPOCH)
+            .unwrap();
+        std::time::UNIX_EPOCH + offset
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native: sync env/fs providers for AWS SDK config loading
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native_providers {
+    use std::future::Future;
+
+    use aws_types::os_shim_internal::{ProvideEnv, ProvideFs};
+
+    use crate::{EnvReadFn, FsReadFn};
+
+    pub(super) struct BexEnvProvider {
+        pub env_read_fn: EnvReadFn,
+    }
+
+    impl std::fmt::Debug for BexEnvProvider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BexEnvProvider").finish()
+        }
+    }
+
+    impl ProvideEnv for BexEnvProvider {
+        fn get(&self, k: &str) -> Result<String, std::env::VarError> {
+            let fut = (self.env_read_fn)(k.to_string());
+            match futures::executor::block_on(fut) {
+                Ok(Some(v)) => Ok(v),
+                Ok(None) | Err(_) => Err(std::env::VarError::NotPresent),
+            }
+        }
+    }
+
+    pub(super) struct BexFsProvider {
+        pub fs_read_fn: FsReadFn,
+    }
+
+    impl std::fmt::Debug for BexFsProvider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BexFsProvider").finish()
+        }
+    }
+
+    impl ProvideFs for BexFsProvider {
+        fn read_to_end(
+            &self,
+            path: &std::path::Path,
+        ) -> std::pin::Pin<Box<dyn Future<Output = std::io::Result<Vec<u8>>> + Send + '_>> {
+            let fut = (self.fs_read_fn)(path.to_string_lossy().into_owned());
+            Box::pin(async move {
+                match fut.await {
+                    Ok(v) => Ok(v),
+                    Err(_) => Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "file not found",
+                    )),
+                }
+            })
+        }
+
+        fn write(
+            &self,
+            _path: &std::path::Path,
+            _contents: &[u8],
+        ) -> std::pin::Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + '_>> {
+            unreachable!()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM: async credential provider for AWS SDK config loading
+// ---------------------------------------------------------------------------
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_providers {
+    use aws_credential_types::{
+        Credentials,
+        provider::{self, future::ProvideCredentials},
+    };
+
+    use crate::EnvReadFn;
+
+    /// Async credential provider that reads AWS env vars via `EnvReadFn`.
+    pub(super) struct EnvCredentialProvider {
+        pub env_read: EnvReadFn,
+    }
+
+    impl std::fmt::Debug for EnvCredentialProvider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("EnvCredentialProvider").finish()
+        }
+    }
+
+    impl EnvCredentialProvider {
+        async fn resolve(&self) -> provider::Result {
+            let access_key_id = (self.env_read)("AWS_ACCESS_KEY_ID".into())
+                .await
+                .ok()
+                .flatten()
+                .ok_or_else(|| {
+                    provider::error::CredentialsError::unhandled("AWS_ACCESS_KEY_ID not set")
+                })?;
+
+            let secret_access_key = (self.env_read)("AWS_SECRET_ACCESS_KEY".into())
+                .await
+                .ok()
+                .flatten()
+                .ok_or_else(|| {
+                    provider::error::CredentialsError::unhandled("AWS_SECRET_ACCESS_KEY not set")
+                })?;
+
+            let session_token = (self.env_read)("AWS_SESSION_TOKEN".into())
+                .await
+                .ok()
+                .flatten();
+
+            Ok(Credentials::new(
+                access_key_id,
+                secret_access_key,
+                session_token,
+                None,
+                "baml-bedrock-wasm",
+            ))
+        }
+    }
+
+    impl aws_credential_types::provider::ProvideCredentials for EnvCredentialProvider {
+        fn provide_credentials<'a>(&'a self) -> ProvideCredentials<'a>
+        where
+            Self: 'a,
+        {
+            ProvideCredentials::new(self.resolve())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Custom HTTP connector bridging to HttpSendFn
+// ---------------------------------------------------------------------------
+
+/// An [`aws_smithy_runtime_api::client::http::HttpConnector`] that delegates
+/// all HTTP traffic to a BAML [`HttpSendFn`](crate::HttpSendFn) closure.
+#[derive(Clone)]
+struct BamlHttpConnector {
+    send_fn: crate::HttpSendFn,
+}
+
+impl std::fmt::Debug for BamlHttpConnector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BamlHttpConnector").finish()
+    }
+}
+
+impl aws_smithy_runtime_api::client::http::HttpConnector for BamlHttpConnector {
+    fn call(&self, request: smithy_http::Request) -> HttpConnectorFuture {
+        let send_fn = self.send_fn.clone();
+        HttpConnectorFuture::new(async move {
+            let method = request.method().to_string();
+            let url = request.uri().to_string();
+            let mut headers = IndexMap::new();
+            for (name, value) in request.headers() {
+                headers.insert(name.to_string(), value.to_string());
+            }
+            let body = request
+                .body()
+                .bytes()
+                .map(|b| String::from_utf8_lossy(b).into_owned())
+                .unwrap_or_default();
+
+            let baml_req = bex_heap::builtin_types::owned::HttpRequest {
+                method,
+                url,
+                headers,
+                body,
+            };
+
+            let resp = send_fn(baml_req)
+                .await
+                .map_err(|e| ConnectorError::other(e.into(), None))?;
+
+            let status = smithy_http::StatusCode::try_from(resp.status_code)
+                .map_err(|e| ConnectorError::other(Box::new(e), None))?;
+            let sdk_body = SdkBody::from(resp.body);
+            let mut aws_resp = smithy_http::Response::new(status, sdk_body);
+            for (name, value) in resp.headers {
+                aws_resp
+                    .headers_mut()
+                    .try_insert(name, value)
+                    .map_err(|e| ConnectorError::other(e.into(), None))?;
+            }
+
+            Ok(aws_resp)
+        })
+    }
+}
+
+fn baml_http_client(
+    send_fn: crate::HttpSendFn,
+) -> aws_smithy_runtime_api::client::http::SharedHttpClient {
+    use aws_smithy_runtime_api::client::http::http_client_fn;
+    let connector = SharedHttpConnector::new(BamlHttpConnector { send_fn });
+    http_client_fn(move |_settings, _components| connector.clone())
+}
+
+// ---------------------------------------------------------------------------
+// AWS SDK config loading
+// ---------------------------------------------------------------------------
+
+/// Load the AWS SDK config with platform-specific providers.
+///
+/// If the client has a `profile` option, it is passed to the SDK config
+/// loader to select the named profile from `~/.aws/config` and
+/// `~/.aws/credentials`.
+async fn load_aws_sdk_config(
+    client: &LlmPrimitiveClient,
+    http_send: &crate::HttpSendFn,
+    env_read: &crate::EnvReadFn,
+    #[cfg_attr(target_arch = "wasm32", allow(unused))] fs_read: &crate::FsReadFn,
+) -> aws_config::SdkConfig {
+    let profile = get_string_option(client, "profile");
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use aws_types::os_shim_internal::{Env, Fs};
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .http_client(baml_http_client(http_send.clone()))
+            .env(Env::from_custom(native_providers::BexEnvProvider {
+                env_read_fn: env_read.clone(),
+            }))
+            .fs(Fs::from_custom(native_providers::BexFsProvider {
+                fs_read_fn: fs_read.clone(),
+            }));
+        if let Some(profile) = profile {
+            loader = loader.profile_name(profile);
+        }
+        loader.load().await
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = profile; // profiles not supported on WASM
+        aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .sleep_impl(crate::wasm::BrowserSleep)
+            .time_source(crate::wasm::BrowserTime)
+            .http_client(baml_http_client(http_send.clone()))
+            .credentials_provider(wasm_providers::EnvCredentialProvider {
+                env_read: env_read.clone(),
+            })
+            .load()
+            .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LlmRequestAuthorizer implementation
+// ---------------------------------------------------------------------------
+
+pub(crate) struct BedrockAuth;
+
+impl LlmRequestAuthorizer for BedrockAuth {
+    async fn authorize(
+        &self,
+        mut request: RawHttpRequest,
+        client: &LlmPrimitiveClient,
+        callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        let credentials = resolve_aws_credentials(
+            client,
+            callbacks.http_send,
+            callbacks.env_read,
+            callbacks.fs_read,
+        )
+        .await?;
+
+        // Extract region from the URL (already set by build_request).
+        let region = extract_region_from_url(&request.url)?;
+
+        // Sign the request with SigV4.
+        let signed_headers = sign_with_credentials(
+            &credentials,
+            &region,
+            &request.method,
+            &request.url,
+            &request.headers,
+            request.body.as_bytes(),
+        )?;
+        request.headers.extend(signed_headers);
+
+        Ok(request)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Credential resolution
+// ---------------------------------------------------------------------------
+
+/// Extract the AWS region from a Bedrock URL like
+/// `https://bedrock-runtime.us-east-1.amazonaws.com/...`
+fn extract_region_from_url(url: &str) -> Result<String, BuildRequestError> {
+    url.strip_prefix("https://bedrock-runtime.")
+        .and_then(|rest| rest.split('.').next())
+        .map(String::from)
+        .ok_or_else(|| {
+            BuildRequestError::AuthorizationFailed(format!(
+                "could not extract region from Bedrock URL: {url}"
+            ))
+        })
+}
+
+/// Resolve AWS credentials from client options or the default provider chain.
+async fn resolve_aws_credentials(
+    client: &LlmPrimitiveClient,
+    http_send: &crate::HttpSendFn,
+    env_read: &crate::EnvReadFn,
+    #[cfg_attr(target_arch = "wasm32", allow(unused))] fs_read: &crate::FsReadFn,
+) -> Result<Credentials, BuildRequestError> {
+    if let Some(creds) = credentials_from_options(client) {
+        return Ok(creds);
+    }
+
+    let sdk_config = load_aws_sdk_config(client, http_send, env_read, fs_read).await;
+
+    let credentials_provider = sdk_config.credentials_provider().ok_or_else(|| {
+        BuildRequestError::MissingOption(
+            "AWS credentials provider not found in default provider chain".into(),
+        )
+    })?;
+
+    credentials_provider
+        .provide_credentials()
+        .await
+        .map_err(|e| {
+            BuildRequestError::AuthorizationFailed(format!(
+                "failed to load credentials from default provider chain: {e}"
+            ))
+        })
+}
+
+/// Try to extract explicit credentials from client options.
+fn credentials_from_options(client: &LlmPrimitiveClient) -> Option<Credentials> {
+    let access_key_id = get_string_option(client, "access_key_id")?;
+    let secret_access_key = get_string_option(client, "secret_access_key")?;
+    let session_token = get_string_option(client, "session_token");
+    Some(Credentials::new(
+        access_key_id,
+        secret_access_key,
+        session_token,
+        None,
+        "baml-bedrock",
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// SigV4 signing
+// ---------------------------------------------------------------------------
+
+/// Sign the request with `SigV4` given resolved credentials and region.
+fn sign_with_credentials(
+    credentials: &Credentials,
+    region: &str,
+    method: &str,
+    url: &str,
+    existing_headers: &IndexMap<String, String>,
+    body: &[u8],
+) -> Result<IndexMap<String, String>, BuildRequestError> {
+    let identity = credentials.clone().into();
+
+    let signing_settings = SigningSettings::default();
+    let signing_params = v4::SigningParams::builder()
+        .identity(&identity)
+        .region(region)
+        .name("bedrock")
+        .time(now())
+        .settings(signing_settings)
+        .build()
+        .map_err(|e| BuildRequestError::AuthorizationFailed(format!("SigV4 params: {e}")))?
+        .into();
+
+    let header_pairs: Vec<(&str, &str)> = existing_headers
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    let signable = SignableRequest::new(
+        method,
+        url,
+        header_pairs.into_iter(),
+        SignableBody::Bytes(body),
+    )
+    .map_err(|e| BuildRequestError::AuthorizationFailed(format!("SigV4 signable request: {e}")))?;
+
+    let (instructions, _signature) = sign(signable, &signing_params)
+        .map_err(|e| BuildRequestError::AuthorizationFailed(format!("SigV4 signing: {e}")))?
+        .into_parts();
+
+    let mut signed_headers = IndexMap::new();
+    for (name, value) in instructions.headers() {
+        signed_headers.insert(name.to_string(), value.to_string());
+    }
+
+    Ok(signed_headers)
+}

--- a/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/auth_request/bedrock.rs
@@ -31,6 +31,7 @@ use crate::build_request::{
 /// Platform-aware `SystemTime::now()`.
 ///
 /// On WASM, `std::time::SystemTime::now()` panics — use `web_time` instead.
+#[allow(clippy::disallowed_types)]
 fn now() -> SystemTime {
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/baml_language/crates/sys_llm/src/auth_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/auth_request/mod.rs
@@ -1,0 +1,95 @@
+//! Provider-specific authentication for LLM HTTP requests.
+//!
+//! Each provider implements [`LlmRequestAuthorizer`] to authorize a built
+//! HTTP request by adding auth headers, signatures, etc.
+//!
+//! Today this is called as a step after request building inside the
+//! [`crate::build_request::build_request`] dispatch function. Eventually it
+//! can be promoted to a standalone operation in the BAML LLM function pipeline
+//! so that auth can be resolved, cached, or refreshed independently of
+//! request building (e.g. short-lived STS tokens, OAuth token refresh, or
+//! vault-based secret retrieval).
+
+mod bedrock;
+
+pub(crate) use bedrock::BedrockAuth;
+use bex_heap::builtin_types::owned::LlmPrimitiveClient;
+
+use crate::build_request::{
+    BuildRequestCallbacks, BuildRequestError, RawHttpRequest, get_string_option,
+};
+
+/// Trait for provider-specific request authorization.
+///
+/// Takes a fully-built [`RawHttpRequest`] and returns the same request with
+/// auth headers (API keys, bearer tokens, `SigV4` signatures, etc.) applied.
+pub(crate) trait LlmRequestAuthorizer {
+    /// Authorize the given request.
+    ///
+    /// Implementations may be async (e.g. Bedrock credential resolution via
+    /// the AWS provider chain, or future OAuth token refresh).
+    async fn authorize(
+        &self,
+        request: RawHttpRequest,
+        client: &LlmPrimitiveClient,
+        callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError>;
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic
+// ---------------------------------------------------------------------------
+
+/// Default Anthropic API version.
+const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
+
+pub(crate) struct AnthropicAuth;
+
+impl LlmRequestAuthorizer for AnthropicAuth {
+    async fn authorize(
+        &self,
+        mut request: RawHttpRequest,
+        client: &LlmPrimitiveClient,
+        _callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        if let Some(api_key) = get_string_option(client, "api_key") {
+            request.headers.insert("x-api-key".to_string(), api_key);
+        }
+        let version = get_string_option(client, "anthropic_version")
+            .unwrap_or_else(|| DEFAULT_ANTHROPIC_VERSION.to_string());
+        request
+            .headers
+            .insert("anthropic-version".to_string(), version);
+        Ok(request)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI (Chat Completions + Responses, including Azure)
+// ---------------------------------------------------------------------------
+
+use crate::LlmProvider;
+
+pub(crate) struct OpenAiAuth<'a> {
+    pub provider: &'a LlmProvider,
+}
+
+impl LlmRequestAuthorizer for OpenAiAuth<'_> {
+    async fn authorize(
+        &self,
+        mut request: RawHttpRequest,
+        client: &LlmPrimitiveClient,
+        _callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        if let Some(api_key) = get_string_option(client, "api_key") {
+            if *self.provider == LlmProvider::AzureOpenAi {
+                request.headers.insert("api-key".to_string(), api_key);
+            } else {
+                request
+                    .headers
+                    .insert("authorization".to_string(), format!("Bearer {api_key}"));
+            }
+        }
+        Ok(request)
+    }
+}

--- a/baml_language/crates/sys_llm/src/auth_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/auth_request/mod.rs
@@ -12,7 +12,7 @@
 
 mod bedrock;
 
-pub(crate) use bedrock::BedrockAuth;
+pub(crate) use bedrock::{BedrockAuth, load_aws_sdk_config};
 use bex_heap::builtin_types::owned::LlmPrimitiveClient;
 
 use crate::build_request::{
@@ -91,5 +91,268 @@ impl LlmRequestAuthorizer for OpenAiAuth<'_> {
             }
         }
         Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bex_external_types::BexExternalValue;
+    use indexmap::IndexMap;
+
+    use super::*;
+
+    fn make_client(options: Vec<(&str, BexExternalValue)>) -> LlmPrimitiveClient {
+        let mut opts = IndexMap::new();
+        for (k, v) in options {
+            opts.insert(k.to_string(), v);
+        }
+        LlmPrimitiveClient {
+            name: "test".to_string(),
+            provider: "test".to_string(),
+            default_role: "user".to_string(),
+            allowed_roles: vec!["user".to_string()],
+            options: opts,
+        }
+    }
+
+    fn fake_request() -> RawHttpRequest {
+        RawHttpRequest {
+            method: "POST".to_string(),
+            url: "https://example.com/v1/chat/completions".to_string(),
+            headers: IndexMap::new(),
+            body: r#"{"messages":[]}"#.to_string(),
+        }
+    }
+
+    fn stub_callbacks() -> (crate::HttpSendFn, crate::EnvReadFn, crate::FsReadFn) {
+        crate::build_request::stub_callbacks()
+    }
+
+    // -----------------------------------------------------------------------
+    // Anthropic
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn anthropic_sets_api_key_header() {
+        let client = make_client(vec![(
+            "api_key",
+            BexExternalValue::String("sk-ant-test".into()),
+        )]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let result = AnthropicAuth
+            .authorize(fake_request(), &client, &cb)
+            .await
+            .unwrap();
+        assert_eq!(result.headers.get("x-api-key").unwrap(), "sk-ant-test");
+    }
+
+    #[tokio::test]
+    async fn anthropic_default_version() {
+        let client = make_client(vec![]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let result = AnthropicAuth
+            .authorize(fake_request(), &client, &cb)
+            .await
+            .unwrap();
+        assert_eq!(
+            result.headers.get("anthropic-version").unwrap(),
+            DEFAULT_ANTHROPIC_VERSION,
+        );
+    }
+
+    #[tokio::test]
+    async fn anthropic_custom_version() {
+        let client = make_client(vec![(
+            "anthropic_version",
+            BexExternalValue::String("2024-01-01".into()),
+        )]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let result = AnthropicAuth
+            .authorize(fake_request(), &client, &cb)
+            .await
+            .unwrap();
+        assert_eq!(
+            result.headers.get("anthropic-version").unwrap(),
+            "2024-01-01"
+        );
+    }
+
+    #[tokio::test]
+    async fn anthropic_no_api_key_omits_header() {
+        let client = make_client(vec![]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let result = AnthropicAuth
+            .authorize(fake_request(), &client, &cb)
+            .await
+            .unwrap();
+        assert!(!result.headers.contains_key("x-api-key"));
+    }
+
+    // -----------------------------------------------------------------------
+    // OpenAI
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn openai_sets_bearer_token() {
+        let client = make_client(vec![(
+            "api_key",
+            BexExternalValue::String("sk-test-key".into()),
+        )]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let auth = OpenAiAuth {
+            provider: &LlmProvider::OpenAi,
+        };
+        let result = auth.authorize(fake_request(), &client, &cb).await.unwrap();
+        assert_eq!(
+            result.headers.get("authorization").unwrap(),
+            "Bearer sk-test-key",
+        );
+    }
+
+    #[tokio::test]
+    async fn openai_no_api_key_omits_header() {
+        let client = make_client(vec![]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let auth = OpenAiAuth {
+            provider: &LlmProvider::OpenAi,
+        };
+        let result = auth.authorize(fake_request(), &client, &cb).await.unwrap();
+        assert!(!result.headers.contains_key("authorization"));
+    }
+
+    #[tokio::test]
+    async fn azure_uses_api_key_header() {
+        let client = make_client(vec![("api_key", BexExternalValue::String("az-key".into()))]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let auth = OpenAiAuth {
+            provider: &LlmProvider::AzureOpenAi,
+        };
+        let result = auth.authorize(fake_request(), &client, &cb).await.unwrap();
+        assert_eq!(result.headers.get("api-key").unwrap(), "az-key");
+        assert!(!result.headers.contains_key("authorization"));
+    }
+
+    #[tokio::test]
+    async fn openai_generic_uses_bearer() {
+        let client = make_client(vec![("api_key", BexExternalValue::String("sk-gen".into()))]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let auth = OpenAiAuth {
+            provider: &LlmProvider::OpenAiGeneric,
+        };
+        let result = auth.authorize(fake_request(), &client, &cb).await.unwrap();
+        assert_eq!(
+            result.headers.get("authorization").unwrap(),
+            "Bearer sk-gen"
+        );
+    }
+
+    #[tokio::test]
+    async fn openrouter_uses_bearer() {
+        let client = make_client(vec![("api_key", BexExternalValue::String("sk-or".into()))]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let auth = OpenAiAuth {
+            provider: &LlmProvider::OpenRouter,
+        };
+        let result = auth.authorize(fake_request(), &client, &cb).await.unwrap();
+        assert_eq!(result.headers.get("authorization").unwrap(), "Bearer sk-or");
+    }
+
+    #[tokio::test]
+    async fn ollama_uses_bearer() {
+        let client = make_client(vec![(
+            "api_key",
+            BexExternalValue::String("ollama-key".into()),
+        )]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let auth = OpenAiAuth {
+            provider: &LlmProvider::Ollama,
+        };
+        let result = auth.authorize(fake_request(), &client, &cb).await.unwrap();
+        assert_eq!(
+            result.headers.get("authorization").unwrap(),
+            "Bearer ollama-key",
+        );
+    }
+
+    #[tokio::test]
+    async fn authorize_preserves_existing_headers() {
+        let client = make_client(vec![(
+            "api_key",
+            BexExternalValue::String("sk-test".into()),
+        )]);
+        let (h, e, f) = stub_callbacks();
+        let cb = BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let mut req = fake_request();
+        req.headers
+            .insert("content-type".to_string(), "application/json".to_string());
+        req.headers
+            .insert("x-custom".to_string(), "value".to_string());
+        let auth = OpenAiAuth {
+            provider: &LlmProvider::OpenAi,
+        };
+        let result = auth.authorize(req, &client, &cb).await.unwrap();
+        assert_eq!(
+            result.headers.get("content-type").unwrap(),
+            "application/json"
+        );
+        assert_eq!(result.headers.get("x-custom").unwrap(), "value");
+        assert_eq!(
+            result.headers.get("authorization").unwrap(),
+            "Bearer sk-test"
+        );
     }
 }

--- a/baml_language/crates/sys_llm/src/build_request/anthropic.rs
+++ b/baml_language/crates/sys_llm/src/build_request/anthropic.rs
@@ -485,8 +485,8 @@ mod tests {
     // Anthropic: message building and metadata
     // ========================================================================
 
-    #[test]
-    fn anthropic_single_user_message() {
+    #[tokio::test]
+    async fn anthropic_single_user_message() {
         let client = make_client(vec![
             (
                 "model",
@@ -495,7 +495,11 @@ mod tests {
             ("max_tokens", BexExternalValue::Int(1000)),
         ]);
         let prompt = msg("user", "Hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -512,8 +516,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn anthropic_three_role_conversation() {
+    #[tokio::test]
+    async fn anthropic_three_role_conversation() {
         let client = make_client(vec![
             (
                 "model",
@@ -526,7 +530,11 @@ mod tests {
             msg("user", "What is 2+2?"),
             msg("assistant", "4"),
         ]));
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -550,8 +558,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn anthropic_multi_turn_conversation() {
+    #[tokio::test]
+    async fn anthropic_multi_turn_conversation() {
         let client = make_client(vec![
             (
                 "model",
@@ -567,7 +575,11 @@ mod tests {
             msg("assistant", "Good, thanks!"),
             msg("user", "Goodbye"),
         ]));
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -603,8 +615,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn anthropic_metadata_merged_to_last_part() {
+    #[tokio::test]
+    async fn anthropic_metadata_merged_to_last_part() {
         let client = make_client(vec![
             (
                 "model",
@@ -617,7 +629,11 @@ mod tests {
             content: Arc::new("hello".to_string().into()),
             metadata: serde_json::json!({"cache_control": {"type": "ephemeral"}}),
         });
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -640,8 +656,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn anthropic_multiple_system_messages_combined() {
+    #[tokio::test]
+    async fn anthropic_multiple_system_messages_combined() {
         let client = make_client(vec![
             (
                 "model",
@@ -654,7 +670,11 @@ mod tests {
             msg("system", "Second instruction."),
             msg("user", "Hello"),
         ]));
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -675,8 +695,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn anthropic_system_metadata_merged_to_last_part() {
+    #[tokio::test]
+    async fn anthropic_system_metadata_merged_to_last_part() {
         let client = make_client(vec![
             (
                 "model",
@@ -692,7 +712,11 @@ mod tests {
             }),
             msg("user", "Hello"),
         ]));
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -716,8 +740,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn anthropic_mixed_text_and_image() {
+    #[tokio::test]
+    async fn anthropic_mixed_text_and_image() {
         let client = make_client(vec![
             (
                 "model",
@@ -746,7 +770,11 @@ mod tests {
             metadata: serde_json::Value::Null,
         });
 
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,

--- a/baml_language/crates/sys_llm/src/build_request/anthropic.rs
+++ b/baml_language/crates/sys_llm/src/build_request/anthropic.rs
@@ -6,16 +6,16 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    BuildRequestError, LlmPrimitiveClient, LlmRequestBuilder, get_string_option, mime_type_as_ok,
+    BuildRequestCallbacks, BuildRequestError, LlmPrimitiveClient, LlmRequestBuilder,
+    RawHttpRequest, build_headers, forward_options, get_string_option, mime_type_as_ok,
 };
 
 /// Builder for the Anthropic provider.
 pub(crate) struct AnthropicBuilder;
 
-/// Default `max_tokens` and version for Anthropic requests (Anthropic requires this field).
+/// Default `max_tokens` for Anthropic requests (Anthropic requires this field).
 /// Matches the default in `engine/baml-lib/llm-client/src/clients/anthropic.rs`.
 const DEFAULT_MAX_TOKENS: u32 = 4096;
-const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
 
 /// A content part within an Anthropic message.
 ///
@@ -39,49 +39,59 @@ enum MediaSource {
     Base64 { media_type: String, data: String },
 }
 
+/// Option keys specific to Anthropic that should not be forwarded to the body.
+const ANTHROPIC_SKIP_KEYS: &[&str] = &["anthropic_version"];
+
 impl LlmRequestBuilder for AnthropicBuilder {
-    fn provider_skip_keys(&self) -> &'static [&'static str] {
-        &["anthropic_version"]
-    }
-
-    fn build_url(&self, client: &LlmPrimitiveClient) -> Result<String, BuildRequestError> {
-        let base_url = get_string_option(client, "base_url")
-            .unwrap_or_else(|| "https://api.anthropic.com".to_string());
-        Ok(format!("{base_url}/v1/messages"))
-    }
-
-    fn build_auth_headers(&self, client: &LlmPrimitiveClient) -> IndexMap<String, String> {
-        let mut headers = IndexMap::new();
-        // Anthropic uses x-api-key header
-        if let Some(api_key) = get_string_option(client, "api_key") {
-            headers.insert("x-api-key".to_string(), api_key);
-        }
-        // Anthropic version header
-        let version = get_string_option(client, "anthropic_version")
-            .unwrap_or_else(|| DEFAULT_ANTHROPIC_VERSION.to_string());
-        headers.insert("anthropic-version".to_string(), version);
-        headers
-    }
-
-    fn build_prompt_body(
+    async fn build_request(
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
-    ) -> Result<serde_json::Map<String, serde_json::Value>, super::BuildRequestError> {
-        let mut map = serde_json::Map::new();
-        // Anthropic requires max_tokens — inject default if not set by user.
+        stream: bool,
+        _callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        // URL
+        let base_url = get_string_option(client, "base_url")
+            .unwrap_or_else(|| "https://api.anthropic.com".to_string());
+        let url = format!("{base_url}/v1/messages");
+
+        // Base headers (auth headers added by LlmRequestAuthorizer after building)
+        let headers = build_headers(IndexMap::new(), client);
+
+        // Body
+        let mut body = serde_json::Map::new();
+        if let Some(model) = get_string_option(client, "model") {
+            body.insert("model".to_string(), serde_json::Value::String(model));
+        }
+        if stream {
+            body.insert("stream".to_string(), serde_json::Value::Bool(true));
+        }
+        // Anthropic requires max_tokens - inject default if not set by user.
         if !client.options.contains_key("max_tokens") {
-            map.insert(
+            body.insert(
                 "max_tokens".to_string(),
                 serde_json::Value::Number(DEFAULT_MAX_TOKENS.into()),
             );
         }
         let (system_parts, messages) = extract_system_and_messages(prompt, &client.default_role)?;
         if !system_parts.is_empty() {
-            map.insert("system".to_string(), serde_json::Value::Array(system_parts));
+            body.insert("system".to_string(), serde_json::Value::Array(system_parts));
         }
-        map.insert("messages".to_string(), serde_json::Value::Array(messages));
-        Ok(map)
+        body.insert("messages".to_string(), serde_json::Value::Array(messages));
+        forward_options(ANTHROPIC_SKIP_KEYS, client, &mut body);
+
+        let body_str =
+            serde_json::to_string(&body).map_err(|e| BuildRequestError::InvalidOption {
+                key: "body".into(),
+                reason: e.to_string(),
+            })?;
+
+        Ok(RawHttpRequest {
+            method: "POST".to_string(),
+            url,
+            headers,
+            body: body_str,
+        })
     }
 }
 

--- a/baml_language/crates/sys_llm/src/build_request/anthropic.rs
+++ b/baml_language/crates/sys_llm/src/build_request/anthropic.rs
@@ -258,7 +258,7 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::*;
-    use crate::build_request::{LlmPrimitiveClient, build_request};
+    use crate::build_request::{LlmPrimitiveClient, LlmRequestBuilder};
 
     // -- helpers --
 
@@ -290,6 +290,22 @@ mod tests {
 
     fn parse_body(body: &str) -> serde_json::Value {
         serde_json::from_str(body).unwrap()
+    }
+
+    async fn build_raw(
+        client: &LlmPrimitiveClient,
+        prompt: Arc<PromptAst>,
+        stream: bool,
+    ) -> Result<crate::build_request::RawHttpRequest, crate::build_request::BuildRequestError> {
+        let (h, e, f) = crate::build_request::stub_callbacks();
+        let callbacks = crate::build_request::BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        AnthropicBuilder
+            .build_request(client, prompt, stream, &callbacks)
+            .await
     }
 
     // ========================================================================
@@ -505,11 +521,7 @@ mod tests {
             ("max_tokens", BexExternalValue::Int(1000)),
         ]);
         let prompt = msg("user", "Hello");
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, prompt, false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw(&client, prompt, false).await.unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -540,11 +552,7 @@ mod tests {
             msg("user", "What is 2+2?"),
             msg("assistant", "4"),
         ]));
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, prompt, false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw(&client, prompt, false).await.unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -585,11 +593,7 @@ mod tests {
             msg("assistant", "Good, thanks!"),
             msg("user", "Goodbye"),
         ]));
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, prompt, false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw(&client, prompt, false).await.unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -639,11 +643,7 @@ mod tests {
             content: Arc::new("hello".to_string().into()),
             metadata: serde_json::json!({"cache_control": {"type": "ephemeral"}}),
         });
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, prompt, false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw(&client, prompt, false).await.unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -680,11 +680,7 @@ mod tests {
             msg("system", "Second instruction."),
             msg("user", "Hello"),
         ]));
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, prompt, false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw(&client, prompt, false).await.unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -722,11 +718,7 @@ mod tests {
             }),
             msg("user", "Hello"),
         ]));
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, prompt, false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw(&client, prompt, false).await.unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -780,11 +772,7 @@ mod tests {
             metadata: serde_json::Value::Null,
         });
 
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, prompt, false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw(&client, prompt, false).await.unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,

--- a/baml_language/crates/sys_llm/src/build_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/build_request/bedrock.rs
@@ -98,7 +98,7 @@ impl LlmRequestBuilder for BedrockBuilder {
 
         // Convert BAML prompt to SDK types.
         let (system_blocks, messages) = prompt_to_sdk_types(prompt, &client.default_role)?;
-        let inference_config = build_sdk_inference_config(client);
+        let inference_config = build_sdk_inference_config(client)?;
         let additional_fields = collect_additional_fields(client);
 
         // Serialize body via the SDK's own serialization pipeline.
@@ -540,21 +540,30 @@ fn media_to_content_block(
 }
 
 /// Build an `InferenceConfiguration` from client options, if any are set.
-#[allow(clippy::cast_possible_truncation)]
-fn build_sdk_inference_config(client: &LlmPrimitiveClient) -> Option<InferenceConfiguration> {
+///
+/// Returns `InvalidOption` if `max_tokens` overflows `i32`.
+fn build_sdk_inference_config(
+    client: &LlmPrimitiveClient,
+) -> Result<Option<InferenceConfiguration>, BuildRequestError> {
     use bex_external_types::BexExternalValue;
 
     let mut builder = InferenceConfiguration::builder();
     let mut has_config = false;
 
     if let Some(BexExternalValue::Int(v)) = client.options.get("max_tokens") {
-        builder = builder.max_tokens(*v as i32);
+        let narrow = i32::try_from(*v).map_err(|_| BuildRequestError::InvalidOption {
+            key: "max_tokens".into(),
+            reason: format!("value {v} is out of the supported range (0..={})", i32::MAX),
+        })?;
+        builder = builder.max_tokens(narrow);
         has_config = true;
     }
+    #[allow(clippy::cast_possible_truncation)]
     if let Some(BexExternalValue::Float(v)) = client.options.get("temperature") {
         builder = builder.temperature(*v as f32);
         has_config = true;
     }
+    #[allow(clippy::cast_possible_truncation)]
     if let Some(BexExternalValue::Float(v)) = client.options.get("top_p") {
         builder = builder.top_p(*v as f32);
         has_config = true;
@@ -574,9 +583,9 @@ fn build_sdk_inference_config(client: &LlmPrimitiveClient) -> Option<InferenceCo
     }
 
     if has_config {
-        Some(builder.build())
+        Ok(Some(builder.build()))
     } else {
-        None
+        Ok(None)
     }
 }
 
@@ -1160,5 +1169,21 @@ mod tests {
         )]);
         let result = build_raw(&client, msg("user", "hi"), false).await;
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Range validation tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn bedrock_max_tokens_overflow_rejected() {
+        let mut opts = base_options();
+        opts.push(("max_tokens", BexExternalValue::Int(i64::from(i32::MAX) + 1)));
+        let client = make_client(opts);
+        let result = build_raw(&client, msg("user", "hi"), false).await;
+        assert!(
+            matches!(&result, Err(BuildRequestError::InvalidOption { key, .. }) if key == "max_tokens"),
+            "expected InvalidOption for max_tokens, got: {result:?}"
+        );
     }
 }

--- a/baml_language/crates/sys_llm/src/build_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/build_request/bedrock.rs
@@ -15,46 +15,15 @@
 //! 1. Explicit `region` in client options
 //! 2. AWS default provider chain
 
-use std::time::SystemTime;
-
-use aws_credential_types::{Credentials, provider::ProvideCredentials};
+use aws_credential_types::Credentials;
 use aws_sdk_bedrockruntime as bedrock;
 use baml_base::MediaKind;
+use baml_builtins::{PromptAst, PromptAstSimple};
 use bedrock::types::{
     ContentBlock, ConversationRole, DocumentBlock, DocumentFormat, DocumentSource, ImageBlock,
     ImageFormat, ImageSource, InferenceConfiguration, Message, SystemContentBlock, VideoBlock,
     VideoFormat, VideoSource,
 };
-
-/// Platform-aware `SystemTime::now()`.
-///
-/// On WASM, `std::time::SystemTime::now()` panics — use `web_time` instead.
-fn now() -> SystemTime {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        SystemTime::now()
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        let offset = web_time::SystemTime::now()
-            .duration_since(web_time::UNIX_EPOCH)
-            .unwrap();
-        std::time::UNIX_EPOCH + offset
-    }
-}
-use aws_sigv4::{
-    http_request::{SignableBody, SignableRequest, SigningSettings, sign},
-    sign::v4,
-};
-use aws_smithy_runtime_api::{
-    client::{
-        http::{HttpConnectorFuture, SharedHttpConnector},
-        result::ConnectorError,
-    },
-    http as smithy_http,
-};
-use aws_smithy_types::body::SdkBody;
-use baml_builtins::{PromptAst, PromptAstSimple};
 use indexmap::IndexMap;
 
 use super::{
@@ -62,178 +31,14 @@ use super::{
     RawHttpRequest, get_string_option, mime_type_as_ok,
 };
 
-// ---------------------------------------------------------------------------
-// Native: sync env/fs providers using block_on (safe on multi-threaded runtimes)
-// ---------------------------------------------------------------------------
-
-#[cfg(not(target_arch = "wasm32"))]
-mod native_providers {
-    use std::future::Future;
-
-    use aws_types::os_shim_internal::{ProvideEnv, ProvideFs};
-
-    use crate::{EnvReadFn, FsReadFn};
-
-    pub(super) struct BexEnvProvider {
-        pub env_read_fn: EnvReadFn,
-    }
-
-    impl std::fmt::Debug for BexEnvProvider {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("BexEnvProvider").finish()
-        }
-    }
-
-    impl ProvideEnv for BexEnvProvider {
-        fn get(&self, k: &str) -> Result<String, std::env::VarError> {
-            let fut = (self.env_read_fn)(k.to_string());
-            match futures::executor::block_on(fut) {
-                Ok(Some(v)) => Ok(v),
-                Ok(None) | Err(_) => Err(std::env::VarError::NotPresent),
-            }
-        }
-    }
-
-    pub(super) struct BexFsProvider {
-        pub fs_read_fn: FsReadFn,
-    }
-
-    impl std::fmt::Debug for BexFsProvider {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("BexFsProvider").finish()
-        }
-    }
-
-    impl ProvideFs for BexFsProvider {
-        fn read_to_end(
-            &self,
-            path: &std::path::Path,
-        ) -> std::pin::Pin<Box<dyn Future<Output = std::io::Result<Vec<u8>>> + Send + '_>> {
-            let fut = (self.fs_read_fn)(path.to_string_lossy().into_owned());
-            Box::pin(async move {
-                match fut.await {
-                    Ok(v) => Ok(v),
-                    Err(_) => Err(std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        "file not found",
-                    )),
-                }
-            })
-        }
-
-        fn write(
-            &self,
-            _path: &std::path::Path,
-            _contents: &[u8],
-        ) -> std::pin::Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + '_>> {
-            unreachable!()
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// WASM: async-safe providers (no block_on — would deadlock on single-threaded runtime)
-// ---------------------------------------------------------------------------
-
-#[cfg(target_arch = "wasm32")]
-mod wasm_providers {
-    use aws_credential_types::{
-        Credentials,
-        provider::{self, future::ProvideCredentials},
-    };
-    use aws_smithy_async::{
-        rt::sleep::{AsyncSleep, Sleep},
-        time::TimeSource,
-    };
-
-    use crate::EnvReadFn;
-
-    /// Browser-compatible time source using `web_time`.
-    #[derive(Debug)]
-    pub(super) struct BrowserTime;
-
-    impl TimeSource for BrowserTime {
-        fn now(&self) -> std::time::SystemTime {
-            let offset = web_time::SystemTime::now()
-                .duration_since(web_time::UNIX_EPOCH)
-                .unwrap();
-            std::time::UNIX_EPOCH + offset
-        }
-    }
-
-    /// Browser-compatible async sleep using `futures_timer`.
-    #[derive(Debug, Clone)]
-    pub(super) struct BrowserSleep;
-
-    impl AsyncSleep for BrowserSleep {
-        fn sleep(&self, duration: std::time::Duration) -> Sleep {
-            Sleep::new(futures_timer::Delay::new(duration))
-        }
-    }
-
-    /// Async credential provider that reads AWS env vars via `EnvReadFn`.
-    ///
-    /// Mirrors the engine's `WasmAwsCreds` but uses the callback architecture
-    /// instead of a JS callback provider.
-    pub(super) struct EnvCredentialProvider {
-        pub env_read: EnvReadFn,
-    }
-
-    impl std::fmt::Debug for EnvCredentialProvider {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("EnvCredentialProvider").finish()
-        }
-    }
-
-    impl EnvCredentialProvider {
-        async fn resolve(&self) -> provider::Result {
-            let access_key_id = (self.env_read)("AWS_ACCESS_KEY_ID".into())
-                .await
-                .ok()
-                .flatten()
-                .ok_or_else(|| {
-                    provider::error::CredentialsError::unhandled("AWS_ACCESS_KEY_ID not set")
-                })?;
-
-            let secret_access_key = (self.env_read)("AWS_SECRET_ACCESS_KEY".into())
-                .await
-                .ok()
-                .flatten()
-                .ok_or_else(|| {
-                    provider::error::CredentialsError::unhandled("AWS_SECRET_ACCESS_KEY not set")
-                })?;
-
-            let session_token = (self.env_read)("AWS_SESSION_TOKEN".into())
-                .await
-                .ok()
-                .flatten();
-
-            Ok(Credentials::new(
-                access_key_id,
-                secret_access_key,
-                session_token,
-                None,
-                "baml-bedrock-wasm",
-            ))
-        }
-    }
-
-    impl aws_credential_types::provider::ProvideCredentials for EnvCredentialProvider {
-        fn provide_credentials<'a>(&'a self) -> ProvideCredentials<'a>
-        where
-            Self: 'a,
-        {
-            ProvideCredentials::new(self.resolve())
-        }
-    }
-}
-
 /// Builder for the AWS Bedrock Converse provider.
 pub(crate) struct BedrockBuilder;
 
 /// Provider-specific option keys consumed by the builder (not forwarded to body).
 const BEDROCK_SKIP_KEYS: &[&str] = &[
     "region",
+    "endpoint_url",
+    "profile",
     "access_key_id",
     "secret_access_key",
     "session_token",
@@ -244,105 +49,69 @@ const BEDROCK_SKIP_KEYS: &[&str] = &[
     "stop_sequences",
 ];
 
-impl LlmRequestBuilder for BedrockBuilder {
-    fn provider_skip_keys(&self) -> &'static [&'static str] {
-        BEDROCK_SKIP_KEYS
-    }
-
-    fn build_url(&self, client: &LlmPrimitiveClient) -> Result<String, BuildRequestError> {
+/// Build the Bedrock request URL.
+///
+/// If `endpoint_url` is set, uses it as the base (for local mocking / custom
+/// proxies like `LocalStack`). Otherwise constructs the standard AWS URL from
+/// the `region` option.
+fn build_bedrock_url(
+    client: &LlmPrimitiveClient,
+    model: &str,
+    endpoint: &str,
+) -> Result<String, BuildRequestError> {
+    if let Some(base) = get_string_option(client, "endpoint_url") {
+        let base = base.trim_end_matches('/');
+        Ok(format!("{base}/model/{model}/{endpoint}"))
+    } else {
         let region = get_string_option(client, "region")
             .ok_or_else(|| BuildRequestError::MissingOption("region".into()))?;
-        let model = get_string_option(client, "model")
-            .ok_or_else(|| BuildRequestError::MissingOption("model".into()))?;
         Ok(format!(
-            "https://bedrock-runtime.{region}.amazonaws.com/model/{model}/converse"
+            "https://bedrock-runtime.{region}.amazonaws.com/model/{model}/{endpoint}"
         ))
     }
+}
 
-    fn build_auth_headers(&self, _client: &LlmPrimitiveClient) -> IndexMap<String, String> {
-        IndexMap::new()
-    }
-
-    fn build_prompt_body(
+impl BedrockBuilder {
+    /// Build the request URL from region + model options.
+    #[cfg(test)]
+    #[allow(clippy::unused_self)]
+    fn build_url(
         &self,
         client: &LlmPrimitiveClient,
-        prompt: bex_vm_types::PromptAst,
-    ) -> Result<serde_json::Map<String, serde_json::Value>, BuildRequestError> {
-        // Fallback manual implementation — only used if `build_body` is called
-        // directly (the normal path goes through `build_request` which uses
-        // SDK-based serialization).
-        let mut map = serde_json::Map::new();
-        let (system_blocks, messages) = prompt_to_sdk_types(prompt, &client.default_role)?;
-        if !system_blocks.is_empty() {
-            let parts: Vec<serde_json::Value> = system_blocks
-                .into_iter()
-                .map(|b| match b {
-                    SystemContentBlock::Text(s) => serde_json::json!({"text": s}),
-                    _ => serde_json::json!({}),
-                })
-                .collect();
-            map.insert("system".to_string(), serde_json::Value::Array(parts));
-        }
-        let msgs: Vec<serde_json::Value> = messages
-            .into_iter()
-            .map(|m| {
-                let role = m.role().as_str().to_string();
-                let content: Vec<serde_json::Value> = m
-                    .content()
-                    .iter()
-                    .map(|b| match b {
-                        ContentBlock::Text(s) => serde_json::json!({"text": s}),
-                        _ => serde_json::json!({}),
-                    })
-                    .collect();
-                serde_json::json!({"role": role, "content": content})
-            })
-            .collect();
-        map.insert("messages".to_string(), serde_json::Value::Array(msgs));
-        if let Some(cfg) = build_sdk_inference_config(client) {
-            let mut ic = serde_json::Map::new();
-            if let Some(v) = cfg.max_tokens() {
-                ic.insert("maxTokens".to_string(), serde_json::json!(v));
-            }
-            if let Some(v) = cfg.temperature() {
-                ic.insert("temperature".to_string(), serde_json::json!(v));
-            }
-            if let Some(v) = cfg.top_p() {
-                ic.insert("topP".to_string(), serde_json::json!(v));
-            }
-            if !cfg.stop_sequences().is_empty() {
-                ic.insert(
-                    "stopSequences".to_string(),
-                    serde_json::json!(cfg.stop_sequences()),
-                );
-            }
-            if !ic.is_empty() {
-                map.insert("inferenceConfig".to_string(), serde_json::Value::Object(ic));
-            }
-        }
-        Ok(map)
+        stream: bool,
+    ) -> Result<String, BuildRequestError> {
+        let model = get_string_option(client, "model")
+            .ok_or_else(|| BuildRequestError::MissingOption("model".into()))?;
+        let endpoint = if stream {
+            "converse-stream"
+        } else {
+            "converse"
+        };
+        build_bedrock_url(client, &model, endpoint)
     }
+}
 
-    /// Resolves credentials from options or the default AWS provider chain, then
-    /// builds the body via the SDK's own serializer and SigV4-signs the request.
+impl LlmRequestBuilder for BedrockBuilder {
+    /// Builds an unsigned Bedrock Converse API request.
+    ///
+    /// Resolves the AWS region (from options or the default provider chain) for
+    /// URL construction. Credential resolution and `SigV4` signing are handled
+    /// by [`crate::auth_request::BedrockAuth`] as a post-build step.
     async fn build_request(
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
-        _stream: bool,
-        callbacks: &BuildRequestCallbacks<'_>,
+        stream: bool,
+        _callbacks: &BuildRequestCallbacks<'_>,
     ) -> Result<RawHttpRequest, BuildRequestError> {
-        let (credentials, region) = resolve_aws_credentials_and_region(
-            client,
-            callbacks.http_send,
-            callbacks.env_read,
-            callbacks.fs_read,
-        )
-        .await?;
-
         let model = get_string_option(client, "model")
             .ok_or_else(|| BuildRequestError::MissingOption("model".into()))?;
-        let url = format!("https://bedrock-runtime.{region}.amazonaws.com/model/{model}/converse");
+        let endpoint = if stream {
+            "converse-stream"
+        } else {
+            "converse"
+        };
+        let url = build_bedrock_url(client, &model, endpoint)?;
 
         // Convert BAML prompt to SDK types.
         let (system_blocks, messages) = prompt_to_sdk_types(prompt, &client.default_role)?;
@@ -363,18 +132,7 @@ impl LlmRequestBuilder for BedrockBuilder {
         headers.insert("content-type".to_string(), "application/json".to_string());
         headers.insert("accept".to_string(), "application/json".to_string());
 
-        // Sign the request.
-        let signed_headers = sign_with_credentials(
-            &credentials,
-            &region,
-            "POST",
-            &url,
-            &headers,
-            body.as_bytes(),
-        )?;
-        headers.extend(signed_headers);
-
-        // Forward custom headers from client.options["headers"] (after signing).
+        // Forward custom headers from client.options["headers"].
         if let Some(bex_external_types::BexExternalValue::Map { entries, .. }) =
             client.options.get("headers")
         {
@@ -427,8 +185,8 @@ fn dry_run_sdk_config() -> bedrock::Config {
     #[cfg(target_arch = "wasm32")]
     {
         builder = builder
-            .sleep_impl(wasm_providers::BrowserSleep)
-            .time_source(wasm_providers::BrowserTime);
+            .sleep_impl(crate::wasm::BrowserSleep)
+            .time_source(crate::wasm::BrowserTime);
     }
 
     builder.build()
@@ -476,10 +234,9 @@ async fn serialize_body_via_sdk(
 
     let body = captured.lock().unwrap().clone();
     if body.is_empty() {
-        return Err(BuildRequestError::InvalidOption {
-            key: "body".into(),
-            reason: "SDK serialization produced no body (dry-run interception failed)".into(),
-        });
+        return Err(BuildRequestError::BodySerialization(
+            "SDK serialization produced no body (dry-run interception failed)".into(),
+        ));
     }
     Ok(body)
 }
@@ -522,9 +279,10 @@ fn prompt_to_sdk_types(
                         .role(conv_role)
                         .set_content(Some(blocks))
                         .build()
-                        .map_err(|e| BuildRequestError::InvalidOption {
-                            key: "message".into(),
-                            reason: e.to_string(),
+                        .map_err(|e| {
+                            BuildRequestError::BodySerialization(format!(
+                                "failed to build message: {e}"
+                            ))
                         })?,
                 );
             }
@@ -536,9 +294,10 @@ fn prompt_to_sdk_types(
                         .role(conv_role)
                         .set_content(Some(blocks))
                         .build()
-                        .map_err(|e| BuildRequestError::InvalidOption {
-                            key: "message".into(),
-                            reason: e.to_string(),
+                        .map_err(|e| {
+                            BuildRequestError::BodySerialization(format!(
+                                "failed to build message: {e}"
+                            ))
                         })?,
                 );
             }
@@ -553,10 +312,9 @@ fn parse_conversation_role(role: &str) -> Result<ConversationRole, BuildRequestE
     match role {
         "user" => Ok(ConversationRole::User),
         "assistant" => Ok(ConversationRole::Assistant),
-        other => Err(BuildRequestError::InvalidOption {
-            key: "role".into(),
-            reason: format!("unsupported conversation role for Bedrock: {other}"),
-        }),
+        other => Err(BuildRequestError::BodySerialization(format!(
+            "unsupported conversation role for Bedrock: {other}"
+        ))),
     }
 }
 
@@ -604,9 +362,8 @@ enum ResolvedMedia {
 ///
 /// HACK: The SDK's `Blob` type stores raw bytes and the Smithy serializer
 /// re-encodes them as base64. We already have base64 data, so this is a
-/// wasteful decode→re-encode round-trip. If this becomes a perf issue, we
-/// should expose the SDK's `protocol_serde` serializers directly (the fork
-/// supports it) instead of going through `map_request`.
+/// wasteful decode then re-encode round-trip. If this becomes a perf issue,
+/// we can upstream a change to allow base64 to be passed directly.
 fn resolve_media_source(
     content: &baml_builtins::MediaContent,
     kind_label: &str,
@@ -636,9 +393,10 @@ fn resolve_media_source(
         } => {
             let bytes = base64::engine::general_purpose::STANDARD
                 .decode(base64_data)
-                .map_err(|e| BuildRequestError::InvalidOption {
-                    key: kind_label.into(),
-                    reason: format!("invalid base64 data: {e}"),
+                .map_err(|e| {
+                    BuildRequestError::BodySerialization(format!(
+                        "invalid base64 {kind_label} data: {e}"
+                    ))
                 })?;
             Ok(ResolvedMedia::Bytes(bytes))
         }
@@ -694,29 +452,6 @@ fn parse_audio_format(mime: &str) -> Result<bedrock::types::AudioFormat, BuildRe
     }
 }
 
-/// Parse a MIME type string into a Bedrock `DocumentFormat`.
-#[allow(dead_code)] // Will be needed when non-PDF document types are supported.
-fn parse_document_format(mime: &str) -> Result<DocumentFormat, BuildRequestError> {
-    match mime {
-        "application/pdf" => Ok(DocumentFormat::Pdf),
-        "text/plain" => Ok(DocumentFormat::Txt),
-        "text/csv" => Ok(DocumentFormat::Csv),
-        "text/html" => Ok(DocumentFormat::Html),
-        "text/markdown" => Ok(DocumentFormat::Md),
-        "application/msword" => Ok(DocumentFormat::Doc),
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => {
-            Ok(DocumentFormat::Docx)
-        }
-        "application/vnd.ms-excel" => Ok(DocumentFormat::Xls),
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => {
-            Ok(DocumentFormat::Xlsx)
-        }
-        other => Err(BuildRequestError::UnsupportedMedia(format!(
-            "unsupported document format for Bedrock: {other}"
-        ))),
-    }
-}
-
 /// Build an `S3Location` from a URI string.
 fn s3_location(uri: String) -> bedrock::types::S3Location {
     bedrock::types::S3Location::builder()
@@ -747,9 +482,10 @@ fn media_to_content_block(
                 .format(format)
                 .source(img_source)
                 .build()
-                .map_err(|e| BuildRequestError::InvalidOption {
-                    key: "image".into(),
-                    reason: e.to_string(),
+                .map_err(|e| {
+                    BuildRequestError::BodySerialization(format!(
+                        "failed to build image block: {e}"
+                    ))
                 })?;
             Ok(vec![ContentBlock::Image(block)])
         }
@@ -765,9 +501,10 @@ fn media_to_content_block(
                 .format(format)
                 .source(vid_source)
                 .build()
-                .map_err(|e| BuildRequestError::InvalidOption {
-                    key: "video".into(),
-                    reason: e.to_string(),
+                .map_err(|e| {
+                    BuildRequestError::BodySerialization(format!(
+                        "failed to build video block: {e}"
+                    ))
                 })?;
             Ok(vec![ContentBlock::Video(block)])
         }
@@ -783,9 +520,10 @@ fn media_to_content_block(
                 .name("document")
                 .source(doc_source)
                 .build()
-                .map_err(|e| BuildRequestError::InvalidOption {
-                    key: "document".into(),
-                    reason: e.to_string(),
+                .map_err(|e| {
+                    BuildRequestError::BodySerialization(format!(
+                        "failed to build document block: {e}"
+                    ))
                 })?;
             Ok(vec![ContentBlock::Document(block)])
         }
@@ -805,9 +543,10 @@ fn media_to_content_block(
                 .format(format)
                 .source(aud_source)
                 .build()
-                .map_err(|e| BuildRequestError::InvalidOption {
-                    key: "audio".into(),
-                    reason: e.to_string(),
+                .map_err(|e| {
+                    BuildRequestError::BodySerialization(format!(
+                        "failed to build audio block: {e}"
+                    ))
                 })?;
             Ok(vec![ContentBlock::Audio(block)])
         }
@@ -916,230 +655,6 @@ fn bex_value_to_document(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Credential resolution
-// ---------------------------------------------------------------------------
-
-/// Try to extract explicit credentials from client options.
-fn credentials_from_options(client: &LlmPrimitiveClient) -> Option<Credentials> {
-    let access_key_id = get_string_option(client, "access_key_id")?;
-    let secret_access_key = get_string_option(client, "secret_access_key")?;
-    let session_token = get_string_option(client, "session_token");
-    Some(Credentials::new(
-        access_key_id,
-        secret_access_key,
-        session_token,
-        None,
-        "baml-bedrock",
-    ))
-}
-
-/// Resolve AWS credentials and region.
-///
-/// 1. If explicit `access_key_id`/`secret_access_key` are in client options, use those.
-/// 2. Otherwise, load from the AWS default provider chain (`aws_config`).
-///
-/// Region follows the same pattern: explicit option first, then default chain.
-async fn resolve_aws_credentials_and_region(
-    client: &LlmPrimitiveClient,
-    http_send: &crate::HttpSendFn,
-    env_read: &crate::EnvReadFn,
-    #[cfg_attr(target_arch = "wasm32", allow(unused))] fs_read: &crate::FsReadFn,
-) -> Result<(Credentials, String), BuildRequestError> {
-    // Try explicit credentials first.
-    if let Some(creds) = credentials_from_options(client) {
-        let region = get_string_option(client, "region")
-            .ok_or_else(|| BuildRequestError::MissingOption("region".into()))?;
-        return Ok((creds, region));
-    }
-
-    // Fall back to the default provider chain with platform-specific config.
-    #[cfg(not(target_arch = "wasm32"))]
-    let sdk_config = {
-        use aws_types::os_shim_internal::{Env, Fs};
-        aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .http_client(baml_http_client(http_send.clone()))
-            .env(Env::from_custom(native_providers::BexEnvProvider {
-                env_read_fn: env_read.clone(),
-            }))
-            .fs(Fs::from_custom(native_providers::BexFsProvider {
-                fs_read_fn: fs_read.clone(),
-            }))
-            .load()
-            .await
-    };
-
-    #[cfg(target_arch = "wasm32")]
-    let sdk_config = {
-        aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .sleep_impl(wasm_providers::BrowserSleep)
-            .time_source(wasm_providers::BrowserTime)
-            .http_client(baml_http_client(http_send.clone()))
-            .credentials_provider(wasm_providers::EnvCredentialProvider {
-                env_read: env_read.clone(),
-            })
-            .load()
-            .await
-    };
-
-    let region = get_string_option(client, "region")
-        .or_else(|| sdk_config.region().map(std::string::ToString::to_string))
-        .ok_or_else(|| {
-            BuildRequestError::MissingOption(
-                "region (not found in client options or AWS default provider chain)".into(),
-            )
-        })?;
-
-    let credentials_provider = sdk_config.credentials_provider().ok_or_else(|| {
-        BuildRequestError::MissingOption(
-            "AWS credentials provider not found in default provider chain".into(),
-        )
-    })?;
-
-    let creds = credentials_provider
-        .provide_credentials()
-        .await
-        .map_err(|e| BuildRequestError::InvalidOption {
-            key: "aws_credentials".into(),
-            reason: format!("failed to load credentials from default provider chain: {e}"),
-        })?;
-
-    Ok((creds, region))
-}
-
-// ---------------------------------------------------------------------------
-// Custom HTTP connector bridging to HttpSendFn
-// ---------------------------------------------------------------------------
-
-/// An [`aws_smithy_runtime_api::client::http::HttpConnector`] that delegates
-/// all HTTP traffic to a BAML [`HttpSendFn`](crate::HttpSendFn) closure.
-#[derive(Clone)]
-struct BamlHttpConnector {
-    send_fn: crate::HttpSendFn,
-}
-
-impl std::fmt::Debug for BamlHttpConnector {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BamlHttpConnector").finish()
-    }
-}
-
-impl aws_smithy_runtime_api::client::http::HttpConnector for BamlHttpConnector {
-    fn call(&self, request: smithy_http::Request) -> HttpConnectorFuture {
-        let send_fn = self.send_fn.clone();
-        HttpConnectorFuture::new(async move {
-            // Convert AWS SDK Request<SdkBody> to a BAML HttpRequest.
-            let method = request.method().to_string();
-            let url = request.uri().to_string();
-            let mut headers = IndexMap::new();
-            for (name, value) in request.headers() {
-                headers.insert(name.to_string(), value.to_string());
-            }
-            let body = request
-                .body()
-                .bytes()
-                .map(|b| String::from_utf8_lossy(b).into_owned())
-                .unwrap_or_default();
-
-            let baml_req = bex_heap::builtin_types::owned::HttpRequest {
-                method,
-                url,
-                headers,
-                body,
-            };
-
-            // Call the BAML HTTP send closure.
-            let resp = send_fn(baml_req)
-                .await
-                .map_err(|e| ConnectorError::other(e.into(), None))?;
-
-            // Convert BAML HttpSendResponse to a AWS SDK Response<SdkBody>.
-            let status = smithy_http::StatusCode::try_from(resp.status_code)
-                .map_err(|e| ConnectorError::other(Box::new(e), None))?;
-            let sdk_body = SdkBody::from(resp.body);
-            let mut aws_resp = smithy_http::Response::new(status, sdk_body);
-            for (name, value) in resp.headers {
-                aws_resp
-                    .headers_mut()
-                    .try_insert(name, value)
-                    .map_err(|e| ConnectorError::other(e.into(), None))?;
-            }
-
-            Ok(aws_resp)
-        })
-    }
-}
-
-/// Build a [`SharedHttpClient`](aws_smithy_runtime_api::client::http::SharedHttpClient)
-/// that delegates to the given [`HttpSendFn`](crate::HttpSendFn).
-fn baml_http_client(
-    send_fn: crate::HttpSendFn,
-) -> aws_smithy_runtime_api::client::http::SharedHttpClient {
-    use aws_smithy_runtime_api::client::http::http_client_fn;
-    let connector = SharedHttpConnector::new(BamlHttpConnector { send_fn });
-    http_client_fn(move |_settings, _components| connector.clone())
-}
-
-// ---------------------------------------------------------------------------
-// SigV4 signing
-// ---------------------------------------------------------------------------
-
-/// Sign the request with `SigV4` given resolved credentials and region.
-fn sign_with_credentials(
-    credentials: &Credentials,
-    region: &str,
-    method: &str,
-    url: &str,
-    existing_headers: &IndexMap<String, String>,
-    body: &[u8],
-) -> Result<IndexMap<String, String>, BuildRequestError> {
-    let identity = credentials.clone().into();
-
-    let signing_settings = SigningSettings::default();
-    let signing_params = v4::SigningParams::builder()
-        .identity(&identity)
-        .region(region)
-        .name("bedrock")
-        .time(now())
-        .settings(signing_settings)
-        .build()
-        .map_err(|e| BuildRequestError::InvalidOption {
-            key: "signing".into(),
-            reason: e.to_string(),
-        })?
-        .into();
-
-    let header_pairs: Vec<(&str, &str)> = existing_headers
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-
-    let signable = SignableRequest::new(
-        method,
-        url,
-        header_pairs.into_iter(),
-        SignableBody::Bytes(body),
-    )
-    .map_err(|e| BuildRequestError::InvalidOption {
-        key: "signable_request".into(),
-        reason: e.to_string(),
-    })?;
-
-    let (instructions, _signature) = sign(signable, &signing_params)
-        .map_err(|e| BuildRequestError::InvalidOption {
-            key: "signing".into(),
-            reason: e.to_string(),
-        })?
-        .into_parts();
-
-    let mut signed_headers = IndexMap::new();
-    for (name, value) in instructions.headers() {
-        signed_headers.insert(name.to_string(), value.to_string());
-    }
-
-    Ok(signed_headers)
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -1149,7 +664,7 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::*;
-    use crate::build_request::{LlmRequestBuilder, build_request};
+    use crate::build_request::build_request;
 
     fn make_client(options: Vec<(&str, BexExternalValue)>) -> LlmPrimitiveClient {
         let mut opts = IndexMap::new();
@@ -1563,7 +1078,7 @@ mod tests {
     #[test]
     fn bedrock_url_contains_model_and_region() {
         let client = make_client(base_options());
-        let url = BedrockBuilder.build_url(&client).unwrap();
+        let url = BedrockBuilder.build_url(&client, false).unwrap();
         assert_eq!(
             url,
             "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1:0/converse"
@@ -1571,9 +1086,62 @@ mod tests {
     }
 
     #[test]
+    fn bedrock_stream_url_uses_converse_stream() {
+        let client = make_client(base_options());
+        let url = BedrockBuilder.build_url(&client, true).unwrap();
+        assert!(url.ends_with("/converse-stream"));
+    }
+
+    #[test]
+    fn bedrock_endpoint_url_overrides_base() {
+        let mut opts = base_options();
+        opts.push((
+            "endpoint_url",
+            BexExternalValue::String("http://localhost:4566".into()),
+        ));
+        let client = make_client(opts);
+        let url = BedrockBuilder.build_url(&client, false).unwrap();
+        assert_eq!(
+            url,
+            "http://localhost:4566/model/anthropic.claude-3-haiku-20240307-v1:0/converse"
+        );
+    }
+
+    #[test]
+    fn bedrock_endpoint_url_with_trailing_slash() {
+        let mut opts = base_options();
+        opts.push((
+            "endpoint_url",
+            BexExternalValue::String("http://localhost:4566/".into()),
+        ));
+        let client = make_client(opts);
+        let url = BedrockBuilder.build_url(&client, false).unwrap();
+        assert_eq!(
+            url,
+            "http://localhost:4566/model/anthropic.claude-3-haiku-20240307-v1:0/converse"
+        );
+    }
+
+    #[test]
+    fn bedrock_endpoint_url_does_not_require_region() {
+        let client = make_client(vec![
+            (
+                "model",
+                BexExternalValue::String("anthropic.claude-3-haiku-20240307-v1:0".into()),
+            ),
+            (
+                "endpoint_url",
+                BexExternalValue::String("http://localhost:4566".into()),
+            ),
+        ]);
+        let url = BedrockBuilder.build_url(&client, false).unwrap();
+        assert!(url.starts_with("http://localhost:4566/"));
+    }
+
+    #[test]
     fn bedrock_missing_region_errors() {
         let client = make_client(vec![("model", BexExternalValue::String("m".into()))]);
-        assert!(BedrockBuilder.build_url(&client).is_err());
+        assert!(BedrockBuilder.build_url(&client, false).is_err());
     }
 
     #[test]
@@ -1582,7 +1150,7 @@ mod tests {
             "region",
             BexExternalValue::String("us-east-1".into()),
         )]);
-        assert!(BedrockBuilder.build_url(&client).is_err());
+        assert!(BedrockBuilder.build_url(&client, false).is_err());
     }
 
     #[tokio::test]
@@ -1658,49 +1226,5 @@ mod tests {
         };
         assert!(result.is_ok());
         assert_eq!(call_count.load(Ordering::SeqCst), 0);
-    }
-
-    #[tokio::test]
-    async fn baml_http_connector_converts_request_and_response() {
-        use aws_smithy_runtime_api::client::http::HttpConnector;
-
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let captured_url = Arc::new(std::sync::Mutex::new(String::new()));
-        let captured_body = Arc::new(std::sync::Mutex::new(String::new()));
-        let cu = captured_url.clone();
-        let cb = captured_body.clone();
-        let cc = call_count.clone();
-
-        let send_fn: crate::HttpSendFn = Arc::new(move |req| {
-            cc.fetch_add(1, Ordering::SeqCst);
-            *cu.lock().unwrap() = req.url.clone();
-            *cb.lock().unwrap() = req.body;
-            Box::pin(async {
-                let mut headers = IndexMap::new();
-                headers.insert("x-test".to_string(), "hello".to_string());
-                Ok(crate::HttpSendResponse {
-                    status_code: 200,
-                    headers,
-                    body: r#"{"ok": true}"#.to_string(),
-                })
-            })
-        });
-
-        let connector = BamlHttpConnector { send_fn };
-        let mut aws_req = smithy_http::Request::new(SdkBody::from(r#"{"test": 1}"#));
-        aws_req.set_uri("https://example.com/test").unwrap();
-        aws_req
-            .headers_mut()
-            .insert("content-type", "application/json");
-
-        let aws_resp = connector.call(aws_req).await.unwrap();
-
-        assert_eq!(call_count.load(Ordering::SeqCst), 1);
-        assert_eq!(*captured_url.lock().unwrap(), "https://example.com/test");
-        assert_eq!(*captured_body.lock().unwrap(), r#"{"test": 1}"#);
-        assert_eq!(aws_resp.status().as_u16(), 200);
-        assert_eq!(aws_resp.headers().get("x-test"), Some("hello"));
-        let body_bytes = aws_resp.body().bytes().unwrap();
-        assert_eq!(std::str::from_utf8(body_bytes).unwrap(), r#"{"ok": true}"#);
     }
 }

--- a/baml_language/crates/sys_llm/src/build_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/build_request/bedrock.rs
@@ -1,0 +1,1706 @@
+//! AWS Bedrock Converse API HTTP request builder.
+//!
+//! Builds raw HTTP requests for the Bedrock Converse API with `SigV4` signing.
+//! Text-only — no media support yet.
+//!
+//! Body serialization is delegated to the `aws-sdk-bedrockruntime` crate: we
+//! build typed SDK structs, then intercept the serialized HTTP body via
+//! `customize().map_request()` before any network I/O occurs.
+//!
+//! Credentials are resolved in order:
+//! 1. Explicit `access_key_id` / `secret_access_key` / `session_token` in client options
+//! 2. AWS default provider chain (`aws_config`) — env vars, profiles, IMDS, etc.
+//!
+//! Region is resolved in order:
+//! 1. Explicit `region` in client options
+//! 2. AWS default provider chain
+
+use std::time::SystemTime;
+
+use aws_credential_types::{Credentials, provider::ProvideCredentials};
+use aws_sdk_bedrockruntime as bedrock;
+use baml_base::MediaKind;
+use bedrock::types::{
+    ContentBlock, ConversationRole, DocumentBlock, DocumentFormat, DocumentSource, ImageBlock,
+    ImageFormat, ImageSource, InferenceConfiguration, Message, SystemContentBlock, VideoBlock,
+    VideoFormat, VideoSource,
+};
+
+/// Platform-aware `SystemTime::now()`.
+///
+/// On WASM, `std::time::SystemTime::now()` panics — use `web_time` instead.
+fn now() -> SystemTime {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        SystemTime::now()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let offset = web_time::SystemTime::now()
+            .duration_since(web_time::UNIX_EPOCH)
+            .unwrap();
+        std::time::UNIX_EPOCH + offset
+    }
+}
+use aws_sigv4::{
+    http_request::{SignableBody, SignableRequest, SigningSettings, sign},
+    sign::v4,
+};
+use aws_smithy_runtime_api::{
+    client::{
+        http::{HttpConnectorFuture, SharedHttpConnector},
+        result::ConnectorError,
+    },
+    http as smithy_http,
+};
+use aws_smithy_types::body::SdkBody;
+use baml_builtins::{PromptAst, PromptAstSimple};
+use indexmap::IndexMap;
+
+use super::{
+    BuildRequestCallbacks, BuildRequestError, LlmPrimitiveClient, LlmRequestBuilder,
+    RawHttpRequest, get_string_option, mime_type_as_ok,
+};
+
+// ---------------------------------------------------------------------------
+// Native: sync env/fs providers using block_on (safe on multi-threaded runtimes)
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native_providers {
+    use std::future::Future;
+
+    use aws_types::os_shim_internal::{ProvideEnv, ProvideFs};
+
+    use crate::{EnvReadFn, FsReadFn};
+
+    pub(super) struct BexEnvProvider {
+        pub env_read_fn: EnvReadFn,
+    }
+
+    impl std::fmt::Debug for BexEnvProvider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BexEnvProvider").finish()
+        }
+    }
+
+    impl ProvideEnv for BexEnvProvider {
+        fn get(&self, k: &str) -> Result<String, std::env::VarError> {
+            let fut = (self.env_read_fn)(k.to_string());
+            match futures::executor::block_on(fut) {
+                Ok(Some(v)) => Ok(v),
+                Ok(None) | Err(_) => Err(std::env::VarError::NotPresent),
+            }
+        }
+    }
+
+    pub(super) struct BexFsProvider {
+        pub fs_read_fn: FsReadFn,
+    }
+
+    impl std::fmt::Debug for BexFsProvider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BexFsProvider").finish()
+        }
+    }
+
+    impl ProvideFs for BexFsProvider {
+        fn read_to_end(
+            &self,
+            path: &std::path::Path,
+        ) -> std::pin::Pin<Box<dyn Future<Output = std::io::Result<Vec<u8>>> + Send + '_>> {
+            let fut = (self.fs_read_fn)(path.to_string_lossy().into_owned());
+            Box::pin(async move {
+                match fut.await {
+                    Ok(v) => Ok(v),
+                    Err(_) => Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "file not found",
+                    )),
+                }
+            })
+        }
+
+        fn write(
+            &self,
+            _path: &std::path::Path,
+            _contents: &[u8],
+        ) -> std::pin::Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + '_>> {
+            unreachable!()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM: async-safe providers (no block_on — would deadlock on single-threaded runtime)
+// ---------------------------------------------------------------------------
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_providers {
+    use aws_credential_types::{
+        Credentials,
+        provider::{self, future::ProvideCredentials},
+    };
+    use aws_smithy_async::{
+        rt::sleep::{AsyncSleep, Sleep},
+        time::TimeSource,
+    };
+
+    use crate::EnvReadFn;
+
+    /// Browser-compatible time source using `web_time`.
+    #[derive(Debug)]
+    pub(super) struct BrowserTime;
+
+    impl TimeSource for BrowserTime {
+        fn now(&self) -> std::time::SystemTime {
+            let offset = web_time::SystemTime::now()
+                .duration_since(web_time::UNIX_EPOCH)
+                .unwrap();
+            std::time::UNIX_EPOCH + offset
+        }
+    }
+
+    /// Browser-compatible async sleep using `futures_timer`.
+    #[derive(Debug, Clone)]
+    pub(super) struct BrowserSleep;
+
+    impl AsyncSleep for BrowserSleep {
+        fn sleep(&self, duration: std::time::Duration) -> Sleep {
+            Sleep::new(futures_timer::Delay::new(duration))
+        }
+    }
+
+    /// Async credential provider that reads AWS env vars via `EnvReadFn`.
+    ///
+    /// Mirrors the engine's `WasmAwsCreds` but uses the callback architecture
+    /// instead of a JS callback provider.
+    pub(super) struct EnvCredentialProvider {
+        pub env_read: EnvReadFn,
+    }
+
+    impl std::fmt::Debug for EnvCredentialProvider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("EnvCredentialProvider").finish()
+        }
+    }
+
+    impl EnvCredentialProvider {
+        async fn resolve(&self) -> provider::Result {
+            let access_key_id = (self.env_read)("AWS_ACCESS_KEY_ID".into())
+                .await
+                .ok()
+                .flatten()
+                .ok_or_else(|| {
+                    provider::error::CredentialsError::unhandled("AWS_ACCESS_KEY_ID not set")
+                })?;
+
+            let secret_access_key = (self.env_read)("AWS_SECRET_ACCESS_KEY".into())
+                .await
+                .ok()
+                .flatten()
+                .ok_or_else(|| {
+                    provider::error::CredentialsError::unhandled("AWS_SECRET_ACCESS_KEY not set")
+                })?;
+
+            let session_token = (self.env_read)("AWS_SESSION_TOKEN".into())
+                .await
+                .ok()
+                .flatten();
+
+            Ok(Credentials::new(
+                access_key_id,
+                secret_access_key,
+                session_token,
+                None,
+                "baml-bedrock-wasm",
+            ))
+        }
+    }
+
+    impl aws_credential_types::provider::ProvideCredentials for EnvCredentialProvider {
+        fn provide_credentials<'a>(&'a self) -> ProvideCredentials<'a>
+        where
+            Self: 'a,
+        {
+            ProvideCredentials::new(self.resolve())
+        }
+    }
+}
+
+/// Builder for the AWS Bedrock Converse provider.
+pub(crate) struct BedrockBuilder;
+
+/// Provider-specific option keys consumed by the builder (not forwarded to body).
+const BEDROCK_SKIP_KEYS: &[&str] = &[
+    "region",
+    "access_key_id",
+    "secret_access_key",
+    "session_token",
+    // inference config fields handled specially
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "stop_sequences",
+];
+
+impl LlmRequestBuilder for BedrockBuilder {
+    fn provider_skip_keys(&self) -> &'static [&'static str] {
+        BEDROCK_SKIP_KEYS
+    }
+
+    fn build_url(&self, client: &LlmPrimitiveClient) -> Result<String, BuildRequestError> {
+        let region = get_string_option(client, "region")
+            .ok_or_else(|| BuildRequestError::MissingOption("region".into()))?;
+        let model = get_string_option(client, "model")
+            .ok_or_else(|| BuildRequestError::MissingOption("model".into()))?;
+        Ok(format!(
+            "https://bedrock-runtime.{region}.amazonaws.com/model/{model}/converse"
+        ))
+    }
+
+    fn build_auth_headers(&self, _client: &LlmPrimitiveClient) -> IndexMap<String, String> {
+        IndexMap::new()
+    }
+
+    fn build_prompt_body(
+        &self,
+        client: &LlmPrimitiveClient,
+        prompt: bex_vm_types::PromptAst,
+    ) -> Result<serde_json::Map<String, serde_json::Value>, BuildRequestError> {
+        // Fallback manual implementation — only used if `build_body` is called
+        // directly (the normal path goes through `build_request` which uses
+        // SDK-based serialization).
+        let mut map = serde_json::Map::new();
+        let (system_blocks, messages) = prompt_to_sdk_types(prompt, &client.default_role)?;
+        if !system_blocks.is_empty() {
+            let parts: Vec<serde_json::Value> = system_blocks
+                .into_iter()
+                .map(|b| match b {
+                    SystemContentBlock::Text(s) => serde_json::json!({"text": s}),
+                    _ => serde_json::json!({}),
+                })
+                .collect();
+            map.insert("system".to_string(), serde_json::Value::Array(parts));
+        }
+        let msgs: Vec<serde_json::Value> = messages
+            .into_iter()
+            .map(|m| {
+                let role = m.role().as_str().to_string();
+                let content: Vec<serde_json::Value> = m
+                    .content()
+                    .iter()
+                    .map(|b| match b {
+                        ContentBlock::Text(s) => serde_json::json!({"text": s}),
+                        _ => serde_json::json!({}),
+                    })
+                    .collect();
+                serde_json::json!({"role": role, "content": content})
+            })
+            .collect();
+        map.insert("messages".to_string(), serde_json::Value::Array(msgs));
+        if let Some(cfg) = build_sdk_inference_config(client) {
+            let mut ic = serde_json::Map::new();
+            if let Some(v) = cfg.max_tokens() {
+                ic.insert("maxTokens".to_string(), serde_json::json!(v));
+            }
+            if let Some(v) = cfg.temperature() {
+                ic.insert("temperature".to_string(), serde_json::json!(v));
+            }
+            if let Some(v) = cfg.top_p() {
+                ic.insert("topP".to_string(), serde_json::json!(v));
+            }
+            if !cfg.stop_sequences().is_empty() {
+                ic.insert(
+                    "stopSequences".to_string(),
+                    serde_json::json!(cfg.stop_sequences()),
+                );
+            }
+            if !ic.is_empty() {
+                map.insert("inferenceConfig".to_string(), serde_json::Value::Object(ic));
+            }
+        }
+        Ok(map)
+    }
+
+    /// Resolves credentials from options or the default AWS provider chain, then
+    /// builds the body via the SDK's own serializer and SigV4-signs the request.
+    async fn build_request(
+        &self,
+        client: &LlmPrimitiveClient,
+        prompt: bex_vm_types::PromptAst,
+        _stream: bool,
+        callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        let (credentials, region) = resolve_aws_credentials_and_region(
+            client,
+            callbacks.http_send,
+            callbacks.env_read,
+            callbacks.fs_read,
+        )
+        .await?;
+
+        let model = get_string_option(client, "model")
+            .ok_or_else(|| BuildRequestError::MissingOption("model".into()))?;
+        let url = format!("https://bedrock-runtime.{region}.amazonaws.com/model/{model}/converse");
+
+        // Convert BAML prompt to SDK types.
+        let (system_blocks, messages) = prompt_to_sdk_types(prompt, &client.default_role)?;
+        let inference_config = build_sdk_inference_config(client);
+        let additional_fields = collect_additional_fields(client);
+
+        // Serialize body via the SDK's own serialization pipeline.
+        let body = serialize_body_via_sdk(
+            &model,
+            system_blocks,
+            messages,
+            inference_config,
+            additional_fields,
+        )
+        .await?;
+
+        let mut headers = IndexMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        headers.insert("accept".to_string(), "application/json".to_string());
+
+        // Sign the request.
+        let signed_headers = sign_with_credentials(
+            &credentials,
+            &region,
+            "POST",
+            &url,
+            &headers,
+            body.as_bytes(),
+        )?;
+        headers.extend(signed_headers);
+
+        // Forward custom headers from client.options["headers"] (after signing).
+        if let Some(bex_external_types::BexExternalValue::Map { entries, .. }) =
+            client.options.get("headers")
+        {
+            for (key, value) in entries {
+                if let bex_external_types::BexExternalValue::String(v) = value {
+                    headers.insert(key.clone(), v.clone());
+                }
+            }
+        }
+
+        Ok(RawHttpRequest {
+            method: "POST".to_string(),
+            url,
+            headers,
+            body,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SDK body serialization via map_request interception
+// ---------------------------------------------------------------------------
+
+/// Sentinel error returned by the `map_request` interceptor to abort the SDK
+/// pipeline after capturing the serialized body.
+#[derive(Debug)]
+struct DryRunError;
+
+impl std::fmt::Display for DryRunError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "dry-run: body captured, request aborted")
+    }
+}
+
+impl std::error::Error for DryRunError {}
+
+/// Build a throwaway SDK client config for serialization only.
+///
+/// On native, a minimal config with dummy credentials suffices. On WASM,
+/// the SDK orchestrator also needs sleep and time-source implementations
+/// (even though we abort before any real I/O) to avoid hanging.
+fn dry_run_sdk_config() -> bedrock::Config {
+    #[allow(unused_mut)] // mut needed on wasm32
+    let mut builder = bedrock::Config::builder()
+        .behavior_version(bedrock::config::BehaviorVersion::latest())
+        .region(bedrock::config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new("AKID", "SECRET", None, None, "dry-run"))
+        .retry_config(aws_smithy_types::retry::RetryConfig::disabled());
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        builder = builder
+            .sleep_impl(wasm_providers::BrowserSleep)
+            .time_source(wasm_providers::BrowserTime);
+    }
+
+    builder.build()
+}
+
+/// Serialize the Converse API request body using the SDK's own Smithy serializer.
+///
+/// Constructs a throwaway SDK client with dummy credentials, builds the Converse
+/// request with typed SDK models, then intercepts the serialized HTTP body via
+/// `customize().map_request()` before any signing or network I/O occurs.
+async fn serialize_body_via_sdk(
+    model: &str,
+    system_blocks: Vec<SystemContentBlock>,
+    messages: Vec<Message>,
+    inference_config: Option<InferenceConfiguration>,
+    additional_fields: Option<aws_smithy_types::Document>,
+) -> Result<String, BuildRequestError> {
+    let captured = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let captured_clone = captured.clone();
+
+    let sdk_client = bedrock::Client::from_conf(dry_run_sdk_config());
+
+    let mut fluent = sdk_client.converse().model_id(model);
+    fluent = fluent.set_messages(Some(messages));
+    if !system_blocks.is_empty() {
+        fluent = fluent.set_system(Some(system_blocks));
+    }
+    if let Some(cfg) = inference_config {
+        fluent = fluent.inference_config(cfg);
+    }
+    if let Some(doc) = additional_fields {
+        fluent = fluent.additional_model_request_fields(doc);
+    }
+
+    let _ = fluent
+        .customize()
+        .map_request(move |req| {
+            if let Some(bytes) = req.body().bytes() {
+                *captured_clone.lock().unwrap() = String::from_utf8_lossy(bytes).into_owned();
+            }
+            Err::<_, DryRunError>(DryRunError)
+        })
+        .send()
+        .await;
+
+    let body = captured.lock().unwrap().clone();
+    if body.is_empty() {
+        return Err(BuildRequestError::InvalidOption {
+            key: "body".into(),
+            reason: "SDK serialization produced no body (dry-run interception failed)".into(),
+        });
+    }
+    Ok(body)
+}
+
+// ---------------------------------------------------------------------------
+// BAML → SDK type conversions
+// ---------------------------------------------------------------------------
+
+/// Convert a BAML `PromptAst` into SDK `SystemContentBlock`s and `Message`s.
+fn prompt_to_sdk_types(
+    prompt: bex_vm_types::PromptAst,
+    default_role: &str,
+) -> Result<(Vec<SystemContentBlock>, Vec<Message>), BuildRequestError> {
+    let mut system_blocks = Vec::new();
+    let mut messages = Vec::new();
+
+    let items = match prompt.as_ref() {
+        PromptAst::Vec(v) => v.clone(),
+        _ => vec![prompt],
+    };
+
+    for item in &items {
+        match item.as_ref() {
+            PromptAst::Message {
+                role,
+                content,
+                metadata: _,
+            } if role == "system" => {
+                system_blocks.extend(content_to_system_blocks(content)?);
+            }
+            PromptAst::Message {
+                role,
+                content,
+                metadata: _,
+            } => {
+                let conv_role = parse_conversation_role(role)?;
+                let blocks = content_to_content_blocks(content)?;
+                messages.push(
+                    Message::builder()
+                        .role(conv_role)
+                        .set_content(Some(blocks))
+                        .build()
+                        .map_err(|e| BuildRequestError::InvalidOption {
+                            key: "message".into(),
+                            reason: e.to_string(),
+                        })?,
+                );
+            }
+            PromptAst::Simple(content) => {
+                let conv_role = parse_conversation_role(default_role)?;
+                let blocks = content_to_content_blocks(content)?;
+                messages.push(
+                    Message::builder()
+                        .role(conv_role)
+                        .set_content(Some(blocks))
+                        .build()
+                        .map_err(|e| BuildRequestError::InvalidOption {
+                            key: "message".into(),
+                            reason: e.to_string(),
+                        })?,
+                );
+            }
+            PromptAst::Vec(_) => unreachable!(),
+        }
+    }
+
+    Ok((system_blocks, messages))
+}
+
+fn parse_conversation_role(role: &str) -> Result<ConversationRole, BuildRequestError> {
+    match role {
+        "user" => Ok(ConversationRole::User),
+        "assistant" => Ok(ConversationRole::Assistant),
+        other => Err(BuildRequestError::InvalidOption {
+            key: "role".into(),
+            reason: format!("unsupported conversation role for Bedrock: {other}"),
+        }),
+    }
+}
+
+fn content_to_content_blocks(
+    content: &PromptAstSimple,
+) -> Result<Vec<ContentBlock>, BuildRequestError> {
+    match content {
+        PromptAstSimple::String(s) => Ok(vec![ContentBlock::Text(s.clone())]),
+        PromptAstSimple::Media(media) => media.read_content(|c| media_to_content_block(media, c)),
+        PromptAstSimple::Multiple(items) => {
+            let mut blocks = Vec::new();
+            for item in items {
+                blocks.extend(content_to_content_blocks(item)?);
+            }
+            Ok(blocks)
+        }
+    }
+}
+
+fn content_to_system_blocks(
+    content: &PromptAstSimple,
+) -> Result<Vec<SystemContentBlock>, BuildRequestError> {
+    match content {
+        PromptAstSimple::String(s) => Ok(vec![SystemContentBlock::Text(s.clone())]),
+        PromptAstSimple::Media(_) => Err(BuildRequestError::UnsupportedMedia(
+            "Bedrock system messages do not support media content".into(),
+        )),
+        PromptAstSimple::Multiple(items) => {
+            let mut blocks = Vec::new();
+            for item in items {
+                blocks.extend(content_to_system_blocks(item)?);
+            }
+            Ok(blocks)
+        }
+    }
+}
+
+/// Resolved media: either an S3 URI or raw bytes ready for a `Blob`.
+enum ResolvedMedia {
+    S3Uri(String),
+    Bytes(Vec<u8>),
+}
+
+/// Resolve media content into either an S3 URI or raw bytes.
+///
+/// HACK: The SDK's `Blob` type stores raw bytes and the Smithy serializer
+/// re-encodes them as base64. We already have base64 data, so this is a
+/// wasteful decode→re-encode round-trip. If this becomes a perf issue, we
+/// should expose the SDK's `protocol_serde` serializers directly (the fork
+/// supports it) instead of going through `map_request`.
+fn resolve_media_source(
+    content: &baml_builtins::MediaContent,
+    kind_label: &str,
+) -> Result<ResolvedMedia, BuildRequestError> {
+    use base64::Engine;
+    match content {
+        baml_builtins::MediaContent::Url {
+            url,
+            base64_data: None,
+        } => {
+            if url.starts_with("s3://") {
+                Ok(ResolvedMedia::S3Uri(url.clone()))
+            } else {
+                Err(BuildRequestError::UnsupportedMedia(format!(
+                    "Bedrock requires s3:// URIs for {kind_label} URLs, got: {url}"
+                )))
+            }
+        }
+        baml_builtins::MediaContent::Base64 { base64_data, .. }
+        | baml_builtins::MediaContent::Url {
+            base64_data: Some(base64_data),
+            ..
+        }
+        | baml_builtins::MediaContent::File {
+            base64_data: Some(base64_data),
+            ..
+        } => {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(base64_data)
+                .map_err(|e| BuildRequestError::InvalidOption {
+                    key: kind_label.into(),
+                    reason: format!("invalid base64 data: {e}"),
+                })?;
+            Ok(ResolvedMedia::Bytes(bytes))
+        }
+        baml_builtins::MediaContent::File {
+            base64_data: None, ..
+        } => Err(BuildRequestError::FileNotResolved(format!(
+            "{kind_label} file content was not resolved properly"
+        ))),
+    }
+}
+
+/// Parse a MIME type string into a Bedrock `ImageFormat`.
+fn parse_image_format(mime: &str) -> Result<ImageFormat, BuildRequestError> {
+    match mime {
+        "image/png" => Ok(ImageFormat::Png),
+        "image/jpeg" | "image/jpg" => Ok(ImageFormat::Jpeg),
+        "image/gif" => Ok(ImageFormat::Gif),
+        "image/webp" => Ok(ImageFormat::Webp),
+        other => Err(BuildRequestError::UnsupportedMedia(format!(
+            "unsupported image format for Bedrock: {other}"
+        ))),
+    }
+}
+
+/// Parse a MIME type string into a Bedrock `VideoFormat`.
+fn parse_video_format(mime: &str) -> Result<VideoFormat, BuildRequestError> {
+    match mime {
+        "video/mp4" => Ok(VideoFormat::Mp4),
+        "video/mpeg" => Ok(VideoFormat::Mpeg),
+        "video/x-matroska" => Ok(VideoFormat::Mkv),
+        "video/quicktime" => Ok(VideoFormat::Mov),
+        "video/x-flv" => Ok(VideoFormat::Flv),
+        "video/webm" => Ok(VideoFormat::Webm),
+        "video/3gpp" => Ok(VideoFormat::ThreeGp),
+        other => Err(BuildRequestError::UnsupportedMedia(format!(
+            "unsupported video format for Bedrock: {other}"
+        ))),
+    }
+}
+
+/// Parse a MIME type string into a Bedrock `AudioFormat`.
+fn parse_audio_format(mime: &str) -> Result<bedrock::types::AudioFormat, BuildRequestError> {
+    use bedrock::types::AudioFormat;
+    match mime {
+        "audio/mpeg" | "audio/mp3" => Ok(AudioFormat::Mp3),
+        "audio/wav" | "audio/x-wav" => Ok(AudioFormat::Wav),
+        "audio/flac" | "audio/x-flac" => Ok(AudioFormat::Flac),
+        "audio/ogg" => Ok(AudioFormat::Ogg),
+        "audio/webm" => Ok(AudioFormat::Webm),
+        other => Err(BuildRequestError::UnsupportedMedia(format!(
+            "unsupported audio format for Bedrock: {other}"
+        ))),
+    }
+}
+
+/// Parse a MIME type string into a Bedrock `DocumentFormat`.
+#[allow(dead_code)] // Will be needed when non-PDF document types are supported.
+fn parse_document_format(mime: &str) -> Result<DocumentFormat, BuildRequestError> {
+    match mime {
+        "application/pdf" => Ok(DocumentFormat::Pdf),
+        "text/plain" => Ok(DocumentFormat::Txt),
+        "text/csv" => Ok(DocumentFormat::Csv),
+        "text/html" => Ok(DocumentFormat::Html),
+        "text/markdown" => Ok(DocumentFormat::Md),
+        "application/msword" => Ok(DocumentFormat::Doc),
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => {
+            Ok(DocumentFormat::Docx)
+        }
+        "application/vnd.ms-excel" => Ok(DocumentFormat::Xls),
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => {
+            Ok(DocumentFormat::Xlsx)
+        }
+        other => Err(BuildRequestError::UnsupportedMedia(format!(
+            "unsupported document format for Bedrock: {other}"
+        ))),
+    }
+}
+
+/// Build an `S3Location` from a URI string.
+fn s3_location(uri: String) -> bedrock::types::S3Location {
+    bedrock::types::S3Location::builder()
+        .uri(uri)
+        .build()
+        .unwrap()
+}
+
+/// Convert a BAML `MediaValue` into Bedrock `ContentBlock`(s).
+fn media_to_content_block(
+    media: &baml_builtins::MediaValue,
+    content: &baml_builtins::MediaContent,
+) -> Result<Vec<ContentBlock>, BuildRequestError> {
+    let mime = mime_type_as_ok(media)?;
+    let kind_label = media.kind.to_string();
+    let source = resolve_media_source(content, &kind_label)?;
+
+    match media.kind {
+        MediaKind::Image => {
+            let format = parse_image_format(mime)?;
+            let img_source = match source {
+                ResolvedMedia::S3Uri(uri) => ImageSource::S3Location(s3_location(uri)),
+                ResolvedMedia::Bytes(bytes) => {
+                    ImageSource::Bytes(aws_smithy_types::Blob::new(bytes))
+                }
+            };
+            let block = ImageBlock::builder()
+                .format(format)
+                .source(img_source)
+                .build()
+                .map_err(|e| BuildRequestError::InvalidOption {
+                    key: "image".into(),
+                    reason: e.to_string(),
+                })?;
+            Ok(vec![ContentBlock::Image(block)])
+        }
+        MediaKind::Video => {
+            let format = parse_video_format(mime)?;
+            let vid_source = match source {
+                ResolvedMedia::S3Uri(uri) => VideoSource::S3Location(s3_location(uri)),
+                ResolvedMedia::Bytes(bytes) => {
+                    VideoSource::Bytes(aws_smithy_types::Blob::new(bytes))
+                }
+            };
+            let block = VideoBlock::builder()
+                .format(format)
+                .source(vid_source)
+                .build()
+                .map_err(|e| BuildRequestError::InvalidOption {
+                    key: "video".into(),
+                    reason: e.to_string(),
+                })?;
+            Ok(vec![ContentBlock::Video(block)])
+        }
+        MediaKind::Pdf => {
+            let doc_source = match source {
+                ResolvedMedia::S3Uri(uri) => DocumentSource::S3Location(s3_location(uri)),
+                ResolvedMedia::Bytes(bytes) => {
+                    DocumentSource::Bytes(aws_smithy_types::Blob::new(bytes))
+                }
+            };
+            let block = DocumentBlock::builder()
+                .format(DocumentFormat::Pdf)
+                .name("document")
+                .source(doc_source)
+                .build()
+                .map_err(|e| BuildRequestError::InvalidOption {
+                    key: "document".into(),
+                    reason: e.to_string(),
+                })?;
+            Ok(vec![ContentBlock::Document(block)])
+        }
+        MediaKind::Audio => {
+            let format = parse_audio_format(mime)?;
+            let aud_source = match source {
+                ResolvedMedia::S3Uri(_) => {
+                    return Err(BuildRequestError::UnsupportedMedia(
+                        "Bedrock does not support S3 URIs for audio".into(),
+                    ));
+                }
+                ResolvedMedia::Bytes(bytes) => {
+                    bedrock::types::AudioSource::Bytes(aws_smithy_types::Blob::new(bytes))
+                }
+            };
+            let block = bedrock::types::AudioBlock::builder()
+                .format(format)
+                .source(aud_source)
+                .build()
+                .map_err(|e| BuildRequestError::InvalidOption {
+                    key: "audio".into(),
+                    reason: e.to_string(),
+                })?;
+            Ok(vec![ContentBlock::Audio(block)])
+        }
+        MediaKind::Generic => Err(BuildRequestError::UnsupportedMedia(
+            "generic media type is not supported — specify image, video, audio, or pdf".into(),
+        )),
+    }
+}
+
+/// Build an `InferenceConfiguration` from client options, if any are set.
+#[allow(clippy::cast_possible_truncation)]
+fn build_sdk_inference_config(client: &LlmPrimitiveClient) -> Option<InferenceConfiguration> {
+    use bex_external_types::BexExternalValue;
+
+    let mut builder = InferenceConfiguration::builder();
+    let mut has_config = false;
+
+    if let Some(BexExternalValue::Int(v)) = client.options.get("max_tokens") {
+        builder = builder.max_tokens(*v as i32);
+        has_config = true;
+    }
+    if let Some(BexExternalValue::Float(v)) = client.options.get("temperature") {
+        builder = builder.temperature(*v as f32);
+        has_config = true;
+    }
+    if let Some(BexExternalValue::Float(v)) = client.options.get("top_p") {
+        builder = builder.top_p(*v as f32);
+        has_config = true;
+    }
+    if let Some(BexExternalValue::Array { items, .. }) = client.options.get("stop_sequences") {
+        let seqs: Vec<String> = items
+            .iter()
+            .filter_map(|v| match v {
+                BexExternalValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        if !seqs.is_empty() {
+            builder = builder.set_stop_sequences(Some(seqs));
+            has_config = true;
+        }
+    }
+
+    if has_config {
+        Some(builder.build())
+    } else {
+        None
+    }
+}
+
+/// Collect non-skipped options as `additionalModelRequestFields` (`Document`).
+fn collect_additional_fields(client: &LlmPrimitiveClient) -> Option<aws_smithy_types::Document> {
+    use super::{BUILD_REQUEST_SKIP_KEYS, SPECIALIZE_PROMPT_SKIP_KEYS};
+
+    let mut fields = std::collections::HashMap::new();
+    for (key, value) in &client.options {
+        if SPECIALIZE_PROMPT_SKIP_KEYS.contains(&key.as_str())
+            || BUILD_REQUEST_SKIP_KEYS.contains(&key.as_str())
+            || BEDROCK_SKIP_KEYS.contains(&key.as_str())
+        {
+            continue;
+        }
+        if let Some(doc) = bex_value_to_document(value) {
+            fields.insert(key.clone(), doc);
+        }
+    }
+
+    if fields.is_empty() {
+        None
+    } else {
+        Some(aws_smithy_types::Document::Object(fields))
+    }
+}
+
+/// Convert a `BexExternalValue` to a Smithy `Document`.
+fn bex_value_to_document(
+    value: &bex_external_types::BexExternalValue,
+) -> Option<aws_smithy_types::Document> {
+    use aws_smithy_types::{Document, Number};
+    use bex_external_types::BexExternalValue;
+
+    match value {
+        BexExternalValue::Null => Some(Document::Null),
+        BexExternalValue::Int(i) => {
+            if *i >= 0 {
+                Some(Document::Number(Number::PosInt((*i).cast_unsigned())))
+            } else {
+                Some(Document::Number(Number::NegInt(*i)))
+            }
+        }
+        BexExternalValue::Float(f) => Some(Document::Number(Number::Float(*f))),
+        BexExternalValue::Bool(b) => Some(Document::Bool(*b)),
+        BexExternalValue::String(s) => Some(Document::String(s.clone())),
+        BexExternalValue::Array { items, .. } => {
+            let arr: Vec<Document> = items.iter().filter_map(bex_value_to_document).collect();
+            Some(Document::Array(arr))
+        }
+        BexExternalValue::Map { entries, .. } => {
+            let map: std::collections::HashMap<String, Document> = entries
+                .iter()
+                .filter_map(|(k, v)| bex_value_to_document(v).map(|d| (k.clone(), d)))
+                .collect();
+            Some(Document::Object(map))
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Credential resolution
+// ---------------------------------------------------------------------------
+
+/// Try to extract explicit credentials from client options.
+fn credentials_from_options(client: &LlmPrimitiveClient) -> Option<Credentials> {
+    let access_key_id = get_string_option(client, "access_key_id")?;
+    let secret_access_key = get_string_option(client, "secret_access_key")?;
+    let session_token = get_string_option(client, "session_token");
+    Some(Credentials::new(
+        access_key_id,
+        secret_access_key,
+        session_token,
+        None,
+        "baml-bedrock",
+    ))
+}
+
+/// Resolve AWS credentials and region.
+///
+/// 1. If explicit `access_key_id`/`secret_access_key` are in client options, use those.
+/// 2. Otherwise, load from the AWS default provider chain (`aws_config`).
+///
+/// Region follows the same pattern: explicit option first, then default chain.
+async fn resolve_aws_credentials_and_region(
+    client: &LlmPrimitiveClient,
+    http_send: &crate::HttpSendFn,
+    env_read: &crate::EnvReadFn,
+    #[cfg_attr(target_arch = "wasm32", allow(unused))] fs_read: &crate::FsReadFn,
+) -> Result<(Credentials, String), BuildRequestError> {
+    // Try explicit credentials first.
+    if let Some(creds) = credentials_from_options(client) {
+        let region = get_string_option(client, "region")
+            .ok_or_else(|| BuildRequestError::MissingOption("region".into()))?;
+        return Ok((creds, region));
+    }
+
+    // Fall back to the default provider chain with platform-specific config.
+    #[cfg(not(target_arch = "wasm32"))]
+    let sdk_config = {
+        use aws_types::os_shim_internal::{Env, Fs};
+        aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .http_client(baml_http_client(http_send.clone()))
+            .env(Env::from_custom(native_providers::BexEnvProvider {
+                env_read_fn: env_read.clone(),
+            }))
+            .fs(Fs::from_custom(native_providers::BexFsProvider {
+                fs_read_fn: fs_read.clone(),
+            }))
+            .load()
+            .await
+    };
+
+    #[cfg(target_arch = "wasm32")]
+    let sdk_config = {
+        aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .sleep_impl(wasm_providers::BrowserSleep)
+            .time_source(wasm_providers::BrowserTime)
+            .http_client(baml_http_client(http_send.clone()))
+            .credentials_provider(wasm_providers::EnvCredentialProvider {
+                env_read: env_read.clone(),
+            })
+            .load()
+            .await
+    };
+
+    let region = get_string_option(client, "region")
+        .or_else(|| sdk_config.region().map(std::string::ToString::to_string))
+        .ok_or_else(|| {
+            BuildRequestError::MissingOption(
+                "region (not found in client options or AWS default provider chain)".into(),
+            )
+        })?;
+
+    let credentials_provider = sdk_config.credentials_provider().ok_or_else(|| {
+        BuildRequestError::MissingOption(
+            "AWS credentials provider not found in default provider chain".into(),
+        )
+    })?;
+
+    let creds = credentials_provider
+        .provide_credentials()
+        .await
+        .map_err(|e| BuildRequestError::InvalidOption {
+            key: "aws_credentials".into(),
+            reason: format!("failed to load credentials from default provider chain: {e}"),
+        })?;
+
+    Ok((creds, region))
+}
+
+// ---------------------------------------------------------------------------
+// Custom HTTP connector bridging to HttpSendFn
+// ---------------------------------------------------------------------------
+
+/// An [`aws_smithy_runtime_api::client::http::HttpConnector`] that delegates
+/// all HTTP traffic to a BAML [`HttpSendFn`](crate::HttpSendFn) closure.
+#[derive(Clone)]
+struct BamlHttpConnector {
+    send_fn: crate::HttpSendFn,
+}
+
+impl std::fmt::Debug for BamlHttpConnector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BamlHttpConnector").finish()
+    }
+}
+
+impl aws_smithy_runtime_api::client::http::HttpConnector for BamlHttpConnector {
+    fn call(&self, request: smithy_http::Request) -> HttpConnectorFuture {
+        let send_fn = self.send_fn.clone();
+        HttpConnectorFuture::new(async move {
+            // Convert AWS SDK Request<SdkBody> to a BAML HttpRequest.
+            let method = request.method().to_string();
+            let url = request.uri().to_string();
+            let mut headers = IndexMap::new();
+            for (name, value) in request.headers() {
+                headers.insert(name.to_string(), value.to_string());
+            }
+            let body = request
+                .body()
+                .bytes()
+                .map(|b| String::from_utf8_lossy(b).into_owned())
+                .unwrap_or_default();
+
+            let baml_req = bex_heap::builtin_types::owned::HttpRequest {
+                method,
+                url,
+                headers,
+                body,
+            };
+
+            // Call the BAML HTTP send closure.
+            let resp = send_fn(baml_req)
+                .await
+                .map_err(|e| ConnectorError::other(e.into(), None))?;
+
+            // Convert BAML HttpSendResponse to a AWS SDK Response<SdkBody>.
+            let status = smithy_http::StatusCode::try_from(resp.status_code)
+                .map_err(|e| ConnectorError::other(Box::new(e), None))?;
+            let sdk_body = SdkBody::from(resp.body);
+            let mut aws_resp = smithy_http::Response::new(status, sdk_body);
+            for (name, value) in resp.headers {
+                aws_resp
+                    .headers_mut()
+                    .try_insert(name, value)
+                    .map_err(|e| ConnectorError::other(e.into(), None))?;
+            }
+
+            Ok(aws_resp)
+        })
+    }
+}
+
+/// Build a [`SharedHttpClient`](aws_smithy_runtime_api::client::http::SharedHttpClient)
+/// that delegates to the given [`HttpSendFn`](crate::HttpSendFn).
+fn baml_http_client(
+    send_fn: crate::HttpSendFn,
+) -> aws_smithy_runtime_api::client::http::SharedHttpClient {
+    use aws_smithy_runtime_api::client::http::http_client_fn;
+    let connector = SharedHttpConnector::new(BamlHttpConnector { send_fn });
+    http_client_fn(move |_settings, _components| connector.clone())
+}
+
+// ---------------------------------------------------------------------------
+// SigV4 signing
+// ---------------------------------------------------------------------------
+
+/// Sign the request with `SigV4` given resolved credentials and region.
+fn sign_with_credentials(
+    credentials: &Credentials,
+    region: &str,
+    method: &str,
+    url: &str,
+    existing_headers: &IndexMap<String, String>,
+    body: &[u8],
+) -> Result<IndexMap<String, String>, BuildRequestError> {
+    let identity = credentials.clone().into();
+
+    let signing_settings = SigningSettings::default();
+    let signing_params = v4::SigningParams::builder()
+        .identity(&identity)
+        .region(region)
+        .name("bedrock")
+        .time(now())
+        .settings(signing_settings)
+        .build()
+        .map_err(|e| BuildRequestError::InvalidOption {
+            key: "signing".into(),
+            reason: e.to_string(),
+        })?
+        .into();
+
+    let header_pairs: Vec<(&str, &str)> = existing_headers
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    let signable = SignableRequest::new(
+        method,
+        url,
+        header_pairs.into_iter(),
+        SignableBody::Bytes(body),
+    )
+    .map_err(|e| BuildRequestError::InvalidOption {
+        key: "signable_request".into(),
+        reason: e.to_string(),
+    })?;
+
+    let (instructions, _signature) = sign(signable, &signing_params)
+        .map_err(|e| BuildRequestError::InvalidOption {
+            key: "signing".into(),
+            reason: e.to_string(),
+        })?
+        .into_parts();
+
+    let mut signed_headers = IndexMap::new();
+    for (name, value) in instructions.headers() {
+        signed_headers.insert(name.to_string(), value.to_string());
+    }
+
+    Ok(signed_headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use baml_builtins::{MediaContent, MediaValue, PromptAst, PromptAstSimple};
+    use bex_external_types::BexExternalValue;
+    use indexmap::IndexMap;
+
+    use super::*;
+    use crate::build_request::{LlmRequestBuilder, build_request};
+
+    fn make_client(options: Vec<(&str, BexExternalValue)>) -> LlmPrimitiveClient {
+        let mut opts = IndexMap::new();
+        for (k, v) in options {
+            opts.insert(k.to_string(), v);
+        }
+        LlmPrimitiveClient {
+            name: "test-bedrock".to_string(),
+            provider: "aws-bedrock".to_string(),
+            default_role: "user".to_string(),
+            allowed_roles: vec![
+                "system".to_string(),
+                "user".to_string(),
+                "assistant".to_string(),
+            ],
+            options: opts,
+        }
+    }
+
+    fn base_options() -> Vec<(&'static str, BexExternalValue)> {
+        vec![
+            ("region", BexExternalValue::String("us-east-1".into())),
+            (
+                "model",
+                BexExternalValue::String("anthropic.claude-3-haiku-20240307-v1:0".into()),
+            ),
+            (
+                "access_key_id",
+                BexExternalValue::String("AKIAIOSFODNN7EXAMPLE".into()),
+            ),
+            (
+                "secret_access_key",
+                BexExternalValue::String("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into()),
+            ),
+        ]
+    }
+
+    fn msg(role: &str, text: &str) -> Arc<PromptAst> {
+        Arc::new(PromptAst::Message {
+            role: role.to_string(),
+            content: Arc::new(text.to_string().into()),
+            metadata: serde_json::Value::Null,
+        })
+    }
+
+    /// Build a message containing a single media item.
+    fn media_msg(
+        role: &str,
+        kind: baml_base::MediaKind,
+        mime: &str,
+        content: MediaContent,
+    ) -> Arc<PromptAst> {
+        let media = Arc::new(MediaValue::new(kind, content, Some(mime.to_string())));
+        Arc::new(PromptAst::Message {
+            role: role.to_string(),
+            content: Arc::new(PromptAstSimple::Media(media)),
+            metadata: serde_json::Value::Null,
+        })
+    }
+
+    /// Build a message with text + media parts.
+    fn multipart_msg(
+        role: &str,
+        text: &str,
+        kind: baml_base::MediaKind,
+        mime: &str,
+        content: MediaContent,
+    ) -> Arc<PromptAst> {
+        let media = Arc::new(MediaValue::new(kind, content, Some(mime.to_string())));
+        Arc::new(PromptAst::Message {
+            role: role.to_string(),
+            content: Arc::new(PromptAstSimple::Multiple(vec![
+                Arc::new(PromptAstSimple::String(text.to_string())),
+                Arc::new(PromptAstSimple::Media(media)),
+            ])),
+            metadata: serde_json::Value::Null,
+        })
+    }
+
+    /// Helper: build a request and return the parsed body JSON.
+    async fn body_for(client: &LlmPrimitiveClient, prompt: Arc<PromptAst>) -> serde_json::Value {
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
+        serde_json::from_str(&result.body).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // Body snapshot tests — each asserts the full JSON body
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn bedrock_system_and_user_text() {
+        let client = make_client(base_options());
+        let prompt = Arc::new(PromptAst::Vec(vec![
+            msg("system", "You are helpful."),
+            msg("user", "Hello"),
+        ]));
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "system": [{"text": "You are helpful."}],
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hello"}]}
+                ]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_user_only() {
+        let client = make_client(base_options());
+        assert_eq!(
+            body_for(&client, msg("user", "Hello")).await,
+            serde_json::json!({
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hello"}]}
+                ]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_multi_turn() {
+        let client = make_client(base_options());
+        let prompt = Arc::new(PromptAst::Vec(vec![
+            msg("system", "Be concise."),
+            msg("user", "What is 2+2?"),
+            msg("assistant", "4"),
+            msg("user", "And 3+3?"),
+        ]));
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "system": [{"text": "Be concise."}],
+                "messages": [
+                    {"role": "user", "content": [{"text": "What is 2+2?"}]},
+                    {"role": "assistant", "content": [{"text": "4"}]},
+                    {"role": "user", "content": [{"text": "And 3+3?"}]},
+                ]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_inference_config() {
+        // Use f32-exact values so the snapshot comparison is deterministic.
+        let mut opts = base_options();
+        opts.push(("max_tokens", BexExternalValue::Int(500)));
+        opts.push(("temperature", BexExternalValue::Float(0.5)));
+        opts.push(("top_p", BexExternalValue::Float(0.75)));
+        let client = make_client(opts);
+        assert_eq!(
+            body_for(&client, msg("user", "Hi")).await,
+            serde_json::json!({
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hi"}]}
+                ],
+                "inferenceConfig": {
+                    "maxTokens": 500,
+                    "temperature": 0.5,
+                    "topP": 0.75,
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_no_model_or_creds_in_body() {
+        let client = make_client(base_options());
+        let body = body_for(&client, msg("user", "Hello")).await;
+        assert!(
+            body.get("model").is_none(),
+            "model should be in URL, not body"
+        );
+        assert!(
+            body.get("modelId").is_none(),
+            "modelId should be in URL, not body"
+        );
+        assert!(body.get("access_key_id").is_none());
+        assert!(body.get("secret_access_key").is_none());
+        assert!(body.get("region").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Media tests
+    // -----------------------------------------------------------------------
+
+    /// `"SGVsbG8="` is base64 for the bytes [0x48, 0x65, 0x6c, 0x6c, 0x6f] ("Hello").
+    const TINY_B64: &str = "SGVsbG8=";
+
+    #[tokio::test]
+    async fn bedrock_image_base64() {
+        let client = make_client(base_options());
+        let prompt = media_msg(
+            "user",
+            baml_base::MediaKind::Image,
+            "image/png",
+            MediaContent::Base64 {
+                base64_data: TINY_B64.into(),
+            },
+        );
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "image": {
+                            "format": "png",
+                            "source": {"bytes": TINY_B64}
+                        }
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_image_s3() {
+        let client = make_client(base_options());
+        let prompt = media_msg(
+            "user",
+            baml_base::MediaKind::Image,
+            "image/jpeg",
+            MediaContent::Url {
+                url: "s3://my-bucket/photo.jpg".into(),
+                base64_data: None,
+            },
+        );
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "image": {
+                            "format": "jpeg",
+                            "source": {"s3Location": {"uri": "s3://my-bucket/photo.jpg"}}
+                        }
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_video_base64() {
+        let client = make_client(base_options());
+        let prompt = media_msg(
+            "user",
+            baml_base::MediaKind::Video,
+            "video/mp4",
+            MediaContent::Base64 {
+                base64_data: TINY_B64.into(),
+            },
+        );
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "video": {
+                            "format": "mp4",
+                            "source": {"bytes": TINY_B64}
+                        }
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_pdf_base64() {
+        let client = make_client(base_options());
+        let prompt = media_msg(
+            "user",
+            baml_base::MediaKind::Pdf,
+            "application/pdf",
+            MediaContent::Base64 {
+                base64_data: TINY_B64.into(),
+            },
+        );
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "document": {
+                            "format": "pdf",
+                            "name": "document",
+                            "source": {"bytes": TINY_B64}
+                        }
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_audio_base64() {
+        let client = make_client(base_options());
+        let prompt = media_msg(
+            "user",
+            baml_base::MediaKind::Audio,
+            "audio/mp3",
+            MediaContent::Base64 {
+                base64_data: TINY_B64.into(),
+            },
+        );
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "audio": {
+                            "format": "mp3",
+                            "source": {"bytes": TINY_B64}
+                        }
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_text_and_image_multipart() {
+        let client = make_client(base_options());
+        let prompt = multipart_msg(
+            "user",
+            "Describe this image",
+            baml_base::MediaKind::Image,
+            "image/jpeg",
+            MediaContent::Base64 {
+                base64_data: TINY_B64.into(),
+            },
+        );
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"text": "Describe this image"},
+                        {"image": {
+                            "format": "jpeg",
+                            "source": {"bytes": TINY_B64}
+                        }}
+                    ]
+                }]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_video_s3() {
+        let client = make_client(base_options());
+        let prompt = media_msg(
+            "user",
+            baml_base::MediaKind::Video,
+            "video/mp4",
+            MediaContent::Url {
+                url: "s3://bucket/clip.mp4".into(),
+                base64_data: None,
+            },
+        );
+        assert_eq!(
+            body_for(&client, prompt).await,
+            serde_json::json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "video": {
+                            "format": "mp4",
+                            "source": {"s3Location": {"uri": "s3://bucket/clip.mp4"}}
+                        }
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bedrock_non_s3_url_rejected() {
+        let client = make_client(base_options());
+        let prompt = media_msg(
+            "user",
+            baml_base::MediaKind::Image,
+            "image/png",
+            MediaContent::Url {
+                url: "https://example.com/img.png".into(),
+                base64_data: None,
+            },
+        );
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        };
+        assert!(result.is_err(), "non-s3 URLs should be rejected");
+    }
+
+    // -----------------------------------------------------------------------
+    // URL, headers, error cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bedrock_url_contains_model_and_region() {
+        let client = make_client(base_options());
+        let url = BedrockBuilder.build_url(&client).unwrap();
+        assert_eq!(
+            url,
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1:0/converse"
+        );
+    }
+
+    #[test]
+    fn bedrock_missing_region_errors() {
+        let client = make_client(vec![("model", BexExternalValue::String("m".into()))]);
+        assert!(BedrockBuilder.build_url(&client).is_err());
+    }
+
+    #[test]
+    fn bedrock_missing_model_errors() {
+        let client = make_client(vec![(
+            "region",
+            BexExternalValue::String("us-east-1".into()),
+        )]);
+        assert!(BedrockBuilder.build_url(&client).is_err());
+    }
+
+    #[tokio::test]
+    async fn bedrock_sigv4_headers_present() {
+        let client = make_client(base_options());
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "Hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
+        assert!(result.headers.contains_key("authorization"));
+        assert!(result.headers.contains_key("x-amz-date"));
+    }
+
+    #[tokio::test]
+    async fn bedrock_fails_without_explicit_credentials() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let send_fn = mock_http_send(call_count, 404, "");
+        let (e, f) = crate::build_request::noop_env_fs_callbacks();
+        let client = make_client(vec![
+            ("region", BexExternalValue::String("us-east-1".into())),
+            ("model", BexExternalValue::String("some-model".into())),
+        ]);
+        let result = build_request(&client, msg("user", "Hi"), false, &send_fn, &e, &f).await;
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // BamlHttpConnector wiring tests
+    // -----------------------------------------------------------------------
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn mock_http_send(
+        call_count: Arc<AtomicUsize>,
+        status: u16,
+        body: &'static str,
+    ) -> crate::HttpSendFn {
+        Arc::new(move |_req| {
+            call_count.fetch_add(1, Ordering::SeqCst);
+            let body = body.to_string();
+            Box::pin(async move {
+                Ok(crate::HttpSendResponse {
+                    status_code: status,
+                    headers: IndexMap::new(),
+                    body,
+                })
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn bedrock_http_send_invoked_during_credential_resolution() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let send_fn = mock_http_send(call_count.clone(), 404, "");
+        let client = make_client(vec![
+            ("region", BexExternalValue::String("us-east-1".into())),
+            ("model", BexExternalValue::String("some-model".into())),
+        ]);
+        let (e, f) = crate::build_request::noop_env_fs_callbacks();
+        let _result = build_request(&client, msg("user", "Hi"), false, &send_fn, &e, &f).await;
+        assert!(call_count.load(Ordering::SeqCst) > 0);
+    }
+
+    #[tokio::test]
+    async fn bedrock_http_send_not_invoked_with_explicit_credentials() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let send_fn = mock_http_send(call_count.clone(), 200, "");
+        let client = make_client(base_options());
+        let result = {
+            let (_h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "Hi"), false, &send_fn, &e, &f).await
+        };
+        assert!(result.is_ok());
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn baml_http_connector_converts_request_and_response() {
+        use aws_smithy_runtime_api::client::http::HttpConnector;
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let captured_url = Arc::new(std::sync::Mutex::new(String::new()));
+        let captured_body = Arc::new(std::sync::Mutex::new(String::new()));
+        let cu = captured_url.clone();
+        let cb = captured_body.clone();
+        let cc = call_count.clone();
+
+        let send_fn: crate::HttpSendFn = Arc::new(move |req| {
+            cc.fetch_add(1, Ordering::SeqCst);
+            *cu.lock().unwrap() = req.url.clone();
+            *cb.lock().unwrap() = req.body;
+            Box::pin(async {
+                let mut headers = IndexMap::new();
+                headers.insert("x-test".to_string(), "hello".to_string());
+                Ok(crate::HttpSendResponse {
+                    status_code: 200,
+                    headers,
+                    body: r#"{"ok": true}"#.to_string(),
+                })
+            })
+        });
+
+        let connector = BamlHttpConnector { send_fn };
+        let mut aws_req = smithy_http::Request::new(SdkBody::from(r#"{"test": 1}"#));
+        aws_req.set_uri("https://example.com/test").unwrap();
+        aws_req
+            .headers_mut()
+            .insert("content-type", "application/json");
+
+        let aws_resp = connector.call(aws_req).await.unwrap();
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+        assert_eq!(*captured_url.lock().unwrap(), "https://example.com/test");
+        assert_eq!(*captured_body.lock().unwrap(), r#"{"test": 1}"#);
+        assert_eq!(aws_resp.status().as_u16(), 200);
+        assert_eq!(aws_resp.headers().get("x-test"), Some("hello"));
+        let body_bytes = aws_resp.body().bytes().unwrap();
+        assert_eq!(std::str::from_utf8(body_bytes).unwrap(), r#"{"ok": true}"#);
+    }
+}

--- a/baml_language/crates/sys_llm/src/build_request/bedrock.rs
+++ b/baml_language/crates/sys_llm/src/build_request/bedrock.rs
@@ -49,48 +49,6 @@ const BEDROCK_SKIP_KEYS: &[&str] = &[
     "stop_sequences",
 ];
 
-/// Build the Bedrock request URL.
-///
-/// If `endpoint_url` is set, uses it as the base (for local mocking / custom
-/// proxies like `LocalStack`). Otherwise constructs the standard AWS URL from
-/// the `region` option.
-fn build_bedrock_url(
-    client: &LlmPrimitiveClient,
-    model: &str,
-    endpoint: &str,
-) -> Result<String, BuildRequestError> {
-    if let Some(base) = get_string_option(client, "endpoint_url") {
-        let base = base.trim_end_matches('/');
-        Ok(format!("{base}/model/{model}/{endpoint}"))
-    } else {
-        let region = get_string_option(client, "region")
-            .ok_or_else(|| BuildRequestError::MissingOption("region".into()))?;
-        Ok(format!(
-            "https://bedrock-runtime.{region}.amazonaws.com/model/{model}/{endpoint}"
-        ))
-    }
-}
-
-impl BedrockBuilder {
-    /// Build the request URL from region + model options.
-    #[cfg(test)]
-    #[allow(clippy::unused_self)]
-    fn build_url(
-        &self,
-        client: &LlmPrimitiveClient,
-        stream: bool,
-    ) -> Result<String, BuildRequestError> {
-        let model = get_string_option(client, "model")
-            .ok_or_else(|| BuildRequestError::MissingOption("model".into()))?;
-        let endpoint = if stream {
-            "converse-stream"
-        } else {
-            "converse"
-        };
-        build_bedrock_url(client, &model, endpoint)
-    }
-}
-
 impl LlmRequestBuilder for BedrockBuilder {
     /// Builds an unsigned Bedrock Converse API request.
     ///
@@ -102,7 +60,7 @@ impl LlmRequestBuilder for BedrockBuilder {
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
         stream: bool,
-        _callbacks: &BuildRequestCallbacks<'_>,
+        callbacks: &BuildRequestCallbacks<'_>,
     ) -> Result<RawHttpRequest, BuildRequestError> {
         let model = get_string_option(client, "model")
             .ok_or_else(|| BuildRequestError::MissingOption("model".into()))?;
@@ -111,7 +69,32 @@ impl LlmRequestBuilder for BedrockBuilder {
         } else {
             "converse"
         };
-        let url = build_bedrock_url(client, &model, endpoint)?;
+
+        // When endpoint_url is set (e.g. LocalStack), region is only needed for
+        // SigV4 signing later, not for URL construction. Otherwise resolve from
+        // explicit option first, then the AWS default provider chain.
+        let url = if let Some(base) = get_string_option(client, "endpoint_url") {
+            let base = base.trim_end_matches('/');
+            format!("{base}/model/{model}/{endpoint}")
+        } else {
+            let region = match get_string_option(client, "region") {
+                Some(r) => r,
+                None => {
+                    let sdk_config = crate::auth_request::load_aws_sdk_config(
+                        client,
+                        callbacks.http_send,
+                        callbacks.env_read,
+                        callbacks.fs_read,
+                    )
+                    .await;
+                    sdk_config
+                        .region()
+                        .map(std::string::ToString::to_string)
+                        .ok_or_else(|| BuildRequestError::MissingOption("region".into()))?
+                }
+            };
+            format!("https://bedrock-runtime.{region}.amazonaws.com/model/{model}/{endpoint}")
+        };
 
         // Convert BAML prompt to SDK types.
         let (system_blocks, messages) = prompt_to_sdk_types(prompt, &client.default_role)?;
@@ -664,7 +647,6 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::*;
-    use crate::build_request::build_request;
 
     fn make_client(options: Vec<(&str, BexExternalValue)>) -> LlmPrimitiveClient {
         let mut opts = IndexMap::new();
@@ -746,11 +728,7 @@ mod tests {
 
     /// Helper: build a request and return the parsed body JSON.
     async fn body_for(client: &LlmPrimitiveClient, prompt: Arc<PromptAst>) -> serde_json::Value {
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(client, prompt, false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw(client, prompt, false).await.unwrap();
         serde_json::from_str(&result.body).unwrap()
     }
 
@@ -1064,10 +1042,7 @@ mod tests {
                 base64_data: None,
             },
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, prompt, false, &h, &e, &f).await
-        };
+        let result = build_raw(&client, prompt, false).await;
         assert!(result.is_err(), "non-s3 URLs should be rejected");
     }
 
@@ -1075,55 +1050,73 @@ mod tests {
     // URL, headers, error cases
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn bedrock_url_contains_model_and_region() {
+    /// Helper: run only the build step (no auth/signing) via the
+    /// `LlmRequestBuilder` trait so URL tests don't need valid credentials.
+    async fn build_raw(
+        client: &LlmPrimitiveClient,
+        prompt: Arc<PromptAst>,
+        stream: bool,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        let (h, e, f) = crate::build_request::stub_callbacks();
+        let callbacks = crate::build_request::BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        BedrockBuilder
+            .build_request(client, prompt, stream, &callbacks)
+            .await
+    }
+
+    #[tokio::test]
+    async fn bedrock_url_contains_model_and_region() {
         let client = make_client(base_options());
-        let url = BedrockBuilder.build_url(&client, false).unwrap();
+        let result = build_raw(&client, msg("user", "hi"), false).await.unwrap();
         assert_eq!(
-            url,
+            result.url,
             "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1:0/converse"
         );
     }
 
-    #[test]
-    fn bedrock_stream_url_uses_converse_stream() {
+    #[tokio::test]
+    async fn bedrock_stream_url_uses_converse_stream() {
         let client = make_client(base_options());
-        let url = BedrockBuilder.build_url(&client, true).unwrap();
-        assert!(url.ends_with("/converse-stream"));
+        let result = build_raw(&client, msg("user", "hi"), true).await.unwrap();
+        assert!(result.url.ends_with("/converse-stream"));
     }
 
-    #[test]
-    fn bedrock_endpoint_url_overrides_base() {
+    #[tokio::test]
+    async fn bedrock_endpoint_url_overrides_base() {
         let mut opts = base_options();
         opts.push((
             "endpoint_url",
             BexExternalValue::String("http://localhost:4566".into()),
         ));
         let client = make_client(opts);
-        let url = BedrockBuilder.build_url(&client, false).unwrap();
+        let result = build_raw(&client, msg("user", "hi"), false).await.unwrap();
         assert_eq!(
-            url,
+            result.url,
             "http://localhost:4566/model/anthropic.claude-3-haiku-20240307-v1:0/converse"
         );
     }
 
-    #[test]
-    fn bedrock_endpoint_url_with_trailing_slash() {
+    #[tokio::test]
+    async fn bedrock_endpoint_url_with_trailing_slash() {
         let mut opts = base_options();
         opts.push((
             "endpoint_url",
             BexExternalValue::String("http://localhost:4566/".into()),
         ));
         let client = make_client(opts);
-        let url = BedrockBuilder.build_url(&client, false).unwrap();
+        let result = build_raw(&client, msg("user", "hi"), false).await.unwrap();
         assert_eq!(
-            url,
+            result.url,
             "http://localhost:4566/model/anthropic.claude-3-haiku-20240307-v1:0/converse"
         );
     }
 
-    #[test]
-    fn bedrock_endpoint_url_does_not_require_region() {
+    #[tokio::test]
+    async fn bedrock_endpoint_url_does_not_require_region() {
         let client = make_client(vec![
             (
                 "model",
@@ -1134,97 +1127,38 @@ mod tests {
                 BexExternalValue::String("http://localhost:4566".into()),
             ),
         ]);
-        let url = BedrockBuilder.build_url(&client, false).unwrap();
-        assert!(url.starts_with("http://localhost:4566/"));
+        let result = build_raw(&client, msg("user", "hi"), false).await.unwrap();
+        assert!(result.url.starts_with("http://localhost:4566/"));
     }
 
-    #[test]
-    fn bedrock_missing_region_errors() {
+    #[tokio::test]
+    async fn bedrock_missing_region_errors() {
+        // No region in options, so build_request falls back to the AWS
+        // provider chain. noop callbacks return "not found" so region
+        // resolution fails, which is what we're testing.
+        use std::sync::Arc;
         let client = make_client(vec![("model", BexExternalValue::String("m".into()))]);
-        assert!(BedrockBuilder.build_url(&client, false).is_err());
+        let h: crate::HttpSendFn =
+            Arc::new(|_| Box::pin(async { Err(crate::LlmOpError::Other("not available".into())) }));
+        let (e, f) = crate::build_request::noop_env_fs_callbacks();
+        let callbacks = crate::build_request::BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let result = BedrockBuilder
+            .build_request(&client, msg("user", "hi"), false, &callbacks)
+            .await;
+        assert!(result.is_err());
     }
 
-    #[test]
-    fn bedrock_missing_model_errors() {
+    #[tokio::test]
+    async fn bedrock_missing_model_errors() {
         let client = make_client(vec![(
             "region",
             BexExternalValue::String("us-east-1".into()),
         )]);
-        assert!(BedrockBuilder.build_url(&client, false).is_err());
-    }
-
-    #[tokio::test]
-    async fn bedrock_sigv4_headers_present() {
-        let client = make_client(base_options());
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "Hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
-        assert!(result.headers.contains_key("authorization"));
-        assert!(result.headers.contains_key("x-amz-date"));
-    }
-
-    #[tokio::test]
-    async fn bedrock_fails_without_explicit_credentials() {
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let send_fn = mock_http_send(call_count, 404, "");
-        let (e, f) = crate::build_request::noop_env_fs_callbacks();
-        let client = make_client(vec![
-            ("region", BexExternalValue::String("us-east-1".into())),
-            ("model", BexExternalValue::String("some-model".into())),
-        ]);
-        let result = build_request(&client, msg("user", "Hi"), false, &send_fn, &e, &f).await;
+        let result = build_raw(&client, msg("user", "hi"), false).await;
         assert!(result.is_err());
-    }
-
-    // -----------------------------------------------------------------------
-    // BamlHttpConnector wiring tests
-    // -----------------------------------------------------------------------
-
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    fn mock_http_send(
-        call_count: Arc<AtomicUsize>,
-        status: u16,
-        body: &'static str,
-    ) -> crate::HttpSendFn {
-        Arc::new(move |_req| {
-            call_count.fetch_add(1, Ordering::SeqCst);
-            let body = body.to_string();
-            Box::pin(async move {
-                Ok(crate::HttpSendResponse {
-                    status_code: status,
-                    headers: IndexMap::new(),
-                    body,
-                })
-            })
-        })
-    }
-
-    #[tokio::test]
-    async fn bedrock_http_send_invoked_during_credential_resolution() {
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let send_fn = mock_http_send(call_count.clone(), 404, "");
-        let client = make_client(vec![
-            ("region", BexExternalValue::String("us-east-1".into())),
-            ("model", BexExternalValue::String("some-model".into())),
-        ]);
-        let (e, f) = crate::build_request::noop_env_fs_callbacks();
-        let _result = build_request(&client, msg("user", "Hi"), false, &send_fn, &e, &f).await;
-        assert!(call_count.load(Ordering::SeqCst) > 0);
-    }
-
-    #[tokio::test]
-    async fn bedrock_http_send_not_invoked_with_explicit_credentials() {
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let send_fn = mock_http_send(call_count.clone(), 200, "");
-        let client = make_client(base_options());
-        let result = {
-            let (_h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "Hi"), false, &send_fn, &e, &f).await
-        };
-        assert!(result.is_ok());
-        assert_eq!(call_count.load(Ordering::SeqCst), 0);
     }
 }

--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -74,6 +74,10 @@ pub(crate) fn build_headers(
 }
 
 /// Forward non-skipped options from `client.options` into the JSON body.
+///
+/// Keys already present in `body` (written by the provider builder) are never
+/// overwritten. The builder's values for prompt-derived fields like `messages`,
+/// `system`, `input`, `stream`, and `stream_options` take precedence.
 pub(crate) fn forward_options(
     provider_skip_keys: &[&str],
     client: &LlmPrimitiveClient,
@@ -84,6 +88,11 @@ pub(crate) fn forward_options(
             || BUILD_REQUEST_SKIP_KEYS.contains(&key.as_str())
             || provider_skip_keys.contains(&key.as_str())
         {
+            continue;
+        }
+        // Never overwrite keys the builder already wrote (e.g. messages,
+        // system, input, stream, stream_options).
+        if body.contains_key(key) {
             continue;
         }
         if let Some(json_val) = bex_value_to_json(value) {

--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use bex_external_types::BexExternalValue;
 use bex_heap::{builtin_types, builtin_types::owned::LlmPrimitiveClient};
 
-use crate::LlmProvider;
+use crate::{LlmProvider, auth_request::LlmRequestAuthorizer};
 
 /// Option keys consumed by `specialize_prompt` — never forwarded to the request body.
 const SPECIALIZE_PROMPT_SKIP_KEYS: &[&str] = &[
@@ -37,102 +37,57 @@ pub(crate) struct BuildRequestCallbacks<'a> {
 
 /// Trait for building provider-specific HTTP requests.
 ///
-/// Default methods handle shared logic (body assembly, option forwarding, header
-/// merging). Each provider implements only the parts that differ.
+/// Each provider implements only `build_request`. Shared helpers
+/// (`build_headers`, `forward_options`) are free functions.
 pub(crate) trait LlmRequestBuilder {
-    /// LlmProvider-specific option keys to skip (in addition to the shared skip-key lists).
-    fn provider_skip_keys(&self) -> &'static [&'static str];
-
-    /// Build the request URL.
-    fn build_url(&self, client: &LlmPrimitiveClient) -> Result<String, BuildRequestError>;
-
-    /// Build auth + provider-specific headers (without content-type or custom headers).
-    fn build_auth_headers(&self, client: &LlmPrimitiveClient)
-    -> indexmap::IndexMap<String, String>;
-
-    /// Convert a specialized prompt into the JSON body fields specific to this provider.
-    fn build_prompt_body(
-        &self,
-        client: &LlmPrimitiveClient,
-        prompt: bex_vm_types::PromptAst,
-    ) -> Result<serde_json::Map<String, serde_json::Value>, BuildRequestError>;
-
-    // --- Default methods (shared logic) ---
-
-    /// Build the full request. Default: POST with url/headers/body from trait methods.
-    ///
-    /// Providers that need async operations (e.g., credential resolution) override
-    /// this method directly.
+    /// Build the full HTTP request for this provider.
     async fn build_request(
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
         stream: bool,
-        _callbacks: &BuildRequestCallbacks<'_>,
-    ) -> Result<RawHttpRequest, BuildRequestError> {
-        let url = self.build_url(client)?;
-        let headers = self.build_headers(client);
-        let body = self.build_body(client, prompt, stream)?;
-        Ok(RawHttpRequest {
-            method: "POST".to_string(),
-            url,
-            headers,
-            body,
-        })
-    }
+        callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError>;
+}
 
-    /// Build headers: auth headers + content-type + custom headers from options.
-    fn build_headers(&self, client: &LlmPrimitiveClient) -> indexmap::IndexMap<String, String> {
-        let mut headers = indexmap::IndexMap::new();
-        headers.insert("content-type".to_string(), "application/json".to_string());
-        headers.extend(self.build_auth_headers(client));
-        // Forward custom headers from client.options["headers"]
-        if let Some(BexExternalValue::Map { entries, .. }) = client.options.get("headers") {
-            for (key, value) in entries {
-                if let BexExternalValue::String(v) = value {
-                    headers.insert(key.clone(), v.clone());
-                }
+// ---------------------------------------------------------------------------
+// Shared default helpers - called by provider `build_request` implementations
+// ---------------------------------------------------------------------------
+
+/// Build headers: content-type + auth headers + custom headers from options.
+pub(crate) fn build_headers(
+    auth_headers: indexmap::IndexMap<String, String>,
+    client: &LlmPrimitiveClient,
+) -> indexmap::IndexMap<String, String> {
+    let mut headers = indexmap::IndexMap::new();
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    headers.extend(auth_headers);
+    // Forward custom headers from client.options["headers"]
+    if let Some(BexExternalValue::Map { entries, .. }) = client.options.get("headers") {
+        for (key, value) in entries {
+            if let BexExternalValue::String(v) = value {
+                headers.insert(key.clone(), v.clone());
             }
         }
-        headers
     }
+    headers
+}
 
-    /// Build JSON body: model + prompt fields + forwarded options.
-    fn build_body(
-        &self,
-        client: &LlmPrimitiveClient,
-        prompt: bex_vm_types::PromptAst,
-        _stream: bool,
-    ) -> Result<String, BuildRequestError> {
-        let mut body = serde_json::Map::new();
-        if let Some(model) = get_string_option(client, "model") {
-            body.insert("model".to_string(), serde_json::Value::String(model));
+/// Forward non-skipped options from `client.options` into the JSON body.
+pub(crate) fn forward_options(
+    provider_skip_keys: &[&str],
+    client: &LlmPrimitiveClient,
+    body: &mut serde_json::Map<String, serde_json::Value>,
+) {
+    for (key, value) in &client.options {
+        if SPECIALIZE_PROMPT_SKIP_KEYS.contains(&key.as_str())
+            || BUILD_REQUEST_SKIP_KEYS.contains(&key.as_str())
+            || provider_skip_keys.contains(&key.as_str())
+        {
+            continue;
         }
-        body.extend(self.build_prompt_body(client, prompt)?);
-        self.forward_options(client, &mut body);
-        serde_json::to_string(&body).map_err(|e| BuildRequestError::InvalidOption {
-            key: "body".into(),
-            reason: e.to_string(),
-        })
-    }
-
-    /// Forward non-skipped options to body.
-    fn forward_options(
-        &self,
-        client: &LlmPrimitiveClient,
-        body: &mut serde_json::Map<String, serde_json::Value>,
-    ) {
-        let provider_keys = self.provider_skip_keys();
-        for (key, value) in &client.options {
-            if SPECIALIZE_PROMPT_SKIP_KEYS.contains(&key.as_str())
-                || BUILD_REQUEST_SKIP_KEYS.contains(&key.as_str())
-                || provider_keys.contains(&key.as_str())
-            {
-                continue;
-            }
-            if let Some(json_val) = bex_value_to_json(value) {
-                body.insert(key.clone(), json_val);
-            }
+        if let Some(json_val) = bex_value_to_json(value) {
+            body.insert(key.clone(), json_val);
         }
     }
 }
@@ -193,7 +148,35 @@ pub(crate) async fn build_request(
         }
     };
 
-    Ok(raw.into_owned())
+    // Authorize the built request (API keys, bearer tokens, SigV4 signatures, etc.)
+    // Eventually this will be moved to its own stage in llm.baml after request building.
+    let authorized = match provider {
+        LlmProvider::Anthropic => {
+            crate::auth_request::AnthropicAuth
+                .authorize(raw, client, &callbacks)
+                .await?
+        }
+        LlmProvider::OpenAi
+        | LlmProvider::OpenAiGeneric
+        | LlmProvider::AzureOpenAi
+        | LlmProvider::Ollama
+        | LlmProvider::OpenRouter
+        | LlmProvider::OpenAiResponses => {
+            crate::auth_request::OpenAiAuth {
+                provider: &provider,
+            }
+            .authorize(raw, client, &callbacks)
+            .await?
+        }
+        LlmProvider::AwsBedrock => {
+            crate::auth_request::BedrockAuth
+                .authorize(raw, client, &callbacks)
+                .await?
+        }
+        _ => unreachable!("unsupported providers rejected above"),
+    };
+
+    Ok(authorized.into_owned())
 }
 
 /// Intermediate struct before converting to an owned `HttpRequest`.
@@ -228,6 +211,12 @@ pub(crate) enum BuildRequestError {
     UnsupportedMedia(String),
     #[error("File not resolved: {0}")]
     FileNotResolved(String),
+    #[error("Failed to serialize request body: {0}")]
+    BodySerialization(String),
+    /// Will move to a dedicated error type once request building and request
+    /// authorization are fully separate.
+    #[error("Authorization failed: {0}")]
+    AuthorizationFailed(String),
 }
 
 /// Returns the MIME type of a media value, or an error if none is set.

--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -3,6 +3,7 @@
 //! Converts a `LlmPrimitiveClient` + `PromptAst` into a `baml.http.Request` instance.
 
 mod anthropic;
+mod bedrock;
 mod openai;
 
 use std::str::FromStr;
@@ -23,6 +24,16 @@ const SPECIALIZE_PROMPT_SKIP_KEYS: &[&str] = &[
 /// Option keys consumed by `build_request` itself (URL, auth, headers, model) —
 /// never forwarded to the request body.
 const BUILD_REQUEST_SKIP_KEYS: &[&str] = &["api_key", "base_url", "model", "headers"];
+
+/// Callbacks available during request building for cross-op calls.
+///
+/// Bridges `SysOpHttp`, `SysOpEnv`, and `SysOpFs` into provider-specific
+/// request builders without a direct dependency on `sys_types`.
+pub(crate) struct BuildRequestCallbacks<'a> {
+    pub http_send: &'a crate::HttpSendFn,
+    pub env_read: &'a crate::EnvReadFn,
+    pub fs_read: &'a crate::FsReadFn,
+}
 
 /// Trait for building provider-specific HTTP requests.
 ///
@@ -49,11 +60,15 @@ pub(crate) trait LlmRequestBuilder {
     // --- Default methods (shared logic) ---
 
     /// Build the full request. Default: POST with url/headers/body from trait methods.
-    fn build_request(
+    ///
+    /// Providers that need async operations (e.g., credential resolution) override
+    /// this method directly.
+    async fn build_request(
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
         stream: bool,
+        _callbacks: &BuildRequestCallbacks<'_>,
     ) -> Result<RawHttpRequest, BuildRequestError> {
         let url = self.build_url(client)?;
         let headers = self.build_headers(client);
@@ -126,13 +141,22 @@ pub(crate) trait LlmRequestBuilder {
 ///
 /// Returns an owned `HttpRequest` matching the `baml.http.Request` class:
 /// `{ method: String, url: String, headers: Map<String, String>, body: String }`
-pub(crate) fn build_request(
+pub(crate) async fn build_request(
     client: &LlmPrimitiveClient,
     prompt: bex_vm_types::PromptAst,
     stream: bool,
+    http_send: &crate::HttpSendFn,
+    env_read: &crate::EnvReadFn,
+    fs_read: &crate::FsReadFn,
 ) -> Result<builtin_types::owned::HttpRequest, BuildRequestError> {
     let provider = LlmProvider::from_str(&client.provider)
         .map_err(|_| BuildRequestError::UnsupportedLlmProvider(client.provider.clone()))?;
+
+    let callbacks = BuildRequestCallbacks {
+        http_send,
+        env_read,
+        fs_read,
+    };
 
     let raw = match provider {
         LlmProvider::OpenAi
@@ -140,17 +164,27 @@ pub(crate) fn build_request(
         | LlmProvider::AzureOpenAi
         | LlmProvider::Ollama
         | LlmProvider::OpenRouter => {
-            openai::OpenAiBuilder::new(&provider).build_request(client, prompt, stream)?
+            openai::OpenAiBuilder::new(&provider)
+                .build_request(client, prompt, stream, &callbacks)
+                .await?
         }
         LlmProvider::OpenAiResponses => {
-            openai::OpenAiResponsesBuilder::new(&provider).build_request(client, prompt, stream)?
+            openai::OpenAiResponsesBuilder::new(&provider)
+                .build_request(client, prompt, stream, &callbacks)
+                .await?
         }
         LlmProvider::Anthropic => {
-            anthropic::AnthropicBuilder.build_request(client, prompt, stream)?
+            anthropic::AnthropicBuilder
+                .build_request(client, prompt, stream, &callbacks)
+                .await?
+        }
+        LlmProvider::AwsBedrock => {
+            bedrock::BedrockBuilder
+                .build_request(client, prompt, stream, &callbacks)
+                .await?
         }
         LlmProvider::GoogleAi
         | LlmProvider::VertexAi
-        | LlmProvider::AwsBedrock
         | LlmProvider::BamlFallback
         | LlmProvider::BamlRoundRobin => {
             return Err(BuildRequestError::UnsupportedLlmProvider(
@@ -239,6 +273,32 @@ pub(crate) fn bex_value_to_json(value: &BexExternalValue) -> Option<serde_json::
     }
 }
 
+/// Test-only stub callbacks that panic if called. Most providers don't invoke
+/// these during request building, so the stubs are safe for unit tests.
+#[cfg(test)]
+pub(crate) fn stub_callbacks() -> (crate::HttpSendFn, crate::EnvReadFn, crate::FsReadFn) {
+    use std::sync::Arc;
+    let http: crate::HttpSendFn =
+        Arc::new(|_| Box::pin(async { panic!("unexpected http_send call in test") }));
+    let env: crate::EnvReadFn =
+        Arc::new(|_| Box::pin(async { panic!("unexpected env_read call in test") }));
+    let fs: crate::FsReadFn =
+        Arc::new(|_| Box::pin(async { panic!("unexpected fs_read call in test") }));
+    (http, env, fs)
+}
+
+/// Test-only no-op env/fs callbacks that return "not found" instead of panicking.
+/// Use these in tests that exercise credential resolution (e.g., bedrock without
+/// explicit credentials) where the AWS SDK will read env vars and files.
+#[cfg(test)]
+pub(crate) fn noop_env_fs_callbacks() -> (crate::EnvReadFn, crate::FsReadFn) {
+    use std::sync::Arc;
+    let env: crate::EnvReadFn = Arc::new(|_| Box::pin(async { Ok(None) }));
+    let fs: crate::FsReadFn =
+        Arc::new(|_| Box::pin(async { Err(crate::LlmOpError::Other("not found".into())) }));
+    (env, fs)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -280,11 +340,14 @@ mod tests {
         serde_json::from_str(&req.body).unwrap()
     }
 
-    #[test]
-    fn test_unsupported_provider() {
+    #[tokio::test]
+    async fn test_unsupported_provider() {
         let client = make_client("unknown-provider", vec![]);
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false);
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        };
         assert!(result.is_err());
         assert!(
             result
@@ -299,8 +362,8 @@ mod tests {
     // ========================================================================
 
     /// Matches `test_expose_request_gpt4` from `test_request.py`.
-    #[test]
-    fn test_openai_gpt4o_system_only() {
+    #[tokio::test]
+    async fn test_openai_gpt4o_system_only() {
         let client = make_client(
             "openai",
             vec![
@@ -312,7 +375,11 @@ mod tests {
         let system_text = "Given the receipt below:\n\n```\ntest@email.com\n```\n\nAnswer in JSON using this schema:\n{\n  items: [\n    {\n      name: string,\n      description: string or null,\n      quantity: int,\n      price: float,\n    }\n  ],\n  total_cost: float or null,\n  venue: \"barisa\" or \"ox_burger\",\n}";
         let prompt = Arc::new(PromptAst::Vec(vec![msg("system", system_text)]));
 
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
 
         // Verify envelope
         assert_eq!(result.method, "POST");
@@ -348,8 +415,8 @@ mod tests {
     }
 
     /// Matches `test_expose_request_fallback` from `test_request.py`.
-    #[test]
-    fn test_openai_gpt4_turbo_system_and_user() {
+    #[tokio::test]
+    async fn test_openai_gpt4_turbo_system_and_user() {
         let client = make_client(
             "openai",
             vec![
@@ -363,7 +430,11 @@ mod tests {
             msg("user", "Write a nice short story about Dr. Pepper"),
         ]));
 
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
 
         assert_eq!(result.url, "https://api.openai.com/v1/chat/completions");
 
@@ -391,22 +462,26 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_openai_content_always_array() {
+    #[tokio::test]
+    async fn test_openai_content_always_array() {
         let client = make_client(
             "openai",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
         let prompt = msg("user", "Hello world");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert!(body["messages"][0]["content"].is_array());
         assert_eq!(body["messages"][0]["content"][0]["type"], "text");
         assert_eq!(body["messages"][0]["content"][0]["text"], "Hello world");
     }
 
-    #[test]
-    fn test_openai_custom_base_url() {
+    #[tokio::test]
+    async fn test_openai_custom_base_url() {
         let client = make_client(
             "openai",
             vec![(
@@ -415,12 +490,16 @@ mod tests {
             )],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(result.url, "https://custom.api.com/chat/completions");
     }
 
-    #[test]
-    fn test_openai_forwards_options_to_body() {
+    #[tokio::test]
+    async fn test_openai_forwards_options_to_body() {
         let client = make_client(
             "openai",
             vec![
@@ -429,13 +508,17 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert_eq!(body["temperature"], 0.7);
     }
 
-    #[test]
-    fn test_openai_skips_internal_options_in_body() {
+    #[tokio::test]
+    async fn test_openai_skips_internal_options_in_body() {
         let client = make_client(
             "openai",
             vec![
@@ -448,7 +531,11 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert!(body.get("api_key").is_none());
         assert!(body.get("base_url").is_none());
@@ -461,8 +548,8 @@ mod tests {
     // ========================================================================
 
     /// Matches `test_expose_request_round_robin` from `test_request.py`.
-    #[test]
-    fn test_anthropic_claude_system_extracted() {
+    #[tokio::test]
+    async fn test_anthropic_claude_system_extracted() {
         let client = make_client(
             "anthropic",
             vec![
@@ -480,7 +567,11 @@ mod tests {
             msg("user", "Write a nice short story about Dr. Pepper"),
         ]));
 
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
 
         // Verify envelope
         assert_eq!(result.method, "POST");
@@ -514,8 +605,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_anthropic_no_system_message() {
+    #[tokio::test]
+    async fn test_anthropic_no_system_message() {
         let client = make_client(
             "anthropic",
             vec![
@@ -527,14 +618,18 @@ mod tests {
             ],
         );
         let prompt = msg("user", "Hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert!(body.get("system").is_none());
         assert_eq!(body["messages"].as_array().unwrap().len(), 1);
     }
 
-    #[test]
-    fn test_anthropic_custom_headers() {
+    #[tokio::test]
+    async fn test_anthropic_custom_headers() {
         let mut header_entries = IndexMap::new();
         header_entries.insert(
             "anthropic-beta".to_string(),
@@ -575,7 +670,11 @@ mod tests {
         );
 
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
 
         assert_eq!(
             result.headers.get("anthropic-beta").unwrap(),
@@ -587,8 +686,8 @@ mod tests {
         assert!(body.get("headers").is_none());
     }
 
-    #[test]
-    fn test_anthropic_custom_version() {
+    #[tokio::test]
+    async fn test_anthropic_custom_version() {
         let client = make_client(
             "anthropic",
             vec![(
@@ -597,26 +696,34 @@ mod tests {
             )],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(
             result.headers.get("anthropic-version").unwrap(),
             "2024-01-01"
         );
     }
 
-    #[test]
-    fn test_anthropic_default_version() {
+    #[tokio::test]
+    async fn test_anthropic_default_version() {
         let client = make_client("anthropic", vec![]);
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(
             result.headers.get("anthropic-version").unwrap(),
             "2023-06-01"
         );
     }
 
-    #[test]
-    fn test_anthropic_forwards_max_tokens() {
+    #[tokio::test]
+    async fn test_anthropic_forwards_max_tokens() {
         let client = make_client(
             "anthropic",
             vec![
@@ -628,7 +735,11 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert_eq!(body["max_tokens"], 1000);
     }
@@ -637,8 +748,8 @@ mod tests {
     // OpenAI Responses API tests
     // ========================================================================
 
-    #[test]
-    fn test_responses_url() {
+    #[tokio::test]
+    async fn test_responses_url() {
         let client = make_client(
             "openai-responses",
             vec![
@@ -647,7 +758,11 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(result.url, "https://api.openai.com/v1/responses");
         assert_eq!(
             result.headers.get("authorization").unwrap(),
@@ -655,14 +770,18 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_responses_uses_input_key() {
+    #[tokio::test]
+    async fn test_responses_uses_input_key() {
         let client = make_client(
             "openai-responses",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert!(
             body.get("input").is_some(),
@@ -674,14 +793,18 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_responses_input_text_type() {
+    #[tokio::test]
+    async fn test_responses_input_text_type() {
         let client = make_client(
             "openai-responses",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert_eq!(
             body,
@@ -697,8 +820,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_responses_output_text_for_assistant() {
+    #[tokio::test]
+    async fn test_responses_output_text_for_assistant() {
         let client = make_client(
             "openai-responses",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
@@ -707,14 +830,18 @@ mod tests {
             msg("user", "hello"),
             msg("assistant", "hi there"),
         ]));
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(body["input"][1]["content"][0]["type"], "output_text");
     }
 
-    #[test]
-    fn test_responses_system_and_user() {
+    #[tokio::test]
+    async fn test_responses_system_and_user() {
         let client = make_client(
             "openai-responses",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
@@ -723,15 +850,19 @@ mod tests {
             msg("system", "You are helpful."),
             msg("user", "Hi"),
         ]));
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert_eq!(body["input"][0]["role"], "system");
         assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(body["input"][1]["role"], "user");
     }
 
-    #[test]
-    fn test_responses_custom_base_url() {
+    #[tokio::test]
+    async fn test_responses_custom_base_url() {
         let client = make_client(
             "openai-responses",
             vec![(
@@ -740,12 +871,16 @@ mod tests {
             )],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(result.url, "https://custom.api.com/v1/responses");
     }
 
-    #[test]
-    fn test_responses_forwards_options() {
+    #[tokio::test]
+    async fn test_responses_forwards_options() {
         let client = make_client(
             "openai-responses",
             vec![
@@ -754,7 +889,11 @@ mod tests {
             ],
         );
         let prompt = msg("user", "hello");
-        let result = build_request(&client, prompt, false).unwrap();
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result);
         assert_eq!(body["temperature"], 0.5);
     }

--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -189,6 +189,7 @@ pub(crate) async fn build_request(
 }
 
 /// Intermediate struct before converting to an owned `HttpRequest`.
+#[derive(Debug)]
 pub(crate) struct RawHttpRequest {
     pub method: String,
     pub url: String,
@@ -894,5 +895,143 @@ mod tests {
         .unwrap();
         let body = parse_body(&result);
         assert_eq!(body["temperature"], 0.5);
+    }
+
+    // ========================================================================
+    // Bedrock integration tests (build + SigV4 auth through the full pipeline)
+    // ========================================================================
+
+    fn bedrock_options() -> Vec<(&'static str, BexExternalValue)> {
+        vec![
+            ("region", BexExternalValue::String("us-east-1".into())),
+            (
+                "model",
+                BexExternalValue::String("anthropic.claude-3-haiku-20240307-v1:0".into()),
+            ),
+            (
+                "access_key_id",
+                BexExternalValue::String("AKIAIOSFODNN7EXAMPLE".into()),
+            ),
+            (
+                "secret_access_key",
+                BexExternalValue::String("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into()),
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_bedrock_url_and_method() {
+        let client = make_client("aws-bedrock", bedrock_options());
+        let prompt = msg("user", "Hello");
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
+        assert_eq!(result.method, "POST");
+        assert_eq!(
+            result.url,
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1:0/converse"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bedrock_sigv4_headers_present() {
+        let client = make_client("aws-bedrock", bedrock_options());
+        let prompt = msg("user", "Hello");
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
+        assert!(result.headers.contains_key("authorization"));
+        assert!(result.headers.contains_key("x-amz-date"));
+        assert_eq!(
+            result.headers.get("content-type").unwrap(),
+            "application/json"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bedrock_stream_url() {
+        let client = make_client("aws-bedrock", bedrock_options());
+        let prompt = msg("user", "Hello");
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, true, &h, &e, &f).await
+        }
+        .unwrap();
+        assert!(result.url.ends_with("/converse-stream"));
+    }
+
+    #[tokio::test]
+    async fn test_bedrock_body_structure() {
+        let client = make_client("aws-bedrock", bedrock_options());
+        let prompt = Arc::new(PromptAst::Vec(vec![
+            msg("system", "You are helpful."),
+            msg("user", "Hi"),
+        ]));
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
+        let body = parse_body(&result);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "system": [{"text": "You are helpful."}],
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hi"}]}
+                ]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bedrock_no_creds_or_region_in_body() {
+        let client = make_client("aws-bedrock", bedrock_options());
+        let prompt = msg("user", "Hello");
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
+        let body = parse_body(&result);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hello"}]}
+                ]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bedrock_inference_config_through_pipeline() {
+        let mut opts = bedrock_options();
+        opts.push(("max_tokens", BexExternalValue::Int(500)));
+        opts.push(("temperature", BexExternalValue::Float(0.5)));
+        let client = make_client("aws-bedrock", opts);
+        let prompt = msg("user", "Hello");
+        let result = {
+            let (h, e, f) = stub_callbacks();
+            build_request(&client, prompt, false, &h, &e, &f).await
+        }
+        .unwrap();
+        let body = parse_body(&result);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hello"}]}
+                ],
+                "inferenceConfig": {
+                    "maxTokens": 500,
+                    "temperature": 0.5,
+                }
+            })
+        );
     }
 }

--- a/baml_language/crates/sys_llm/src/build_request/openai/chat_completions.rs
+++ b/baml_language/crates/sys_llm/src/build_request/openai/chat_completions.rs
@@ -925,8 +925,8 @@ mod tests {
         assert!(headers.get("authorization").is_none());
     }
 
-    #[test]
-    fn azure_defaults_max_tokens_4096() {
+    #[tokio::test]
+    async fn azure_defaults_max_tokens_4096() {
         let client = make_client(
             "azure-openai",
             vec![
@@ -939,7 +939,11 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk".into())),
             ],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -953,8 +957,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn azure_no_default_when_max_tokens_set() {
+    #[tokio::test]
+    async fn azure_no_default_when_max_tokens_set() {
         let client = make_client(
             "azure-openai",
             vec![
@@ -967,7 +971,11 @@ mod tests {
                 ("max_tokens", BexExternalValue::Int(1000)),
             ],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -981,8 +989,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn azure_no_default_when_max_completion_tokens_set() {
+    #[tokio::test]
+    async fn azure_no_default_when_max_completion_tokens_set() {
         let client = make_client(
             "azure-openai",
             vec![
@@ -995,7 +1003,11 @@ mod tests {
                 ("max_completion_tokens", BexExternalValue::Int(2000)),
             ],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1009,13 +1021,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn openai_no_default_max_tokens() {
+    #[tokio::test]
+    async fn openai_no_default_max_tokens() {
         let client = make_client(
             "openai",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1028,10 +1044,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn openai_no_model_when_absent() {
+    #[tokio::test]
+    async fn openai_no_model_when_absent() {
         let client = make_client("openai", vec![]);
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1043,8 +1063,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn azure_missing_api_version() {
+    #[tokio::test]
+    async fn azure_missing_api_version() {
         let client = make_client(
             "azure-openai",
             vec![
@@ -1052,7 +1072,11 @@ mod tests {
                 ("resource_name", BexExternalValue::String("res".into())),
             ],
         );
-        let err = build_request(&client, msg("user", "hi"), false).unwrap_err();
+        let err = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap_err();
         assert!(err.to_string().contains("api_version"));
     }
 
@@ -1060,15 +1084,19 @@ mod tests {
     // Chat Completions: other OpenAI-like providers
     // ========================================================================
 
-    #[test]
-    fn openai_generic_requires_base_url() {
+    #[tokio::test]
+    async fn openai_generic_requires_base_url() {
         let client = make_client("openai-generic", vec![]);
-        let err = build_request(&client, msg("user", "hi"), false).unwrap_err();
+        let err = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap_err();
         assert!(err.to_string().contains("base_url"));
     }
 
-    #[test]
-    fn openai_generic_with_base_url() {
+    #[tokio::test]
+    async fn openai_generic_with_base_url() {
         let client = make_client(
             "openai-generic",
             vec![
@@ -1080,7 +1108,11 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk-custom".into())),
             ],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(result.url, "https://my-llm.example.com/v1/chat/completions");
         assert_eq!(
             result.headers.get("authorization").unwrap(),
@@ -1098,13 +1130,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn ollama_default_url() {
+    #[tokio::test]
+    async fn ollama_default_url() {
         let client = make_client(
             "ollama",
             vec![("model", BexExternalValue::String("llama3".into()))],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(result.url, "http://localhost:11434/v1/chat/completions");
         let body = parse_body(&result.body);
         assert_eq!(
@@ -1118,8 +1154,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn ollama_custom_base_url() {
+    #[tokio::test]
+    async fn ollama_custom_base_url() {
         let client = make_client(
             "ollama",
             vec![
@@ -1130,23 +1166,31 @@ mod tests {
                 ("model", BexExternalValue::String("llama3".into())),
             ],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(result.url, "http://remote:11434/v1/chat/completions");
     }
 
-    #[test]
-    fn ollama_no_auth_header() {
+    #[tokio::test]
+    async fn ollama_no_auth_header() {
         let client = make_client(
             "ollama",
             vec![("model", BexExternalValue::String("llama3".into()))],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         assert!(result.headers.get("authorization").is_none());
         assert!(result.headers.get("api-key").is_none());
     }
 
-    #[test]
-    fn openrouter_default_url() {
+    #[tokio::test]
+    async fn openrouter_default_url() {
         let client = make_client(
             "openrouter",
             vec![
@@ -1154,7 +1198,11 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk-or-test".into())),
             ],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         assert_eq!(result.url, "https://openrouter.ai/api/v1/chat/completions");
         assert_eq!(
             result.headers.get("authorization").unwrap(),
@@ -1172,8 +1220,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn openrouter_forwards_options() {
+    #[tokio::test]
+    async fn openrouter_forwards_options() {
         let client = make_client(
             "openrouter",
             vec![
@@ -1182,7 +1230,11 @@ mod tests {
                 ("max_tokens", BexExternalValue::Int(500)),
             ],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1197,13 +1249,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn stream_true_sets_stream_and_stream_options() {
+    #[tokio::test]
+    async fn stream_true_sets_stream_and_stream_options() {
         let client = make_client(
             "openai",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let result = build_request(&client, msg("user", "hi"), true).unwrap();
+        let (h, e, f) = crate::build_request::stub_callbacks();
+        let result = build_request(&client, msg("user", "hi"), true, &h, &e, &f)
+            .await
+            .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1218,13 +1273,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn stream_false_omits_stream_fields() {
+    #[tokio::test]
+    async fn stream_false_omits_stream_fields() {
         let client = make_client(
             "openai",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let result = build_request(&client, msg("user", "hi"), false).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
+        }
+        .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,

--- a/baml_language/crates/sys_llm/src/build_request/openai/chat_completions.rs
+++ b/baml_language/crates/sys_llm/src/build_request/openai/chat_completions.rs
@@ -9,8 +9,9 @@ use serde::Serialize;
 use crate::{
     LlmProvider,
     build_request::{
-        BuildRequestError, LlmPrimitiveClient, LlmRequestBuilder, get_string_option,
-        mime_type_as_ok, openai::build_openai_url,
+        BuildRequestCallbacks, BuildRequestError, LlmPrimitiveClient, LlmRequestBuilder,
+        RawHttpRequest, build_headers, forward_options, get_string_option, mime_type_as_ok,
+        openai::build_openai_url,
     },
 };
 
@@ -68,33 +69,24 @@ impl<'a> OpenAiBuilder<'a> {
     }
 }
 
+/// Option keys specific to `OpenAI` that should not be forwarded to the body.
+const OPENAI_SKIP_KEYS: &[&str] = &["resource_name", "api_version"];
+
 impl LlmRequestBuilder for OpenAiBuilder<'_> {
-    fn provider_skip_keys(&self) -> &'static [&'static str] {
-        &["resource_name", "api_version"]
-    }
-
-    fn build_url(&self, client: &LlmPrimitiveClient) -> Result<String, BuildRequestError> {
-        build_openai_url(*self.provider, client, "/chat/completions")
-    }
-
-    fn build_auth_headers(&self, client: &LlmPrimitiveClient) -> IndexMap<String, String> {
-        let mut headers = IndexMap::new();
-        if let Some(api_key) = get_string_option(client, "api_key") {
-            if *self.provider == LlmProvider::AzureOpenAi {
-                headers.insert("api-key".to_string(), api_key);
-            } else {
-                headers.insert("authorization".to_string(), format!("Bearer {api_key}"));
-            }
-        }
-        headers
-    }
-
-    fn build_body(
+    async fn build_request(
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
         stream: bool,
-    ) -> Result<String, BuildRequestError> {
+        _callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        // URL
+        let url = build_openai_url(*self.provider, client, "/chat/completions")?;
+
+        // Base headers (auth headers added by LlmRequestAuthorizer after building)
+        let headers = build_headers(IndexMap::new(), client);
+
+        // Body
         let mut body = serde_json::Map::new();
         if let Some(model) = get_string_option(client, "model") {
             body.insert("model".to_string(), serde_json::Value::String(model));
@@ -106,8 +98,15 @@ impl LlmRequestBuilder for OpenAiBuilder<'_> {
                 serde_json::json!({ "include_usage": true }),
             );
         }
-        body.extend(self.build_prompt_body(client, prompt)?);
-        self.forward_options(client, &mut body);
+
+        // TODO: Handle default role in Ollama once compiler2 is merged.
+        let messages = prompt_to_openai_messages(&prompt, client.default_role.as_str())?;
+        body.insert(
+            "messages".to_string(),
+            serde_json::to_value(messages).expect("infallible"),
+        );
+
+        forward_options(OPENAI_SKIP_KEYS, client, &mut body);
 
         // Azure OpenAI: default max_tokens to 4096 if neither max_tokens nor
         // max_completion_tokens is set. Holdover from engine, not sure why this was the case.
@@ -122,27 +121,18 @@ impl LlmRequestBuilder for OpenAiBuilder<'_> {
             }
         }
 
-        serde_json::to_string(&body).map_err(|e| BuildRequestError::InvalidOption {
-            key: "body".into(),
-            reason: e.to_string(),
+        let body_str =
+            serde_json::to_string(&body).map_err(|e| BuildRequestError::InvalidOption {
+                key: "body".into(),
+                reason: e.to_string(),
+            })?;
+
+        Ok(RawHttpRequest {
+            method: "POST".to_string(),
+            url,
+            headers,
+            body: body_str,
         })
-    }
-
-    fn build_prompt_body(
-        &self,
-        client: &LlmPrimitiveClient,
-        prompt: bex_vm_types::PromptAst,
-    ) -> Result<serde_json::Map<String, serde_json::Value>, BuildRequestError> {
-        let mut map = serde_json::Map::new();
-
-        // TODO: Handle default role in Ollama once compiler2 is merged.
-
-        let messages = prompt_to_openai_messages(&prompt, client.default_role.as_str())?;
-        map.insert(
-            "messages".to_string(),
-            serde_json::to_value(messages).expect("infallible"),
-        );
-        Ok(map)
     }
 }
 
@@ -370,7 +360,7 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::*;
-    use crate::build_request::{LlmPrimitiveClient, LlmRequestBuilder, build_request};
+    use crate::build_request::{LlmPrimitiveClient, build_request};
 
     // -- helpers --
 
@@ -881,8 +871,7 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk-test".into())),
             ],
         );
-        let builder = OpenAiBuilder::new(&LlmProvider::AzureOpenAi);
-        let url = builder.build_url(&client).unwrap();
+        let url = build_openai_url(LlmProvider::AzureOpenAi, &client, "/chat/completions").unwrap();
         assert_eq!(
             url,
             "https://my-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-02-15-preview"
@@ -905,24 +894,11 @@ mod tests {
                 ),
             ],
         );
-        let builder = OpenAiBuilder::new(&LlmProvider::AzureOpenAi);
-        let url = builder.build_url(&client).unwrap();
+        let url = build_openai_url(LlmProvider::AzureOpenAi, &client, "/chat/completions").unwrap();
         assert_eq!(
             url,
             "https://my-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-02-15-preview"
         );
-    }
-
-    #[test]
-    fn azure_auth_header_uses_api_key() {
-        let client = make_client(
-            "azure-openai",
-            vec![("api_key", BexExternalValue::String("sk-azure".into()))],
-        );
-        let builder = OpenAiBuilder::new(&LlmProvider::AzureOpenAi);
-        let headers = builder.build_auth_headers(&client);
-        assert_eq!(headers.get("api-key").unwrap(), "sk-azure");
-        assert!(headers.get("authorization").is_none());
     }
 
     #[tokio::test]

--- a/baml_language/crates/sys_llm/src/build_request/openai/chat_completions.rs
+++ b/baml_language/crates/sys_llm/src/build_request/openai/chat_completions.rs
@@ -352,7 +352,7 @@ fn openai_media_part(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{str::FromStr, sync::Arc};
 
     use baml_base::MediaKind;
     use baml_builtins::{MediaContent, MediaValue, PromptAst};
@@ -360,7 +360,7 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::*;
-    use crate::build_request::{LlmPrimitiveClient, build_request};
+    use crate::build_request::{LlmPrimitiveClient, LlmRequestBuilder};
 
     // -- helpers --
 
@@ -392,6 +392,27 @@ mod tests {
 
     fn parse_body(body: &str) -> serde_json::Value {
         serde_json::from_str(body).unwrap()
+    }
+
+    /// Build an [`OpenAiBuilder`] request directly, bypassing auth.
+    async fn build_raw(
+        provider: &str,
+        client: &LlmPrimitiveClient,
+        prompt: Arc<PromptAst>,
+        stream: bool,
+    ) -> Result<crate::build_request::RawHttpRequest, crate::build_request::BuildRequestError> {
+        let (h, e, f) = crate::build_request::stub_callbacks();
+        let callbacks = crate::build_request::BuildRequestCallbacks {
+            http_send: &h,
+            env_read: &e,
+            fs_read: &f,
+        };
+        let provider = crate::LlmProvider::from_str(provider).map_err(|_| {
+            crate::build_request::BuildRequestError::UnsupportedLlmProvider(provider.to_string())
+        })?;
+        OpenAiBuilder::new(&provider)
+            .build_request(client, prompt, stream, &callbacks)
+            .await
     }
 
     // ========================================================================
@@ -915,11 +936,9 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk".into())),
             ],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("azure-openai", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -947,11 +966,9 @@ mod tests {
                 ("max_tokens", BexExternalValue::Int(1000)),
             ],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("azure-openai", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -979,11 +996,9 @@ mod tests {
                 ("max_completion_tokens", BexExternalValue::Int(2000)),
             ],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("azure-openai", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1003,11 +1018,9 @@ mod tests {
             "openai",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("openai", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1023,11 +1036,9 @@ mod tests {
     #[tokio::test]
     async fn openai_no_model_when_absent() {
         let client = make_client("openai", vec![]);
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("openai", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1048,11 +1059,9 @@ mod tests {
                 ("resource_name", BexExternalValue::String("res".into())),
             ],
         );
-        let err = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap_err();
+        let err = build_raw("azure-openai", &client, msg("user", "hi"), false)
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("api_version"));
     }
 
@@ -1063,11 +1072,9 @@ mod tests {
     #[tokio::test]
     async fn openai_generic_requires_base_url() {
         let client = make_client("openai-generic", vec![]);
-        let err = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap_err();
+        let err = build_raw("openai-generic", &client, msg("user", "hi"), false)
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("base_url"));
     }
 
@@ -1084,16 +1091,10 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk-custom".into())),
             ],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("openai-generic", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         assert_eq!(result.url, "https://my-llm.example.com/v1/chat/completions");
-        assert_eq!(
-            result.headers.get("authorization").unwrap(),
-            "Bearer sk-custom"
-        );
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1112,11 +1113,9 @@ mod tests {
             "ollama",
             vec![("model", BexExternalValue::String("llama3".into()))],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("ollama", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         assert_eq!(result.url, "http://localhost:11434/v1/chat/completions");
         let body = parse_body(&result.body);
         assert_eq!(
@@ -1142,27 +1141,10 @@ mod tests {
                 ("model", BexExternalValue::String("llama3".into())),
             ],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("ollama", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         assert_eq!(result.url, "http://remote:11434/v1/chat/completions");
-    }
-
-    #[tokio::test]
-    async fn ollama_no_auth_header() {
-        let client = make_client(
-            "ollama",
-            vec![("model", BexExternalValue::String("llama3".into()))],
-        );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
-        assert!(result.headers.get("authorization").is_none());
-        assert!(result.headers.get("api-key").is_none());
     }
 
     #[tokio::test]
@@ -1174,16 +1156,10 @@ mod tests {
                 ("api_key", BexExternalValue::String("sk-or-test".into())),
             ],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("openrouter", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         assert_eq!(result.url, "https://openrouter.ai/api/v1/chat/completions");
-        assert_eq!(
-            result.headers.get("authorization").unwrap(),
-            "Bearer sk-or-test"
-        );
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1206,11 +1182,9 @@ mod tests {
                 ("max_tokens", BexExternalValue::Int(500)),
             ],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("openrouter", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,
@@ -1231,8 +1205,7 @@ mod tests {
             "openai",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let (h, e, f) = crate::build_request::stub_callbacks();
-        let result = build_request(&client, msg("user", "hi"), true, &h, &e, &f)
+        let result = build_raw("openai", &client, msg("user", "hi"), true)
             .await
             .unwrap();
         let body = parse_body(&result.body);
@@ -1255,11 +1228,9 @@ mod tests {
             "openai",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let result = {
-            let (h, e, f) = crate::build_request::stub_callbacks();
-            build_request(&client, msg("user", "hi"), false, &h, &e, &f).await
-        }
-        .unwrap();
+        let result = build_raw("openai", &client, msg("user", "hi"), false)
+            .await
+            .unwrap();
         let body = parse_body(&result.body);
         assert_eq!(
             body,

--- a/baml_language/crates/sys_llm/src/build_request/openai/responses.rs
+++ b/baml_language/crates/sys_llm/src/build_request/openai/responses.rs
@@ -8,8 +8,9 @@ use indexmap::IndexMap;
 use serde::Serialize;
 
 use crate::build_request::{
-    BuildRequestError, LlmPrimitiveClient, LlmProvider, LlmRequestBuilder, get_string_option,
-    mime_type_as_ok, openai::build_openai_url,
+    BuildRequestCallbacks, BuildRequestError, LlmPrimitiveClient, LlmProvider, LlmRequestBuilder,
+    RawHttpRequest, build_headers, forward_options, get_string_option, mime_type_as_ok,
+    openai::build_openai_url,
 };
 
 /// A single message in the `OpenAI` Responses API format.
@@ -71,28 +72,20 @@ pub(crate) struct OpenAiResponsesBuilder<'a> {
 }
 
 impl LlmRequestBuilder for OpenAiResponsesBuilder<'_> {
-    fn provider_skip_keys(&self) -> &'static [&'static str] {
-        &[]
-    }
-
-    fn build_url(&self, client: &LlmPrimitiveClient) -> Result<String, BuildRequestError> {
-        build_openai_url(*self.provider, client, "/responses")
-    }
-
-    fn build_auth_headers(&self, client: &LlmPrimitiveClient) -> IndexMap<String, String> {
-        let mut headers = IndexMap::new();
-        if let Some(api_key) = get_string_option(client, "api_key") {
-            headers.insert("authorization".to_string(), format!("Bearer {api_key}"));
-        }
-        headers
-    }
-
-    fn build_body(
+    async fn build_request(
         &self,
         client: &LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
         stream: bool,
-    ) -> Result<String, BuildRequestError> {
+        _callbacks: &BuildRequestCallbacks<'_>,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        // URL
+        let url = build_openai_url(*self.provider, client, "/responses")?;
+
+        // Base headers (auth headers added by LlmRequestAuthorizer after building)
+        let headers = build_headers(IndexMap::new(), client);
+
+        // Body
         let mut body = serde_json::Map::new();
         if let Some(model) = get_string_option(client, "model") {
             body.insert("model".to_string(), serde_json::Value::String(model));
@@ -100,26 +93,25 @@ impl LlmRequestBuilder for OpenAiResponsesBuilder<'_> {
         if stream {
             body.insert("stream".to_string(), serde_json::Value::Bool(true));
         }
-        body.extend(self.build_prompt_body(client, prompt)?);
-        self.forward_options(client, &mut body);
-        serde_json::to_string(&body).map_err(|e| BuildRequestError::InvalidOption {
-            key: "body".into(),
-            reason: e.to_string(),
-        })
-    }
-
-    fn build_prompt_body(
-        &self,
-        client: &LlmPrimitiveClient,
-        prompt: bex_vm_types::PromptAst,
-    ) -> Result<serde_json::Map<String, serde_json::Value>, BuildRequestError> {
-        let mut map = serde_json::Map::new();
         let input = prompt_to_responses_input(&prompt, &client.default_role)?;
-        map.insert(
+        body.insert(
             "input".to_string(),
             serde_json::to_value(input).expect("infallible"),
         );
-        Ok(map)
+        forward_options(&[], client, &mut body);
+
+        let body_str =
+            serde_json::to_string(&body).map_err(|e| BuildRequestError::InvalidOption {
+                key: "body".into(),
+                reason: e.to_string(),
+            })?;
+
+        Ok(RawHttpRequest {
+            method: "POST".to_string(),
+            url,
+            headers,
+            body: body_str,
+        })
     }
 }
 
@@ -621,9 +613,7 @@ mod tests {
     #[test]
     fn responses_url_default() {
         let client = make_client("openai-responses", vec![]);
-        let url = OpenAiResponsesBuilder::new(&LlmProvider::OpenAiResponses)
-            .build_url(&client)
-            .unwrap();
+        let url = build_openai_url(LlmProvider::OpenAiResponses, &client, "/responses").unwrap();
         assert_eq!(url, "https://api.openai.com/v1/responses");
     }
 
@@ -636,23 +626,34 @@ mod tests {
                 BexExternalValue::String("https://custom.api.com/v1".into()),
             )],
         );
-        let url = OpenAiResponsesBuilder::new(&LlmProvider::OpenAiResponses)
-            .build_url(&client)
-            .unwrap();
+        let url = build_openai_url(LlmProvider::OpenAiResponses, &client, "/responses").unwrap();
         assert_eq!(url, "https://custom.api.com/v1/responses");
     }
 
-    #[test]
-    fn stream_true_sets_stream() {
+    #[tokio::test]
+    async fn stream_true_sets_stream() {
         let client = make_client(
             "openai-responses",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let builder = OpenAiResponsesBuilder::new(&LlmProvider::OpenAiResponses);
-        let body_str = builder
-            .build_body(&client, msg("user", "hi"), true)
-            .unwrap();
-        let body: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            let builder = OpenAiResponsesBuilder::new(&LlmProvider::OpenAiResponses);
+            builder
+                .build_request(
+                    &client,
+                    msg("user", "hi"),
+                    true,
+                    &crate::build_request::BuildRequestCallbacks {
+                        http_send: &h,
+                        env_read: &e,
+                        fs_read: &f,
+                    },
+                )
+                .await
+        }
+        .unwrap();
+        let body: serde_json::Value = serde_json::from_str(&result.body).unwrap();
         assert_eq!(
             body,
             serde_json::json!({
@@ -665,17 +666,30 @@ mod tests {
         );
     }
 
-    #[test]
-    fn stream_false_omits_stream() {
+    #[tokio::test]
+    async fn stream_false_omits_stream() {
         let client = make_client(
             "openai-responses",
             vec![("model", BexExternalValue::String("gpt-4o".into()))],
         );
-        let builder = OpenAiResponsesBuilder::new(&LlmProvider::OpenAiResponses);
-        let body_str = builder
-            .build_body(&client, msg("user", "hi"), false)
-            .unwrap();
-        let body: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+        let result = {
+            let (h, e, f) = crate::build_request::stub_callbacks();
+            let builder = OpenAiResponsesBuilder::new(&LlmProvider::OpenAiResponses);
+            builder
+                .build_request(
+                    &client,
+                    msg("user", "hi"),
+                    false,
+                    &crate::build_request::BuildRequestCallbacks {
+                        http_send: &h,
+                        env_read: &e,
+                        fs_read: &f,
+                    },
+                )
+                .await
+        }
+        .unwrap();
+        let body: serde_json::Value = serde_json::from_str(&result.body).unwrap();
         assert_eq!(
             body,
             serde_json::json!({

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -15,7 +15,13 @@ mod render_prompt;
 mod specialize_prompt;
 pub(crate) mod types;
 
-use std::{future::Future, pin::Pin, str::FromStr, sync::Arc};
+use std::{
+    future::Future,
+    panic::{RefUnwindSafe, UnwindSafe},
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+};
 
 use bex_external_types::BexExternalValue;
 use bex_heap::builtin_types;
@@ -71,7 +77,7 @@ pub type EnvReadFut = Pin<Box<dyn Future<Output = Result<Option<String>, LlmOpEr
 /// Injected by the `SysOpLlm` blanket impl in `sys_types`, bridging to the
 /// `SysOpEnv` trait so that `sys_llm` can read env vars without depending
 /// on `std::env` or a specific runtime.
-pub type EnvReadFn = Arc<dyn Fn(String) -> EnvReadFut + Send + Sync>;
+pub type EnvReadFn = Arc<dyn Fn(String) -> EnvReadFut + Send + Sync + UnwindSafe + RefUnwindSafe>;
 
 // ============================================================================
 // Fs callback types (for reading files from build_request)
@@ -85,7 +91,7 @@ pub type FsReadFut = Pin<Box<dyn Future<Output = Result<Vec<u8>, LlmOpError>> + 
 /// Injected by the `SysOpLlm` blanket impl in `sys_types`, bridging to the
 /// `SysOpFs` trait so that `sys_llm` can read files without depending
 /// on `std::fs` or a specific runtime.
-pub type FsReadFn = Arc<dyn Fn(String) -> FsReadFut + Send + Sync>;
+pub type FsReadFn = Arc<dyn Fn(String) -> FsReadFut + Send + Sync + UnwindSafe + RefUnwindSafe>;
 
 // ============================================================================
 // Clean (owned-type) entry points for trait-based dispatch

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -6,6 +6,7 @@
 //! - `specialize_prompt()` - Transform a generic `PromptAst` for a specific LLM provider
 //! - `execute_*` entry points for trait-based dispatch from `sys_types`
 
+pub(crate) mod auth_request;
 mod build_request;
 pub(crate) mod jinja;
 mod model_features;
@@ -14,6 +15,8 @@ mod provider;
 mod render_prompt;
 mod specialize_prompt;
 pub(crate) mod types;
+#[cfg(target_arch = "wasm32")]
+pub(crate) mod wasm;
 
 use std::{
     future::Future,

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -15,7 +15,7 @@ mod render_prompt;
 mod specialize_prompt;
 pub(crate) mod types;
 
-use std::str::FromStr;
+use std::{future::Future, pin::Pin, str::FromStr, sync::Arc};
 
 use bex_external_types::BexExternalValue;
 use bex_heap::builtin_types;
@@ -34,6 +34,58 @@ pub use types::{
     Class as OutputClass, ClassField as OutputClassField, Enum as OutputEnum,
     EnumValue as OutputEnumValue, LlmOpError, RenderOptions,
 };
+
+// ============================================================================
+// HTTP callback types (for cross-op calls from build_request)
+// ============================================================================
+
+/// Response from an HTTP call made during provider-specific request building.
+pub struct HttpSendResponse {
+    /// HTTP status code.
+    pub status_code: u16,
+    /// Response headers.
+    pub headers: indexmap::IndexMap<String, String>,
+    /// Response body text.
+    pub body: String,
+}
+
+/// Future returned by an [`HttpSendFn`] callback.
+pub type HttpSendFut = Pin<Box<dyn Future<Output = Result<HttpSendResponse, LlmOpError>> + Send>>;
+
+/// Callback for making HTTP requests from within provider-specific `build_request` code.
+///
+/// Injected by the `SysOpLlm` blanket impl in `sys_types`, bridging to the
+/// `SysOpHttp` trait so that `sys_llm` can make HTTP calls without depending
+/// on a specific HTTP client.
+pub type HttpSendFn = Arc<dyn Fn(builtin_types::owned::HttpRequest) -> HttpSendFut + Send + Sync>;
+
+// ============================================================================
+// Env callback types (for reading environment variables from build_request)
+// ============================================================================
+
+/// Future returned by an [`EnvReadFn`] callback.
+pub type EnvReadFut = Pin<Box<dyn Future<Output = Result<Option<String>, LlmOpError>> + Send>>;
+
+/// Callback for reading environment variables from within provider-specific code.
+///
+/// Injected by the `SysOpLlm` blanket impl in `sys_types`, bridging to the
+/// `SysOpEnv` trait so that `sys_llm` can read env vars without depending
+/// on `std::env` or a specific runtime.
+pub type EnvReadFn = Arc<dyn Fn(String) -> EnvReadFut + Send + Sync>;
+
+// ============================================================================
+// Fs callback types (for reading files from build_request)
+// ============================================================================
+
+/// Future returned by an [`FsReadFn`] callback.
+pub type FsReadFut = Pin<Box<dyn Future<Output = Result<Vec<u8>, LlmOpError>> + Send>>;
+
+/// Callback for reading file contents from within provider-specific code.
+///
+/// Injected by the `SysOpLlm` blanket impl in `sys_types`, bridging to the
+/// `SysOpFs` trait so that `sys_llm` can read files without depending
+/// on `std::fs` or a specific runtime.
+pub type FsReadFn = Arc<dyn Fn(String) -> FsReadFut + Send + Sync>;
 
 // ============================================================================
 // Clean (owned-type) entry points for trait-based dispatch
@@ -89,11 +141,18 @@ pub fn execute_specialize_prompt_from_owned(
 }
 
 /// Build an HTTP request from a prompt given already-extracted owned types.
-pub fn execute_build_request_from_owned(
+///
+/// The callback arguments bridge `sys_types` traits (`SysOpHttp`, `SysOpEnv`,
+/// `SysOpFs`) into `sys_llm` without creating a direct dependency.
+pub async fn execute_build_request_from_owned(
     client: &builtin_types::owned::LlmPrimitiveClient,
     prompt: bex_vm_types::PromptAst,
+    http_send: &HttpSendFn,
+    env_read: &EnvReadFn,
+    fs_read: &FsReadFn,
 ) -> Result<builtin_types::owned::HttpRequest, LlmOpError> {
-    build_request::build_request(client, prompt, false)
+    build_request::build_request(client, prompt, false, http_send, env_read, fs_read)
+        .await
         .map_err(|e| LlmOpError::Other(e.to_string()))
 }
 

--- a/baml_language/crates/sys_llm/src/provider.rs
+++ b/baml_language/crates/sys_llm/src/provider.rs
@@ -42,7 +42,7 @@ pub(crate) enum LlmProvider {
     #[strum(serialize = "vertex-ai")]
     VertexAi,
 
-    /// AWS Bedrock — deferred (uses AWS SDK, not HTTP)
+    /// AWS Bedrock — uses Converse API with `SigV4` signing
     #[strum(serialize = "aws-bedrock")]
     AwsBedrock,
 

--- a/baml_language/crates/sys_llm/src/wasm.rs
+++ b/baml_language/crates/sys_llm/src/wasm.rs
@@ -1,0 +1,37 @@
+//! WASM-compatible implementations for AWS SDK requirements.
+//!
+//! On WASM, `std::time::SystemTime::now()` panics and `block_on` deadlocks.
+//! This module provides browser-compatible replacements used by both
+//! `build_request` (dry-run SDK config) and `auth_request` (credential resolution).
+
+#![cfg(target_arch = "wasm32")]
+
+use std::time::SystemTime;
+
+use aws_smithy_async::{
+    rt::sleep::{AsyncSleep, Sleep},
+    time::TimeSource,
+};
+
+/// Browser-compatible time source using `web_time`.
+#[derive(Debug)]
+pub(crate) struct BrowserTime;
+
+impl TimeSource for BrowserTime {
+    fn now(&self) -> SystemTime {
+        let offset = web_time::SystemTime::now()
+            .duration_since(web_time::UNIX_EPOCH)
+            .unwrap();
+        std::time::UNIX_EPOCH + offset
+    }
+}
+
+/// Browser-compatible async sleep using `futures_timer`.
+#[derive(Debug, Clone)]
+pub(crate) struct BrowserSleep;
+
+impl AsyncSleep for BrowserSleep {
+    fn sleep(&self, duration: std::time::Duration) -> Sleep {
+        Sleep::new(futures_timer::Delay::new(duration))
+    }
+}

--- a/baml_language/crates/sys_llm/src/wasm.rs
+++ b/baml_language/crates/sys_llm/src/wasm.rs
@@ -21,7 +21,7 @@ impl TimeSource for BrowserTime {
     fn now(&self) -> SystemTime {
         let offset = web_time::SystemTime::now()
             .duration_since(web_time::UNIX_EPOCH)
-            .unwrap();
+            .unwrap_or_default();
         std::time::UNIX_EPOCH + offset
     }
 }

--- a/baml_language/crates/sys_llm/src/wasm.rs
+++ b/baml_language/crates/sys_llm/src/wasm.rs
@@ -4,8 +4,6 @@
 //! This module provides browser-compatible replacements used by both
 //! `build_request` (dry-run SDK config) and `auth_request` (credential resolution).
 
-#![cfg(target_arch = "wasm32")]
-
 #[allow(clippy::disallowed_types)]
 use std::time::SystemTime;
 
@@ -18,6 +16,7 @@ use aws_smithy_async::{
 #[derive(Debug)]
 pub(crate) struct BrowserTime;
 
+#[allow(clippy::disallowed_types)]
 impl TimeSource for BrowserTime {
     fn now(&self) -> SystemTime {
         let offset = web_time::SystemTime::now()

--- a/baml_language/crates/sys_llm/src/wasm.rs
+++ b/baml_language/crates/sys_llm/src/wasm.rs
@@ -6,6 +6,7 @@
 
 #![cfg(target_arch = "wasm32")]
 
+#[allow(clippy::disallowed_types)]
 use std::time::SystemTime;
 
 use aws_smithy_async::{

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -732,7 +732,9 @@ impl<T: SysOpHttp + SysOpEnv + SysOpFs + Default + 'static> SysOpLlm for T {
                 };
 
                 Ok(sys_llm::HttpSendResponse {
-                    status_code: u16::try_from(status).unwrap(),
+                    status_code: u16::try_from(status).map_err(|_| {
+                        sys_llm::LlmOpError::Other(format!("invalid HTTP status code: {status}"))
+                    })?,
                     headers,
                     body,
                 })

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -651,13 +651,13 @@ impl Default for SysOpsBuilder {
 // Blanket SysOpLlm implementation (delegates to sys_llm)
 // ============================================================================
 
-/// Blanket implementation of `SysOpLlm` for all types.
+/// Blanket implementation of `SysOpLlm` for types that also implement
+/// `SysOpHttp`, `SysOpEnv`, and `SysOpFs`.
 ///
 /// Every type gets the real LLM behavior via `sys_llm::execute_*` functions.
-/// When future cross-op calls are needed (e.g., HTTP for media URL resolution),
-/// the bound can be tightened to `impl<T: SysOpHttp> SysOpLlm for T` and
-/// closures can be passed to the `execute_*` functions.
-impl<T> SysOpLlm for T {
+/// The trait bounds allow `build_request` to bridge through the caller's
+/// implementations of HTTP, env, and fs operations.
+impl<T: SysOpHttp + SysOpEnv + SysOpFs + Default + 'static> SysOpLlm for T {
     fn baml_llm_primitive_client_render_prompt(
         &self,
         _call_id: CallId,
@@ -702,10 +702,100 @@ impl<T> SysOpLlm for T {
         primitive_client: bex_heap::builtin_types::owned::LlmPrimitiveClient,
         prompt: bex_vm_types::PromptAst,
     ) -> SysOpOutput<bex_heap::builtin_types::owned::HttpRequest> {
-        SysOpOutput::Ready(
-            sys_llm::execute_build_request_from_owned(&primitive_client, prompt)
-                .map_err(OpErrorKind::from),
-        )
+        // Bridge SysOpHttp into an HttpSendFn callback that sys_llm can use
+        // without depending on sys_types or a specific HTTP client.
+        let http_send: sys_llm::HttpSendFn = Arc::new(|req| {
+            Box::pin(async move {
+                let output = T::default().baml_http_send(CallId::next(), req);
+                let resp = match output {
+                    SysOpOutput::Ready(Ok(v)) => v,
+                    SysOpOutput::Ready(Err(e)) => {
+                        return Err(sys_llm::LlmOpError::Other(format!("{e}")));
+                    }
+                    SysOpOutput::Async(fut) => fut
+                        .await
+                        .map_err(|e| sys_llm::LlmOpError::Other(format!("{e}")))?,
+                };
+
+                let status = resp.status_code;
+                let headers = resp.headers.clone();
+
+                let text_output = T::default().baml_http_response_text(CallId::next(), resp);
+                let body = match text_output {
+                    SysOpOutput::Ready(Ok(v)) => v,
+                    SysOpOutput::Ready(Err(e)) => {
+                        return Err(sys_llm::LlmOpError::Other(format!("{e}")));
+                    }
+                    SysOpOutput::Async(fut) => fut
+                        .await
+                        .map_err(|e| sys_llm::LlmOpError::Other(format!("{e}")))?,
+                };
+
+                Ok(sys_llm::HttpSendResponse {
+                    status_code: u16::try_from(status).unwrap(),
+                    headers,
+                    body,
+                })
+            })
+        });
+
+        // Bridge SysOpEnv into an EnvReadFn callback.
+        let env_read: sys_llm::EnvReadFn = Arc::new(|key| {
+            Box::pin(async move {
+                let output = T::default().env_get(CallId::next(), key);
+                match output {
+                    SysOpOutput::Ready(Ok(v)) => Ok(v),
+                    SysOpOutput::Ready(Err(e)) => Err(sys_llm::LlmOpError::Other(format!("{e}"))),
+                    SysOpOutput::Async(fut) => fut
+                        .await
+                        .map_err(|e| sys_llm::LlmOpError::Other(format!("{e}"))),
+                }
+            })
+        });
+
+        // Bridge SysOpFs into an FsReadFn callback.
+        // Composes baml.fs.open + File.read to read a file by path.
+        let fs_read: sys_llm::FsReadFn = Arc::new(|path| {
+            Box::pin(async move {
+                // Open the file.
+                let open_output = T::default().baml_fs_open(CallId::next(), path);
+                let file = match open_output {
+                    SysOpOutput::Ready(Ok(v)) => v,
+                    SysOpOutput::Ready(Err(e)) => {
+                        return Err(sys_llm::LlmOpError::Other(format!("{e}")));
+                    }
+                    SysOpOutput::Async(fut) => fut
+                        .await
+                        .map_err(|e| sys_llm::LlmOpError::Other(format!("{e}")))?,
+                };
+
+                // Read the file contents.
+                let read_output = T::default().baml_fs_file_read(CallId::next(), file);
+                let contents = match read_output {
+                    SysOpOutput::Ready(Ok(v)) => v,
+                    SysOpOutput::Ready(Err(e)) => {
+                        return Err(sys_llm::LlmOpError::Other(format!("{e}")));
+                    }
+                    SysOpOutput::Async(fut) => fut
+                        .await
+                        .map_err(|e| sys_llm::LlmOpError::Other(format!("{e}")))?,
+                };
+
+                Ok(contents.into_bytes())
+            })
+        });
+
+        SysOpOutput::async_op(async move {
+            sys_llm::execute_build_request_from_owned(
+                &primitive_client,
+                prompt,
+                &http_send,
+                &env_read,
+                &fs_read,
+            )
+            .await
+            .map_err(OpErrorKind::from)
+        })
     }
 
     fn baml_llm_primitive_client_parse(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,6 +640,9 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.5
+        version: 3.3.5
       '@types/file-saver':
         specifier: ^2.0.7
         version: 2.0.7
@@ -3135,8 +3138,8 @@ packages:
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.3.3':
-    resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@9.39.2':
@@ -8097,6 +8100,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
@@ -12115,6 +12121,9 @@ packages:
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
@@ -17954,16 +17963,16 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.3':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -18408,7 +18417,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -24410,6 +24419,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -26387,7 +26403,7 @@ snapshots:
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.3
+      '@eslint/eslintrc': 3.3.5
       '@eslint/js': 9.39.2
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -29653,6 +29669,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.12
+
   minimatch@5.1.6:
     dependencies:
       brace-expansion: 2.0.2
@@ -30731,7 +30751,7 @@ snapshots:
   rc-config-loader@4.1.3:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:

--- a/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
+++ b/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
@@ -14,6 +14,17 @@ interface HttpRequestShape {
   body?: string;
 }
 
+/**
+ * Whether the body must not be reformatted (e.g. SigV4-signed requests where
+ * the body hash is part of the signature).
+ *
+ * TODO: maybe pass a flag through BAML that tells us if we need to preserve
+ * the exact request body?
+ */
+function preserveExactBody(req: HttpRequestShape): boolean {
+  return (req.url ?? '').includes('bedrock-runtime');
+}
+
 function isHttpRequest(value: unknown): value is HttpRequestShape {
   if (value == null || typeof value !== 'object') return false;
   const o = value as Record<string, unknown>;
@@ -54,12 +65,7 @@ function toCurl(req: HttpRequestShape): string {
     }
   }
   if (body != null && body !== '') {
-    // HACK: AWS Bedrock requests are SigV4-signed, so the body hash is part
-    // of the signature. Pretty-printing changes the body and invalidates it.
-    // Ideally we'd check the LLM provider, but the renderer only has the
-    // HTTP request shape. URL sniffing is a workaround for now.
-    const isBedrock = url.includes('bedrock-runtime');
-    const formatted = isBedrock ? body : prettyBody(body);
+    const formatted = preserveExactBody(req) ? body : prettyBody(body);
     const heredoc = safeHeredoc(formatted);
     parts.push('-d @-');
     parts.push(`'${url.replace(/'/g, "'\\''")}'`);
@@ -87,7 +93,7 @@ function toJsFetch(req: HttpRequestShape): string {
     opts.push(`  headers: {\n${headersStr}\n  }`);
   }
   if (body != null && body !== '') {
-    const formatted = prettyBody(body);
+    const formatted = preserveExactBody(req) ? body : prettyBody(body);
     const escaped = formatted.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
     opts.push(`  body: \`${escaped}\``);
   }
@@ -114,7 +120,8 @@ function toPythonRequests(req: HttpRequestShape): string {
     kwargs.push(`    headers={\n${headersStr}\n    }`);
   }
   if (body != null && body !== '') {
-    const safeBody = prettyBody(body).replace(/'''/g, "\\'\\'\\'" );
+    const formatted = preserveExactBody(req) ? body : prettyBody(body);
+    const safeBody = formatted.replace(/'''/g, "\\'\\'\\'");
     kwargs.push(`    data='''\n${safeBody}\n    '''`);
   }
   const kwargsBlock = kwargs.length ? ',\n' + kwargs.join(',\n') : '';
@@ -130,7 +137,8 @@ function toGo(req: HttpRequestShape): string {
   const url = req.url ?? '';
   const headers = req.headers ?? {};
   const body = req.body ?? '';
-  const bodyArg = body ? `strings.NewReader("${escapeGoString(prettyBody(body))}")` : 'nil';
+  const bodyFormatted = body ? (preserveExactBody(req) ? body : prettyBody(body)) : '';
+  const bodyArg = body ? `strings.NewReader("${escapeGoString(bodyFormatted)}")` : 'nil';
   const lines: string[] = [
     `req, err := http.NewRequest("${method}", "${escapeGoString(url)}", ${bodyArg})`,
     'if err != nil { log.Fatal(err) }',
@@ -164,7 +172,7 @@ function toRust(req: HttpRequestShape): string {
   const url = req.url ?? '';
   const headers = req.headers ?? {};
   const body = req.body ?? '';
-  const bodyFormatted = body ? prettyBody(body) : '';
+  const bodyFormatted = body ? (preserveExactBody(req) ? body : prettyBody(body)) : '';
   const clientCall = REQWEST_SHORTCUT_METHODS.has(method)
     ? `client.${method}("${escapeRustString(url)}")`
     : `client.request("${method.toUpperCase()}".parse().unwrap(), "${escapeRustString(url)}")`;

--- a/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
+++ b/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
@@ -54,10 +54,16 @@ function toCurl(req: HttpRequestShape): string {
     }
   }
   if (body != null && body !== '') {
-    const heredoc = safeHeredoc(prettyBody(body));
+    // HACK: AWS Bedrock requests are SigV4-signed, so the body hash is part
+    // of the signature. Pretty-printing changes the body and invalidates it.
+    // Ideally we'd check the LLM provider, but the renderer only has the
+    // HTTP request shape. URL sniffing is a workaround for now.
+    const isBedrock = url.includes('bedrock-runtime');
+    const formatted = isBedrock ? body : prettyBody(body);
+    const heredoc = safeHeredoc(formatted);
     parts.push('-d @-');
     parts.push(`'${url.replace(/'/g, "'\\''")}'`);
-    return parts.join(' \\\n  ') + ` <<'${heredoc}'\n${prettyBody(body)}\n${heredoc}`;
+    return parts.join(' \\\n  ') + ` <<'${heredoc}'\n${formatted}\n${heredoc}`;
   }
   parts.push(`'${url.replace(/'/g, "'\\''")}'`);
   return parts.join(' \\\n  ');

--- a/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
+++ b/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
@@ -65,11 +65,17 @@ function toCurl(req: HttpRequestShape): string {
     }
   }
   if (body != null && body !== '') {
-    const formatted = preserveExactBody(req) ? body : prettyBody(body);
-    const heredoc = safeHeredoc(formatted);
-    parts.push('-d @-');
-    parts.push(`'${url.replace(/'/g, "'\\''")}'`);
-    return parts.join(' \\\n  ') + ` <<'${heredoc}'\n${formatted}\n${heredoc}`;
+    const preserve = preserveExactBody(req);
+    const formatted = preserve ? body : prettyBody(body);
+    if (preserve) {
+      const escaped = formatted.replace(/'/g, "'\\''");
+      parts.push(`-d '${escaped}'`);
+    } else {
+      const heredoc = safeHeredoc(formatted);
+      parts.push('-d @-');
+      parts.push(`'${url.replace(/'/g, "'\\''")}'`);
+      return parts.join(' \\\n  ') + ` <<'${heredoc}'\n${formatted}\n${heredoc}`;
+    }
   }
   parts.push(`'${url.replace(/'/g, "'\\''")}'`);
   return parts.join(' \\\n  ');
@@ -93,7 +99,8 @@ function toJsFetch(req: HttpRequestShape): string {
     opts.push(`  headers: {\n${headersStr}\n  }`);
   }
   if (body != null && body !== '') {
-    const formatted = preserveExactBody(req) ? body : prettyBody(body);
+    const preserve = preserveExactBody(req);
+    const formatted = preserve ? body : prettyBody(body);
     const escaped = formatted.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
     opts.push(`  body: \`${escaped}\``);
   }
@@ -120,9 +127,15 @@ function toPythonRequests(req: HttpRequestShape): string {
     kwargs.push(`    headers={\n${headersStr}\n    }`);
   }
   if (body != null && body !== '') {
-    const formatted = preserveExactBody(req) ? body : prettyBody(body);
-    const safeBody = formatted.replace(/'''/g, "\\'\\'\\'");
-    kwargs.push(`    data='''\n${safeBody}\n    '''`);
+    const preserve = preserveExactBody(req);
+    const formatted = preserve ? body : prettyBody(body);
+    if (preserve) {
+      const escaped = formatted.replace(/'/g, "\\'");
+      kwargs.push(`    data='${escaped}'`);
+    } else {
+      const safeBody = formatted.replace(/'''/g, "\\'\\'\\'");
+      kwargs.push(`    data='''\n${safeBody}\n    '''`);
+    }
   }
   const kwargsBlock = kwargs.length ? ',\n' + kwargs.join(',\n') : '';
   return `import requests\n\nresponse = requests.${fn}(\n    ${args}'${escapePySingle(url)}'${kwargsBlock}\n)`;
@@ -184,15 +197,21 @@ function toRust(req: HttpRequestShape): string {
     if (v != null) lines.push(`    .header("${escapeRustString(k)}", "${escapeRustString(String(v))}")`);
   }
   if (body) {
-    let maxHashes = 0;
-    const re = /"(#+)/g;
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(bodyFormatted)) !== null) {
-      maxHashes = Math.max(maxHashes, m[1].length);
+    const preserve = preserveExactBody(req);
+    if (preserve) {
+      const escaped = bodyFormatted.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      lines.push(`    .body("${escaped}")`);
+    } else {
+      let maxHashes = 0;
+      const re = /"(#+)/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(bodyFormatted)) !== null) {
+        maxHashes = Math.max(maxHashes, m[1].length);
+      }
+      const hashCount = maxHashes + 1;
+      const hash = '#'.repeat(hashCount);
+      lines.push(`    .body(r${hash}"\n${bodyFormatted}\n"${hash})`);
     }
-    const hashCount = maxHashes + 1;
-    const hash = '#'.repeat(hashCount);
-    lines.push(`    .body(r${hash}"\n${bodyFormatted}\n"${hash})`);
   }
   lines.push('    .send()?;');
   return '// reqwest = { version = "0.11", features = ["blocking"] }\n\n' + lines.join('\n');


### PR DESCRIPTION
Draft implementation of bedrock request builder. Brings in aws-config for auth and nothing else, manually forms Bedrock Converse request bodies. Wires the HTTP requests for aws-config through the bex implementation. Once complete this will also patch AWS SDK crates to allow for environment variables and filesystem i/o to be wired through bex implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Bedrock LLM provider with SigV4-signed requests, media content support, and WASM/native runtime handling.
  * Request-building and authorization moved to an async flow with pluggable HTTP, env, and filesystem callbacks and public request/response callback types.

* **Bug Fixes & Tests**
  * Migrated request-building tests to async; added Bedrock integration and auth tests.

* **Chores**
  * Updated Rust MSRV and added AWS SDK and async/timing dependencies.

* **Style**
  * Curl/snippet renderer preserves exact bodies for Bedrock requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->