### PR TITLE
Improve reporting of jsonish errors

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
@@ -378,8 +378,9 @@ impl DefaultValue for TypeIR {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use baml_types::JinjaExpression;
+
+    use super::*;
 
     fn make_assert(label: Option<&str>, expr: &str) -> (Constraint, bool) {
         (

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
@@ -245,22 +245,39 @@ pub fn validate_asserts(constraints: &[(Constraint, bool)]) -> Result<(), Parsin
             },
         )
         .collect::<Vec<_>>();
-    let causes = failing_asserts
+    let total = failing_asserts.len();
+    const MAX_CAUSES: usize = 5;
+    const MAX_CAUSE_LEN: usize = 100;
+    let causes: Vec<_> = failing_asserts
         .into_iter()
-        .map(|(label, expr)| ParsingError {
-            causes: vec![],
-            reason: format!(
+        .take(MAX_CAUSES)
+        .map(|(label, expr)| {
+            let mut reason = format!(
                 "Failed: {}{}",
                 label.as_ref().map_or("".to_string(), |l| format!("{l} ")),
                 expr.0
-            ),
-            scope: vec![],
+            );
+            if reason.len() > MAX_CAUSE_LEN {
+                reason.truncate(MAX_CAUSE_LEN);
+                reason.push_str("...");
+            }
+            ParsingError {
+                causes: vec![],
+                reason,
+                scope: vec![],
+            }
         })
-        .collect::<Vec<_>>();
+        .collect();
     if !causes.is_empty() {
+        // IMPORTANT: DO NOT CHANGE THIS MESSAGE. TALK TO GREG.
+        let reason = if total > MAX_CAUSES {
+            format!("Assertions failed. {total} (truncated to first {MAX_CAUSES})")
+        } else {
+            "Assertions failed.".to_string()
+        };
         Err(ParsingError {
-            causes: vec![],
-            reason: "Assertions failed.".to_string(), // IMPORTANT: DO NOT CHANGE THIS MESSAGE. TALK TO GREG.
+            causes,
+            reason,
             scope: vec![],
         })
     } else {
@@ -356,5 +373,110 @@ impl DefaultValue for TypeIR {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use baml_types::JinjaExpression;
+
+    fn make_assert(label: Option<&str>, expr: &str) -> (Constraint, bool) {
+        (
+            Constraint {
+                level: ConstraintLevel::Assert,
+                expression: JinjaExpression(expr.to_string()),
+                label: label.map(|l| l.to_string()),
+            },
+            false, // failing
+        )
+    }
+
+    fn make_passing_assert(label: Option<&str>, expr: &str) -> (Constraint, bool) {
+        (
+            Constraint {
+                level: ConstraintLevel::Assert,
+                expression: JinjaExpression(expr.to_string()),
+                label: label.map(|l| l.to_string()),
+            },
+            true, // passing
+        )
+    }
+
+    #[test]
+    fn test_validate_asserts_no_failures() {
+        let constraints = vec![make_passing_assert(Some("ok"), "this > 0")];
+        assert!(validate_asserts(&constraints).is_ok());
+    }
+
+    #[test]
+    fn test_validate_asserts_includes_causes() {
+        let constraints = vec![
+            make_assert(Some("nonneg"), "this >= 0"),
+            make_assert(Some("bounded"), "this < 100"),
+        ];
+        let err = validate_asserts(&constraints).unwrap_err();
+        assert_eq!(err.reason, "Assertions failed.");
+        assert_eq!(err.causes.len(), 2);
+        assert_eq!(err.causes[0].reason, "Failed: nonneg this >= 0");
+        assert_eq!(err.causes[1].reason, "Failed: bounded this < 100");
+    }
+
+    #[test]
+    fn test_validate_asserts_truncates_to_5_causes() {
+        let constraints: Vec<_> = (0..7)
+            .map(|i| make_assert(Some(&format!("a{i}")), &format!("this > {i}")))
+            .collect();
+        let err = validate_asserts(&constraints).unwrap_err();
+        assert_eq!(err.reason, "Assertions failed. 7 (truncated to first 5)");
+        assert_eq!(err.causes.len(), 5);
+        // Verify we got the first 5
+        for i in 0..5 {
+            assert!(err.causes[i].reason.contains(&format!("a{i}")));
+        }
+    }
+
+    #[test]
+    fn test_validate_asserts_exactly_5_no_truncation_message() {
+        let constraints: Vec<_> = (0..5)
+            .map(|i| make_assert(Some(&format!("a{i}")), &format!("this > {i}")))
+            .collect();
+        let err = validate_asserts(&constraints).unwrap_err();
+        assert_eq!(err.reason, "Assertions failed.");
+        assert_eq!(err.causes.len(), 5);
+    }
+
+    #[test]
+    fn test_validate_asserts_truncates_long_cause() {
+        let long_expr = "x".repeat(200);
+        let constraints = vec![make_assert(Some("lbl"), &long_expr)];
+        let err = validate_asserts(&constraints).unwrap_err();
+        assert_eq!(err.causes.len(), 1);
+        let cause = &err.causes[0].reason;
+        // "Failed: lbl " is 13 chars, so truncated at 100 + "..."
+        assert!(cause.ends_with("..."), "Expected truncation, got: {cause}");
+        assert_eq!(cause.len(), 103); // 100 truncated + "..."
+    }
+
+    #[test]
+    fn test_validate_asserts_short_cause_not_truncated() {
+        let constraints = vec![make_assert(Some("x"), "this > 0")];
+        let err = validate_asserts(&constraints).unwrap_err();
+        let cause = &err.causes[0].reason;
+        assert!(!cause.ends_with("..."));
+        assert_eq!(cause, "Failed: x this > 0");
+    }
+
+    #[test]
+    fn test_validate_asserts_ignores_checks() {
+        let constraints = vec![(
+            Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this > 0".to_string()),
+                label: Some("chk".to_string()),
+            },
+            false, // failing check — should be ignored
+        )];
+        assert!(validate_asserts(&constraints).is_ok());
     }
 }

--- a/engine/baml-lib/jsonish/src/tests/test_constraints.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_constraints.rs
@@ -974,7 +974,11 @@ class Item {
     ]}"#;
 
     let parsed = from_str(&target, &target_type, raw, true);
-    assert!(parsed.is_ok(), "Parse should succeed (items dropped, not error): {:?}", parsed);
+    assert!(
+        parsed.is_ok(),
+        "Parse should succeed (items dropped, not error): {:?}",
+        parsed
+    );
 
     let bvwf = parsed.unwrap();
 

--- a/engine/baml-lib/jsonish/src/tests/test_constraints.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_constraints.rs
@@ -937,3 +937,83 @@ mod try_cast_tests {
         assert!(result.is_none());
     }
 }
+
+/// Test that when list items are dropped due to failing asserts, the
+/// explanation_json on ResponseBamlValue surfaces those failures.
+#[test_log::test]
+fn test_dropped_list_items_appear_in_explanation() {
+    use crate::helpers::{load_test_ir, parsed_value_to_response, render_output_format};
+
+    let schema = r#"
+class Receipt {
+    name string
+    items Item[]
+}
+
+class Item {
+    label string
+    price float @assert(expensive, {{ this > 100.0 }})
+}
+"#;
+
+    let ir = load_test_ir(schema);
+    let mut target_type = TypeIR::class("Receipt");
+    ir.finalize_type(&mut target_type);
+    let target = render_output_format(
+        &ir,
+        &target_type,
+        &Default::default(),
+        baml_types::StreamingMode::NonStreaming,
+    )
+    .unwrap();
+
+    // All items have price < 100, so all should fail the assert and be dropped.
+    let raw = r#"{"name": "Test Store", "items": [
+        {"label": "Apple", "price": 1.50},
+        {"label": "Banana", "price": 0.75}
+    ]}"#;
+
+    let parsed = from_str(&target, &target_type, raw, true);
+    assert!(parsed.is_ok(), "Parse should succeed (items dropped, not error): {:?}", parsed);
+
+    let bvwf = parsed.unwrap();
+
+    // The parsed value should have an empty items list.
+    let value: BamlValue = bvwf.clone().into();
+    let items = match &value {
+        BamlValue::Class(_, fields) => fields.get("items"),
+        _ => panic!("Expected class"),
+    };
+    assert_eq!(
+        items.map(|v| match v {
+            BamlValue::List(l) => l.len(),
+            _ => panic!("Expected list"),
+        }),
+        Some(0),
+        "All items should have been dropped by the assert"
+    );
+
+    // Check BamlValueWithFlags-level explanation.
+    let bvwf_explanations = bvwf.explanation_json();
+    assert!(
+        !bvwf_explanations.is_empty(),
+        "Expected non-empty BamlValueWithFlags explanations"
+    );
+
+    // Check ResponseBamlValue-level explanation.
+    let response = parsed_value_to_response(&ir, bvwf, baml_types::StreamingMode::NonStreaming)
+        .expect("parsed_value_to_response should succeed");
+
+    let explanations = response.explanation_json();
+    let explanation_str = serde_json::to_string(&explanations).unwrap();
+    assert!(
+        !explanations.is_empty(),
+        "Expected non-empty ResponseBamlValue explanations"
+    );
+
+    // The explanation should mention "Assertions failed" somewhere in the tree.
+    assert!(
+        explanation_str.contains("Assertions failed"),
+        "Expected 'Assertions failed' in explanation, got: {explanation_str}"
+    );
+}

