### PR TITLE
Raise error messages from baml-cli optimize

### DIFF
--- a/engine/baml-lib/baml-log/src/lib.rs
+++ b/engine/baml-lib/baml-log/src/lib.rs
@@ -46,9 +46,9 @@ mod logger;
 
 // Re-export the core types and functions
 pub use logger::{
-    get_log_level, init, log_event_internal, log_internal, log_internal_once, reload_from_env,
-    set_color_mode, set_from_env, set_json_mode, set_log_level, set_max_message_length,
-    set_running_in_lsp, Level, LogError, Loggable, MaxMessageLength,
+    clear_log_file, get_log_level, init, log_event_internal, log_internal, log_internal_once,
+    reload_from_env, set_color_mode, set_from_env, set_json_mode, set_log_file, set_log_level,
+    set_max_message_length, set_running_in_lsp, Level, LogError, Loggable, MaxMessageLength,
 };
 
 pub use crate::{

--- a/engine/baml-lib/baml-log/src/logger.rs
+++ b/engine/baml-lib/baml-log/src/logger.rs
@@ -2,9 +2,11 @@ use std::{
     collections::{HashMap, HashSet},
     env,
     fmt::{self, Display},
+    fs::OpenOptions,
     io::{self, Write},
+    path::{Path, PathBuf},
     str::FromStr,
-    sync::{Once, RwLock},
+    sync::{Mutex, Once, RwLock},
 };
 
 use colored::*;
@@ -398,6 +400,8 @@ lazy_static! {
     /// Thread-safe configuration with runtime modification support
     static ref CONFIG: RwLock<LogConfig> = RwLock::new(LogConfig::from_env());
     static ref LOGGED_LINES: RwLock<HashSet<(Option<String>, Option<String>, Option<u32>)>> = RwLock::new(HashSet::new());
+    /// Optional log file path — when set, log output goes to this file instead of stdout.
+    static ref LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
 }
 
 /// Error type for logging operations
@@ -606,6 +610,23 @@ pub fn set_running_in_lsp(running_in_lsp: bool) -> Result<(), LogError> {
     }
 }
 
