### PR TITLE
Engine: allow newlines in union types

### DIFF
--- a/engine/baml-lib/ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/ast/src/parser/datamodel.pest
@@ -62,7 +62,7 @@ field_attribute = { "@" ~ (path_identifier | identifier) ~ arguments_list? }
 // Pest is greedy, order is very important here.
 field_type          = { (union | non_union) ~ optional_token? }
 optional_token      = { "?" }
-union               = { base_type_with_attr ~ (field_operator ~ base_type_with_attr)+ }
+union               = { base_type_with_attr ~ (NEWLINE? ~ field_operator ~ NEWLINE? ~ base_type_with_attr)+ }
 literal_type        = { numeric_literal | quoted_string_literal }
 base_type_with_attr = { base_type ~ (NEWLINE? ~ field_attribute)* }
 base_type           = { array_notation | map | path_identifier | identifier | group | tuple | parenthesized_type | literal_type }

--- a/engine/baml-lib/ast/src/parser/parse_types.rs
+++ b/engine/baml-lib/ast/src/parser/parse_types.rs
@@ -81,7 +81,7 @@ fn parse_union(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<FieldTyp
                     types.push(f)
                 }
             }
-            Rule::field_operator => {}
+            Rule::field_operator | Rule::NEWLINE => {}
 
             _ => unreachable_rule(&current, "union", diagnostics),
         }

--- a/engine/baml-lib/baml/tests/validation_files/class/type_aliases.baml
+++ b/engine/baml-lib/baml/tests/validation_files/class/type_aliases.baml
@@ -1,5 +1,14 @@
 type Primitive = int | string | bool | float
 
+// Wrapped union type aliases (newlines around pipe operators)
+type WrappedUnion = int
+    | string
+    | bool
+
+type WrappedUnion2 = int |
+    string |
+    bool
+
 type List = string[]
 
 type Graph = map<string, string[]>


### PR DESCRIPTION
Only allowed if newline follows or is preceded by a union `|`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Union types now support line breaks around the pipe operator, enabling cleaner, multi-line formatting of type definitions.

* **Tests**
  * Added validation test cases for union types with newline-separated pipe operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->