--- a/engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs
+++ b/engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs
@@ -461,12 +461,17 @@ where
                     );
                     BAML_TRACER.lock().unwrap().put(Arc::new(trace_event));
                 }
-                // Don't include flags in final resopnse either until we
-                // figure out how to reduce memory usage.
+                // Strip most flags to reduce memory usage, but keep the
+                // lightweight ones that the UI needs for diagnostics.
                 let response_value_without_flags = match response_value {
                     Some(Ok(baml_value)) => {
                         Some(Ok(ResponseBamlValue(baml_value.0.map_meta_owned(|m| {
-                            jsonish::ResponseValueMeta(vec![], m.1, m.2, m.3)
+                            use jsonish::deserializer::deserialize_flags::Flag;
+                            const MAX_KEPT_FLAGS: usize = 10;
+                            let kept: Vec<Flag> = m.0.into_iter().filter(|f| {
+                                matches!(f, Flag::ArrayItemParseError(..) | Flag::ConstraintResults(..))
+                            }).take(MAX_KEPT_FLAGS).collect();
+                            jsonish::ResponseValueMeta(kept, m.1, m.2, m.3)
                         }))))
                     }
                     Some(Err(e)) => Some(Err(e)),

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ParsedResponseRender.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ParsedResponseRender.tsx
@@ -1,16 +1,16 @@
-import JsonView from "@uiw/react-json-view"
-import { githubLightTheme as lightTheme } from "@uiw/react-json-view/githubLight"
-import { vscodeTheme as darkTheme } from "@uiw/react-json-view/vscode"
-import type { TestResponseData } from "../../../../../../sdk/interface"
-import { useTheme } from "next-themes"
-import { RenderPromptPart } from "../../render-text"
-import { ScrollArea } from "@baml/ui/scroll-area"
-import { useState } from "react"
-import { AlertTriangle, ChevronDown, ChevronUp } from "lucide-react"
+import JsonView from '@uiw/react-json-view'
+import { githubLightTheme as lightTheme } from '@uiw/react-json-view/githubLight'
+import { vscodeTheme as darkTheme } from '@uiw/react-json-view/vscode'
+import type { TestResponseData } from '../../../../../../sdk/interface'
+import { useTheme } from 'next-themes'
+import { RenderPromptPart } from '../../render-text'
+import { ScrollArea } from '@baml/ui/scroll-area'
+import { useState } from 'react'
+import { AlertTriangle, ChevronDown, ChevronUp } from 'lucide-react'
 
 const ErrorText = ({ text }: { text: string }) => {
-  return <pre className="text-xs text-red-500 whitespace-pre-wrap">{text}</pre>
-};
+  return <pre className='text-xs text-red-500 whitespace-pre-wrap'>{text}</pre>
+}
 
 const ExplanationView = ({ explanation }: { explanation: string }) => {
   const [isExpanded, setIsExpanded] = useState(false)
@@ -24,37 +24,37 @@ const ExplanationView = ({ explanation }: { explanation: string }) => {
   }
 
   return (
-    <div className="mt-2 rounded-md border border-yellow-500/30 bg-yellow-500/5 p-2">
+    <div className='mt-2 rounded-md border border-yellow-500/30 bg-yellow-500/5 p-2'>
       <button
-        className="flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400 hover:underline"
+        className='flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400 hover:underline'
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <AlertTriangle className="w-3 h-3" />
+        <AlertTriangle className='w-3 h-3' />
         <span>
-          {parsed.length} parsing {parsed.length === 1 ? "issue" : "issues"}{" "}
+          {parsed.length} parsing {parsed.length === 1 ? 'issue' : 'issues'}{' '}
           (items may have been dropped)
         </span>
         {isExpanded ? (
-          <ChevronUp className="w-3 h-3" />
+          <ChevronUp className='w-3 h-3' />
         ) : (
-          <ChevronDown className="w-3 h-3" />
+          <ChevronDown className='w-3 h-3' />
         )}
       </button>
       {isExpanded && (
-        <pre className="mt-2 text-xs text-yellow-700 dark:text-yellow-300 whitespace-pre-wrap max-h-[300px] overflow-auto">
+        <pre className='mt-2 text-xs text-yellow-700 dark:text-yellow-300 whitespace-pre-wrap max-h-[300px] overflow-auto'>
           {JSON.stringify(parsed, null, 2)}
         </pre>
       )}
     </div>
-  );
-};
+  )
+}
 
 // Renders the parsed response only
 export const ParsedResponseRenderer: React.FC<{
   response?: TestResponseData
 }> = ({ response }) => {
   if (!response) {
-    return <div className="text-xs text-muted-foreground"> Waiting for response...  </div>
+    return <div className='text-xs text-muted-foreground'>Waiting for response...</div>
   }
 
   const llmFailure = response.llm_failure
@@ -74,39 +74,35 @@ export const ParsedResponseRenderer: React.FC<{
         <ExplanationView explanation={parsedResponse.explanation} />
       )}
     </div>