+/// Redirect all log output to a file instead of stdout.
+///
+/// When set, `log_internal` and `log_event_internal` append to this file
+/// instead of writing to stdout. This is useful when a TUI owns stdout.
+pub fn set_log_file(path: &Path) -> Result<(), LogError> {
+    let mut log_file = LOG_FILE.lock().map_err(|_| LogError::LockError)?;
+    *log_file = Some(path.to_path_buf());
+    Ok(())
+}
+
+/// Stop redirecting log output to a file (reverts to stdout).
+pub fn clear_log_file() -> Result<(), LogError> {
+    let mut log_file = LOG_FILE.lock().map_err(|_| LogError::LockError)?;
+    *log_file = None;
+    Ok(())
+}
+
 /// Reload all configuration from environment variables
 pub fn reload_from_env() -> Result<(), LogError> {
     match CONFIG.write() {
@@ -696,6 +717,16 @@ impl Logger {
             ColorMode::Auto => {} // Use default detection
         }
 
+        // Check if output should go to a log file instead of stdout
+        if let Ok(log_file_guard) = LOG_FILE.lock() {
+            if let Some(ref path) = *log_file_guard {
+                if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+                    let _ = writeln!(file, "{} [BAML {}] {}", now, level.as_str(), message.trim());
+                }
+                return;
+            }
+        }
+
         if self.running_in_lsp {
             // When running in the context of our LSP, we can't write to stdout since that will
             // mess up the LSP communication protocol, which uses stdout/stderr for communication.
@@ -764,6 +795,9 @@ pub fn log_event_internal<T: Loggable>(
         .format("%Y-%m-%dT%H:%M:%S%.3f")
         .to_string();
 
+    // Check if output should go to a log file instead of stdout
+    let log_file_path = LOG_FILE.lock().ok().and_then(|g| g.clone());
+
     if config.use_json {
         // In JSON mode, use the payload directly
         if let Ok(json_value) = payload.as_baml_log_json(&config.max_message_length) {
@@ -784,7 +818,13 @@ pub fn log_event_internal<T: Loggable>(
             }
 
             let json_str = serde_json::to_string(&event_json).unwrap_or_default();
-            let _ = writeln!(io::stdout(), "{json_str}");
+            if let Some(ref path) = log_file_path {
+                if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+                    let _ = writeln!(file, "{json_str}");
+                }
+            } else {
+                let _ = writeln!(io::stdout(), "{json_str}");
+            }
         }
     } else {
         // In regular mode, convert payload to a debug string
@@ -800,42 +840,54 @@ pub fn log_event_internal<T: Loggable>(
             payload_str
         };
 
-        // Configure color control based on mode
-        match config.color_mode {
-            ColorMode::Always => control::set_override(true),
-            ColorMode::Never => control::set_override(false),
-            ColorMode::Auto => {} // Use default detection
-        }
-
-        if !config.running_in_lsp {
-            let _ = writeln!(
-                io::stdout(),
-                "{} [BAML {}] {}",
-                now,
-                level.colored(),
-                payload_str.trim()
-            );
+        if let Some(ref path) = log_file_path {
+            if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+                let _ = writeln!(
+                    file,
+                    "{} [BAML {}] {}",
+                    now,
+                    level.as_str(),
+                    payload_str.trim()
+                );
+            }
         } else {
-            match level {
-                Level::Fatal => {
-                    log::error!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
+            // Configure color control based on mode
+            match config.color_mode {
+                ColorMode::Always => control::set_override(true),
+                ColorMode::Never => control::set_override(false),
+                ColorMode::Auto => {} // Use default detection
+            }
+
+            if !config.running_in_lsp {
+                let _ = writeln!(
+                    io::stdout(),
+                    "{} [BAML {}] {}",
+                    now,
+                    level.colored(),
+                    payload_str.trim()
+                );
+            } else {
+                match level {
+                    Level::Fatal => {
+                        log::error!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
+                    }
+                    Level::Error => {
+                        log::error!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
+                    }
+                    Level::Warn => {
+                        log::warn!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
+                    }
+                    Level::Info => {
+                        log::info!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
+                    }
+                    Level::Debug => {
+                        log::debug!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
+                    }
+                    Level::Trace => {
+                        log::trace!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
+                    }
+                    Level::Off => {}
                 }
-                Level::Error => {
-                    log::error!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
-                }
-                Level::Warn => {
-                    log::warn!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
-                }
-                Level::Info => {
-                    log::info!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
-                }
-                Level::Debug => {
-                    log::debug!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
-                }
-                Level::Trace => {
-                    log::trace!("{} [BAML {}] {}", now, level.colored(), payload_str.trim())
-                }
-                Level::Off => {}
             }
         }
     }

--- a/engine/baml-runtime/src/cli/optimize.rs
+++ b/engine/baml-runtime/src/cli/optimize.rs
@@ -267,10 +267,8 @@ impl OptimizeArgs {
 
         self.dotenv.load()?;
 
-        // Suppress BAML logging and tracing when TUI is active
+        // Redirect BAML logging to a file when TUI is active (instead of suppressing it)
         if !self.no_ui {
-            // Set BAML_LOG=off to disable all logging output
-            std::env::set_var("BAML_LOG", "off");
             // Remove BAML_TRACE_FILE to prevent trace output during TUI
             std::env::remove_var("BAML_TRACE_FILE");
         }
@@ -485,6 +483,11 @@ impl OptimizeArgs {
         // Launch live TUI in a separate thread (default behavior, unless --no-ui)
         let tui_handle = if !self.no_ui {
             let run_dir_clone = run_dir.clone();
+            // Redirect BAML log output to a file so the TUI can display it on error
+            let log_file_path = run_dir.join("optimize.log");
+            if let Err(e) = baml_log::set_log_file(&log_file_path) {
+                eprintln!("Warning: could not redirect logs to file: {}", e);
+            }
             println!("Launching live TUI viewer...");
             println!("(Press 'q' to close TUI, 'Enter' to stop optimization and apply selected candidate)\n");
 
@@ -505,6 +508,8 @@ impl OptimizeArgs {
             Ok(result) => {
                 // If TUI was launched in live mode, wait for it to close and get the selected candidate
                 if let Some(handle) = tui_handle {
+                    // Stop redirecting logs now that optimization is done
+                    let _ = baml_log::clear_log_file();
                     // Wait for TUI to close - user can press Enter to apply a candidate
                     let tui_result = handle.join();
 
@@ -588,10 +593,46 @@ impl OptimizeArgs {
             Err(e) => {
                 // Signal the error to the TUI via file, then wait for it to close
                 if let Some(handle) = tui_handle {
+                    // Stop redirecting logs before writing error
+                    let _ = baml_log::clear_log_file();
+
                     if let Ok(storage) =
                         crate::optimize::storage::OptimizationStorage::from_existing(&run_dir)
                     {
-                        let _ = storage.write_error(&format!("{e}"));
+                        // Build a detailed error message from the full anyhow chain
+                        let mut detail = String::new();
+                        for (i, cause) in e.chain().enumerate() {
+                            if i == 0 {
+                                detail.push_str(&format!("{cause}\n"));
+                            } else {
+                                detail.push_str(&format!("  Caused by: {cause}\n"));
+                            }
+                        }
+
+                        // Append unique error/warning lines from the log file
+                        let log_path = run_dir.join("optimize.log");
+                        if let Ok(log_content) = std::fs::read_to_string(&log_path) {
+                            let mut seen = std::collections::HashSet::new();
+                            let error_lines: Vec<&str> = log_content
+                                .lines()
+                                .rev()
+                                .filter(|line| {
+                                    line.contains("ERROR")
+                                        || line.contains("WARN")
+                                        || line.contains("error")
+                                })
+                                .filter(|line| seen.insert(*line))
+                                .take(15)
+                                .collect();
+                            if !error_lines.is_empty() {
+                                detail.push_str("\nRecent log errors:\n");
+                                for line in error_lines.into_iter().rev() {
+                                    detail.push_str(&format!("  {line}\n"));
+                                }
+                            }
+                        }
+
+                        let _ = storage.write_error(&detail);
                     }
                     let _ = handle.join();
                 }

--- a/engine/baml-runtime/src/cli/optimize.rs
+++ b/engine/baml-runtime/src/cli/optimize.rs
@@ -586,8 +586,13 @@ impl OptimizeArgs {
                 Ok(OptimizeRunResult::Success)
             }
             Err(e) => {
-                // If TUI was launched, wait for it to close even on error
+                // Signal the error to the TUI via file, then wait for it to close
                 if let Some(handle) = tui_handle {
+                    if let Ok(storage) =
+                        crate::optimize::storage::OptimizationStorage::from_existing(&run_dir)
+                    {
+                        let _ = storage.write_error(&format!("{e}"));
+                    }
                     let _ = handle.join();
                 }
 

--- a/engine/baml-runtime/src/optimize/storage.rs
+++ b/engine/baml-runtime/src/optimize/storage.rs
@@ -396,6 +396,26 @@ impl OptimizationStorage {
         Ok(())
     }
 
+    // =========================================================================
+    // Errors
+    // =========================================================================
+
+    /// Write an error message to signal failure to the TUI
+    pub fn write_error(&self, message: &str) -> Result<()> {
+        let path = self.run_dir.join("error.json");
+        let content = serde_json::json!({ "error": message });
+        std::fs::write(path, serde_json::to_string_pretty(&content)?)?;
+        Ok(())
+    }
+
+    /// Load an error message if one was written
+    pub fn load_error(&self) -> Option<String> {
+        let path = self.run_dir.join("error.json");
+        let content = std::fs::read_to_string(path).ok()?;
+        let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+        value.get("error")?.as_str().map(|s| s.to_string())
+    }
+
     /// Get path to the best candidate file
     pub fn best_candidate_path(&self, candidate_id: usize) -> PathBuf {
         let filename = format!("{:02}_", candidate_id);

--- a/engine/baml-runtime/src/optimize/tui.rs
+++ b/engine/baml-runtime/src/optimize/tui.rs
@@ -26,8 +26,8 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{
-        Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-        Wrap,
+        Block, BorderType, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation,
+        ScrollbarState, Wrap,
     },
     Frame, Terminal,
 };
@@ -565,6 +565,56 @@ fn render_ui(frame: &mut Frame, app: &mut App) {
     render_tree_panel(frame, app, content_chunks[0]);
     render_details_panel(frame, app, content_chunks[1]);
     render_footer(frame, app, main_chunks[2]);
+
+    // Render error modal overlay if the optimization has failed
+    if let OptimizationStatus::Failed { ref message } = app.status {
+        render_error_modal(frame, message);
+    }
+}
+
+/// Render a centered error modal overlay
+fn render_error_modal(frame: &mut Frame, message: &str) {
+    let area = frame.area();
+
+    // Size the modal to fill most of the screen
+    let modal_width = area.width.saturating_sub(4);
+    let modal_height = area.height.saturating_sub(4);
+    let x = (area.width.saturating_sub(modal_width)) / 2;
+    let y = (area.height.saturating_sub(modal_height)) / 2;
+    let modal_area = Rect::new(x, y, modal_width, modal_height);
+
+    // Clear the area behind the modal
+    frame.render_widget(Clear, modal_area);
+
+    let block = Block::default()
+        .title(" Optimization Error ")
+        .title_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(Style::default().fg(Color::Red));
+
+    let inner = block.inner(modal_area);
+    frame.render_widget(block, modal_area);
+
+    // Build the error text with a hint at the bottom
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(""));
+    for text_line in message.lines() {
+        lines.push(Line::from(Span::raw(format!(" {text_line}"))));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        " Press 'q' to exit",
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC),
+    )));
+
+    let paragraph = Paragraph::new(lines)
+        .style(Style::default().fg(Color::White))
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(paragraph, inner);
 }
 
 /// Spinner frames for running status

--- a/engine/baml-runtime/src/optimize/tui.rs
+++ b/engine/baml-runtime/src/optimize/tui.rs
@@ -67,6 +67,8 @@ pub enum OptimizationStatus {
     },
     /// Optimization has completed
     Completed,
+    /// Optimization failed with an error
+    Failed { message: String },
     /// Status unknown (couldn't read state)
     Unknown,
 }
@@ -223,6 +225,14 @@ impl App {
         let Ok(storage) = OptimizationStorage::from_existing(storage_path) else {
             return;
         };
+
+        // Check for error signal from orchestrator
+        if let Some(error_message) = storage.load_error() {
+            self.status = OptimizationStatus::Failed {
+                message: error_message,
+            };
+            return;
+        }
 
         // Load candidates
         let Ok(new_candidates) = storage.load_candidates() else {
@@ -602,9 +612,11 @@ fn render_header(frame: &mut Frame, app: &App, area: Rect) {
             format!("{} Running {}/{}", spinner, display_iteration, total_trials)
         }
         OptimizationStatus::Completed => "✓ Complete".to_string(),
+        OptimizationStatus::Failed { ref message } => format!("✗ Error: {}", message),
         OptimizationStatus::Unknown => "".to_string(),
     };
 
+    let is_error = matches!(app.status, OptimizationStatus::Failed { .. });
     let stats = format!(
         "Candidates: {} | Pareto: {} | Objectives: {} | {}",
         app.candidates.len(),
@@ -612,8 +624,9 @@ fn render_header(frame: &mut Frame, app: &App, area: Rect) {
         objectives_str,
         status_display
     );
+    let stats_color = if is_error { Color::Red } else { Color::Gray };
     let paragraph = Paragraph::new(stats)
-        .style(Style::default().fg(Color::Gray))
+        .style(Style::default().fg(stats_color))
         .block(block);
 
     frame.render_widget(paragraph, area);


### PR DESCRIPTION
Previously, when `baml-cli optimize` encountered an error, the TUI would just loop forever looking as though it's waiting for LLM data to come back, because we hide stderr, to preserve the integrity of the TUI in the console.

This change gives BAML_LOG the ability to log to file, and arranges for the TUI to read logs from that file when it detects an error. Now errors from the optimization process are surfaced in a modal dialog in the TUI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file-based logging capability to redirect logs for better diagnostics and troubleshooting.
  * Enhanced error reporting in the optimization interface with detailed error messages displayed during failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->