### PR TITLE
Enable Media and PromptAst serialization in FFI encoding

### DIFF
--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -105,17 +105,17 @@ pub fn external_to_baml_value(
             )))
         }
 
-        // BexExternalValue::Adt(BexExternalAdt::Media(media)) if options.serialize_media => Some(
-        //     BamlValueVariant::MediaValue(bex_media_to_proto_media(media)),
-        // ),
+        BexExternalValue::Adt(BexExternalAdt::Media(media)) if options.serialize_media => Some(
+            BamlValueVariant::MediaValue(bex_media_to_proto_media(media)),
+        ),
 
-        // BexExternalValue::Adt(BexExternalAdt::PromptAst(prompt_ast))
-        //     if options.serialize_prompt_ast =>
-        // {
-        //     Some(BamlValueVariant::PromptAstValue(
-        //         bex_prompt_ast_to_proto_prompt_ast(prompt_ast),
-        //     ))
-        // }
+        BexExternalValue::Adt(BexExternalAdt::PromptAst(prompt_ast))
+            if options.serialize_prompt_ast =>
+        {
+            Some(BamlValueVariant::PromptAstValue(
+                bex_prompt_ast_to_proto_prompt_ast(prompt_ast),
+            ))
+        }
         BexExternalValue::RustData(arc) => {
             if let Some(converted) = bex_project::try_convert_rust_data(arc) {
                 return external_to_baml_value(&converted, options);


### PR DESCRIPTION
## Summary
- Uncomment the `Adt::Media` and `Adt::PromptAst` match arms in `value_encode.rs` so they serialize directly to proto messages when `serialize_media` / `serialize_prompt_ast` options are set
- Without these arms, Media and PromptAst values always fall through to the handle table instead of being serialized inline

## Test plan
- [ ] Existing tests pass