-  );
-};
+  )
+}
 
-const ParsedResponseRender = ({
-  response,
-}: {
-  response: string | undefined;
-}) => {
-  const { theme } = useTheme();
+const ParsedResponseRender = ({ response }: { response: string | undefined }) => {
+  const { theme } = useTheme()
 
   if (!response) {
-    return null;
+    return null
   }
 
-  let parsedResponseObj;
+  let parsedResponseObj
   try {
-    parsedResponseObj = JSON.parse(response);
-    if (parsedResponseObj === null || typeof parsedResponseObj !== "object") {
-      return <RenderPromptPart text={response} />;
+    parsedResponseObj = JSON.parse(response)
+    if (parsedResponseObj === null || typeof parsedResponseObj !== 'object') {
+      return <RenderPromptPart text={response} />
     }
   } catch (e) {
-    parsedResponseObj = response;
+    parsedResponseObj = response
   }
 
-  if (typeof parsedResponseObj === "string") {
-    return <RenderPromptPart text={parsedResponseObj} />;
+  if (typeof parsedResponseObj === 'string') {
+    return <RenderPromptPart text={parsedResponseObj} />
   }
 
   return (
-    <div className="flex max-h-[600px]  text-xs">
-      <ScrollArea className="pr-2 w-full text-xs" type="always">
+    <div className='flex max-h-[600px]  text-xs'>
+      <ScrollArea className='pr-2 w-full text-xs' type='always'>
         <JsonView
-          className="p-1 w-full rounded-md"
+          className='p-1 w-full rounded-md'
           value={parsedResponseObj || {}}
           collapsed={false}
           enableClipboard={true}
@@ -114,48 +110,41 @@ const ParsedResponseRender = ({
           displayObjectSize={true}
           indentWidth={16}
           shortenTextAfterLength={700}
-          style={theme === "dark" ? darkTheme : lightTheme}
+          style={theme === 'dark' ? darkTheme : lightTheme}
         >
           <JsonView.String
-            render={(
-              { children, style: _style, ...reset },
-              { type, value, keyName },
-            ) => {
-              if (type === "type") {
-                return <span />;
+            render={({ children, style: _style, ...reset }, { type, value, keyName }) => {
+              if (type === 'type') {
+                return <span />
               }
-              if (type === "value") {
+              if (type === 'value') {
                 return (
-                  <span {...reset} className="whitespace-pre-wrap break-all">
-                    &quot;{children}&quot;
-                    <span className="text-muted-foreground">, </span>
+                  <span {...reset} className='whitespace-pre-wrap break-all'>
+                    &quot;{children}&quot;<span className='text-muted-foreground'>, </span>
                   </span>
-                );
+                )
               }
             }}
           />
           <JsonView.Colon
-            render={(
-              { style: _style, ...props },
-              { parentValue, value, keyName },
-            ) => {
-              if (Array.isArray(parentValue) && props.children == ":") {
-                return <span />;
+            render={({ style: _style, ...props }, { parentValue, value, keyName }) => {
+              if (Array.isArray(parentValue) && props.children == ':') {
+                return <span />
               }
-              return <span {...props}>: </span>;
+              return <span {...props}>: </span>
             }}
           />
 
           <JsonView.Null
             render={({ children, style: _style, ...reset }) => (
-              <span {...reset} className="whitespace-pre-wrap break-words">
+              <span {...reset} className='whitespace-pre-wrap break-words'>
                 null
               </span>
             )}
           />
           <JsonView.Undefined
             render={({ children, style: _style, ...reset }) => (
-              <span {...reset} className="whitespace-pre-wrap break-words">
+              <span {...reset} className='whitespace-pre-wrap break-words'>
                 undefined
               </span>
             )}
@@ -169,13 +158,13 @@ const ParsedResponseRender = ({
                 Array.isArray(parentValue) &&
                 Number.isFinite(props.children)
               ) {
-                return <span className="" />;
+                return <span className='' />;
               }
-              return <span className="" {...props} />;
+              return <span className='' {...props} />
             }}
           />
         </JsonView>
       </ScrollArea>
     </div>
-  );
-};
+  )
+}

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ParsedResponseRender.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ParsedResponseRender.tsx
@@ -1,21 +1,60 @@
-import JsonView from '@uiw/react-json-view'
-import { githubLightTheme as lightTheme } from '@uiw/react-json-view/githubLight'
-import { vscodeTheme as darkTheme } from '@uiw/react-json-view/vscode'
-import type { TestResponseData } from '../../../../../../sdk/interface'
-import { useTheme } from 'next-themes'
-import { RenderPromptPart } from '../../render-text'
-import { ScrollArea } from '@baml/ui/scroll-area'
+import JsonView from "@uiw/react-json-view"
+import { githubLightTheme as lightTheme } from "@uiw/react-json-view/githubLight"
+import { vscodeTheme as darkTheme } from "@uiw/react-json-view/vscode"
+import type { TestResponseData } from "../../../../../../sdk/interface"
+import { useTheme } from "next-themes"
+import { RenderPromptPart } from "../../render-text"
+import { ScrollArea } from "@baml/ui/scroll-area"
+import { useState } from "react"
+import { AlertTriangle, ChevronDown, ChevronUp } from "lucide-react"
 
 const ErrorText = ({ text }: { text: string }) => {
-  return <pre className='text-xs text-red-500 whitespace-pre-wrap'>{text}</pre>
-}
+  return <pre className="text-xs text-red-500 whitespace-pre-wrap">{text}</pre>
+};
+
+const ExplanationView = ({ explanation }: { explanation: string }) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  let parsed: unknown[];
+  try {
+    parsed = JSON.parse(explanation)
+    if (!Array.isArray(parsed) || parsed.length === 0) return null
+  } catch {
+    return null
+  }
+
+  return (
+    <div className="mt-2 rounded-md border border-yellow-500/30 bg-yellow-500/5 p-2">
+      <button
+        className="flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400 hover:underline"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <AlertTriangle className="w-3 h-3" />
+        <span>
+          {parsed.length} parsing {parsed.length === 1 ? "issue" : "issues"}{" "}
+          (items may have been dropped)
+        </span>
+        {isExpanded ? (
+          <ChevronUp className="w-3 h-3" />
+        ) : (
+          <ChevronDown className="w-3 h-3" />
+        )}
+      </button>
+      {isExpanded && (
+        <pre className="mt-2 text-xs text-yellow-700 dark:text-yellow-300 whitespace-pre-wrap max-h-[300px] overflow-auto">
+          {JSON.stringify(parsed, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+};
 
 // Renders the parsed response only
 export const ParsedResponseRenderer: React.FC<{
   response?: TestResponseData
 }> = ({ response }) => {
   if (!response) {
-    return <div className='text-xs text-muted-foreground'>Waiting for response...</div>
+    return <div className="text-xs text-muted-foreground"> Waiting for response...  </div>
   }
 
   const llmFailure = response.llm_failure
@@ -31,36 +70,43 @@ export const ParsedResponseRenderer: React.FC<{
     <div>
       <ParsedResponseRender response={parsedResponse?.value} />
       {failureMessage && <ErrorText text={failureMessage} />}
+      {parsedResponse?.explanation && (
+        <ExplanationView explanation={parsedResponse.explanation} />
+      )}
     </div>
-  )
-}
+  );
+};
 
-const ParsedResponseRender = ({ response }: { response: string | undefined }) => {
-  const { theme } = useTheme()
+const ParsedResponseRender = ({
+  response,
+}: {
+  response: string | undefined;
+}) => {
+  const { theme } = useTheme();
 
   if (!response) {
-    return null
+    return null;
   }
 
-  let parsedResponseObj
+  let parsedResponseObj;
   try {
-    parsedResponseObj = JSON.parse(response)
-    if (parsedResponseObj === null || typeof parsedResponseObj !== 'object') {
-      return <RenderPromptPart text={response} />
+    parsedResponseObj = JSON.parse(response);
+    if (parsedResponseObj === null || typeof parsedResponseObj !== "object") {
+      return <RenderPromptPart text={response} />;
     }
   } catch (e) {
-    parsedResponseObj = response
+    parsedResponseObj = response;
   }
 
-  if (typeof parsedResponseObj === 'string') {
-    return <RenderPromptPart text={parsedResponseObj} />
+  if (typeof parsedResponseObj === "string") {
+    return <RenderPromptPart text={parsedResponseObj} />;
   }
 
   return (
-    <div className='flex max-h-[600px]  text-xs'>
-      <ScrollArea className='pr-2 w-full text-xs' type='always'>
+    <div className="flex max-h-[600px]  text-xs">
+      <ScrollArea className="pr-2 w-full text-xs" type="always">
         <JsonView
-          className='p-1 w-full rounded-md'
+          className="p-1 w-full rounded-md"
           value={parsedResponseObj || {}}
           collapsed={false}
           enableClipboard={true}
@@ -68,55 +114,68 @@ const ParsedResponseRender = ({ response }: { response: string | undefined }) =>
           displayObjectSize={true}
           indentWidth={16}
           shortenTextAfterLength={700}
-          style={theme === 'dark' ? darkTheme : lightTheme}
+          style={theme === "dark" ? darkTheme : lightTheme}
         >
           <JsonView.String
-            render={({ children, style: _style, ...reset }, { type, value, keyName }) => {
-              if (type === 'type') {
-                return <span />
+            render={(
+              { children, style: _style, ...reset },
+              { type, value, keyName },
+            ) => {
+              if (type === "type") {
+                return <span />;
               }
-              if (type === 'value') {
+              if (type === "value") {
                 return (
-                  <span {...reset} className='whitespace-pre-wrap break-all'>
-                    &quot;{children}&quot;<span className='text-muted-foreground'>, </span>
+                  <span {...reset} className="whitespace-pre-wrap break-all">
+                    &quot;{children}&quot;
+                    <span className="text-muted-foreground">, </span>
                   </span>
-                )
+                );
               }
             }}
           />
           <JsonView.Colon
-            render={({ style: _style, ...props }, { parentValue, value, keyName }) => {
-              if (Array.isArray(parentValue) && props.children == ':') {
-                return <span />
+            render={(
+              { style: _style, ...props },
+              { parentValue, value, keyName },
+            ) => {
+              if (Array.isArray(parentValue) && props.children == ":") {
+                return <span />;
               }
-              return <span {...props}>: </span>
+              return <span {...props}>: </span>;
             }}
           />
 
           <JsonView.Null
             render={({ children, style: _style, ...reset }) => (
-              <span {...reset} className='whitespace-pre-wrap break-words'>
+              <span {...reset} className="whitespace-pre-wrap break-words">
                 null
               </span>
             )}
           />
           <JsonView.Undefined
             render={({ children, style: _style, ...reset }) => (
-              <span {...reset} className='whitespace-pre-wrap break-words'>
+              <span {...reset} className="whitespace-pre-wrap break-words">
                 undefined
               </span>
             )}
           />
           <JsonView.KeyName
-            render={({ style: _style, ...props }, { parentValue, value, keyName }) => {
-              if (Array.isArray(parentValue) && Number.isFinite(props.children)) {
-                return <span className='' />
+            render={(
+              { style: _style, ...props },
+              { parentValue, value, keyName },
+            ) => {
+              if (
+                Array.isArray(parentValue) &&
+                Number.isFinite(props.children)
+              ) {
+                return <span className="" />;
               }
-              return <span className='' {...props} />
+              return <span className="" {...props} />;
             }}
           />
         </JsonView>
       </ScrollArea>
     </div>
-  )
-}
+  );
+};

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
@@ -14,7 +14,7 @@ import { TruncatedString } from '../../TruncatedString'
 import { testcaseObjectAtom, TestState } from '../../../atoms'
 import { type TestHistoryRun } from '../atoms'
 import { useRunBamlTests } from '../test-runner'
-import { getExplanation, getStatus, getTestStateResponse } from '../testStateUtils'
+import { getStatus, getTestStateResponse } from '../testStateUtils'
 import { ResponseViewType, tabularViewConfigAtom } from './atoms'
 import { MarkdownRenderer } from './MarkdownRenderer'
 import { ParsedResponseRenderer } from './ParsedResponseRender'
@@ -89,17 +89,7 @@ const ResponseContent = ({
     <div className=''>
       {/* todo: render the failure if pretty or raw is selected. */}
       {responseViewType === 'parsed' && (
-        <>
-          <ParsedResponseRenderer response={getTestStateResponse(state) as TestResponseData | undefined} />
-
-          {/* Don't show the explanation for now. */}
-          {false && getExplanation(state) && (
-            <div className='flex flex-col gap-2 mt-2 text-xs text-muted-foreground/80'>
-              <div>BAML parser fixed the following issues:</div>
-              <pre>{getExplanation(state)}</pre>
-            </div>
-          )}
-        </>
+        <ParsedResponseRenderer response={getTestStateResponse(state) as TestResponseData | undefined} />
       )}
       {responseViewType === 'pretty' && typeof getTestStateResponse(state) === 'object' && (
         <MarkdownRenderer source={(getTestStateResponse(state) as TestResponseData)?.llm_response?.content || ''} />

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/testStateUtils.ts
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/testStateUtils.ts
@@ -20,10 +20,3 @@ export const getTestStateResponse = (response: TestState) => {
   }
   return undefined;
 };
-
-export const getExplanation = (response: TestState) => {
-  if (response.status === 'done') {
-    return response.response.parsed_response?.explanation;
-  }
-  return undefined;
-};


### PR DESCRIPTION
When an item is removed from a list due to a parsing error in that item, we now report this in the playground.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assertion and constraint failures are now displayed in an explanation view within the parsed response panel.
  * Failure messages are automatically truncated and capped at five issues for improved readability.

* **Bug Fixes**
  * Constraint violation details for dropped list items now properly appear in response explanations.

* **Refactor**
  * Streamlined explanation extraction utilities in the test panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->