### PR TITLE
feat(google-ai): Add use_shorthand_url option for API gateway proxies

### DIFF
--- a/engine/baml-lib/llm-client/src/clients/google_ai.rs
+++ b/engine/baml-lib/llm-client/src/clients/google_ai.rs
@@ -27,6 +27,10 @@ pub struct UnresolvedGoogleAI<Meta> {
     properties: IndexMap<String, (Meta, UnresolvedValue<Meta>)>,
     media_url_handler: UnresolvedMediaUrlHandler,
     http_config: HttpConfig,
+    /// When true, sends POST requests directly to base_url without appending
+    /// `/models/{model}:generateContent`. Useful for API gateways like OpenCode Zen
+    /// that handle routing internally.
+    use_shorthand_url: bool,
 }
 
 impl<Meta> UnresolvedGoogleAI<Meta> {
@@ -51,6 +55,7 @@ impl<Meta> UnresolvedGoogleAI<Meta> {
             finish_reason_filter: self.finish_reason_filter.clone(),
             media_url_handler: self.media_url_handler.clone(),
             http_config: self.http_config.clone(),
+            use_shorthand_url: self.use_shorthand_url,
         }
     }
 }
@@ -68,6 +73,10 @@ pub struct ResolvedGoogleAI {
     pub finish_reason_filter: FinishReasonFilter,
     pub media_url_handler: MediaUrlHandler,
     pub http_config: HttpConfig,
+    /// When true, sends POST requests directly to base_url without appending
+    /// `/models/{model}:generateContent`. Useful for API gateways like OpenCode Zen
+    /// that handle routing internally.
+    pub use_shorthand_url: bool,
 }
 
 impl ResolvedGoogleAI {
@@ -165,6 +174,7 @@ impl<Meta: Clone> UnresolvedGoogleAI<Meta> {
             finish_reason_filter: self.finish_reason_filter.resolve(ctx)?,
             media_url_handler: self.media_url_handler.resolve(ctx)?,
             http_config: self.http_config.clone(),
+            use_shorthand_url: self.use_shorthand_url,
         })
     }
 
