### PR TITLE
Convert RustData to BexExternalValue via ToBexExternalValue trait

### DIFF
--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -195,9 +195,13 @@ impl BexEngine {
             }),
             Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
             Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(ty.clone()))),
-            Object::RustData(_) => Err(EngineError::CannotConvert {
-                type_name: "rust_data".to_string(),
-            }),
+            Object::RustData(arc) => {
+                bex_external_types::try_convert_rust_data(arc).ok_or_else(|| {
+                    EngineError::CannotConvert {
+                        type_name: "rust_data".to_string(),
+                    }
+                })
+            }
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Err(EngineError::CannotSnapshot {
                 type_name: "sentinel".to_string(),

--- a/baml_language/crates/bex_external_types/src/bex_external_value.rs
+++ b/baml_language/crates/bex_external_types/src/bex_external_value.rs
@@ -536,3 +536,42 @@ impl AsBexExternalValue for Vec<String> {
         .into_bex_external_value()
     }
 }
+
+/// Trait for opaque Rust data stored in `Object::RustData` that knows how to
+/// convert itself to a [`BexExternalValue`].
+///
+/// Implement this for any type that is stored as `RustData` on the VM heap and
+/// needs to survive the VM-to-external conversion boundary (e.g. `PromptAst`,
+/// `MediaValue`).
+pub trait ToBexExternalValue: std::any::Any + Send + Sync {
+    fn to_bex_external_value(self: std::sync::Arc<Self>) -> BexExternalValue;
+}
+
+impl ToBexExternalValue for baml_builtins::PromptAst {
+    fn to_bex_external_value(self: std::sync::Arc<Self>) -> BexExternalValue {
+        BexExternalValue::Adt(BexExternalAdt::PromptAst(self))
+    }
+}
+
+impl ToBexExternalValue for baml_builtins::MediaValue {
+    fn to_bex_external_value(self: std::sync::Arc<Self>) -> BexExternalValue {
+        BexExternalValue::Adt(BexExternalAdt::Media(self))
+    }
+}
+
+/// Try to convert an `Arc<dyn Any + Send + Sync>` from `Object::RustData` to a
+/// [`BexExternalValue`] by attempting downcast to known [`ToBexExternalValue`]
+/// implementors.
+///
+/// Returns `None` if the concrete type is not recognised.
+pub fn try_convert_rust_data(
+    arc: &std::sync::Arc<dyn std::any::Any + Send + Sync>,
+) -> Option<BexExternalValue> {
+    if let Ok(typed) = arc.clone().downcast::<baml_builtins::PromptAst>() {
+        return Some(typed.to_bex_external_value());
+    }
+    if let Ok(typed) = arc.clone().downcast::<baml_builtins::MediaValue>() {
+        return Some(typed.to_bex_external_value());
+    }
+    None
+}

--- a/baml_language/crates/bex_external_types/src/lib.rs
+++ b/baml_language/crates/bex_external_types/src/lib.rs
@@ -27,7 +27,8 @@ mod handle;
 
 pub use baml_type::MediaKind;
 pub use bex_external_value::{
-    AsBexExternalValue, BexExternalAdt, BexExternalValue, Ty, TyAttr, TypeName, UnionMetadata,
+    AsBexExternalValue, BexExternalAdt, BexExternalValue, ToBexExternalValue, Ty, TyAttr, TypeName,
+    UnionMetadata, try_convert_rust_data,
 };
 pub use epoch_guard::EpochGuard;
 pub use handle::{Handle, HandleInner, WeakHeapRef};

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -473,8 +473,9 @@ mod tests {
     #[cfg(feature = "heap_debug")]
     #[test]
     fn test_full_verify_panics_on_bad_variant() {
-        use crate::{HeapDebuggerConfig, heap_debugger::HeapVerifyMode};
         use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        use crate::{HeapDebuggerConfig, heap_debugger::HeapVerifyMode};
 
         let compile_time = vec![Object::Enum(Enum {
             name: baml_type::TypeName::local(baml_type::Name::new("E")),
@@ -510,8 +511,9 @@ mod tests {
     #[cfg(feature = "heap_debug")]
     #[test]
     fn test_full_verify_panics_on_instance_field_mismatch() {
-        use crate::{HeapDebuggerConfig, heap_debugger::HeapVerifyMode};
         use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        use crate::{HeapDebuggerConfig, heap_debugger::HeapVerifyMode};
 
         let compile_time = vec![Object::Class(Class {
             name: baml_type::TypeName::local(baml_type::Name::new("C")),

--- a/baml_language/crates/bex_project/src/lib.rs
+++ b/baml_language/crates/bex_project/src/lib.rs
@@ -13,7 +13,9 @@ pub use baml_builtins::{MediaContent, MediaValue, PromptAst, PromptAstSimple};
 pub use bex::Bex;
 pub use bex_engine::{EngineError, FunctionCallContextBuilder};
 pub use bex_events::EventSink;
-pub use bex_external_types::{BexExternalAdt, BexExternalValue, Handle, MediaKind, Ty, TyAttr};
+pub use bex_external_types::{
+    BexExternalAdt, BexExternalValue, Handle, MediaKind, Ty, TyAttr, try_convert_rust_data,
+};
 pub use sys_types::{CallId, CancellationToken, SysOps};
 use thiserror::Error;
 

--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -259,6 +259,60 @@ fn bex_prompt_ast_simple_to_proto_prompt_ast_simple(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bex_project::{BexExternalValue, MediaContent, MediaValue, PromptAst, PromptAstSimple};
+
+    use super::*;
+    use crate::baml::cffi::baml_outbound_value::Value as BamlValueVariant;
+
+    #[test]
+    fn rust_data_prompt_ast_converts_to_handle() {
+        let prompt = Arc::new(PromptAst::Simple(Arc::new(PromptAstSimple::String(
+            "hello".to_string(),
+        ))));
+        let value = BexExternalValue::RustData(prompt);
+        let options = HandleTableOptions::for_in_process();
+        let result = external_to_baml_value(&value, &options);
+        assert!(result.is_ok());
+        assert!(matches!(
+            result.unwrap().value,
+            Some(BamlValueVariant::HandleValue(_))
+        ));
+    }
+
+    #[test]
+    fn rust_data_media_value_converts_to_handle() {
+        let media = Arc::new(MediaValue::new(
+            bex_project::MediaKind::Image,
+            MediaContent::Url {
+                url: "https://example.com/img.png".to_string(),
+                base64_data: None,
+            },
+            Some("image/png".to_string()),
+        ));
+        let value = BexExternalValue::RustData(media);
+        let options = HandleTableOptions::for_in_process();
+        let result = external_to_baml_value(&value, &options);
+        assert!(result.is_ok());
+        assert!(matches!(
+            result.unwrap().value,
+            Some(BamlValueVariant::HandleValue(_))
+        ));
+    }
+
+    #[test]
+    fn rust_data_unknown_type_returns_error() {
+        let unknown: Arc<dyn std::any::Any + Send + Sync> = Arc::new(42u32);
+        let value = BexExternalValue::RustData(unknown);
+        let options = HandleTableOptions::for_in_process();
+        let result = external_to_baml_value(&value, &options);
+        assert!(result.is_err());
+    }
+}
+
 fn ty_to_field_type(ty: &Ty) -> BamlFieldType {
     let field_type = match ty {
         Ty::Null { .. } => Some(FieldType::NullType(BamlFieldTypeNull {})),

--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -116,7 +116,10 @@ pub fn external_to_baml_value(
         //         bex_prompt_ast_to_proto_prompt_ast(prompt_ast),
         //     ))
         // }
-        BexExternalValue::RustData(_) => {
+        BexExternalValue::RustData(arc) => {
+            if let Some(converted) = bex_project::try_convert_rust_data(arc) {
+                return external_to_baml_value(&converted, options);
+            }
             return Err(CtypesError::InternalError(
                 "RustData cannot be serialized over FFI".to_string(),
             ));


### PR DESCRIPTION
## Summary
- Add `ToBexExternalValue` trait in `bex_external_types` for opaque Rust data that can convert itself to `BexExternalValue`
- Implement the trait for `PromptAst` and `MediaValue`
- Add `try_convert_rust_data()` helper that attempts downcast to known implementors
- Use the helper in `bex_engine` conversion instead of unconditionally returning `CannotConvert` for `Object::RustData`

## Test plan
- [x] `cargo check` passes for `bex_external_types` and `bex_engine`
- [ ] Existing tests pass (pre-existing clippy issues in `baml_compiler2_ast` block full workspace clippy)