### PR TITLE
Add table of contents to BEP pages

### DIFF
--- a/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
@@ -921,45 +921,47 @@ const [copied, setCopied] = useState(false);
                         />
                       </div>
                     ) : (
-                      <div className="relative">
-                        <BepContent
-                          content={currentContent}
-                          linkContext={{
-                            bepNumber,
-                            isHistorical: isViewingHistorical,
-                            versionNumber:
-                              isViewingHistorical && routeInfo.versionNumber !== latestVersionNumber
-                                ? routeInfo.versionNumber
-                                : null,
-                          }}
-                        />
-                        {effectiveVersionId && (
-                          <CommentSidebar
-                            contentSelector="[data-bep-content]"
-                            bepId={bep._id}
-                            versionId={effectiveVersionId}
-                            pageId={currentPageId}
-                            readOnly={isViewingHistorical}
-                            comments={(pageComments ?? [])
-                              .filter((c) => c.anchor)
-                              .map((c) => ({
-                                _id: c._id,
-                                parentId: c.parentId,
-                                anchor: c.anchor as {
-                                  nodeId: string;
-                                  nodeType: string;
-                                  nodeText: string;
-                                },
-                                authorName: c.authorName,
-                                content: c.content,
-                                type: c.type,
-                                createdAt: c.createdAt,
-                                resolved: c.resolved,
-                              }))}
-                          />
-                        )}
+                      <>
                         <BepTableOfContents content={currentContent} />
-                      </div>
+                        <div className="relative">
+                          <BepContent
+                            content={currentContent}
+                            linkContext={{
+                              bepNumber,
+                              isHistorical: isViewingHistorical,
+                              versionNumber:
+                                isViewingHistorical && routeInfo.versionNumber !== latestVersionNumber
+                                  ? routeInfo.versionNumber
+                                  : null,
+                            }}
+                          />
+                          {effectiveVersionId && (
+                            <CommentSidebar
+                              contentSelector="[data-bep-content]"
+                              bepId={bep._id}
+                              versionId={effectiveVersionId}
+                              pageId={currentPageId}
+                              readOnly={isViewingHistorical}
+                              comments={(pageComments ?? [])
+                                .filter((c) => c.anchor)
+                                .map((c) => ({
+                                  _id: c._id,
+                                  parentId: c.parentId,
+                                  anchor: c.anchor as {
+                                    nodeId: string;
+                                    nodeType: string;
+                                    nodeText: string;
+                                  },
+                                  authorName: c.authorName,
+                                  content: c.content,
+                                  type: c.type,
+                                  createdAt: c.createdAt,
+                                  resolved: c.resolved,
+                                }))}
+                            />
+                          )}
+                        </div>
+                      </>
                     )}
                   </>
                 )}

--- a/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
@@ -15,6 +15,7 @@ import { Id } from "../../../convex/_generated/dataModel";
 import { useUser } from "@/components/providers/user-provider";
 import { BepContent } from "@/components/bep/bep-content";
 import { BepNav } from "@/components/bep/bep-nav";
+import { BepTableOfContents } from "@/components/bep/bep-table-of-contents";
 import { BepStatusSelect } from "@/components/bep/bep-status-select";
 import { BepVersionSelect } from "@/components/bep/bep-version-select";
 import { BepExportDialog } from "@/components/bep/bep-export-dialog";
@@ -957,6 +958,7 @@ const [copied, setCopied] = useState(false);
                               }))}
                           />
                         )}
+                        <BepTableOfContents content={currentContent} />
                       </div>
                     )}
                   </>

