### PR TITLE
Fix ignored tests in bex_heap

### DIFF
--- a/baml_language/crates/bex_heap/src/chunked_vec.rs
+++ b/baml_language/crates/bex_heap/src/chunked_vec.rs
@@ -732,60 +732,25 @@ mod tests {
     /// # Why this race cannot happen in practice
     ///
     /// The VM uses `HeapPtr` (raw pointers) instead of `ObjectIndex` (indices).
-    /// HeapPtr is obtained once at allocation time via `get_ptr()` and stored in
-    /// `Value::Object(HeapPtr)`. When the VM reads an object, it calls
-    /// `HeapPtr::get()` which is a direct pointer dereference - it never goes
-    /// through `ChunkedVec::get()`.
-    ///
-    /// See `test_miri_heap_ptr_access_is_race_free` which proves the HeapPtr
-    /// approach is race-free.
-    #[test]
-    #[ignore = "Demonstrates ChunkedVec::get() race that VM avoids by using HeapPtr"]
-    fn test_miri_concurrent_read_during_vec_reallocation() {
-        use std::{sync::Arc, thread};
-
-        let vec: Arc<ChunkedVec<i32, 2>> = Arc::new(ChunkedVec::new());
-
-        unsafe {
-            vec.resize_to(2);
-            vec.set(0, 42);
-            vec.set(1, 43);
-        }
-
-        let vec_reader = Arc::clone(&vec);
-        let vec_writer = Arc::clone(&vec);
-
-        // Reader uses get() which has the race
-        let reader = thread::spawn(move || {
-            for _ in 0..1000 {
-                let val = *vec_reader.get(0);
-                assert_eq!(val, 42);
-            }
-        });
-
-        let writer = thread::spawn(move || {
-            for i in 1..100 {
-                let new_len = 2 + (i * 2);
-                unsafe {
-                    vec_writer.resize_to(new_len);
-                }
-            }
-        });
-
-        reader.join().expect("reader panicked");
-        writer.join().expect("writer panicked");
-    }
-
     /// Test that HeapPtr-style access (raw pointers obtained upfront) is race-free.
     ///
-    /// This is the fixed code path that the VM uses. Instead of calling get()
-    /// which internally reads the Vec's buffer pointer, we obtain a raw pointer
-    /// via get_ptr() and use that directly. The raw pointer remains stable even
-    /// when the Vec reallocates because chunks themselves are heap-allocated
-    /// and never move.
+    /// **The race that could happen:** `ChunkedVec::get(index)` reads the
+    /// internal `Vec<*mut [T; CHUNK_SIZE]>` to find the chunk pointer for a
+    /// given index. If another thread calls `resize_to()` concurrently, the
+    /// `Vec` may reallocate its buffer, causing the reader to follow a dangling
+    /// buffer pointer — a use-after-free that Miri catches.
     ///
-    /// This test demonstrates the fix for the data race exposed in
-    /// test_miri_concurrent_read_during_vec_reallocation.
+    /// **Why it can't happen in practice:** The VM never uses `get()` at
+    /// runtime. Instead, at allocation time it obtains a raw pointer via
+    /// `get_ptr()` and stores it in a `HeapPtr`. All subsequent reads go
+    /// through that raw pointer directly (`HeapPtr::get()` is just a deref).
+    /// Because `ChunkedVec` is backed by individually heap-allocated
+    /// fixed-size chunks, those chunks are never moved or freed by growth —
+    /// only new chunks are appended. So raw pointers into existing chunks
+    /// remain stable regardless of concurrent `resize_to()` calls.
+    ///
+    /// This test exercises that exact pattern: one thread reads through raw
+    /// pointers obtained upfront while another thread grows the vec.
     #[test]
     fn test_miri_heap_ptr_access_is_race_free() {
         use std::{sync::Arc, thread};

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -406,7 +406,7 @@ impl BexHeap {
 mod tests {
     use std::sync::Arc;
 
-    use bex_vm_types::{Object, Value};
+    use bex_vm_types::{Class, Enum, Object, Value};
 
     use super::*;
     use crate::Tlab;
@@ -464,78 +464,92 @@ mod tests {
         assert!(stats.collected_count > 0);
     }
 
-    #[cfg(feature = "heap_debug")]
-    #[test]
-    #[ignore = "Requires heap_debug feature and epoch validation which now uses HeapPtr"]
-    fn test_gc_stale_runtime_index_panics() {
-        // This test was checking that stale ObjectIndex causes panic.
-        // With HeapPtr, the safety model is different - we need to update
-        // how epoch validation works with pointers.
-        //
-        // use std::panic::{AssertUnwindSafe, catch_unwind};
-        // use crate::{HeapDebuggerConfig, HeapVerifyMode};
-        //
-        // let debug = HeapDebuggerConfig {
-        //     enabled: true,
-        //     verify: HeapVerifyMode::Off,
-        // };
-        // let heap = BexHeap::with_tlab_size_and_debug(vec![], 8, debug);
-        // let mut tlab = Tlab::new(Arc::clone(&heap));
-        //
-        // let old_ptr = tlab.alloc_string("alive".to_string());
-        // let (_, remapped) = unsafe { heap.collect_garbage(&[old_ptr]) };
-        // let new_ptr = remapped[0];
-        // assert_ne!(old_ptr.as_ptr(), new_ptr.as_ptr());
-        //
-        // // Using old_ptr after GC should be detectable
-        // // (would need epoch stored in HeapPtr)
-    }
+    // TODO: Epoch-based stale pointer detection tests removed.
+    // HeapPtr::get() does not currently validate epochs — it's a raw dereference.
+    // If epoch validation is added to get() in the future, add tests here for:
+    // - test_gc_stale_heap_ptr_panics: using a pre-GC HeapPtr after GC should panic
+    // - test_handle_resolved_ptr_stale_after_gc_panics: similar for handle-resolved ptrs
 
     #[cfg(feature = "heap_debug")]
     #[test]
-    #[ignore = "Requires heap_debug feature and epoch validation which now uses HeapPtr"]
-    fn test_handle_resolved_index_stale_after_gc_panics() {
-        // See above - this test needs updating for HeapPtr model
-    }
-
-    #[cfg(feature = "heap_debug")]
-    #[test]
-    #[ignore = "Requires heap_debug feature with Instance/Variant using HeapPtr"]
     fn test_full_verify_panics_on_bad_variant() {
-        // This test creates a Variant with an ObjectIndex, which is now HeapPtr
-        // We need to create a valid HeapPtr pointing to an Enum.
-        //
-        // use std::panic::{AssertUnwindSafe, catch_unwind};
-        // use crate::{HeapDebuggerConfig, HeapVerifyMode};
-        //
-        // let compile_time = vec![Object::Enum(Enum {
-        //     name: "E".to_string(),
-        //     variant_names: vec!["A".to_string()],
-        // })];
-        // let debug = HeapDebuggerConfig {
-        //     enabled: true,
-        //     verify: HeapVerifyMode::Full,
-        // };
-        // let heap = BexHeap::with_tlab_size_and_debug(compile_time, 4, debug);
-        // let mut tlab = Tlab::new(Arc::clone(&heap));
-        //
-        // let enm_ptr = heap.compile_time_ptr(0);
-        // let _bad_variant = tlab.alloc(Object::Variant(bex_vm_types::types::Variant {
-        //     enm: enm_ptr,
-        //     index: 3, // Out of bounds variant index
-        // }));
-        //
-        // let result = catch_unwind(AssertUnwindSafe(|| {
-        //     heap.verify_quick();
-        // }));
-        // assert!(result.is_err());
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        use crate::{HeapDebuggerConfig, heap_debugger::HeapVerifyMode};
+
+        let compile_time = vec![Object::Enum(Enum {
+            name: baml_type::TypeName::local(baml_type::Name::new("E")),
+            variants: vec![bex_vm_types::EnumVariant {
+                name: "A".to_string(),
+                description: None,
+                alias: None,
+                skip: false,
+            }],
+            description: None,
+            alias: None,
+            ty_attr: baml_type::TyAttr::default(),
+        })];
+        let debug = HeapDebuggerConfig {
+            enabled: true,
+            verify: HeapVerifyMode::Full,
+        };
+        let heap = BexHeap::with_tlab_size_and_debug(compile_time, 4, debug);
+        let mut tlab = Tlab::new(Arc::clone(&heap));
+
+        let enm_ptr = heap.compile_time_ptr(0);
+        let _bad_variant = tlab.alloc(Object::Variant(bex_vm_types::types::Variant {
+            enm: enm_ptr,
+            index: 3, // Out of bounds variant index
+        }));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            heap.verify_quick();
+        }));
+        assert!(result.is_err());
     }
 
     #[cfg(feature = "heap_debug")]
     #[test]
-    #[ignore = "Requires heap_debug feature with Instance using HeapPtr"]
     fn test_full_verify_panics_on_instance_field_mismatch() {
-        // Similar to above - needs Instance.class to be a valid HeapPtr
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        use crate::{HeapDebuggerConfig, heap_debugger::HeapVerifyMode};
+
+        let compile_time = vec![Object::Class(Class {
+            name: baml_type::TypeName::local(baml_type::Name::new("C")),
+            fields: vec![
+                bex_vm_types::ClassField {
+                    name: "x".to_string(),
+                    field_type: baml_type::Ty::Int {
+                        attr: baml_type::TyAttr::default(),
+                    },
+                    description: None,
+                    alias: None,
+                    skip: false,
+                    field_attr: Default::default(),
+                },
+            ],
+            description: None,
+            alias: None,
+            type_tag: 100,
+            ty_attr: baml_type::TyAttr::default(),
+        })];
+        let debug = HeapDebuggerConfig {
+            enabled: true,
+            verify: HeapVerifyMode::Full,
+        };
+        let heap = BexHeap::with_tlab_size_and_debug(compile_time, 4, debug);
+        let mut tlab = Tlab::new(Arc::clone(&heap));
+
+        let class_ptr = heap.compile_time_ptr(0);
+        // Instance has 3 fields but class expects 1 — should panic on verify
+        let _bad_instance = tlab.alloc(Object::Instance(bex_vm_types::types::Instance {
+            class: class_ptr,
+            fields: vec![Value::Int(1), Value::Int(2), Value::Int(3)],
+        }));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            heap.verify_quick();
+        }));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -473,8 +473,8 @@ mod tests {
     #[cfg(feature = "heap_debug")]
     #[test]
     fn test_full_verify_panics_on_bad_variant() {
-        use std::panic::{AssertUnwindSafe, catch_unwind};
         use crate::{HeapDebuggerConfig, heap_debugger::HeapVerifyMode};
+        use std::panic::{AssertUnwindSafe, catch_unwind};
 
         let compile_time = vec![Object::Enum(Enum {
             name: baml_type::TypeName::local(baml_type::Name::new("E")),
@@ -510,23 +510,21 @@ mod tests {
     #[cfg(feature = "heap_debug")]
     #[test]
     fn test_full_verify_panics_on_instance_field_mismatch() {
-        use std::panic::{AssertUnwindSafe, catch_unwind};
         use crate::{HeapDebuggerConfig, heap_debugger::HeapVerifyMode};
+        use std::panic::{AssertUnwindSafe, catch_unwind};
 
         let compile_time = vec![Object::Class(Class {
             name: baml_type::TypeName::local(baml_type::Name::new("C")),
-            fields: vec![
-                bex_vm_types::ClassField {
-                    name: "x".to_string(),
-                    field_type: baml_type::Ty::Int {
-                        attr: baml_type::TyAttr::default(),
-                    },
-                    description: None,
-                    alias: None,
-                    skip: false,
-                    field_attr: Default::default(),
+            fields: vec![bex_vm_types::ClassField {
+                name: "x".to_string(),
+                field_type: baml_type::Ty::Int {
+                    attr: baml_type::TyAttr::default(),
                 },
-            ],
+                description: None,
+                alias: None,
+                skip: false,
+                field_attr: Default::default(),
+            }],
             description: None,
             alias: None,
             type_tag: 100,

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -607,7 +607,6 @@ mod tests {
                 _ => panic!("Expected String"),
             }
         }
-
     }
 
     /// Tests set_object for field mutation patterns.

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -570,21 +570,19 @@ mod tests {
     /// The test needs `collect_garbage_with_forwarding` to return a
     /// `HashMap<HeapPtr, HeapPtr>` forwarding table.
     #[test]
-    #[ignore = "Requires GC update to use HeapPtr"]
     fn test_miri_tlab_invalidation_and_refill() {
         let heap = BexHeap::with_tlab_size(vec![], 10);
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
         // Allocate some objects before GC
-        let _obj1 = tlab.alloc_string("before_gc_1".to_string());
-        let _obj2 = tlab.alloc_string("before_gc_2".to_string());
+        let obj1 = tlab.alloc_string("before_gc_1".to_string());
+        let obj2 = tlab.alloc_string("before_gc_2".to_string());
 
         assert!(tlab.is_valid());
 
-        // TODO: Update once GC returns HeapPtr forwarding map
-        // let (stats, _remapped, forwarding) =
-        //     unsafe { heap.collect_garbage_with_forwarding(&[obj1, obj2]) };
-        // assert_eq!(stats.live_count, 2);
+        let (stats, _remapped, _forwarding) =
+            unsafe { heap.collect_garbage_with_forwarding(&[obj1, obj2]) };
+        assert_eq!(stats.live_count, 2);
 
         // Invalidate TLAB (what bex_engine does after GC)
         tlab.invalidate();
@@ -610,7 +608,6 @@ mod tests {
             }
         }
 
-        // Note: Verifying forwarded objects (obj1, obj2) requires GC update
     }
 
     /// Tests set_object for field mutation patterns.

--- a/baml_language/crates/bex_sap/src/deserializer/coercer/match_string.rs
+++ b/baml_language/crates/bex_sap/src/deserializer/coercer/match_string.rs
@@ -7,16 +7,13 @@ use std::{borrow::Cow, cmp::Ordering, collections::HashMap};
 use super::ParsingContext;
 // use baml_types::TypeValue;
 use crate::{
-    deserializer::types::DeserializerMeta,
-    sap_model::{TyResolvedRef, TyWithMeta, TypeAnnotations, TypeIdent},
-};
-use crate::{
     deserializer::{
         coercer::ParsingError,
         deserialize_flags::{DeserializerConditions, Flag},
-        types::ValueWithFlags,
+        types::{DeserializerMeta, ValueWithFlags},
     },
     jsonish,
+    sap_model::{TyResolvedRef, TyWithMeta, TypeAnnotations, TypeIdent},
 };
 
 /// Checks if `raw_value` matches `parse_into` using the same heuristic


### PR DESCRIPTION
## Summary
- Deleted permanently-ignored `test_miri_concurrent_read_during_vec_reallocation` (race demo superseded by doc on the passing companion test)
- Un-ignored `test_miri_tlab_invalidation_and_refill` — GC already supports HeapPtr forwarding, just needed uncommenting
- Deleted empty epoch-validation stubs (`test_gc_stale_runtime_index_panics`, `test_handle_resolved_index_stale_after_gc_panics`) — `HeapPtr::get()` doesn't check epochs, left TODO for when/if it does
- Un-ignored and updated `test_full_verify_panics_on_bad_variant` for current `Enum` type (now uses `Vec<EnumVariant>`, `TypeName`, etc.)
- Wrote `test_full_verify_panics_on_instance_field_mismatch` body using current `Class`/`Instance` types

## Test plan
- [x] `cargo test -p bex_heap` — 49 passed, 0 ignored
- [x] `cargo test -p bex_heap --features heap_debug` — 52 passed, 0 ignored