### PR TITLE
Fix VM instanceof crash on null/non-instance values

### DIFF
--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1968,19 +1968,20 @@ impl BexVm {
                                 CmpOp::NotEq => left != right,
 
                                 CmpOp::InstanceOf => {
-                                    let left = self.as_object_ptr(&left, ObjectType::Instance)?;
-
-                                    let Object::Instance(instance) = self.get_object(left) else {
-                                        return Err(InternalError::TypeError {
-                                            expected: ObjectType::Instance.into(),
-                                            got: ObjectType::of(self.get_object(left)).into(),
+                                    // null/non-object is never an instance of anything.
+                                    match left {
+                                        Value::Object(left_ptr) => {
+                                            match self.get_object(left_ptr) {
+                                                Object::Instance(instance) => {
+                                                    let right_ptr = self
+                                                        .as_object_ptr(&right, ObjectType::Class)?;
+                                                    instance.class == right_ptr
+                                                }
+                                                _ => false,
+                                            }
                                         }
-                                        .into());
-                                    };
-
-                                    let right = self.as_object_ptr(&right, ObjectType::Class)?;
-
-                                    instance.class == right
+                                        _ => false,
+                                    }
                                 }
 
                                 _ => {


### PR DESCRIPTION
## Summary

- The `CmpOp::InstanceOf` instruction in `bex_vm` would call `as_object_ptr` on the left operand, which throws a `TypeError` when the value is `Null` (since `Null` maps to `ObjectType::Any`, not `ObjectType::Instance`). This caused **"Function call failed: VM type error: expected instance, got any"** errors in the WASM playground after PR #3300 consolidated name resolution.
- Instead of erroring, `instanceof` on null or non-instance values now correctly evaluates to `false`, matching standard language semantics (e.g. JavaScript's `null instanceof Foo === false`).

## Root Cause

The `InstanceOf` handler in `vm.rs` unconditionally called `self.as_object_ptr(&left, ObjectType::Instance)`, which returns a `TypeError` for any value that isn't an instance object. When the left operand was `Value::Null` (whose type resolves to `ObjectType::Any`), this produced the cryptic "expected instance, got any" error.

This was exposed (not caused) by PR #3300's name resolution changes — the new fully-qualified name paths altered control flow so that `instanceof` checks were reached with null values that previously took a different code path.

## Fix

Replaced the unconditional `as_object_ptr` call with a nested `match` that:
1. Checks if the left value is a `Value::Object` — if not, returns `false`
2. Checks if the object is an `Object::Instance` — if not, returns `false`  
3. Only then performs the class pointer comparison

## Test plan

- [x] `cargo test --lib` passes across all workspace crates
- [x] `cargo test -p bex_vm --lib` passes
- [x] `cargo test -p bex_engine --lib` passes
- [x] `cargo clippy` passes (verified by pre-commit hook)
- [ ] Manual verification in WASM playground that the error is resolved

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `instanceof` operator to properly handle non-object values and `null` by returning `false` instead of raising an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->