### PR TITLE
baml-language: fix baml_type::Ty for new SAP attrs

### DIFF
--- a/baml_language/crates/baml_base/src/attr.rs
+++ b/baml_language/crates/baml_base/src/attr.rs
@@ -1,112 +1,32 @@
-//! Type and field attributes.
+//! Type attributes.
 //!
 //! Currently only contains SAP metadata (i.e. controls for the schema-aligned parser).
 //!
 //! These live in `baml_base` b/c they're shared by `baml_compiler_tir::Ty`
 //! (TIR) and `baml_type::Ty` (VIR+).
 
-/// A SAP attribute value. Shared across all `@sap.*` attributes.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum SapAttrValue<N> {
-    Never,
-
-    /// A constant value expression (literal, null, empty container, etc.)
-    ConstValueExpr(SapConstValue<N>),
-}
-impl<N> SapAttrValue<N> {
-    pub fn try_map_name<M, F: FnOnce(&N) -> Option<M>>(self, f: F) -> Option<SapAttrValue<M>> {
-        match self {
-            SapAttrValue::Never => Some(SapAttrValue::Never),
-            SapAttrValue::ConstValueExpr(v) => v.try_map_name(f).map(SapAttrValue::ConstValueExpr),
-        }
-    }
-    pub fn expect_map_name<M, F: FnOnce(&N) -> Option<M>>(
-        self,
-        f: F,
-    ) -> Result<SapAttrValue<M>, N> {
-        match self {
-            SapAttrValue::Never => Ok(SapAttrValue::Never),
-            SapAttrValue::ConstValueExpr(v) => {
-                v.expect_map_name(f).map(SapAttrValue::ConstValueExpr)
-            }
-        }
-    }
-}
-
-/// A constant value for SAP annotations.
+/// Binary present/absent flag for SAP attributes.
 ///
-/// Represents SAP attr args, e.g. `@sap.class_completed_field_missing("Loading...")`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum SapConstValue<N> {
-    Null,
-    String(String),
-    Int(i64),
-    Float(String), // String to avoid f64 Eq/Hash issues
-    Bool(bool),
-    EmptyList,
-    EmptyMap,
-    EnumValue { enum_name: N, variant_name: String },
-}
-impl<N> SapConstValue<N> {
-    pub fn try_map_name<M, F: FnOnce(&N) -> Option<M>>(self, f: F) -> Option<SapConstValue<M>> {
-        match self {
-            SapConstValue::Null => Some(SapConstValue::Null),
-            SapConstValue::String(s) => Some(SapConstValue::String(s)),
-            SapConstValue::Int(i) => Some(SapConstValue::Int(i)),
-            SapConstValue::Float(s) => Some(SapConstValue::Float(s)),
-            SapConstValue::Bool(b) => Some(SapConstValue::Bool(b)),
-            SapConstValue::EmptyList => Some(SapConstValue::EmptyList),
-            SapConstValue::EmptyMap => Some(SapConstValue::EmptyMap),
-            SapConstValue::EnumValue {
-                enum_name,
-                variant_name,
-            } => f(&enum_name).map(|enum_name| SapConstValue::EnumValue {
-                enum_name,
-                variant_name,
-            }),
-        }
-    }
-    pub fn expect_map_name<M, F: FnOnce(&N) -> Option<M>>(
-        self,
-        f: F,
-    ) -> Result<SapConstValue<M>, N> {
-        match self {
-            SapConstValue::Null => Ok(SapConstValue::Null),
-            SapConstValue::String(s) => Ok(SapConstValue::String(s)),
-            SapConstValue::Int(i) => Ok(SapConstValue::Int(i)),
-            SapConstValue::Float(s) => Ok(SapConstValue::Float(s)),
-            SapConstValue::Bool(b) => Ok(SapConstValue::Bool(b)),
-            SapConstValue::EmptyList => Ok(SapConstValue::EmptyList),
-            SapConstValue::EmptyMap => Ok(SapConstValue::EmptyMap),
-            SapConstValue::EnumValue {
-                enum_name,
-                variant_name,
-            } => match f(&enum_name) {
-                Some(enum_name) => Ok(SapConstValue::EnumValue {
-                    enum_name,
-                    variant_name,
-                }),
-                None => Err(enum_name),
-            },
-        }
-    }
+/// Used instead of `bool` for extensibility — future attributes may
+/// need additional states (e.g., `Inherited`, `Explicit`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum TyAttrValue {
+    #[default]
+    Unset,
+    Set,
 }
 
