### PR TITLE
Remove some baml_tests test ignores

### DIFF
--- a/baml_language/crates/baml_tests/tests/match_basics.rs
+++ b/baml_language/crates/baml_tests/tests/match_basics.rs
@@ -1544,7 +1544,6 @@ async fn match_float_literal() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "compiler2: negative literal patterns produce unreachable arm errors"]
 async fn match_negative_int_first_arm() {
     let output = baml_test!(
         r#"
@@ -1615,7 +1614,6 @@ async fn match_negative_int_first_arm() {
 }
 
 #[tokio::test]
-#[ignore = "compiler2: negative literal patterns produce unreachable arm errors"]
 async fn match_negative_int_fallback() {
     let output = baml_test!(
         r#"
@@ -1741,7 +1739,6 @@ async fn match_negative_int_with_variable() {
 }
 
 #[tokio::test]
-#[ignore = "compiler2: negative literal patterns produce unreachable arm errors"]
 async fn match_negative_float_pattern() {
     let output = baml_test!(
         r#"
@@ -1810,7 +1807,6 @@ async fn match_negative_float_pattern() {
 }
 
 #[tokio::test]
-#[ignore = "compiler2: negative literal patterns produce unreachable arm errors"]
 async fn match_multiple_negative_patterns() {
     let output = baml_test!(
         r#"
@@ -1880,7 +1876,6 @@ async fn match_multiple_negative_patterns() {
 }
 
 #[tokio::test]
-#[ignore = "compiler2: negative literal patterns produce unreachable arm errors"]
 async fn match_negative_in_union_pattern() {
     let output = baml_test!(
         r#"

--- a/baml_language/crates/baml_tests/tests/match_types.rs
+++ b/baml_language/crates/baml_tests/tests/match_types.rs
@@ -10,7 +10,6 @@ use bex_engine::BexExternalValue;
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "compiler2: typed pattern match produces unreachable arm error"]
 async fn match_typed_pattern_first_arm() {
     let output = baml_test!(
         r#"
@@ -46,6 +45,10 @@ async fn match_typed_pattern_first_arm() {
         jump L1
 
       L0:
+        load_var result
+        load_const Failure
+        cmp_op instanceof
+        pop_jump_if_false L2
         load_const "failure"
         jump L2
 
@@ -132,7 +135,6 @@ async fn match_typed_pattern_second_arm() {
 }
 
 #[tokio::test]
-#[ignore = "compiler2: typed pattern match produces unreachable arm error"]
 async fn match_typed_pattern_with_field_access() {
     let output = baml_test!(
         r#"

--- a/baml_language/crates/baml_tests/tests/typed_outputs.rs
+++ b/baml_language/crates/baml_tests/tests/typed_outputs.rs
@@ -103,7 +103,6 @@ async fn class_with_union_field() {
 }
 
 #[tokio::test]
-#[ignore = "compiler2: class TypeName has module_path=['user'] but test expects module_path=[]"]
 async fn union_of_classes_returns_success() {
     let output = baml_test!(
         r#"
@@ -127,14 +126,13 @@ async fn union_of_classes_returns_success() {
                 class_name: "Success".to_string(),
                 fields: indexmap! { "value".to_string() => BexExternalValue::Int(42) },
             },
-            [Ty::class("Success"), Ty::class("Failure")],
-            Ty::class("Success"),
+            [Ty::user_class("Success"), Ty::user_class("Failure")],
+            Ty::user_class("Success"),
         ))
     );
 }
 
 #[tokio::test]
-#[ignore = "compiler2: class TypeName has module_path=['user'] but test expects module_path=[]"]
 async fn union_of_classes_returns_failure() {
     let output = baml_test!(
         r#"
@@ -158,8 +156,8 @@ async fn union_of_classes_returns_failure() {
                 class_name: "Failure".to_string(),
                 fields: indexmap! { "error".to_string() => BexExternalValue::String("something went wrong".to_string()) },
             },
-            [Ty::class("Success"), Ty::class("Failure")],
-            Ty::class("Failure"),
+            [Ty::user_class("Success"), Ty::user_class("Failure")],
+            Ty::user_class("Failure"),
         ))
     );
 }
@@ -225,7 +223,6 @@ async fn array_of_unions() {
 }
 
 #[tokio::test]
-#[ignore = "compiler2: class TypeName has module_path=['user'] but test expects module_path=[]"]
 async fn optional_class() {
     let output = baml_test!(
         r#"
@@ -245,13 +242,12 @@ async fn optional_class() {
                 class_name: "Data".to_string(),
                 fields: indexmap! { "value".to_string() => BexExternalValue::Int(42) },
             },
-            Ty::class("Data"),
+            Ty::user_class("Data"),
         ))
     );
 }
 
 #[tokio::test]
-#[ignore = "compiler2: class TypeName has module_path=['user'] but test expects module_path=[]"]
 async fn optional_class_returns_null() {
     let output = baml_test!(
         r#"
@@ -268,7 +264,7 @@ async fn optional_class_returns_null() {
         output.result,
         Ok(BexExternalValue::optional(
             BexExternalValue::Null,
-            Ty::class("Data")
+            Ty::user_class("Data")
         ))
     );
 }

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -312,6 +312,18 @@ impl Ty {
         Ty::Class(TypeName::local(name.into()), TyAttr::default())
     }
 
+    /// `Class(name)` under the `"user"` package (matches compiler2 output for user-defined classes).
+    pub fn user_class(name: &str) -> Self {
+        Ty::Class(
+            TypeName {
+                display_name: Name::new(name),
+                name: Name::new(name),
+                module_path: vec![Name::new("user")],
+            },
+            TyAttr::default(),
+        )
+    }
+
     /// `unknown` with default attributes.
     pub fn unknown() -> Self {
         Ty::BuiltinUnknown {


### PR DESCRIPTION
- `match_basics.rs`
- `match_types.rs`
- `typed_outputs.rs`

There are a few cases left that error due to the typechecker not allowing union of int literals with int