### PR TITLE
fix(beps): add backwards compatibility for legacy user roles

### DIFF
--- a/typescript/apps/beps/convex/migrations.ts
+++ b/typescript/apps/beps/convex/migrations.ts
@@ -1,6 +1,58 @@
 import { mutation } from "./_generated/server";
 
 /**
+ * Migration: User Roles to New Format
+ *
+ * This migration converts legacy roles to the new role format:
+ *   - admin → bdfl
+ *   - shepherd → team
+ *   - member → unset
+ *
+ * Run this migration ONCE after deploying the schema changes:
+ *   npx convex run migrations:migrateUserRoles
+ */
+export const migrateUserRoles = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const results = {
+      adminToBdfl: 0,
+      shepherdToTeam: 0,
+      memberToUnset: 0,
+      unchanged: 0,
+      errors: [] as string[],
+    };
+
+    const users = await ctx.db.query("users").collect();
+
+    for (const user of users) {
+      try {
+        const role = user.role as string;
+
+        if (role === "admin") {
+          await ctx.db.patch(user._id, { role: "bdfl" });
+          results.adminToBdfl++;
+        } else if (role === "shepherd") {
+          await ctx.db.patch(user._id, { role: "team" });
+          results.shepherdToTeam++;
+        } else if (role === "member") {
+          await ctx.db.patch(user._id, { role: "unset" });
+          results.memberToUnset++;
+        } else {
+          results.unchanged++;
+        }
+      } catch (error) {
+        results.errors.push(`User ${user._id}: ${String(error)}`);
+      }
+    }
+
+    return {
+      ...results,
+      message: `Migration complete. Converted ${results.adminToBdfl} admin→bdfl, ${results.shepherdToTeam} shepherd→team, ${results.memberToUnset} member→unset. ${results.unchanged} users unchanged.`,
+    };
+  },
+});
+
+/**
  * Migration: Content Model Refactor (Phase 9)
  *
  * This migration updates existing data from the old 4-field section model

--- a/typescript/apps/beps/convex/schema.ts
+++ b/typescript/apps/beps/convex/schema.ts
@@ -27,9 +27,15 @@ export const summaryStatus = v.union(
 );
 
 export const userRole = v.union(
+  // New roles
   v.literal("bdfl"),
   v.literal("team"),
-  v.literal("unset")
+  v.literal("unset"),
+  // Legacy roles (kept for backwards compatibility with existing data)
+  // Run `npx convex run migrations:migrateUserRoles` to migrate to new roles
+  v.literal("admin"),
+  v.literal("shepherd"),
+  v.literal("member")
 );
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/typescript/apps/beps/convex/users.ts
+++ b/typescript/apps/beps/convex/users.ts
@@ -3,6 +3,16 @@ import { v } from "convex/values";
 import { userRole } from "./schema";
 import { internal } from "./_generated/api";
 
+// Helper to check if a role has admin-level permissions (bdfl or legacy admin)
+function hasAdminPermissions(role: string): boolean {
+  return role === "bdfl" || role === "admin";
+}
+
+// Helper to check if a role has team-level permissions (team, bdfl, or legacy equivalents)
+function hasTeamPermissions(role: string): boolean {
+  return role === "bdfl" || role === "team" || role === "admin" || role === "shepherd";
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // QUERIES
 // ─────────────────────────────────────────────────────────────────────────────
@@ -40,8 +50,8 @@ export const listForManagement = query({
       throw new Error("Requester not found");
     }
 
-    // Only BDFL and Team members can view user management
-    if (requester.role !== "bdfl" && requester.role !== "team") {
+    // Only BDFL and Team members (or legacy equivalents) can view user management
+    if (!hasTeamPermissions(requester.role)) {
       throw new Error("Unauthorized: Only BDFL and Team members can view users");
     }
 
@@ -50,7 +60,7 @@ export const listForManagement = query({
   },
 });
 
-// Check if a user has management permissions (BDFL or Team)
+// Check if a user has management permissions (BDFL or Team, including legacy roles)
 export const hasManagementPermissions = query({
   args: { userId: v.id("users") },
   handler: async (ctx, args) => {
@@ -58,7 +68,7 @@ export const hasManagementPermissions = query({
     if (!user) {
       return false;
     }
-    return user.role === "bdfl" || user.role === "team";
+    return hasTeamPermissions(user.role);
   },
 });
 
@@ -245,13 +255,13 @@ export const updateRoleWithPermissions = mutation({
       throw new Error("Requester not found");
     }
 
-    // Only BDFL and Team members can update roles
-    if (requester.role !== "bdfl" && requester.role !== "team") {
+    // Only BDFL and Team members (or legacy equivalents) can update roles
+    if (!hasTeamPermissions(requester.role)) {
       throw new Error("Unauthorized: Only BDFL and Team members can update roles");
     }
 
-    // Only BDFL can assign BDFL role
-    if (args.role === "bdfl" && requester.role !== "bdfl") {
+    // Only BDFL (or legacy admin) can assign BDFL role
+    if (args.role === "bdfl" && !hasAdminPermissions(requester.role)) {
       throw new Error("Unauthorized: Only BDFL can assign the BDFL role");
     }
 
@@ -260,8 +270,8 @@ export const updateRoleWithPermissions = mutation({
       throw new Error("Target user not found");
     }
 
-    // Cannot change the role of a BDFL unless you are also BDFL
-    if (targetUser.role === "bdfl" && requester.role !== "bdfl") {
+    // Cannot change the role of a BDFL (or legacy admin) unless you are also BDFL/admin
+    if (hasAdminPermissions(targetUser.role) && !hasAdminPermissions(requester.role)) {
       throw new Error("Unauthorized: Only BDFL can change another BDFL's role");
     }
 

--- a/typescript/apps/beps/src/app/profile/page.tsx
+++ b/typescript/apps/beps/src/app/profile/page.tsx
@@ -25,13 +25,22 @@ import {
   XCircle,
 } from "lucide-react";
 
-type UserRole = "bdfl" | "team" | "unset";
+type UserRole = "bdfl" | "team" | "unset" | "admin" | "shepherd" | "member";
+
+// Check if role is a legacy role that needs migration
+function isLegacyRole(role: string): boolean {
+  return role === "admin" || role === "shepherd" || role === "member";
+}
 
 function RoleBadge({ role }: { role: UserRole }) {
   const roleConfig = {
     bdfl: { label: "BDFL", variant: "bdfl" as const, icon: Crown, description: "Full administrative access" },
     team: { label: "Team", variant: "team" as const, icon: Shield, description: "Team member with management access" },
     unset: { label: "Unset", variant: "unset" as const, icon: UserMinus, description: "No special permissions" },
+    // Legacy roles
+    admin: { label: "Admin (legacy)", variant: "admin" as const, icon: Crown, description: "Full administrative access (legacy role)" },
+    shepherd: { label: "Shepherd (legacy)", variant: "shepherd" as const, icon: Shield, description: "Team member with management access (legacy role)" },
+    member: { label: "Member (legacy)", variant: "member" as const, icon: UserMinus, description: "No special permissions (legacy role)" },
   };
 
   const config = roleConfig[role];
@@ -189,30 +198,45 @@ export default function ProfilePage() {
               <div className="p-4 border rounded-lg">
                 <RoleBadge role={user.role} />
 
-                {user.role === "bdfl" && (
+                {(user.role === "bdfl" || user.role === "admin") && (
                   <div className="mt-3 text-sm text-muted-foreground">
-                    <p>As a BDFL, you have:</p>
+                    <p>As a {user.role === "bdfl" ? "BDFL" : "Admin"}, you have:</p>
                     <ul className="list-disc list-inside mt-2 space-y-1">
                       <li>Access to user management</li>
                       <li>Ability to assign any role to any user</li>
                       <li>Full administrative access</li>
                     </ul>
+                    {isLegacyRole(user.role) && (
+                      <p className="mt-2 text-amber-600 dark:text-amber-400">
+                        Note: Your role will be migrated to BDFL automatically.
+                      </p>
+                    )}
                   </div>
                 )}
 
-                {user.role === "team" && (
+                {(user.role === "team" || user.role === "shepherd") && (
                   <div className="mt-3 text-sm text-muted-foreground">
-                    <p>As a Team member, you have:</p>
+                    <p>As a {user.role === "team" ? "Team member" : "Shepherd"}, you have:</p>
                     <ul className="list-disc list-inside mt-2 space-y-1">
                       <li>Access to user management</li>
                       <li>Ability to assign Team or Unset roles</li>
                     </ul>
+                    {isLegacyRole(user.role) && (
+                      <p className="mt-2 text-amber-600 dark:text-amber-400">
+                        Note: Your role will be migrated to Team automatically.
+                      </p>
+                    )}
                   </div>
                 )}
 
-                {user.role === "unset" && (
+                {(user.role === "unset" || user.role === "member") && (
                   <div className="mt-3 text-sm text-muted-foreground">
                     <p>You currently have no special permissions. Contact a Team member or BDFL to request access.</p>
+                    {isLegacyRole(user.role) && (
+                      <p className="mt-2 text-amber-600 dark:text-amber-400">
+                        Note: Your role will be migrated to Unset automatically.
+                      </p>
+                    )}
                   </div>
                 )}
               </div>

--- a/typescript/apps/beps/src/app/users/page.tsx
+++ b/typescript/apps/beps/src/app/users/page.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/select";
 import { ArrowLeft, Users, Shield, Crown, UserMinus } from "lucide-react";
 
-type UserRole = "bdfl" | "team" | "unset";
+type UserRole = "bdfl" | "team" | "unset" | "admin" | "shepherd" | "member";
 
 interface UserRecord {
   _id: Id<"users">;
@@ -38,11 +38,22 @@ interface UserRecord {
   createdAt: number;
 }
 
+// Get the equivalent new role for a legacy role (for sorting purposes)
+function getNormalizedRole(role: string): "bdfl" | "team" | "unset" {
+  if (role === "bdfl" || role === "admin") return "bdfl";
+  if (role === "team" || role === "shepherd") return "team";
+  return "unset";
+}
+
 function RoleBadge({ role }: { role: UserRole }) {
   const roleConfig = {
     bdfl: { label: "BDFL", variant: "bdfl" as const, icon: Crown },
     team: { label: "Team", variant: "team" as const, icon: Shield },
     unset: { label: "Unset", variant: "unset" as const, icon: UserMinus },
+    // Legacy roles - show original name with "(legacy)" suffix
+    admin: { label: "Admin (legacy)", variant: "admin" as const, icon: Crown },
+    shepherd: { label: "Shepherd (legacy)", variant: "shepherd" as const, icon: Shield },
+    member: { label: "Member (legacy)", variant: "member" as const, icon: UserMinus },
   };
 
   const config = roleConfig[role];
@@ -68,8 +79,11 @@ function UserRow({
   onRoleChange: (userId: Id<"users">, newRole: UserRole) => void;
 }) {
   const isCurrentUser = user._id === currentUserId;
-  const canEditBdfl = currentUserRole === "bdfl";
-  const canEditThisUser = canEditBdfl || user.role !== "bdfl";
+  // Check if current user has admin-level permissions (bdfl or legacy admin)
+  const canEditBdfl = currentUserRole === "bdfl" || currentUserRole === "admin";
+  // Can edit this user if we have admin permissions, or if the target user is not an admin
+  const targetIsAdmin = user.role === "bdfl" || user.role === "admin";
+  const canEditThisUser = canEditBdfl || !targetIsAdmin;
 
   return (
     <div className="flex items-center justify-between p-4 border rounded-lg bg-card">
@@ -189,17 +203,20 @@ export default function UsersPage() {
   const sortedUsers = users
     ? [...users].sort((a, b) => {
         const roleOrder = { bdfl: 0, team: 1, unset: 2 };
-        if (roleOrder[a.role] !== roleOrder[b.role]) {
-          return roleOrder[a.role] - roleOrder[b.role];
+        const aOrder = roleOrder[getNormalizedRole(a.role)];
+        const bOrder = roleOrder[getNormalizedRole(b.role)];
+        if (aOrder !== bOrder) {
+          return aOrder - bOrder;
         }
         return a.name.localeCompare(b.name);
       })
     : [];
 
+  // Group users by normalized role (legacy roles grouped with their modern equivalents)
   const usersByRole = {
-    bdfl: sortedUsers.filter((u) => u.role === "bdfl"),
-    team: sortedUsers.filter((u) => u.role === "team"),
-    unset: sortedUsers.filter((u) => u.role === "unset"),
+    bdfl: sortedUsers.filter((u) => getNormalizedRole(u.role) === "bdfl"),
+    team: sortedUsers.filter((u) => getNormalizedRole(u.role) === "team"),
+    unset: sortedUsers.filter((u) => getNormalizedRole(u.role) === "unset"),
   };
 
   return (

--- a/typescript/apps/beps/src/components/providers/user-provider.tsx
+++ b/typescript/apps/beps/src/components/providers/user-provider.tsx
@@ -15,7 +15,8 @@ import { Id } from "../../../convex/_generated/dataModel";
 interface User {
   _id: Id<"users">;
   name: string;
-  role: "bdfl" | "team" | "unset";
+  // Includes both new roles and legacy roles (for backwards compatibility)
+  role: "bdfl" | "team" | "unset" | "admin" | "shepherd" | "member";
   avatarUrl?: string;
   boundaryEmail?: string;
   slackUserId?: string;
@@ -123,8 +124,11 @@ export function UserProvider({ children }: { children: ReactNode }) {
     setStoredUserId(null);
   };
 
-  // Check if user has management permissions (BDFL or Team)
-  const hasManagementPermissions = user ? (user.role === "bdfl" || user.role === "team") : false;
+  // Check if user has management permissions (BDFL or Team, including legacy roles)
+  const hasManagementPermissions = user ? (
+    user.role === "bdfl" || user.role === "team" ||
+    user.role === "admin" || user.role === "shepherd"
+  ) : false;
 
   return (
     <UserContext.Provider

--- a/typescript/apps/beps/src/components/ui/badge.tsx
+++ b/typescript/apps/beps/src/components/ui/badge.tsx
@@ -28,6 +28,10 @@ const badgeVariants = cva(
         bdfl: "border-transparent bg-amber-500 text-white",
         team: "border-transparent bg-indigo-500 text-white",
         unset: "border-transparent bg-gray-400 text-white",
+        // Legacy role variants (shown with striped pattern to indicate migration needed)
+        admin: "border-transparent bg-amber-500/70 text-white",
+        shepherd: "border-transparent bg-indigo-500/70 text-white",
+        member: "border-transparent bg-gray-400/70 text-white",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
- [x] This PR fixes the Convex deployment failure due to schema validation error with existing `member` roles

## Changes
The Convex deployment was failing because existing users in the database had the `member` role, which didn't match the new schema that only allowed `bdfl`, `team`, `unset`.

**Schema Changes:**
- Added legacy roles (`admin`, `shepherd`, `member`) alongside new roles for backwards compatibility

**Migration:**
- Added `migrateUserRoles` migration function that maps:
  - `admin` → `bdfl`
  - `shepherd` → `team`
  - `member` → `unset`

**Backend Changes:**
- Added helper functions `hasAdminPermissions()` and `hasTeamPermissions()` to recognize both legacy and new roles
- Updated permission checks in `listForManagement`, `hasManagementPermissions`, and `updateRoleWithPermissions`

**UI Changes:**
- Added badge variants for legacy roles with slightly faded colors
- Updated role displays to show "(legacy)" suffix for old roles
- Profile page shows migration notice for users with legacy roles
- Users are grouped by their equivalent new role in the management page
- Updated `User` interface type in `user-provider.tsx` to include legacy roles

## Testing
- [x] Manual code review
- [x] ESLint passes with 0 errors

## Post-deployment Steps
After the deployment succeeds, run:
```
npx convex run migrations:migrateUserRoles
```

Then in a future PR, the legacy roles can be removed from the schema.

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
This is a backwards-compatible fix that allows deployment to succeed while existing users have legacy roles. The migration function will convert all legacy roles to the new format.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1773887303875989?thread_ts=1773887303.875989&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-81f77a03-7d34-5889-9cd1-db4c94c83058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81f77a03-7d34-5889-9cd1-db4c94c83058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for legacy user roles (admin, shepherd, member) across the app.
  * Automatic migration of legacy roles into current role buckets with progress reporting.
  * Profile pages now show migration notes for legacy-role users.
  * Role badges and user lists render legacy roles (marked as legacy) consistently.
  * Management and edit permissions now recognize equivalent legacy roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->