### PR TITLE
bump CI timeouts

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -25,7 +25,7 @@ jobs:
     name: "cargo test (linux)"
     runs-on: ubuntu-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,7 +82,7 @@ jobs:
     name: "cargo test (macos)"
     runs-on: macos-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 30
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
         with:
@@ -119,7 +119,7 @@ jobs:
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
-    timeout-minutes: 45
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v4
         with:
@@ -155,7 +155,7 @@ jobs:
     name: "cargo test (wasm)"
     runs-on: ubuntu-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -192,7 +192,7 @@ jobs:
     name: "size-gate (linux)"
     runs-on: ubuntu-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -241,7 +241,7 @@ jobs:
     name: "size-gate (macos)"
     runs-on: macos-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -284,7 +284,7 @@ jobs:
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
-    timeout-minutes: 40
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -325,7 +325,7 @@ jobs:
     name: "size-gate (wasm)"
     runs-on: ubuntu-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -426,7 +426,7 @@ jobs:
     name: "cargo build (msrv)"
     runs-on: ubuntu-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -486,7 +486,7 @@ jobs:
     name: "snapshot tests"
     runs-on: ubuntu-latest
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       # Disable Python + pipx tools: mise 2025.12.12 downloads a broken
       # freethreaded Python build that's missing a lib/ directory.
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.unsafe == 'true'
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -368,7 +368,7 @@ jobs:
         needs.determine_changes.outputs.thir == 'true' ||
         needs.determine_changes.outputs.codegen == 'true'
       )
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@v4

--- a/.github/workflows/wasm-pack-tests.reusable.yaml
+++ b/.github/workflows/wasm-pack-tests.reusable.yaml
@@ -24,7 +24,7 @@ jobs:
   wasm-pack-test:
     name: "wasm-pack test"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/webview-tests.reusable.yaml
+++ b/.github/workflows/webview-tests.reusable.yaml
@@ -18,7 +18,7 @@ jobs:
   unit-tests:
     name: "Unit Tests (jsdom)"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,7 +56,7 @@ jobs:
   browser-tests:
     name: "Browser Tests (Playwright)"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,7 +98,7 @@ jobs:
   hmr-tests:
     name: "HMR Tests (Hot Reload)"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended timeout limits for continuous integration jobs to allow additional time for test execution and checks to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->