### PR TITLE
type simplification fixups

### DIFF
--- a/baml_language/crates/baml_type/src/simplify_sap.rs
+++ b/baml_language/crates/baml_type/src/simplify_sap.rs
@@ -470,7 +470,17 @@ fn simplify_impl(ty: Ty, aliases: &HashMap<TypeName, Ty>, recursive: &HashSet<Ty
 
         // Recurse into compound types.
         Ty::Optional(inner, attr) => {
-            Ty::Optional(Box::new(simplify_impl(*inner, aliases, recursive)), attr)
+            let inner_ty: Ty = inner.as_ref().clone();
+            let optional_as_union = Ty::Union(
+                vec![
+                    inner_ty,
+                    Ty::Null {
+                        attr: TyAttr::default(),
+                    },
+                ],
+                attr,
+            );
+            simplify_impl(optional_as_union, aliases, recursive)
         }
         Ty::List(inner, attr) => {
             Ty::List(Box::new(simplify_impl(*inner, aliases, recursive)), attr)

--- a/baml_language/crates/baml_type/tests/simplify_sap_tests.md
+++ b/baml_language/crates/baml_type/tests/simplify_sap_tests.md
@@ -366,7 +366,7 @@ int[]
 (int | int)?
 
 ### expected
-int?
+int | null
 
 ---
 
@@ -621,7 +621,7 @@ Optional wraps a union — inner null moves to end.
 (null | int)?
 
 ### expected
-(int | null)?
+int | null
 
 ---
 


### PR DESCRIPTION
Type simplification failed to treat Options as union-with-null. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated optional type simplification to use explicit union representation with null instead of optional syntax.
  * Updated corresponding test cases to reflect the new type representation format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->