--- a/typescript/apps/beps/src/components/bep/bep-table-of-contents.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-table-of-contents.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { List } from "lucide-react";
+
+interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface BepTableOfContentsProps {
+  content: string;
+  className?: string;
+}
+
+function slugifyHeading(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function extractHeadings(content: string): TocItem[] {
+  if (!content) return [];
+
+  const contentWithoutFrontmatter = content.replace(/^---[\s\S]*?---\n*/, "");
+  const headingRegex = /^(#{1,4})\s+(.+)$/gm;
+  const headings: TocItem[] = [];
+  const slugCounts = new Map<string, number>();
+
+  let match;
+  while ((match = headingRegex.exec(contentWithoutFrontmatter)) !== null) {
+    const level = match[1].length;
+    const text = match[2].trim();
+    const baseSlug = slugifyHeading(text);
+
+    if (!baseSlug) continue;
+
+    const count = (slugCounts.get(baseSlug) ?? 0) + 1;
+    slugCounts.set(baseSlug, count);
+    const id = count === 1 ? baseSlug : `${baseSlug}-${count}`;
+
+    headings.push({ id, text, level });
+  }
+
+  return headings;
+}
+
+export function BepTableOfContents({ content, className }: BepTableOfContentsProps) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const headingElementsRef = useRef<Map<string, IntersectionObserverEntry>>(new Map());
+
+  const headings = useMemo(() => extractHeadings(content), [content]);
+
+  const getActiveHeading = useCallback(() => {
+    const entries = Array.from(headingElementsRef.current.values());
+    const visibleEntries = entries.filter((entry) => entry.isIntersecting);
+
+    if (visibleEntries.length > 0) {
+      const sorted = visibleEntries.sort(
+        (a, b) => a.boundingClientRect.top - b.boundingClientRect.top
+      );
+      return sorted[0].target.id;
+    }
+
+    const aboveViewport = entries
+      .filter((entry) => entry.boundingClientRect.top < 100)
+      .sort((a, b) => b.boundingClientRect.top - a.boundingClientRect.top);
+
+    if (aboveViewport.length > 0) {
+      return aboveViewport[0].target.id;
+    }
+
+    return null;
+  }, []);
+
+  useEffect(() => {
+    if (headings.length === 0) return;
+
+    const headingElements = headingElementsRef.current;
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          headingElements.set(entry.target.id, entry);
+        });
+
+        const activeHeading = getActiveHeading();
+        if (activeHeading) {
+          setActiveId(activeHeading);
+        }
+      },
+      {
+        rootMargin: "-80px 0px -70% 0px",
+        threshold: [0, 1],
+      }
+    );
+
+    const observer = observerRef.current;
+
+    headings.forEach(({ id }) => {
+      const element = document.getElementById(id);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      observer.disconnect();
+      headingElements.clear();
+    };
+  }, [headings, getActiveHeading]);
+
+  const handleClick = useCallback((id: string) => {
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
+      setActiveId(id);
+    }
+  }, []);
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  const minLevel = Math.min(...headings.map((h) => h.level));
+
+  return (
+    <nav
+      className={cn(
+        "hidden xl:block fixed right-8 top-32 w-56 max-h-[calc(100vh-10rem)] overflow-y-auto",
+        className
+      )}
+      aria-label="Table of contents"
+    >
+      <div className="border-l border-border pl-4">
+        <button
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground mb-3 w-full"
+        >
+          <List className="h-4 w-4" />
+          <span>On this page</span>
+        </button>
+
+        {!isCollapsed && (
+          <ul className="space-y-1 text-sm">
+            {headings.map(({ id, text, level }) => {
+              const indent = (level - minLevel) * 12;
+              const isActive = activeId === id;
+
+              return (
+                <li key={id} style={{ paddingLeft: indent }}>
+                  <button
+                    onClick={() => handleClick(id)}
+                    className={cn(
+                      "text-left w-full py-1 px-2 rounded-sm transition-colors text-[13px] leading-snug",
+                      "hover:text-foreground hover:bg-accent/50",
+                      isActive
+                        ? "text-primary font-medium bg-accent/30"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    {text}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/typescript/apps/beps/src/components/bep/bep-table-of-contents.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-table-of-contents.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { List } from "lucide-react";
+import { ChevronDown, ChevronUp, List } from "lucide-react";
 
 interface TocItem {
   id: string;
@@ -51,9 +51,48 @@ function extractHeadings(content: string): TocItem[] {
   return headings;
 }
 
+function TocList({
+  headings,
+  activeId,
+  minLevel,
+  onItemClick,
+}: {
+  headings: TocItem[];
+  activeId: string | null;
+  minLevel: number;
+  onItemClick: (id: string) => void;
+}) {
+  return (
+    <ul className="space-y-1 text-sm">
+      {headings.map(({ id, text, level }) => {
+        const indent = (level - minLevel) * 12;
+        const isActive = activeId === id;
+
+        return (
+          <li key={id} style={{ paddingLeft: indent }}>
+            <button
+              onClick={() => onItemClick(id)}
+              className={cn(
+                "text-left w-full py-1 px-2 rounded-sm transition-colors text-[13px] leading-snug",
+                "hover:text-foreground hover:bg-accent/50",
+                isActive
+                  ? "text-primary font-medium bg-accent/30"
+                  : "text-muted-foreground"
+              )}
+            >
+              {text}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
 export function BepTableOfContents({ content, className }: BepTableOfContentsProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isDesktopCollapsed, setIsDesktopCollapsed] = useState(false);
+  const [isMobileExpanded, setIsMobileExpanded] = useState(false);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const headingElementsRef = useRef<Map<string, IntersectionObserverEntry>>(new Map());
 
@@ -123,6 +162,7 @@ export function BepTableOfContents({ content, className }: BepTableOfContentsPro
     if (element) {
       element.scrollIntoView({ behavior: "smooth", block: "start" });
       setActiveId(id);
+      setIsMobileExpanded(false);
     }
   }, []);
 
@@ -133,48 +173,64 @@ export function BepTableOfContents({ content, className }: BepTableOfContentsPro
   const minLevel = Math.min(...headings.map((h) => h.level));
 
   return (
-    <nav
-      className={cn(
-        "hidden xl:block fixed right-8 top-32 w-56 max-h-[calc(100vh-10rem)] overflow-y-auto",
-        className
-      )}
-      aria-label="Table of contents"
-    >
-      <div className="border-l border-border pl-4">
-        <button
-          onClick={() => setIsCollapsed(!isCollapsed)}
-          className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground mb-3 w-full"
-        >
-          <List className="h-4 w-4" />
-          <span>On this page</span>
-        </button>
+    <>
+      {/* Mobile TOC - collapsible at top */}
+      <div className={cn("xl:hidden mb-6", className)}>
+        <div className="border rounded-lg bg-card">
+          <button
+            onClick={() => setIsMobileExpanded(!isMobileExpanded)}
+            className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            <span className="flex items-center gap-2">
+              <List className="h-4 w-4" />
+              On this page
+            </span>
+            {isMobileExpanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </button>
 
-        {!isCollapsed && (
-          <ul className="space-y-1 text-sm">
-            {headings.map(({ id, text, level }) => {
-              const indent = (level - minLevel) * 12;
-              const isActive = activeId === id;
-
-              return (
-                <li key={id} style={{ paddingLeft: indent }}>
-                  <button
-                    onClick={() => handleClick(id)}
-                    className={cn(
-                      "text-left w-full py-1 px-2 rounded-sm transition-colors text-[13px] leading-snug",
-                      "hover:text-foreground hover:bg-accent/50",
-                      isActive
-                        ? "text-primary font-medium bg-accent/30"
-                        : "text-muted-foreground"
-                    )}
-                  >
-                    {text}
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        )}
+          {isMobileExpanded && (
+            <div className="px-4 pb-4 border-t">
+              <div className="pt-3">
+                <TocList
+                  headings={headings}
+                  activeId={activeId}
+                  minLevel={minLevel}
+                  onItemClick={handleClick}
+                />
+              </div>
+            </div>
+          )}
+        </div>
       </div>
-    </nav>
+
+      {/* Desktop TOC - fixed sidebar on right */}
+      <nav
+        className="hidden xl:block fixed right-8 top-32 w-56 max-h-[calc(100vh-10rem)] overflow-y-auto"
+        aria-label="Table of contents"
+      >
+        <div className="border-l border-border pl-4">
+          <button
+            onClick={() => setIsDesktopCollapsed(!isDesktopCollapsed)}
+            className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground mb-3 w-full"
+          >
+            <List className="h-4 w-4" />
+            <span>On this page</span>
+          </button>
+
+          {!isDesktopCollapsed && (
+            <TocList
+              headings={headings}
+              activeId={activeId}
+              minLevel={minLevel}
+              onItemClick={handleClick}
+            />
+          )}
+        </div>
+      </nav>
+    </>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR addresses user request to add a table of contents to BEP pages

## Changes
Please describe the changes proposed in this pull request

This PR adds a table of contents (TOC) to the BEP pages, making it easier to navigate and see the full structure of a BEP document.

### New Component: `BepTableOfContents`
- Extracts headings (h1-h4) from markdown content
- **Mobile (< xl screens)**: Collapsible card at the top of the content area
  - Tap to expand/collapse
  - Auto-collapses after clicking a heading
- **Desktop (xl screens and up)**: Fixed sidebar on the right side
  - Always visible while scrolling
  - Collapsible "On this page" header
- Uses IntersectionObserver to highlight the currently active section while scrolling
- Supports clicking headings to smooth scroll to that section
- Shows nested indentation based on heading level

### Changes to `BepRouteShell`
- Imported and integrated the new `BepTableOfContents` component
- TOC appears above content on mobile, fixed on right for desktop
- TOC only shows when viewing content (not in edit mode)

## Testing
Please describe how you tested these changes

- [x] TypeScript type checking passes (`pnpm tsc --noEmit`)
- [x] ESLint passes for both new and modified files
- [ ] Manual testing performed (requires Convex environment)

## Screenshots
If applicable, add screenshots to help explain your changes

**Mobile view**: Collapsible card at top with "On this page" header and chevron icon
**Desktop view**: Fixed sidebar on right showing nested heading list

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (N/A - internal UI feature)

## Additional Notes
Add any other context about the PR here

- The mobile TOC uses a bordered card design for visual clarity
- The component reuses the same heading slugification logic as `BepContent` to ensure IDs match
- Extracted `TocList` as a shared component to avoid code duplication between mobile and desktop views
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1774380573153339?thread_ts=1774380573.153339&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-10bd6792-81b9-52bc-87ec-45238f05c52d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10bd6792-81b9-52bc-87ec-45238f05c52d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a table of contents to content pages that displays all headings and sections
* Features both a mobile collapsible toggle and a fixed desktop sidebar view
* Active section highlighting updates as you scroll through the page
* Click any item to smoothly navigate to that section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->