-/// Non-default type attributes.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TyAttrInner<N> {
-    pub sap_in_progress: SapAttrValue<N>,
-}
-impl<N> TyAttrInner<N> {
-    pub fn try_map_name<M, F: FnOnce(&N) -> Option<M>>(self, f: F) -> Option<TyAttrInner<M>> {
-        Some(TyAttrInner {
-            sap_in_progress: self.sap_in_progress.try_map_name(f)?,
-        })
-    }
-    pub fn expect_map_name<M, F: FnOnce(&N) -> Option<M>>(self, f: F) -> Result<TyAttrInner<M>, N> {
-        Ok(TyAttrInner {
-            sap_in_progress: self.sap_in_progress.expect_map_name(f)?,
-        })
+impl TyAttrValue {
+    /// Merge two flags: Set wins over Unset.
+    ///
+    /// Used when `@@stream.*` block attributes merge into field attributes
+    /// during `stream_expand`.
+    #[must_use]
+    pub fn or(self, other: TyAttrValue) -> TyAttrValue {
+        match (self, other) {
+            (TyAttrValue::Set, _) | (_, TyAttrValue::Set) => TyAttrValue::Set,
+            _ => TyAttrValue::Unset,
+        }
     }
 }
 
@@ -115,86 +35,20 @@ impl<N> TyAttrInner<N> {
 /// Carried on every `Ty` variant from HIR through runtime.
 /// Describes how values of this type behave during streaming.
 ///
-/// `Option<Box<...>>` makes the default (`None`) memory-cheap (8 bytes).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TyAttr<N>(pub Option<Box<TyAttrInner<N>>>);
+/// BEP-006 v12 defines three binary (present/absent) SAP attributes
+/// that control how the schema-aligned parser handles each streaming state.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct TyAttr {
+    /// `@sap.parse_without_null`: during parsing (both in-progress and done
+    /// states), exclude `null` from the type's parse candidates.
+    pub sap_parse_without_null: TyAttrValue,
 
-impl<N> Default for TyAttr<N> {
-    fn default() -> Self {
-        Self(None)
-    }
-}
-impl<N> TyAttr<N> {
-    /// Returns true if all attributes are at their default values.
-    pub fn is_default(&self) -> bool {
-        self.0.is_none()
-    }
-    pub fn try_map_name<M, F: FnOnce(&N) -> Option<M>>(self, f: F) -> Option<TyAttr<M>> {
-        match self.0 {
-            None => Some(TyAttr(None)),
-            Some(inner) => Some(TyAttr(Some(Box::new(inner.try_map_name(f)?)))),
-        }
-    }
-    /// Like `try_map_name`, but returns an error if the name is not mapped.
-    pub fn expect_map_name<M, F: FnOnce(&N) -> Option<M>>(self, f: F) -> Result<TyAttr<M>, N> {
-        match self.0 {
-            None => Ok(TyAttr(None)),
-            Some(inner) => Ok(TyAttr(Some(Box::new(inner.expect_map_name(f)?)))),
-        }
-    }
-}
+    /// `@sap.pending_never`: no value is yielded for this field while it is
+    /// in the pending state (i.e., the JSON key has not yet appeared).
+    pub sap_pending_never: TyAttrValue,
 
-/// Non-default field attributes.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FieldAttrInner<N> {
-    pub sap_class_completed_field_missing: SapAttrValue<N>,
-    pub sap_class_in_progress_field_missing: SapAttrValue<N>,
-}
-impl<N> FieldAttrInner<N> {
-    pub fn try_map_name<M, F: Fn(&N) -> Option<M>>(self, f: F) -> Option<FieldAttrInner<M>> {
-        Some(FieldAttrInner {
-            sap_class_completed_field_missing: self
-                .sap_class_completed_field_missing
-                .try_map_name(&f)?,
-            sap_class_in_progress_field_missing: self
-                .sap_class_in_progress_field_missing
-                .try_map_name(f)?,
-        })
-    }
-    pub fn expect_map_name<M, F: Fn(&N) -> Option<M>>(self, f: F) -> Result<FieldAttrInner<M>, N> {
-        Ok(FieldAttrInner {
-            sap_class_completed_field_missing: self
-                .sap_class_completed_field_missing
-                .expect_map_name(&f)?,
-            sap_class_in_progress_field_missing: self
-                .sap_class_in_progress_field_missing
-                .expect_map_name(f)?,
-        })
-    }
-}
-
-/// Attributes intrinsic to a field (not its type).
-///
-/// `Option<Box<...>>` makes the default (`None`) memory-cheap (8 bytes).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FieldAttr<N>(pub Option<Box<FieldAttrInner<N>>>);
-
-impl<N> Default for FieldAttr<N> {
-    fn default() -> Self {
-        Self(None)
-    }
-}
-impl<N> FieldAttr<N> {
-    pub fn try_map_name<M, F: Fn(&N) -> Option<M>>(self, f: F) -> Option<FieldAttr<M>> {
-        match self.0 {
-            None => Some(FieldAttr(None)),
-            Some(inner) => Some(FieldAttr(Some(Box::new(inner.try_map_name(f)?)))),
-        }
-    }
-    pub fn expect_map_name<M, F: Fn(&N) -> Option<M>>(self, f: F) -> Result<FieldAttr<M>, N> {
-        match self.0 {
-            None => Ok(FieldAttr(None)),
-            Some(inner) => Ok(FieldAttr(Some(Box::new(inner.expect_map_name(f)?)))),
-        }
-    }
+    /// `@sap.in_progress_never`: no value is yielded for this field while it
+    /// is in the in-progress state (i.e., the JSON value has started but is
+    /// not yet complete).
+    pub sap_in_progress_never: TyAttrValue,
 }

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -195,7 +195,6 @@ pub fn generate_project_bytecode(
                     description: None,
                     alias: None,
                     skip: false,
-                    field_attr: baml_type::FieldAttr::default(),
                 });
             }
 

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_5_mir.snap
@@ -648,7 +648,7 @@ fn baml.llm.Client.build_plan_with_state(self: null, planner_state: void) -> voi
 
     bb0: {
         _3 = copy _1.3;
-        _4 = is_type(copy _3, Void { attr: TyAttr(None) });
+        _4 = is_type(copy _3, Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _4 -> [bb5, bb1];
     }
 
@@ -838,7 +838,7 @@ fn baml.llm.Client.execute(self: null, context: void, inherited_delay_ms: int) -
 
     bb0: {
         _4 = copy _1.3;
-        _5 = is_type(copy _4, Void { attr: TyAttr(None) });
+        _5 = is_type(copy _4, Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _5 -> [bb6, bb1];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/catch_all_keyword/baml_tests__catch_all_keyword__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/catch_all_keyword/baml_tests__catch_all_keyword__04_5_mir.snap
@@ -15,12 +15,12 @@ fn user.CatchAllTyped(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb5, bb2];
     }
 
     bb2: {
-        _4 = is_type(copy _2, Int { attr: TyAttr(None) });
+        _4 = is_type(copy _2, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _4 -> [bb4, bb3];
     }
 
@@ -95,7 +95,7 @@ fn user.CatchThenCatchAll(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb4, bb2];
     }
 
@@ -169,7 +169,7 @@ fn user.PartialCatch(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb3, bb2];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/catch_throw/baml_tests__catch_throw__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/catch_throw/baml_tests__catch_throw__04_5_mir.snap
@@ -77,12 +77,12 @@ fn user.CatchWithFallback(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb5, bb2];
     }
 
     bb2: {
-        _4 = is_type(copy _2, Int { attr: TyAttr(None) });
+        _4 = is_type(copy _2, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _4 -> [bb4, bb3];
     }
 
@@ -125,7 +125,7 @@ fn user.CatchWithTypedArm(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb3, bb2];
     }
 
@@ -164,12 +164,12 @@ fn user.ChainedCatchClauses(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb5, bb2];
     }
 
     bb2: {
-        _4 = is_type(copy _2, Int { attr: TyAttr(None) });
+        _4 = is_type(copy _2, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _4 -> [bb4, bb3];
     }
 
@@ -271,12 +271,12 @@ fn user.MultipleCatchArms(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb5, bb2];
     }
 
     bb2: {
-        _4 = is_type(copy _2, Int { attr: TyAttr(None) });
+        _4 = is_type(copy _2, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _4 -> [bb4, bb3];
     }
 
@@ -370,7 +370,7 @@ fn user.SingleCatchTyped(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb3, bb2];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/catch_throw_regressions/baml_tests__catch_throw_regressions__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/catch_throw_regressions/baml_tests__catch_throw_regressions__04_5_mir.snap
@@ -104,12 +104,12 @@ fn user.CatchAlwaysThrows(n: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb5, bb2];
     }
 
     bb2: {
-        _4 = is_type(copy _2, Int { attr: TyAttr(None) });
+        _4 = is_type(copy _2, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _4 -> [bb4, bb3];
     }
 
@@ -152,7 +152,7 @@ fn user.CatchRecursiveThrow(n: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _2, String { attr: TyAttr(None) });
+        _3 = is_type(copy _2, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb3, bb2];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_5_mir.snap
@@ -10,7 +10,7 @@ fn user.Broken.BadUnionPattern(x: int | bool) -> string {
     let _3: null
 
     bb0: {
-        _2 = is_type(copy _1, Union([Int { attr: TyAttr(None) }, Void { attr: TyAttr(None) }], TyAttr(None)));
+        _2 = is_type(copy _1, Union([Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb5, bb1];
     }
 
@@ -67,7 +67,7 @@ fn user.Broken.MixedLiteralAndTyped(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _3 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb3, bb2];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_5_mir.snap
@@ -5231,7 +5231,7 @@ fn user.LoopStmts(items: int[], flag: bool) -> int {
     }
 
     bb201: {
-        _291 = is_type(copy _287, Int { attr: TyAttr(None) });
+        _291 = is_type(copy _287, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _291 -> [bb202, bb203];
     }
 
@@ -5243,7 +5243,7 @@ fn user.LoopStmts(items: int[], flag: bool) -> int {
     }
 
     bb203: {
-        _295 = is_type(copy _287, Int { attr: TyAttr(None) });
+        _295 = is_type(copy _287, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _295 -> [bb205, bb204];
     }
 
@@ -5890,7 +5890,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb19: {
-        _5 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _5 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _5 -> [bb20, bb21];
     }
 
@@ -5914,7 +5914,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb24: {
-        _9 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _9 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _9 -> [bb25, bb26];
     }
 
@@ -6019,7 +6019,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb48: {
-        _18 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _18 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _18 -> [bb50, bb49];
     }
 
@@ -6102,12 +6102,12 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb68: {
-        _21 = is_type(copy _3, Class(TypeName { name: "MatchSuccess", module_path: ["user"], display_name: "MatchSuccess" }, TyAttr(None)));
+        _21 = is_type(copy _3, Class(TypeName { name: "MatchSuccess", module_path: ["user"], display_name: "MatchSuccess" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _21 -> [bb72, bb69];
     }
 
     bb69: {
-        _24 = is_type(copy _3, Class(TypeName { name: "MatchFailure", module_path: ["user"], display_name: "MatchFailure" }, TyAttr(None)));
+        _24 = is_type(copy _3, Class(TypeName { name: "MatchFailure", module_path: ["user"], display_name: "MatchFailure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _24 -> [bb71, bb70];
     }
 
@@ -6128,7 +6128,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb73: {
-        _27 = is_type(copy _3, Union([Class(TypeName { name: "MatchSuccess", module_path: ["user"], display_name: "MatchSuccess" }, TyAttr(None)), Class(TypeName { name: "MatchFailure", module_path: ["user"], display_name: "MatchFailure" }, TyAttr(None))], TyAttr(None)));
+        _27 = is_type(copy _3, Union([Class(TypeName { name: "MatchSuccess", module_path: ["user"], display_name: "MatchSuccess" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(TypeName { name: "MatchFailure", module_path: ["user"], display_name: "MatchFailure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _27 -> [bb75, bb74];
     }
 
@@ -6154,7 +6154,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb79: {
-        _29 = is_type(copy _28, Int { attr: TyAttr(None) });
+        _29 = is_type(copy _28, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _29 -> [bb80, bb81];
     }
 
@@ -6166,7 +6166,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb81: {
-        _33 = is_type(copy _28, Int { attr: TyAttr(None) });
+        _33 = is_type(copy _28, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _33 -> [bb82, bb83];
     }
 
@@ -6194,7 +6194,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb87: {
-        _37 = is_type(copy _28, Int { attr: TyAttr(None) });
+        _37 = is_type(copy _28, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _37 -> [bb88, bb99];
     }
 
@@ -6340,7 +6340,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb118: {
-        _53 = is_type(copy _28, Int { attr: TyAttr(None) });
+        _53 = is_type(copy _28, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _53 -> [bb119, bb128];
     }
 
@@ -6408,7 +6408,7 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb131: {
-        _65 = is_type(copy _28, Int { attr: TyAttr(None) });
+        _65 = is_type(copy _28, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _65 -> [bb132, bb141];
     }
 
@@ -6599,12 +6599,12 @@ fn user.MatchExprs(x: int, s: MatchStatus, r: MatchSuccess | MatchFailure, b: bo
     }
 
     bb166: {
-        _115 = is_type(copy _3, Class(TypeName { name: "MatchSuccess", module_path: ["user"], display_name: "MatchSuccess" }, TyAttr(None)));
+        _115 = is_type(copy _3, Class(TypeName { name: "MatchSuccess", module_path: ["user"], display_name: "MatchSuccess" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _115 -> [bb170, bb167];
     }
 
     bb167: {
-        _120 = is_type(copy _3, Class(TypeName { name: "MatchFailure", module_path: ["user"], display_name: "MatchFailure" }, TyAttr(None)));
+        _120 = is_type(copy _3, Class(TypeName { name: "MatchFailure", module_path: ["user"], display_name: "MatchFailure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _120 -> [bb169, bb168];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -10,7 +10,7 @@ fn user.BoolLiteralAfterTypedBool(b: bool) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Bool { attr: TyAttr(None) });
+        _2 = is_type(copy _1, Bool { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _2 -> [bb4, bb1];
     }
 
@@ -326,7 +326,7 @@ fn user.EnumVariantAfterTypedEnum(s: Status) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: ["user"], display_name: "Status" }, TyAttr(None)));
+        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: ["user"], display_name: "Status" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
@@ -504,7 +504,7 @@ fn user.ExhaustiveClassPlusLiteral(x: Success | 200) -> string {
     let _5: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
@@ -591,12 +591,12 @@ fn user.ExhaustiveDoubleMaybe(dm: Success | Failure??) -> string {
     let _8: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb6, bb1];
     }
 
     bb1: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None)));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _5 -> [bb5, bb2];
     }
 
@@ -713,7 +713,7 @@ fn user.ExhaustiveEnumWithTypedPattern(s: Status) -> string {
     let _2: bool
 
     bb0: {
-        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: ["user"], display_name: "Status" }, TyAttr(None)));
+        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: ["user"], display_name: "Status" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb2, bb1];
     }
 
@@ -814,7 +814,7 @@ fn user.ExhaustiveLiteralWithBaseType(x: int) -> string {
     }
 
     bb1: {
-        _3 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _3 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb3, bb2];
     }
 
@@ -962,7 +962,7 @@ fn user.ExhaustiveNullableEnumWithTypedPattern(s: Status?) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: ["user"], display_name: "Status" }, TyAttr(None)));
+        _2 = is_type(copy _1, Enum(TypeName { name: "Status", module_path: ["user"], display_name: "Status" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
@@ -1002,7 +1002,7 @@ fn user.ExhaustiveOptional(x: int?) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _2 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _2 -> [bb4, bb1];
     }
 
@@ -1193,12 +1193,12 @@ fn user.ExhaustiveTypeAlias(r: Success | Failure) -> string {
     let _7: Failure
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
     bb1: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None)));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _5 -> [bb3, bb2];
     }
 
@@ -1238,7 +1238,7 @@ fn user.ExhaustiveTypeAliasWithCatchAll(r: Success | Failure) -> string {
     let _4: Success
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb3, bb1];
     }
 
@@ -1363,7 +1363,7 @@ fn user.GuardedOnlyNonExhaustive(x: int) -> int {
     let _12: -1
 
     bb0: {
-        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _2 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _2 -> [bb1, bb2];
     }
 
@@ -1375,7 +1375,7 @@ fn user.GuardedOnlyNonExhaustive(x: int) -> int {
     }
 
     bb2: {
-        _7 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _7 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _7 -> [bb3, bb4];
     }
 
@@ -1423,7 +1423,7 @@ fn user.GuardedWithFallback(x: int) -> int {
     let _6: int
 
     bb0: {
-        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _2 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _2 -> [bb1, bb2];
     }
 
@@ -1529,22 +1529,22 @@ fn user.JumpTableClassTypeTag(pet: Cat | Dog | Bird | Fish) -> string {
     let _5: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Cat", module_path: ["user"], display_name: "Cat" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Cat", module_path: ["user"], display_name: "Cat" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb8, bb1];
     }
 
     bb1: {
-        _3 = is_type(copy _1, Class(TypeName { name: "Dog", module_path: ["user"], display_name: "Dog" }, TyAttr(None)));
+        _3 = is_type(copy _1, Class(TypeName { name: "Dog", module_path: ["user"], display_name: "Dog" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _3 -> [bb7, bb2];
     }
 
     bb2: {
-        _4 = is_type(copy _1, Class(TypeName { name: "Bird", module_path: ["user"], display_name: "Bird" }, TyAttr(None)));
+        _4 = is_type(copy _1, Class(TypeName { name: "Bird", module_path: ["user"], display_name: "Bird" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _4 -> [bb6, bb3];
     }
 
     bb3: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Fish", module_path: ["user"], display_name: "Fish" }, TyAttr(None)));
+        _5 = is_type(copy _1, Class(TypeName { name: "Fish", module_path: ["user"], display_name: "Fish" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _5 -> [bb5, bb4];
     }
 
@@ -1635,22 +1635,22 @@ fn user.JumpTableTypeTag(value: int | string | bool | float) -> string {
     let _5: bool
 
     bb0: {
-        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _2 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _2 -> [bb8, bb1];
     }
 
     bb1: {
-        _3 = is_type(copy _1, String { attr: TyAttr(None) });
+        _3 = is_type(copy _1, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _3 -> [bb7, bb2];
     }
 
     bb2: {
-        _4 = is_type(copy _1, Bool { attr: TyAttr(None) });
+        _4 = is_type(copy _1, Bool { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _4 -> [bb6, bb3];
     }
 
     bb3: {
-        _5 = is_type(copy _1, Float { attr: TyAttr(None) });
+        _5 = is_type(copy _1, Float { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _5 -> [bb5, bb4];
     }
 
@@ -1695,7 +1695,7 @@ fn user.LiteralAfterTypedPattern(x: int) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _2 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _2 -> [bb4, bb1];
     }
 
@@ -1898,7 +1898,7 @@ fn user.MixedPatterns(x: int) -> string {
     }
 
     bb2: {
-        _4 = is_type(copy _1, Int { attr: TyAttr(None) });
+        _4 = is_type(copy _1, Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _4 -> [bb3, bb4];
     }
 
@@ -2185,12 +2185,12 @@ fn user.NestedTypeAlias(mr: Success | Failure?) -> string {
     let _8: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb6, bb1];
     }
 
     bb1: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None)));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _5 -> [bb5, bb2];
     }
 
@@ -2239,12 +2239,12 @@ fn user.NestedTypeBindings(r: Success | Failure) -> int {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
+        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
     bb1: {
-        _3 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None)));
+        _3 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _3 -> [bb3, bb2];
     }
 
@@ -2392,7 +2392,7 @@ fn user.NonExhaustiveClassPlusLiteralMissingLiteral(x: Success | 200) -> string 
     let _4: Success
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb2, bb1];
     }
 
@@ -2457,12 +2457,12 @@ fn user.NonExhaustiveDoubleMaybeMissingNull(dm: Success | Failure??) -> string {
     let _7: Failure
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
     bb1: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None)));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _5 -> [bb3, bb2];
     }
 
@@ -2568,12 +2568,12 @@ fn user.NonExhaustiveFullResultMissingOne(r: Success | Failure | Pending) -> str
     let _7: Failure
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
     bb1: {
-        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None)));
+        _5 = is_type(copy _1, Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _5 -> [bb3, bb2];
     }
 
@@ -2900,7 +2900,7 @@ fn user.NonExhaustiveTypeAliasMissingOne(r: Success | Failure) -> string {
     let _4: Success
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb2, bb1];
     }
 
@@ -2966,12 +2966,12 @@ fn user.OverlappingTypedPatterns(r: Success | Failure) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
     bb1: {
-        _3 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
+        _3 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _3 -> [bb3, bb2];
     }
 
@@ -3008,12 +3008,12 @@ fn user.OverlappingWithBindings(r: Success | Failure) -> string {
     let _5: bool
 
     bb0: {
-        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)));
+        _2 = is_type(copy _1, Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
     bb1: {
-        _5 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
+        _5 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _5 -> [bb3, bb2];
     }
 
@@ -3089,7 +3089,7 @@ fn user.PartialUnionPatternCoverage(r: Success | Failure | Pending) -> string {
     let _2: bool
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
+        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb2, bb1];
     }
 
@@ -3119,12 +3119,12 @@ fn user.PartialUnionPlusCatchAll(r: Success | Failure | Pending) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
+        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb4, bb1];
     }
 
     bb1: {
-        _3 = is_type(copy _1, Class(TypeName { name: "Pending", module_path: ["user"], display_name: "Pending" }, TyAttr(None)));
+        _3 = is_type(copy _1, Class(TypeName { name: "Pending", module_path: ["user"], display_name: "Pending" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _3 -> [bb3, bb2];
     }
 
@@ -3159,7 +3159,7 @@ fn user.StringLiteralAfterStringType(s: string) -> string {
     let _3: bool
 
     bb0: {
-        _2 = is_type(copy _1, String { attr: TyAttr(None) });
+        _2 = is_type(copy _1, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } });
         branch copy _2 -> [bb4, bb1];
     }
 
@@ -3345,7 +3345,7 @@ fn user.UnionPatternCoversAll(r: Success | Failure) -> string {
     let _2: bool
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr(None)), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr(None))], TyAttr(None)));
+        _2 = is_type(copy _1, Union([Class(TypeName { name: "Success", module_path: ["user"], display_name: "Success" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(TypeName { name: "Failure", module_path: ["user"], display_name: "Failure" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }));
         branch copy _2 -> [bb2, bb1];
     }
 

--- a/baml_language/crates/baml_type/src/attr.rs
+++ b/baml_language/crates/baml_type/src/attr.rs
@@ -2,10 +2,5 @@
 //!
 //! The canonical definitions live in `baml_base::attr` so that both
 //! `baml_type` and `baml_compiler_tir` can use them without a cyclic dependency.
-//!
-//! `TyAttr` and `FieldAttr` are type aliases that fix the generic name
-//! parameter to `TypeName`, matching the rest of `baml_type::Ty`.
 
-pub use baml_base::{SapAttrValue, SapConstValue};
-pub type TyAttr = baml_base::TyAttr<super::TypeName>;
-pub type FieldAttr = baml_base::FieldAttr<super::TypeName>;
+pub use baml_base::{TyAttr, TyAttrValue};

--- a/baml_language/crates/baml_type/src/defs.rs
+++ b/baml_language/crates/baml_type/src/defs.rs
@@ -5,7 +5,7 @@
 
 use baml_base::Name;
 
-use crate::{FieldAttr, Ty, TyAttr};
+use crate::{Ty, TyAttr};
 
 /// Top-level container for all schema definitions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,7 +35,6 @@ pub struct FieldDef {
     pub description: Option<String>,
     pub alias: Option<String>,
     pub skip: bool,
-    pub field_attr: FieldAttr,
 }
 
 /// An enum definition with propagated attributes.

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -525,7 +525,6 @@ mod tests {
                 description: None,
                 alias: None,
                 skip: false,
-                field_attr: Default::default(),
             }],
             description: None,
             alias: None,

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -465,7 +465,6 @@ mod tests {
                     description: None,
                     alias: None,
                     skip: false,
-                    field_attr: Default::default(),
                 },
                 bex_vm_types::ClassField {
                     name: "y".to_string(),
@@ -475,7 +474,6 @@ mod tests {
                     description: None,
                     alias: None,
                     skip: false,
-                    field_attr: Default::default(),
                 },
             ],
             description: None,

--- a/baml_language/crates/bex_sap/src/sap_model/convert.rs
+++ b/baml_language/crates/bex_sap/src/sap_model/convert.rs
@@ -2,8 +2,7 @@
 
 use std::borrow::Cow;
 
-use baml_type::{SapAttrValue, SapConstValue, TypeName};
-use indexmap::IndexMap;
+use baml_type::{TyAttrValue, TypeName};
 
 use crate::sap_model::{
     self, AnnotatedTy, ArrayTy, AttrLiteral, BoolLiteralTy, BoolTy, FloatTy, IntLiteralTy, IntTy,
@@ -146,37 +145,13 @@ pub fn convert(ty: &baml_type::Ty) -> Result<AnnotatedTy<'_, TypeName>, ConvertE
 pub fn convert_ty_attrs(
     attrs: &baml_type::TyAttr,
 ) -> Result<TypeAnnotations<'_, TypeName>, ConvertError<'_>> {
-    let Some(attrs) = &attrs.0 else {
-        return Ok(TypeAnnotations::default());
+    let in_progress = match attrs.sap_in_progress_never {
+        TyAttrValue::Set => Some(AttrLiteral::Never),
+        TyAttrValue::Unset => None,
     };
     Ok(TypeAnnotations {
-        in_progress: Some(convert_attr_literal(&attrs.sap_in_progress)?),
+        in_progress,
         parse_as: None,      // TODO: parse_as
         asserts: Vec::new(), // TODO: assertions
     })
-}
-
-pub fn convert_attr_literal(
-    lit: &SapAttrValue<TypeName>,
-) -> Result<AttrLiteral<'_, TypeName>, ConvertError<'_>> {
-    let lit = match lit {
-        SapAttrValue::Never => AttrLiteral::Never,
-        SapAttrValue::ConstValueExpr(SapConstValue::Null) => AttrLiteral::Null,
-        SapAttrValue::ConstValueExpr(SapConstValue::String(s)) => {
-            AttrLiteral::String(Cow::Borrowed(s))
-        }
-        SapAttrValue::ConstValueExpr(SapConstValue::Int(i)) => AttrLiteral::Int(*i),
-        SapAttrValue::ConstValueExpr(SapConstValue::Float(f)) => AttrLiteral::Float(f.parse()?),
-        SapAttrValue::ConstValueExpr(SapConstValue::Bool(b)) => AttrLiteral::Bool(*b),
-        SapAttrValue::ConstValueExpr(SapConstValue::EmptyList) => AttrLiteral::Array(Vec::new()),
-        SapAttrValue::ConstValueExpr(SapConstValue::EmptyMap) => AttrLiteral::Map(IndexMap::new()),
-        SapAttrValue::ConstValueExpr(SapConstValue::EnumValue {
-            enum_name,
-            variant_name,
-        }) => AttrLiteral::EnumVariant {
-            enum_name,
-            variant_name: Cow::Borrowed(variant_name),
-        },
-    };
-    Ok(lit)
 }

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -364,7 +364,6 @@ pub struct ClassField {
     pub description: Option<String>,
     pub alias: Option<String>,
     pub skip: bool,
-    pub field_attr: baml_type::FieldAttr,
 }
 
 /// Runtime class representation.


### PR DESCRIPTION
Replay #3205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated the attribute model into a small set of non-generic, binary type-level flags for simpler semantics.
  * Removed per-field attribute storage from public schemas and runtime field representations.
* **Behavior**
  * Type "in-progress" annotation is now derived directly from the new type-level flag, simplifying interpretation and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->