### PR TITLE
feat(beps): add drag-and-drop support for kanban card status migration

### DIFF
--- a/typescript/apps/beps/package-lock.json
+++ b/typescript/apps/beps/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@boundaryml/baml": "^0.217.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@lexical/code": "^0.39.0",
         "@lexical/list": "^0.39.0",
         "@lexical/markdown": "^0.39.0",
@@ -730,6 +732,59 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",

--- a/typescript/apps/beps/package.json
+++ b/typescript/apps/beps/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
     "@boundaryml/baml": "^0.217.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@lexical/code": "^0.39.0",
     "@lexical/list": "^0.39.0",
     "@lexical/markdown": "^0.39.0",

--- a/typescript/apps/beps/src/components/bep/bep-kanban-card.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-kanban-card.tsx
@@ -2,8 +2,11 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Card, CardContent } from "@/components/ui/card";
-import { MessageSquare, AlertCircle } from "lucide-react";
+import { MessageSquare, AlertCircle, GripVertical } from "lucide-react";
+import { Id } from "../../../convex/_generated/dataModel";
 
 type BepStatus =
   | "draft"
@@ -14,6 +17,7 @@ type BepStatus =
   | "superseded";
 
 interface BepKanbanCardProps {
+  id: Id<"beps">;
   number: number;
   title: string;
   status: BepStatus;
@@ -21,6 +25,7 @@ interface BepKanbanCardProps {
   commentCount: number;
   openIssueCount: number;
   updatedAt: number;
+  isDragging?: boolean;
 }
 
 function formatRelativeTime(timestamp: number, now: number): string {
@@ -37,6 +42,7 @@ function formatRelativeTime(timestamp: number, now: number): string {
 }
 
 export function BepKanbanCard({
+  id,
   number,
   title,
   shepherdNames,
@@ -46,29 +52,72 @@ export function BepKanbanCard({
 }: BepKanbanCardProps) {
   const [relativeTime, setRelativeTime] = useState<string>("");
 
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: id,
+    data: {
+      type: "bep",
+      bepId: id,
+      number,
+    },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
   useEffect(() => {
     setRelativeTime(formatRelativeTime(updatedAt, Date.now()));
   }, [updatedAt]);
 
   return (
-    <Link href={`/beps/${number}`}>
-      <Card className="hover:bg-accent/50 transition-colors cursor-pointer">
+    <div ref={setNodeRef} style={style}>
+      <Card
+        className={`hover:bg-accent/50 transition-colors ${
+          isDragging ? "shadow-lg ring-2 ring-primary" : ""
+        }`}
+      >
         <CardContent className="p-3">
           <div className="space-y-2">
-            <div>
-              <span className="text-xs text-muted-foreground font-mono">
-                BEP-{String(number).padStart(3, "0")}
-              </span>
-              <h4 className="text-sm font-medium leading-tight mt-0.5 line-clamp-2">
-                {title}
-              </h4>
+            <div className="flex items-start gap-1">
+              <button
+                className="mt-0.5 cursor-grab touch-none text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                {...attributes}
+                {...listeners}
+              >
+                <GripVertical className="h-4 w-4" />
+              </button>
+              <Link
+                href={`/beps/${number}`}
+                className="flex-1 min-w-0"
+                onClick={(e) => {
+                  if (isDragging) {
+                    e.preventDefault();
+                  }
+                }}
+              >
+                <span className="text-xs text-muted-foreground font-mono">
+                  BEP-{String(number).padStart(3, "0")}
+                </span>
+                <h4 className="text-sm font-medium leading-tight mt-0.5 line-clamp-2">
+                  {title}
+                </h4>
+              </Link>
             </div>
             {shepherdNames.length > 0 && (
-              <p className="text-xs text-muted-foreground truncate">
+              <p className="text-xs text-muted-foreground truncate pl-5">
                 {shepherdNames.join(", ")}
               </p>
             )}
-            <div className="flex items-center justify-between text-xs text-muted-foreground pt-1 border-t">
+            <div className="flex items-center justify-between text-xs text-muted-foreground pt-1 border-t pl-5">
               <div className="flex items-center gap-2">
                 <span className="flex items-center gap-0.5">
                   <MessageSquare className="h-3 w-3" />
@@ -86,6 +135,6 @@ export function BepKanbanCard({
           </div>
         </CardContent>
       </Card>
-    </Link>
+    </div>
   );
 }

--- a/typescript/apps/beps/src/components/bep/bep-list.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-list.tsx
@@ -1,8 +1,25 @@
 "use client";
 
-import { useState } from "react";
-import { useQuery } from "convex/react";
+import { useState, useCallback } from "react";
+import { useQuery, useMutation } from "convex/react";
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverEvent,
+  DragOverlay,
+  DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCorners,
+  useDroppable,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { api } from "../../../convex/_generated/api";
+import { Id } from "../../../convex/_generated/dataModel";
 import { BepCard } from "./bep-card";
 import { BepKanbanCard } from "./bep-kanban-card";
 import { Badge } from "@/components/ui/badge";
@@ -40,15 +57,97 @@ const KANBAN_COLUMNS: { status: BepStatus; label: string; color: string }[] = [
   { status: "superseded", label: "Superseded", color: "bg-orange-500" },
 ];
 
+interface KanbanColumnProps {
+  status: BepStatus;
+  label: string;
+  color: string;
+  beps: Array<{
+    _id: Id<"beps">;
+    number: number;
+    title: string;
+    status: BepStatus;
+    shepherdNames: string[];
+    commentCount: number;
+    openIssueCount: number;
+    updatedAt: number;
+  }>;
+  isOver?: boolean;
+}
+
+function KanbanColumn({ status, label, color, beps, isOver }: KanbanColumnProps) {
+  const { setNodeRef } = useDroppable({
+    id: status,
+    data: {
+      type: "column",
+      status,
+    },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex flex-col min-h-[200px] transition-colors ${
+        isOver ? "bg-accent/30 rounded-lg" : ""
+      }`}
+    >
+      <div className="flex items-center gap-2 mb-3 pb-2 border-b">
+        <div className={`w-3 h-3 rounded-full ${color}`} />
+        <h3 className="font-medium text-sm">{label}</h3>
+        <span className="text-xs text-muted-foreground ml-auto">
+          {beps.length}
+        </span>
+      </div>
+      <SortableContext
+        items={beps.map((bep) => bep._id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="flex flex-col gap-2 flex-1 min-h-[100px]">
+          {beps.length > 0 ? (
+            beps.map((bep) => (
+              <BepKanbanCard
+                key={bep._id}
+                id={bep._id}
+                number={bep.number}
+                title={bep.title}
+                status={bep.status}
+                shepherdNames={bep.shepherdNames}
+                commentCount={bep.commentCount}
+                openIssueCount={bep.openIssueCount}
+                updatedAt={bep.updatedAt}
+              />
+            ))
+          ) : (
+            <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground bg-muted/30 rounded-md min-h-[100px]">
+              {isOver ? "Drop here" : "No BEPs"}
+            </div>
+          )}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}
+
 export function BepList() {
   const [statusFilter, setStatusFilter] = useState<BepStatus | "all">("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [showOldestFirst, setShowOldestFirst] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("kanban");
+  const [activeId, setActiveId] = useState<Id<"beps"> | null>(null);
+  const [overColumn, setOverColumn] = useState<BepStatus | null>(null);
 
   const beps = useQuery(api.beps.list, {
     status: viewMode === "kanban" ? undefined : statusFilter === "all" ? undefined : statusFilter,
   });
+
+  const updateStatus = useMutation(api.beps.updateStatus);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    })
+  );
 
   const filteredBeps = beps
     ?.filter((bep) => {
@@ -64,9 +163,82 @@ export function BepList() {
       showOldestFirst ? a.number - b.number : b.number - a.number
     );
 
-  const getBepsByStatus = (status: BepStatus) => {
-    return filteredBeps?.filter((bep) => bep.status === status) || [];
-  };
+  const getBepsByStatus = useCallback(
+    (status: BepStatus) => {
+      return filteredBeps?.filter((bep) => bep.status === status) || [];
+    },
+    [filteredBeps]
+  );
+
+  const activeBep = activeId
+    ? filteredBeps?.find((bep) => bep._id === activeId)
+    : null;
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const { active } = event;
+    setActiveId(active.id as Id<"beps">);
+  }, []);
+
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    const { over } = event;
+    if (!over) {
+      setOverColumn(null);
+      return;
+    }
+
+    const overData = over.data.current;
+    if (overData?.type === "column") {
+      setOverColumn(overData.status as BepStatus);
+    } else if (overData?.type === "bep") {
+      const overBep = filteredBeps?.find((bep) => bep._id === over.id);
+      if (overBep) {
+        setOverColumn(overBep.status);
+      }
+    }
+  }, [filteredBeps]);
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event;
+      setActiveId(null);
+      setOverColumn(null);
+
+      if (!over) return;
+
+      const activeBepId = active.id as Id<"beps">;
+      const activeBepData = filteredBeps?.find((bep) => bep._id === activeBepId);
+      if (!activeBepData) return;
+
+      let targetStatus: BepStatus | null = null;
+
+      const overData = over.data.current;
+      if (overData?.type === "column") {
+        targetStatus = overData.status as BepStatus;
+      } else if (overData?.type === "bep") {
+        const overBep = filteredBeps?.find((bep) => bep._id === over.id);
+        if (overBep) {
+          targetStatus = overBep.status;
+        }
+      }
+
+      if (targetStatus && targetStatus !== activeBepData.status) {
+        try {
+          await updateStatus({
+            id: activeBepId,
+            status: targetStatus,
+          });
+        } catch (error) {
+          console.error("Failed to update BEP status:", error);
+        }
+      }
+    },
+    [filteredBeps, updateStatus]
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setActiveId(null);
+    setOverColumn(null);
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -141,42 +313,44 @@ export function BepList() {
           <Skeleton className="h-24 w-full" />
         </div>
       ) : viewMode === "kanban" ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
-          {KANBAN_COLUMNS.map((column) => {
-            const columnBeps = getBepsByStatus(column.status);
-            return (
-              <div key={column.status} className="flex flex-col min-h-[200px]">
-                <div className="flex items-center gap-2 mb-3 pb-2 border-b">
-                  <div className={`w-3 h-3 rounded-full ${column.color}`} />
-                  <h3 className="font-medium text-sm">{column.label}</h3>
-                  <span className="text-xs text-muted-foreground ml-auto">
-                    {columnBeps.length}
-                  </span>
-                </div>
-                <div className="flex flex-col gap-2 flex-1">
-                  {columnBeps.length > 0 ? (
-                    columnBeps.map((bep) => (
-                      <BepKanbanCard
-                        key={bep._id}
-                        number={bep.number}
-                        title={bep.title}
-                        status={bep.status}
-                        shepherdNames={bep.shepherdNames}
-                        commentCount={bep.commentCount}
-                        openIssueCount={bep.openIssueCount}
-                        updatedAt={bep.updatedAt}
-                      />
-                    ))
-                  ) : (
-                    <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground bg-muted/30 rounded-md">
-                      No BEPs
-                    </div>
-                  )}
-                </div>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCorners}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
+            {KANBAN_COLUMNS.map((column) => (
+              <KanbanColumn
+                key={column.status}
+                status={column.status}
+                label={column.label}
+                color={column.color}
+                beps={getBepsByStatus(column.status)}
+                isOver={overColumn === column.status}
+              />
+            ))}
+          </div>
+          <DragOverlay>
+            {activeBep ? (
+              <div className="opacity-90">
+                <BepKanbanCard
+                  id={activeBep._id}
+                  number={activeBep.number}
+                  title={activeBep.title}
+                  status={activeBep.status}
+                  shepherdNames={activeBep.shepherdNames}
+                  commentCount={activeBep.commentCount}
+                  openIssueCount={activeBep.openIssueCount}
+                  updatedAt={activeBep.updatedAt}
+                  isDragging
+                />
               </div>
-            );
-          })}
-        </div>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
       ) : filteredBeps && filteredBeps.length > 0 ? (
         <div className="flex flex-col gap-1">
           {filteredBeps.map((bep) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
- [x] This PR fixes an issue where users could not migrate kanban cards from one status to another

## Changes
This PR adds drag-and-drop functionality to the BEP kanban board, allowing users to easily change a BEP's status by dragging cards between columns.

### Key Changes:
- **Installed @dnd-kit/core and @dnd-kit/sortable** - Modern, accessible drag-and-drop libraries for React
- **Updated BepKanbanCard component** - Added draggable functionality with a grip handle icon for clear drag affordance
- **Updated BepList component** - Implemented DndContext with droppable columns for each status
- **Visual feedback** - Shows highlighting when dragging over valid drop targets
- **Status update on drop** - Calls the existing `updateStatus` mutation when a card is dropped in a new column

### User Experience:
- Cards now have a grip icon (⠿) on the left side indicating they can be dragged
- Dragging a card shows a semi-transparent preview
- Dropping a card in a different column immediately updates the BEP's status
- The card link still works - clicking on the card title navigates to the BEP detail page
- Drag requires 8px of movement to activate (prevents accidental drags when clicking)

## Testing
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] ESLint checks pass for modified files
- [ ] Manual testing performed (requires Convex credentials)

## PR Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
The implementation uses @dnd-kit which is a modern, accessible, and performant drag-and-drop library. It supports touch devices and keyboard navigation out of the box.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1774842545937889?thread_ts=1774842545.937889&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-bb694b98-1fa1-5612-bb59-961ba6468e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb694b98-1fa1-5612-bb59-961ba6468e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

