### PR TITLE
bump some CI runner resources

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -23,7 +23,9 @@ env:
 jobs:
   cargo-test-linux:
     name: "cargo test (linux)"
-    runs-on: ubuntu-latest
+    # Bumped to ubuntu-32gb: ubuntu-latest was hitting resource issues, using
+    # this overkill runner until we can root-cause and right-size.
+    runs-on: ubuntu-32gb
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
     timeout-minutes: 25
     steps:

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           workspaces: "baml_language -> target"
           # Share cache across similar Linux jobs for better hit rates
-          shared-key: "linux-cargo"
+          shared-key: "linux-cargo-32gb"
 
       - name: "Install cargo insta"
         uses: taiki-e/install-action@v2

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -426,7 +426,9 @@ jobs:
 
   cargo-build-msrv:
     name: "cargo build (msrv)"
-    runs-on: ubuntu-latest
+    # Bumped to ubuntu-32gb: ubuntu-latest was hitting resource issues, using
+    # this overkill runner until we can root-cause and right-size.
+    runs-on: ubuntu-32gb
     if: ${{ inputs.code_changed == 'true' || inputs.run_all }}
     timeout-minutes: 25
     steps:
@@ -452,8 +454,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
-          # Share cache across Linux MSRV jobs
-          shared-key: "linux-msrv"
+          # Share cache across Linux MSRV jobs (32gb runner)
+          shared-key: "linux-msrv-32gb"
 
       - name: "Build with MSRV"
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,9 @@ jobs:
   # Lint checks
   prek:
     name: "Pre-commit Checks"
-    runs-on: ubuntu-latest
+    # Bumped to ubuntu-32gb: ubuntu-latest was hitting resource issues, using
+    # this overkill runner until we can root-cause and right-size.
+    runs-on: ubuntu-32gb
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     timeout-minutes: 20

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,7 +246,7 @@ jobs:
         with:
           workspaces: "baml_language -> target"
           # Share cache across similar Linux jobs for better hit rates
-          shared-key: "linux-cargo"
+          shared-key: "linux-cargo-32gb"
 
       - name: "Install cargo-binstall"
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI jobs switched to higher-resource runners (ubuntu-32gb).
  * CI cache keys updated to match new runners (e.g., linux-cargo-32gb, linux-msrv-32gb).
  * No application code or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->