@@ -189,6 +199,10 @@ impl<Meta: Clone> UnresolvedGoogleAI<Meta> {
         let headers = properties.ensure_headers().unwrap_or_default();
         let finish_reason_filter = properties.ensure_finish_reason_filter();
         let media_url_handler = properties.ensure_media_url_handler();
+        let use_shorthand_url = properties
+            .ensure_bool("use_shorthand_url", false)
+            .map(|(_, v, _)| v)
+            .unwrap_or(false);
         let (properties, errors) = properties.finalize();
 
         if !errors.is_empty() {
@@ -207,6 +221,113 @@ impl<Meta: Clone> UnresolvedGoogleAI<Meta> {
             finish_reason_filter,
             media_url_handler,
             http_config,
+            use_shorthand_url,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use baml_types::{StringOr, UnresolvedValue};
+    use indexmap::IndexMap;
+
+    use super::*;
+    use crate::clients::helpers::PropertyHandler;
+
+    fn create_test_options(
+        options: &[(&str, UnresolvedValue<()>)],
+    ) -> IndexMap<String, ((), UnresolvedValue<()>)> {
+        options
+            .iter()
+            .map(|(k, v)| (k.to_string(), ((), v.clone())))
+            .collect()
+    }
+
+    #[test]
+    fn test_use_shorthand_url_defaults_to_false() {
+        let options = create_test_options(&[
+            (
+                "model",
+                UnresolvedValue::String(StringOr::Value("gemini-3-flash".to_string()), ()),
+            ),
+            (
+                "api_key",
+                UnresolvedValue::String(StringOr::Value("test-key".to_string()), ()),
+            ),
+        ]);
+        let handler = PropertyHandler::new(options, ());
+        let result = UnresolvedGoogleAI::create_from(handler);
+        match result {
+            Ok(unresolved) => assert!(!unresolved.use_shorthand_url),
+            Err(errors) => panic!("Expected Ok but got {} errors", errors.len()),
+        }
+    }
+
+    #[test]
+    fn test_use_shorthand_url_can_be_set_true() {
+        let options = create_test_options(&[
+            (
+                "model",
+                UnresolvedValue::String(StringOr::Value("gemini-3-flash".to_string()), ()),
+            ),
+            (
+                "api_key",
+                UnresolvedValue::String(StringOr::Value("test-key".to_string()), ()),
+            ),
+            ("use_shorthand_url", UnresolvedValue::Bool(true, ())),
+        ]);
+        let handler = PropertyHandler::new(options, ());
+        let result = UnresolvedGoogleAI::create_from(handler);
+        match result {
+            Ok(unresolved) => assert!(unresolved.use_shorthand_url),
+            Err(errors) => panic!("Expected Ok but got {} errors", errors.len()),
+        }
+    }
+
+    #[test]
+    fn test_use_shorthand_url_can_be_set_false() {
+        let options = create_test_options(&[
+            (
+                "model",
+                UnresolvedValue::String(StringOr::Value("gemini-3-flash".to_string()), ()),
+            ),
+            (
+                "api_key",
+                UnresolvedValue::String(StringOr::Value("test-key".to_string()), ()),
+            ),
+            ("use_shorthand_url", UnresolvedValue::Bool(false, ())),
+        ]);
+        let handler = PropertyHandler::new(options, ());
+        let result = UnresolvedGoogleAI::create_from(handler);
+        match result {
+            Ok(unresolved) => assert!(!unresolved.use_shorthand_url),
+            Err(errors) => panic!("Expected Ok but got {} errors", errors.len()),
+        }
+    }
+
+    #[test]
+    fn test_resolved_use_shorthand_url_is_passed_through() {
+        let options = create_test_options(&[
+            (
+                "model",
+                UnresolvedValue::String(StringOr::Value("gemini-3-flash".to_string()), ()),
+            ),
+            (
+                "api_key",
+                UnresolvedValue::String(StringOr::Value("test-key".to_string()), ()),
+            ),
+            ("use_shorthand_url", UnresolvedValue::Bool(true, ())),
+        ]);
+        let handler = PropertyHandler::new(options, ());
+        let unresolved = match UnresolvedGoogleAI::create_from(handler) {
+            Ok(u) => u,
+            Err(errors) => panic!("Expected Ok but got {} errors", errors.len()),
+        };
+
+        let empty_env = std::collections::HashMap::new();
+        let ctx = EvaluationContext::new(&empty_env, true);
+        let resolved = unresolved.resolve(&ctx).unwrap();
+        assert!(resolved.use_shorthand_url);
+        assert_eq!(resolved.model, "gemini-3-flash");
     }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
@@ -221,16 +221,11 @@ impl RequestBuilder for GoogleAIClient {
         stream: bool,
         expose_secrets: bool,
     ) -> Result<reqwest::RequestBuilder> {
-        let mut should_stream = "generateContent";
-        if stream {
-            should_stream = "streamGenerateContent?alt=sse";
-        }
-
-        let baml_original_url = format!(
-            "{}/models/{}:{}",
-            self.properties.base_url,
-            self.properties.model.clone(),
-            should_stream
+        let baml_original_url = build_google_ai_url(
+            &self.properties.base_url,
+            &self.properties.model,
+            stream,
+            self.properties.use_shorthand_url,
         );
 
         let mut req = match (&self.properties.proxy_url, allow_proxy) {
@@ -409,5 +404,99 @@ impl CompletionToProviderBody for GoogleAIClient {
         prompt: &str,
     ) -> serde_json::Map<String, serde_json::Value> {
         convert_completion_prompt_to_body(prompt)
+    }
+}
+
+/// Builds the URL for Google AI API requests.
+///
+/// When `use_shorthand_url` is true, returns the base_url directly without any suffix.
+/// This is useful for API gateways like OpenCode Zen that handle routing internally.
+///
+/// When `use_shorthand_url` is false (the default), builds the full Google Gemini API URL:
+/// `{base_url}/models/{model}:generateContent` or `{base_url}/models/{model}:streamGenerateContent?alt=sse`
+pub fn build_google_ai_url(
+    base_url: &str,
+    model: &str,
+    stream: bool,
+    use_shorthand_url: bool,
+) -> String {
+    if use_shorthand_url {
+        base_url.to_string()
+    } else {
+        let method = if stream {
+            "streamGenerateContent?alt=sse"
+        } else {
+            "generateContent"
+        };
+        format!("{}/models/{}:{}", base_url, model, method)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_url_format_non_streaming() {
+        let url = build_google_ai_url(
+            "https://generativelanguage.googleapis.com/v1beta",
+            "gemini-3-flash",
+            false,
+            false,
+        );
+        assert_eq!(
+            url,
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent"
+        );
+    }
+
+    #[test]
+    fn test_default_url_format_streaming() {
+        let url = build_google_ai_url(
+            "https://generativelanguage.googleapis.com/v1beta",
+            "gemini-3-flash",
+            true,
+            false,
+        );
+        assert_eq!(
+            url,
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:streamGenerateContent?alt=sse"
+        );
+    }
+
+    #[test]
+    fn test_shorthand_url_non_streaming() {
+        let url = build_google_ai_url(
+            "https://opencode.ai/zen/v1/models/gemini-3-flash",
+            "gemini-3-flash",
+            false,
+            true,
+        );
+        assert_eq!(url, "https://opencode.ai/zen/v1/models/gemini-3-flash");
+    }
+
+    #[test]
+    fn test_shorthand_url_streaming() {
+        let url = build_google_ai_url(
+            "https://opencode.ai/zen/v1/models/gemini-3-flash",
+            "gemini-3-flash",
+            true,
+            true,
+        );
+        assert_eq!(url, "https://opencode.ai/zen/v1/models/gemini-3-flash");
+    }
+
+    #[test]
+    fn test_custom_base_url_without_shorthand() {
+        let url = build_google_ai_url(
+            "https://custom-proxy.example.com/api",
+            "gemini-pro",
+            false,
+            false,
+        );
+        assert_eq!(
+            url,
+            "https://custom-proxy.example.com/api/models/gemini-pro:generateContent"
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR addresses a user request to support OpenCode Zen with Gemini models

## Changes
Please describe the changes proposed in this pull request

This PR adds a new `use_shorthand_url` option to the `google-ai` provider that allows users to use API gateways like OpenCode Zen that proxy to Google's Gemini API but expect a different URL format.

### The Problem

When using the `google-ai` provider with OpenCode Zen's Gemini endpoint:
- User configures `base_url: "https://opencode.ai/zen/v1/models/gemini-3-flash"`
- BAML appends `:generateContent` suffix, resulting in `https://opencode.ai/zen/v1/models/gemini-3-flash:generateContent`
- OpenCode Zen expects just `https://opencode.ai/zen/v1/models/gemini-3-flash` and returns a 500 error

### The Solution

Added a new `use_shorthand_url` option (defaults to `false`) that when set to `true`:
- Skips appending `/models/{model}:generateContent` to the URL
- Posts directly to the `base_url` as-is
- Maintains the same request/response body format (Gemini API format)

### Usage Example

```baml
client MyGeminiClient {
  provider google-ai
  options {
    model gemini-3-flash
    base_url "https://opencode.ai/zen/v1/models/gemini-3-flash"
    api_key env.OPENCODE_ZEN_API_KEY
    use_shorthand_url true
  }
}
```

### Files Changed

- `engine/baml-lib/llm-client/src/clients/google_ai.rs` - Added `use_shorthand_url` field and parsing
- `engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs` - Updated URL building logic

## Testing
Please describe how you tested these changes

- [x] Unit tests added/updated
  - Added 4 tests in `google_ai.rs` for option parsing
  - Added 5 tests in `googleai_client.rs` for URL generation logic
- [x] All existing tests pass (`cargo test --lib -p internal-llm-client -p baml-runtime`)

## Screenshots
If applicable, add screenshots to help explain your changes

N/A - This is a backend change

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (documentation update would be helpful to mention the new option)

## Additional Notes
Add any other context about the PR here

The error the user saw was:
```
POST https://opencode.ai/zen/v1/models/gemini-3-flash:generateContent
{"type":"error","error":{"type":"error","message":"Cannot read properties of undefined (reading 'promptTokenCount')"}}
```

This was happening because OpenCode Zen couldn't parse the unexpected `:generateContent` in the URL path. With `use_shorthand_url: true`, the URL is now correctly formed as `https://opencode.ai/zen/v1/models/gemini-3-flash` and OpenCode Zen can proxy the request properly.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1775077936666239?thread_ts=1775077936.666239&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-a981ce36-f19a-5b9d-b5fa-8324a5cb2197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a981ce36-f19a-5b9d-b5fa-8324a5cb2197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

