### PR TITLE
docs: update README editor support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ final = stream.get_final_response()
 And get fully type-safe outputs for each chunk in the stream.
 
 ## Test prompts 10x faster, right in your IDE
-BAML comes with native tooling for VSCode (jetbrains + neovim coming soon). 
+BAML comes with native tooling for [VS Code](https://docs.boundaryml.com/guide/installation-editors/vs-code-extension) and [JetBrains IDEs](https://docs.boundaryml.com/guide/installation-editors/jetbrains), with support for [other editors](https://docs.boundaryml.com/guide/installation-editors/others) continuing to expand.
 
 **Visualize full prompt (including any multi-modal assets), and the API request**. BAML gives you full transparency and control of the prompt.
 


### PR DESCRIPTION
## Summary
- replace the outdated README note that still says JetBrains support is coming soon
- link the README editor section to the existing VS Code, JetBrains, and other editor installation docs

## Why
The repository already ships a JetBrains plugin and publishes JetBrains installation docs, so the current README copy can mislead new users about available editor support.

## Testing
- not run (README-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to provide clearer information about BAML IDE tooling support, including explicit links for VS Code and JetBrains IDEs, and noted that support for other editors is expanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->