### PR TITLE
feat: add record-replay system for playground HTTP calls

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -7254,11 +7254,14 @@ dependencies = [
  "bex_external_types",
  "bex_heap",
  "bex_vm_types",
+ "hex",
  "indexmap 2.13.0",
+ "serde",
  "sha2 0.10.9",
  "sys_llm",
  "sys_types",
  "tokio",
+ "web-time",
 ]
 
 [[package]]

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -7255,6 +7255,7 @@ dependencies = [
  "bex_heap",
  "bex_vm_types",
  "indexmap 2.13.0",
+ "sha2 0.10.9",
  "sys_llm",
  "sys_types",
  "tokio",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -192,6 +192,7 @@ wasm-logger = "0.2.0"
 web-time = "1.1.0"
 getrandom = { version = "0.2" }
 rsa = { version = "0.9", default-features = false, features = [ "std", "pem" ] }
+hex = { version = "0.4" }
 sha2 = { version = "0.10", features = [ "oid" ] }
 
 [workspace.lints.rust]

--- a/baml_language/crates/baml_lsp_server/src/lib.rs
+++ b/baml_language/crates/baml_lsp_server/src/lib.rs
@@ -73,11 +73,35 @@ fn build_playground_sys_ops(
         broadcast_tx.clone(),
         fetch_id_alloc.clone(),
     ));
+
+    let broadcast_tx_for_replay = broadcast_tx.clone();
+    let on_replay: Arc<dyn Fn(sys_ops::replay::ReplayFetchEvent) + Send + Sync> =
+        Arc::new(move |event: sys_ops::replay::ReplayFetchEvent| {
+            let _ = broadcast_tx_for_replay.send(WsOutMessage::FetchLogNew {
+                call_id: event.call_id,
+                id: event.fetch_id,
+                method: event.method,
+                url: event.url,
+                request_headers: event.request_headers,
+                request_body: event.request_body,
+                replayed: Some(true),
+            });
+            let _ = broadcast_tx_for_replay.send(WsOutMessage::FetchLogUpdate {
+                call_id: event.call_id,
+                log_id: event.fetch_id,
+                status: Some(event.status),
+                duration_ms: Some(event.duration_ms),
+                response_body: Some(event.response_body),
+                error: None,
+                response_headers: Some(event.response_headers),
+            });
+        });
+
     let replay = ReplayHttp::new(
         Arc::new(PlaygroundHttp(http_state)),
         replay_store,
         fetch_id_alloc,
-        None, // on_replay callback added in Phase 2
+        Some(on_replay),
     );
     sys_ops::SysOpsBuilder::new()
         .with_fs::<sys_native::NativeSysOps>()

--- a/baml_language/crates/baml_lsp_server/src/lib.rs
+++ b/baml_language/crates/baml_lsp_server/src/lib.rs
@@ -40,12 +40,20 @@ pub mod playground_sender;
 pub mod playground_server;
 pub mod playground_ws;
 
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock, atomic::AtomicU64},
+};
 
 use playground_env::{PlaygroundEnv, PlaygroundEnvState};
 use playground_http::{PlaygroundHttp, PlaygroundHttpState};
 use playground_ws::WsOutMessage;
+use sys_ops::replay::{RecordReplay, RecordedResponse, ReplayHttp, RequestKey};
 use tokio::net::TcpListener;
+
+/// Per-project replay store map, shared between the sys_op_factory and the WS server.
+pub type ReplayStoreMap =
+    Arc<std::sync::Mutex<HashMap<String, Arc<RwLock<RecordReplay<RequestKey, RecordedResponse>>>>>>;
 
 pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -58,13 +66,24 @@ pub fn version() -> &'static str {
 fn build_playground_sys_ops(
     broadcast_tx: &tokio::sync::broadcast::Sender<WsOutMessage>,
     env_state: &Arc<PlaygroundEnvState>,
+    replay_store: Arc<RwLock<RecordReplay<RequestKey, RecordedResponse>>>,
 ) -> sys_ops::SysOps {
-    let http_state = Arc::new(PlaygroundHttpState::new(broadcast_tx.clone()));
+    let fetch_id_alloc = Arc::new(AtomicU64::new(1));
+    let http_state = Arc::new(PlaygroundHttpState::new(
+        broadcast_tx.clone(),
+        fetch_id_alloc.clone(),
+    ));
+    let replay = ReplayHttp::new(
+        Arc::new(PlaygroundHttp(http_state)),
+        replay_store,
+        fetch_id_alloc,
+        None, // on_replay callback added in Phase 2
+    );
     sys_ops::SysOpsBuilder::new()
         .with_fs::<sys_native::NativeSysOps>()
         .with_sys::<sys_native::NativeSysOps>()
         .with_net::<sys_native::NativeSysOps>()
-        .with_http_instance(Arc::new(PlaygroundHttp(http_state)))
+        .with_http_instance(Arc::new(replay))
         .with_env_instance(Arc::new(PlaygroundEnv(env_state.clone())))
         .build()
 }
@@ -98,15 +117,24 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
     let env_state = Arc::new(PlaygroundEnvState::new(broadcast_tx.clone()));
 
     // Build SysOps with playground interception.
-    // The factory creates the same ops for every project.
+    // The factory creates per-project ops with replay stores.
+    let replay_stores: ReplayStoreMap = Arc::new(std::sync::Mutex::new(HashMap::new()));
+    let replay_stores_for_factory = replay_stores.clone();
+
     let broadcast_tx_for_factory = broadcast_tx.clone();
     let env_state_for_factory = env_state.clone();
     #[allow(clippy::type_complexity)]
     let sys_op_factory: Arc<dyn Fn(&vfs::VfsPath) -> Arc<sys_ops::SysOps> + Send + Sync> =
-        Arc::new(move |_path: &vfs::VfsPath| {
+        Arc::new(move |path: &vfs::VfsPath| {
+            let replay_store = Arc::new(RwLock::new(RecordReplay::new()));
+            replay_stores_for_factory
+                .lock()
+                .unwrap()
+                .insert(path.as_str().to_string(), replay_store.clone());
             Arc::new(build_playground_sys_ops(
                 &broadcast_tx_for_factory,
                 &env_state_for_factory,
+                replay_store,
             ))
         });
 
@@ -160,8 +188,10 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
         let bex_for_playground = bex.clone();
         let btx = broadcast_tx.clone();
         let es = env_state.clone();
+        let rs = replay_stores.clone();
         tokio_runtime.spawn(async move {
-            if let Err(e) = playground_server::run(listener, bex_for_playground, btx, es).await {
+            if let Err(e) = playground_server::run(listener, bex_for_playground, btx, es, rs).await
+            {
                 tracing::error!("Playground server exited: {e}");
             }
         });

--- a/baml_language/crates/baml_lsp_server/src/playground_http.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_http.rs
@@ -21,16 +21,19 @@ use crate::playground_ws::WsOutMessage;
 /// Shared state for the HTTP interceptor.
 pub struct PlaygroundHttpState {
     broadcast_tx: broadcast::Sender<WsOutMessage>,
-    next_fetch_id: AtomicU64,
+    next_fetch_id: Arc<AtomicU64>,
     /// Maps response body pointer → (call_id, fetch_id) for response_text tracking.
-    response_to_fetch: std::sync::Mutex<HashMap<usize, (u64, u64)>>,
+    pub response_to_fetch: std::sync::Mutex<HashMap<usize, (u64, u64)>>,
 }
 
 impl PlaygroundHttpState {
-    pub fn new(broadcast_tx: broadcast::Sender<WsOutMessage>) -> Self {
+    pub fn new(
+        broadcast_tx: broadcast::Sender<WsOutMessage>,
+        fetch_id_allocator: Arc<AtomicU64>,
+    ) -> Self {
         Self {
             broadcast_tx,
-            next_fetch_id: AtomicU64::new(1),
+            next_fetch_id: fetch_id_allocator,
             response_to_fetch: std::sync::Mutex::new(HashMap::new()),
         }
     }

--- a/baml_language/crates/baml_lsp_server/src/playground_http.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_http.rs
@@ -116,6 +116,7 @@ impl io::IoNamespaceHttp for PlaygroundHttp {
             url: request.url.clone(),
             request_headers: extract_headers_as_hashmap(&request.headers),
             request_body: request.body.clone(),
+            replayed: None,
         });
 
         let native_result = <sys_native::NativeSysOps as io::IoNamespaceHttp>::send(

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -70,7 +70,6 @@ struct WsState {
     bex: Arc<dyn bex_project::BexLsp>,
     broadcast_tx: broadcast::Sender<WsOutMessage>,
     env_state: Arc<PlaygroundEnvState>,
-    #[allow(dead_code)] // Used in Phase 2
     replay_stores: ReplayStoreMap,
 }
 
@@ -424,6 +423,19 @@ async fn handle_ws_in_message(
                 && sink.send(ws_msg).await.is_err()
             {
                 tracing::warn!("Failed to send cursor context");
+            }
+        }
+
+        WsInMessage::ToggleReplay {
+            project,
+            fetch_id,
+            pinned,
+        } => {
+            let stores = state.replay_stores.lock().unwrap();
+            if let Some(store) = stores.get(&project) {
+                store.write().unwrap().set_pinned(fetch_id, pinned);
+            } else {
+                tracing::warn!("ToggleReplay: no replay store for project {project}");
             }
         }
     }

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -63,11 +63,15 @@ pub async fn pick_port(base_port: u16, max_attempts: u16) -> anyhow::Result<(Tcp
 // Shared state for Axum handlers
 // ---------------------------------------------------------------------------
 
+use crate::ReplayStoreMap;
+
 #[derive(Clone)]
 struct WsState {
     bex: Arc<dyn bex_project::BexLsp>,
     broadcast_tx: broadcast::Sender<WsOutMessage>,
     env_state: Arc<PlaygroundEnvState>,
+    #[allow(dead_code)] // Used in Phase 2
+    replay_stores: ReplayStoreMap,
 }
 
 /// Start the playground server on the given listener.
@@ -76,8 +80,9 @@ pub async fn run(
     bex: Arc<dyn bex_project::BexLsp>,
     broadcast_tx: broadcast::Sender<WsOutMessage>,
     env_state: Arc<PlaygroundEnvState>,
+    replay_stores: ReplayStoreMap,
 ) -> anyhow::Result<()> {
-    let app = build_router(bex, broadcast_tx, env_state)?;
+    let app = build_router(bex, broadcast_tx, env_state, replay_stores)?;
 
     tracing::info!(
         "Playground: http://localhost:{}",
@@ -93,11 +98,13 @@ fn build_router(
     bex: Arc<dyn bex_project::BexLsp>,
     broadcast_tx: broadcast::Sender<WsOutMessage>,
     env_state: Arc<PlaygroundEnvState>,
+    replay_stores: ReplayStoreMap,
 ) -> anyhow::Result<Router> {
     let ws_state = WsState {
         bex,
         broadcast_tx,
         env_state,
+        replay_stores,
     };
 
     let api = Router::new()

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -438,6 +438,34 @@ async fn handle_ws_in_message(
                 tracing::warn!("ToggleReplay: no replay store for project {project}");
             }
         }
+
+        WsInMessage::RequestReplayState { project } => {
+            // Collect entries while holding the lock, then drop it before await.
+            let entries: Vec<serde_json::Value> = {
+                let stores = state.replay_stores.lock().unwrap();
+                if let Some(store) = stores.get(&project) {
+                    let store = store.read().unwrap();
+                    store
+                        .snapshot()
+                        .into_iter()
+                        .map(|g| serde_json::to_value(g).unwrap())
+                        .collect()
+                } else {
+                    vec![]
+                }
+            };
+            // Send via sink (per-session), not broadcast.
+            if let Err(e) = sink
+                .send(axum::extract::ws::Message::Text(
+                    serde_json::to_string(&WsOutMessage::ReplayState { entries })
+                        .unwrap()
+                        .into(),
+                ))
+                .await
+            {
+                tracing::warn!("Failed to send ReplayState: {e}");
+            }
+        }
     }
 }
 

--- a/baml_language/crates/baml_lsp_server/src/playground_ws.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_ws.rs
@@ -67,6 +67,8 @@ pub enum WsInMessage {
         fetch_id: u64,
         pinned: bool,
     },
+    #[serde(rename = "requestReplayState")]
+    RequestReplayState { project: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -134,4 +136,6 @@ pub enum WsOutMessage {
     },
     #[serde(rename = "cursorContext")]
     CursorContext { context: serde_json::Value },
+    #[serde(rename = "replayState")]
+    ReplayState { entries: Vec<serde_json::Value> },
 }

--- a/baml_language/crates/baml_lsp_server/src/playground_ws.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_ws.rs
@@ -60,6 +60,13 @@ pub enum WsInMessage {
         line: u32,
         column: u32,
     },
+    #[serde(rename = "toggleReplay")]
+    ToggleReplay {
+        project: String,
+        #[serde(rename = "fetchId")]
+        fetch_id: u64,
+        pinned: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -99,6 +106,8 @@ pub enum WsOutMessage {
         request_headers: std::collections::HashMap<String, String>,
         #[serde(rename = "requestBody")]
         request_body: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        replayed: Option<bool>,
     },
     #[serde(rename = "fetchLogUpdate")]
     FetchLogUpdate {

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -161,6 +161,11 @@ extern "C" {
 #[wasm_bindgen]
 pub struct BamlWasmRuntime {
     bex: Box<dyn bex_project::BexLsp>,
+    // TODO: This is a single shared store across all projects. In the LSP path,
+    // each project gets its own store via `sys_op_factory`. In practice this is
+    // fine because promptfiddle loads one project at a time, but if multi-project
+    // support is added, this should become a per-project map (requires threading
+    // project context through to the HTTP sys_op layer).
     replay_store: std::sync::Arc<
         std::sync::RwLock<
             sys_ops::replay::RecordReplay<
@@ -474,8 +479,8 @@ impl BamlWasmRuntime {
     /// Return a snapshot of all recorded requests for the Replay Manager popover.
     ///
     /// Returns an array of `ReplayGroupSnapshot` objects as a JS value.
-    /// Each entry has: `key` (hex string), `display` (`method`, `url`, `body_preview`),
-    /// `recordings` (array of `{fetch_id, status, body_preview}`), and `pinned_fetch_id`.
+    /// Each entry has: `key` (hex string), `display` (`method`, `url`, `body`),
+    /// `recordings` (array of `{fetch_id, status, body}`), and `pinned_fetch_id`.
     #[wasm_bindgen(js_name = "replayState")]
     pub fn replay_state(&self) -> JsValue {
         let store = self.replay_store.read().unwrap();

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -122,7 +122,8 @@ extern "C" {
         lsp_send_notification: WasmSendNotificationCallback;
         lsp_send_response: WasmSendResponseCallback;
         lsp_make_request: WasmMakeRequestCallback;
-        playground_send_notification: WasmPlaygroundNotificationCallback
+        playground_send_notification: WasmPlaygroundNotificationCallback;
+        replay_notify: (callId: number, fetchId: number, method: string, url: string, requestHeadersJson: string, requestBody: string, status: number, responseHeadersJson: string, responseBody: string) => void;
 }"#)]
     pub type WasmCallbacks;
 
@@ -143,6 +144,14 @@ extern "C" {
 
     #[wasm_bindgen(method, getter, structural, js_name = "playground_send_notification")]
     fn playground_send_notification(this: &WasmCallbacks) -> Function;
+
+    /// Called when a pinned response is replayed (bypasses `loggingFetch`).
+    /// Posts `fetchLogNew` with `replayed: true` to the main thread.
+    ///
+    /// Arguments: callId, fetchId, method, url, requestHeadersJson, requestBody,
+    ///            status, responseHeadersJson, responseBody, durationMs
+    #[wasm_bindgen(method, getter, structural, js_name = "replay_notify")]
+    fn replay_notify(this: &WasmCallbacks) -> Function;
 }
 
 /// A BAML runtime for WASM environments.
@@ -152,6 +161,14 @@ extern "C" {
 #[wasm_bindgen]
 pub struct BamlWasmRuntime {
     bex: Box<dyn bex_project::BexLsp>,
+    replay_store: std::sync::Arc<
+        std::sync::RwLock<
+            sys_ops::replay::RecordReplay<
+                sys_ops::replay::RequestKey,
+                sys_ops::replay::RecordedResponse,
+            >,
+        >,
+    >,
 }
 
 // SAFETY: wasm32-unknown-unknown is single-threaded, so unwind safety is
@@ -180,8 +197,44 @@ impl BamlWasmRuntime {
         let make_request_fn = callbacks.make_request();
         let playground_send_notification_fn = callbacks.playground_send_notification();
 
+        let replay_store =
+            std::sync::Arc::new(std::sync::RwLock::new(sys_ops::replay::RecordReplay::new()));
+        let fetch_id_alloc = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(1_000_000));
+
+        // Build the on_replay callback that notifies JS when a pinned response is replayed.
+        // Arguments are passed via a JS Array to avoid the deprecated callN methods.
+        // The JS `replay_notify` function posts `fetchLogNew` with `replayed: true` to the
+        // main thread.
+        let replay_notify_fn = send_wrapper::SendWrapper::new(callbacks.replay_notify());
+        let on_replay: std::sync::Arc<dyn Fn(sys_ops::replay::ReplayFetchEvent) + Send + Sync> =
+            std::sync::Arc::new(move |event: sys_ops::replay::ReplayFetchEvent| {
+                let request_headers_json =
+                    serde_json::to_string(&event.request_headers).unwrap_or_default();
+                let response_headers_json =
+                    serde_json::to_string(&event.response_headers).unwrap_or_default();
+                let args = js_sys::Array::new();
+                #[allow(clippy::cast_precision_loss)]
+                args.push(&wasm_bindgen::JsValue::from_f64(event.call_id as f64));
+                #[allow(clippy::cast_precision_loss)]
+                args.push(&wasm_bindgen::JsValue::from_f64(event.fetch_id as f64));
+                args.push(&event.method.into());
+                args.push(&event.url.into());
+                args.push(&request_headers_json.into());
+                args.push(&event.request_body.into());
+                #[allow(clippy::cast_precision_loss)]
+                args.push(&wasm_bindgen::JsValue::from_f64(event.status as f64));
+                args.push(&response_headers_json.into());
+                args.push(&event.response_body.into());
+                let _ = replay_notify_fn.apply(&wasm_bindgen::JsValue::NULL, &args);
+            });
+
         let sys_ops = sys_ops::SysOpsBuilder::new()
-            .with_http_instance(std::sync::Arc::new(wasm_http::WasmHttp::new(fetch_fn)))
+            .with_http_instance(std::sync::Arc::new(sys_ops::replay::ReplayHttp::new(
+                std::sync::Arc::new(wasm_http::WasmHttp::new(fetch_fn)),
+                replay_store.clone(),
+                fetch_id_alloc,
+                Some(on_replay),
+            )))
             .with_env_instance(std::sync::Arc::new(wasm_env::WasmEnv::new(env_vars_fn)))
             .with_sys_instance(std::sync::Arc::new(wasm_sys::WasmSys::new()))
             .build();
@@ -203,7 +256,10 @@ impl BamlWasmRuntime {
             None,
         );
 
-        Ok(BamlWasmRuntime { bex: Box::new(bex) })
+        Ok(BamlWasmRuntime {
+            bex: Box::new(bex),
+            replay_store,
+        })
     }
 
     /// Call a BAML function for a specific project.
@@ -395,5 +451,23 @@ impl BamlWasmRuntime {
     pub fn expand_test_set(&self, project: &str, generation: u32, testset_name: &str) {
         self.bex
             .expand_test_set(project, u64::from(generation), testset_name);
+    }
+
+    /// Pin or unpin a recorded HTTP response for replay.
+    ///
+    /// When `pinned` is `true`, subsequent requests with the same content key
+    /// (SHA-256 of method + url + sorted headers + body) will be served from
+    /// the recorded response instead of making a live network call.
+    ///
+    /// `fetch_id` is the ID from the `fetchLogNew` event. Returns `true` if the
+    /// `fetch_id` was found in the recordings, `false` otherwise.
+    #[wasm_bindgen(js_name = "toggleReplay")]
+    pub fn toggle_replay(&self, fetch_id: f64, pinned: bool) -> bool {
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let fetch_id = fetch_id as u64;
+        self.replay_store
+            .write()
+            .unwrap()
+            .set_pinned(fetch_id, pinned)
     }
 }

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -470,4 +470,19 @@ impl BamlWasmRuntime {
             .unwrap()
             .set_pinned(fetch_id, pinned)
     }
+
+    /// Return a snapshot of all recorded requests for the Replay Manager popover.
+    ///
+    /// Returns an array of `ReplayGroupSnapshot` objects as a JS value.
+    /// Each entry has: `key` (hex string), `display` (`method`, `url`, `body_preview`),
+    /// `recordings` (array of `{fetch_id, status, body_preview}`), and `pinned_fetch_id`.
+    #[wasm_bindgen(js_name = "replayState")]
+    pub fn replay_state(&self) -> JsValue {
+        let store = self.replay_store.read().unwrap();
+        let snapshot = store.snapshot();
+        match serde_json::to_string(&snapshot) {
+            Ok(json) => js_sys::JSON::parse(&json).unwrap_or(JsValue::NULL),
+            Err(_) => JsValue::NULL,
+        }
+    }
 }

--- a/baml_language/crates/sys_ops/Cargo.toml
+++ b/baml_language/crates/sys_ops/Cargo.toml
@@ -19,8 +19,11 @@ bex_heap = { workspace = true }
 bex_vm_types = { workspace = true }
 sys_llm = { workspace = true }
 sys_types = { workspace = true }
+hex = { workspace = true }
 indexmap = { workspace = true }
+serde = { workspace = true, features = [ "derive" ] }
 sha2 = { workspace = true }
+web-time = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = [ "rt", "macros" ] }

--- a/baml_language/crates/sys_ops/Cargo.toml
+++ b/baml_language/crates/sys_ops/Cargo.toml
@@ -20,6 +20,7 @@ bex_vm_types = { workspace = true }
 sys_llm = { workspace = true }
 sys_types = { workspace = true }
 indexmap = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = [ "rt", "macros" ] }

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -37,6 +37,8 @@ pub mod io {
     include!(concat!(env!("OUT_DIR"), "/io_generated.rs"));
 }
 
+pub mod replay;
+
 // ============================================================================
 // Blanket IO LLM implementation (delegates to sys_llm)
 // ============================================================================

--- a/baml_language/crates/sys_ops/src/replay.rs
+++ b/baml_language/crates/sys_ops/src/replay.rs
@@ -12,10 +12,42 @@ use std::{
     },
 };
 
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 use sys_types::{BexHeap, CallId, OpErrorKind, SysOpContext, SysOpOutput};
 
 use crate::io::{IoClassHttpResponse, IoNamespaceHttp, owned};
+
+// ---------------------------------------------------------------------------
+// Display info and snapshot types
+// ---------------------------------------------------------------------------
+
+/// Human-readable request metadata for popover display.
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestDisplayInfo {
+    pub method: String,
+    pub url: String,
+    pub body_preview: String,
+}
+
+/// Snapshot of a single request group for the popover.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReplayGroupSnapshot {
+    pub key: String,
+    pub display: RequestDisplayInfo,
+    pub recordings: Vec<RecordingSnapshot>,
+    pub pinned_fetch_id: Option<u64>,
+}
+
+/// Snapshot of a single recording within a group.
+#[derive(Debug, Clone, Serialize)]
+pub struct RecordingSnapshot {
+    pub fetch_id: u64,
+    pub status: i64,
+    pub body_preview: String,
+    /// Seconds since UNIX epoch when the recording was captured.
+    pub recorded_at: u64,
+}
 
 // ---------------------------------------------------------------------------
 // Generic record-replay store
@@ -25,6 +57,8 @@ use crate::io::{IoClassHttpResponse, IoNamespaceHttp, owned};
 pub struct RecordedEntry<V> {
     pub fetch_id: u64,
     pub value: V,
+    /// Seconds since UNIX epoch when recorded.
+    pub recorded_at: u64,
 }
 
 pub struct RecordReplay<K: std::hash::Hash + Eq + Clone, V: Clone> {
@@ -34,6 +68,8 @@ pub struct RecordReplay<K: std::hash::Hash + Eq + Clone, V: Clone> {
     fetch_id_to_key: HashMap<u64, K>,
     /// Content key to pinned entry (at most one per key).
     pinned_by_key: HashMap<K, RecordedEntry<V>>,
+    /// Human-readable request metadata, one per unique key.
+    request_display: HashMap<K, RequestDisplayInfo>,
 }
 
 impl<K: std::hash::Hash + Eq + Clone, V: Clone> Default for RecordReplay<K, V> {
@@ -48,16 +84,24 @@ impl<K: std::hash::Hash + Eq + Clone, V: Clone> RecordReplay<K, V> {
             recordings: HashMap::new(),
             fetch_id_to_key: HashMap::new(),
             pinned_by_key: HashMap::new(),
+            request_display: HashMap::new(),
         }
     }
 
     /// Record a response. Called after every successful HTTP round-trip.
-    pub fn record(&mut self, key: K, fetch_id: u64, value: V) {
+    pub fn record(&mut self, key: K, fetch_id: u64, value: V, display: RequestDisplayInfo) {
         self.fetch_id_to_key.insert(fetch_id, key.clone());
-        self.recordings
-            .entry(key)
-            .or_default()
-            .push(RecordedEntry { fetch_id, value });
+        // Store display info only on first recording for this key.
+        self.request_display.entry(key.clone()).or_insert(display);
+        let recorded_at = web_time::SystemTime::now()
+            .duration_since(web_time::SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        self.recordings.entry(key).or_default().push(RecordedEntry {
+            fetch_id,
+            value,
+            recorded_at,
+        });
     }
 
     /// Look up a pinned entry by content key.
@@ -83,6 +127,34 @@ impl<K: std::hash::Hash + Eq + Clone, V: Clone> RecordReplay<K, V> {
             self.pinned_by_key.remove(&key);
             true
         }
+    }
+}
+
+impl RecordReplay<RequestKey, RecordedResponse> {
+    /// Return a full snapshot of the store for the popover UI.
+    pub fn snapshot(&self) -> Vec<ReplayGroupSnapshot> {
+        self.recordings
+            .iter()
+            .filter_map(|(key, entries)| {
+                let display = self.request_display.get(key)?.clone();
+                let pinned_fetch_id = self.pinned_by_key.get(key).map(|e| e.fetch_id);
+                let recordings = entries
+                    .iter()
+                    .map(|e| RecordingSnapshot {
+                        fetch_id: e.fetch_id,
+                        status: e.value.status,
+                        body_preview: e.value.body.chars().take(1000).collect(),
+                        recorded_at: e.recorded_at,
+                    })
+                    .collect();
+                Some(ReplayGroupSnapshot {
+                    key: hex::encode(key.0),
+                    display,
+                    recordings,
+                    pinned_fetch_id,
+                })
+            })
+            .collect()
     }
 }
 
@@ -151,7 +223,8 @@ pub struct ReplayHttp {
     /// Callback for replay-hit fetch log events.
     on_replay: Option<Arc<dyn Fn(ReplayFetchEvent) + Send + Sync>>,
     /// Correlates `send()` to `text()` via response body pointer identity.
-    pending_recordings: Arc<Mutex<HashMap<usize, RequestKey>>>,
+    #[allow(clippy::type_complexity)]
+    pending_recordings: Arc<Mutex<HashMap<usize, (RequestKey, RequestDisplayInfo, u64)>>>,
 }
 
 impl ReplayHttp {
@@ -200,7 +273,7 @@ impl IoClassHttpResponse for ReplayHttp {
 
         // Look up correlation from `send()`.
         let body_ptr = Self::response_body_key(&response);
-        let request_key = self.pending_recordings.lock().unwrap().remove(&body_ptr);
+        let pending_entry = self.pending_recordings.lock().unwrap().remove(&body_ptr);
 
         // Capture response metadata before delegating.
         let resp_status = response.status_code;
@@ -209,13 +282,11 @@ impl IoClassHttpResponse for ReplayHttp {
 
         let inner_result = self.inner.text(heap, call_id, response, ctx);
         let store = self.store.clone();
-        let fetch_id_alloc = self.fetch_id_allocator.clone();
 
-        match request_key {
-            Some(key) => match inner_result {
+        match pending_entry {
+            Some((key, display, fetch_id)) => match inner_result {
                 SysOpOutput::Async(fut) => SysOpOutput::async_op(async move {
                     let text = fut.await?;
-                    let fetch_id = fetch_id_alloc.load(Ordering::Relaxed) - 1;
                     store.write().unwrap().record(
                         key,
                         fetch_id,
@@ -225,6 +296,7 @@ impl IoClassHttpResponse for ReplayHttp {
                             body: text.clone(),
                             url: resp_url,
                         },
+                        display,
                     );
                     Ok(text)
                 }),
@@ -282,6 +354,13 @@ impl IoNamespaceHttp for ReplayHttp {
         }
 
         // No replay hit — delegate to inner.
+        let display = RequestDisplayInfo {
+            method: request.method.clone(),
+            url: request.url.clone(),
+            body_preview: request.body.chars().take(1000).collect(),
+        };
+        // Pre-allocate a unique fetch_id now so it's deterministic (not racy).
+        let fetch_id = self.fetch_id_allocator.fetch_add(1, Ordering::Relaxed);
         let inner_result = self.inner.send(heap, call_id, request, ctx);
         let pending = self.pending_recordings.clone();
         let key = request_key;
@@ -290,7 +369,10 @@ impl IoNamespaceHttp for ReplayHttp {
             SysOpOutput::Async(fut) => SysOpOutput::async_op(async move {
                 let resp = fut.await?;
                 let body_ptr = Arc::as_ptr(&resp._body).cast::<()>() as usize;
-                pending.lock().unwrap().insert(body_ptr, key);
+                pending
+                    .lock()
+                    .unwrap()
+                    .insert(body_ptr, (key, display, fetch_id));
                 Ok(resp)
             }),
             SysOpOutput::Ready(Ok(resp)) => {
@@ -298,7 +380,7 @@ impl IoNamespaceHttp for ReplayHttp {
                 self.pending_recordings
                     .lock()
                     .unwrap()
-                    .insert(body_ptr, key);
+                    .insert(body_ptr, (key, display, fetch_id));
                 SysOpOutput::Ready(Ok(resp))
             }
             other @ SysOpOutput::Ready(Err(_)) => other,
@@ -326,11 +408,19 @@ impl IoNamespaceHttp for ReplayHttp {
 mod tests {
     use super::*;
 
+    fn dummy_display() -> RequestDisplayInfo {
+        RequestDisplayInfo {
+            method: "GET".to_string(),
+            url: "https://example.com".to_string(),
+            body_preview: String::new(),
+        }
+    }
+
     #[test]
     fn test_record_and_lookup() {
         let mut store = RecordReplay::new();
         let key = RequestKey([0u8; 32]);
-        store.record(key.clone(), 1, "response body".to_string());
+        store.record(key.clone(), 1, "response body".to_string(), dummy_display());
 
         assert!(store.get_pinned(&key).is_none());
 
@@ -347,8 +437,8 @@ mod tests {
     fn test_multiple_recordings_per_key() {
         let mut store = RecordReplay::new();
         let key = RequestKey([0u8; 32]);
-        store.record(key.clone(), 1, "first".to_string());
-        store.record(key.clone(), 2, "second".to_string());
+        store.record(key.clone(), 1, "first".to_string(), dummy_display());
+        store.record(key.clone(), 2, "second".to_string(), dummy_display());
 
         assert!(store.set_pinned(2, true));
         let pinned = store.get_pinned(&key).unwrap();
@@ -425,5 +515,121 @@ mod tests {
     fn test_set_pinned_unknown_fetch_id() {
         let mut store: RecordReplay<RequestKey, String> = RecordReplay::new();
         assert!(!store.set_pinned(999, true));
+    }
+
+    // ---------------------------------------------------------------------------
+    // snapshot() tests
+    // ---------------------------------------------------------------------------
+
+    fn make_key(s: &str) -> RequestKey {
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(s.as_bytes());
+        RequestKey(hasher.finalize().into())
+    }
+
+    fn make_display(method: &str, url: &str) -> RequestDisplayInfo {
+        RequestDisplayInfo {
+            method: method.to_string(),
+            url: url.to_string(),
+            body_preview: String::new(),
+        }
+    }
+
+    fn make_response(status: i64, body: &str) -> RecordedResponse {
+        RecordedResponse {
+            status,
+            headers: indexmap::IndexMap::new(),
+            body: body.to_string(),
+            url: "https://example.com".to_string(),
+        }
+    }
+
+    #[test]
+    fn snapshot_returns_all_groups_with_display_info() {
+        let mut store = RecordReplay::new();
+        let key_a = make_key("request-a");
+        let key_b = make_key("request-b");
+
+        store.record(
+            key_a.clone(),
+            1,
+            make_response(200, "resp1"),
+            make_display("POST", "https://a.com"),
+        );
+        store.record(
+            key_a,
+            2,
+            make_response(200, "resp2"),
+            make_display("POST", "https://a.com"),
+        );
+        store.record(
+            key_b,
+            3,
+            make_response(404, "not found"),
+            make_display("GET", "https://b.com"),
+        );
+
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 2);
+
+        let group_a = snap
+            .iter()
+            .find(|g| g.display.url == "https://a.com")
+            .unwrap();
+        assert_eq!(group_a.display.method, "POST");
+        assert_eq!(group_a.recordings.len(), 2);
+        assert_eq!(group_a.pinned_fetch_id, None);
+
+        let group_b = snap
+            .iter()
+            .find(|g| g.display.url == "https://b.com")
+            .unwrap();
+        assert_eq!(group_b.recordings.len(), 1);
+        assert_eq!(group_b.recordings[0].status, 404);
+    }
+
+    #[test]
+    fn snapshot_shows_pinned_fetch_id() {
+        let mut store = RecordReplay::new();
+        let key = make_key("req");
+        store.record(
+            key.clone(),
+            10,
+            make_response(200, "ok"),
+            make_display("GET", "https://x.com"),
+        );
+        store.record(
+            key,
+            11,
+            make_response(200, "ok2"),
+            make_display("GET", "https://x.com"),
+        );
+        store.set_pinned(11, true);
+
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].pinned_fetch_id, Some(11));
+    }
+
+    #[test]
+    fn display_info_stored_only_on_first_record() {
+        let mut store = RecordReplay::new();
+        let key = make_key("req");
+        store.record(
+            key.clone(),
+            1,
+            make_response(200, "a"),
+            make_display("POST", "https://first.com"),
+        );
+        store.record(
+            key,
+            2,
+            make_response(200, "b"),
+            make_display("POST", "https://second.com"),
+        );
+
+        let snap = store.snapshot();
+        // Display info should be from the first recording, not overwritten.
+        assert_eq!(snap[0].display.url, "https://first.com");
     }
 }

--- a/baml_language/crates/sys_ops/src/replay.rs
+++ b/baml_language/crates/sys_ops/src/replay.rs
@@ -1,0 +1,396 @@
+//! Record-replay system for HTTP calls.
+//!
+//! [`RecordReplay`] is a generic recording/pinning/lookup store.
+//! [`ReplayHttp`] wraps any `dyn IoNamespaceHttp` to add transparent recording
+//! and replay-hit interception.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex, RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use sha2::{Digest, Sha256};
+use sys_types::{BexHeap, CallId, OpErrorKind, SysOpContext, SysOpOutput};
+
+use crate::io::{IoClassHttpResponse, IoNamespaceHttp, owned};
+
+// ---------------------------------------------------------------------------
+// Generic record-replay store
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct RecordedEntry<V> {
+    pub fetch_id: u64,
+    pub value: V,
+}
+
+pub struct RecordReplay<K: std::hash::Hash + Eq + Clone, V: Clone> {
+    /// Content key to ordered list of recordings (most recent last).
+    recordings: HashMap<K, Vec<RecordedEntry<V>>>,
+    /// Fetch ID to content key (for resolving pin commands by `fetch_id`).
+    fetch_id_to_key: HashMap<u64, K>,
+    /// Content key to pinned entry (at most one per key).
+    pinned_by_key: HashMap<K, RecordedEntry<V>>,
+}
+
+impl<K: std::hash::Hash + Eq + Clone, V: Clone> Default for RecordReplay<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: std::hash::Hash + Eq + Clone, V: Clone> RecordReplay<K, V> {
+    pub fn new() -> Self {
+        Self {
+            recordings: HashMap::new(),
+            fetch_id_to_key: HashMap::new(),
+            pinned_by_key: HashMap::new(),
+        }
+    }
+
+    /// Record a response. Called after every successful HTTP round-trip.
+    pub fn record(&mut self, key: K, fetch_id: u64, value: V) {
+        self.fetch_id_to_key.insert(fetch_id, key.clone());
+        self.recordings
+            .entry(key)
+            .or_default()
+            .push(RecordedEntry { fetch_id, value });
+    }
+
+    /// Look up a pinned entry by content key.
+    pub fn get_pinned(&self, key: &K) -> Option<&RecordedEntry<V>> {
+        self.pinned_by_key.get(key)
+    }
+
+    /// Pin or unpin a recording identified by its `fetch_id`.
+    /// Returns true if the operation succeeded (`fetch_id` was found).
+    pub fn set_pinned(&mut self, fetch_id: u64, pinned: bool) -> bool {
+        let Some(key) = self.fetch_id_to_key.get(&fetch_id).cloned() else {
+            return false;
+        };
+        if pinned {
+            if let Some(entries) = self.recordings.get(&key) {
+                if let Some(entry) = entries.iter().find(|e| e.fetch_id == fetch_id) {
+                    self.pinned_by_key.insert(key, entry.clone());
+                    return true;
+                }
+            }
+            false
+        } else {
+            self.pinned_by_key.remove(&key);
+            true
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP-specific types
+// ---------------------------------------------------------------------------
+
+/// SHA-256 hash of (method, url, sorted headers, body).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RequestKey([u8; 32]);
+
+impl RequestKey {
+    pub fn from_request(request: &owned::http::Request) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(request.method.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(request.url.as_bytes());
+        hasher.update(b"\0");
+        let mut sorted_headers: Vec<_> = request.headers.iter().collect();
+        sorted_headers.sort_by_key(|(k, _)| k.as_str());
+        for (k, v) in &sorted_headers {
+            hasher.update(k.as_bytes());
+            hasher.update(b":");
+            hasher.update(v.as_bytes());
+            hasher.update(b"\0");
+        }
+        hasher.update(request.body.as_bytes());
+        RequestKey(hasher.finalize().into())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RecordedResponse {
+    pub status: i64,
+    pub headers: indexmap::IndexMap<String, String>,
+    pub body: String,
+    pub url: String,
+}
+
+/// Synthetic response body stored in `_body` for replay hits.
+/// Follows the existing `Option::take` single-consumption pattern.
+pub struct ReplayResponseBody(pub Mutex<Option<String>>);
+
+/// Event emitted when a replay hit occurs (used for fetch log broadcasting).
+pub struct ReplayFetchEvent {
+    pub call_id: u64,
+    pub fetch_id: u64,
+    pub method: String,
+    pub url: String,
+    pub request_headers: HashMap<String, String>,
+    pub request_body: String,
+    pub status: i64,
+    pub response_headers: HashMap<String, String>,
+    pub response_body: String,
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// ReplayHttp wrapper
+// ---------------------------------------------------------------------------
+
+pub struct ReplayHttp {
+    inner: Arc<dyn IoNamespaceHttp + Send + Sync>,
+    store: Arc<RwLock<RecordReplay<RequestKey, RecordedResponse>>>,
+    fetch_id_allocator: Arc<AtomicU64>,
+    /// Callback for replay-hit fetch log events.
+    #[allow(dead_code)]
+    on_replay: Option<Arc<dyn Fn(ReplayFetchEvent) + Send + Sync>>,
+    /// Correlates `send()` to `text()` via response body pointer identity.
+    pending_recordings: Arc<Mutex<HashMap<usize, RequestKey>>>,
+}
+
+impl ReplayHttp {
+    pub fn new(
+        inner: Arc<dyn IoNamespaceHttp + Send + Sync>,
+        store: Arc<RwLock<RecordReplay<RequestKey, RecordedResponse>>>,
+        fetch_id_allocator: Arc<AtomicU64>,
+        on_replay: Option<Arc<dyn Fn(ReplayFetchEvent) + Send + Sync>>,
+    ) -> Self {
+        Self {
+            inner,
+            store,
+            fetch_id_allocator,
+            on_replay,
+            pending_recordings: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn store(&self) -> &Arc<RwLock<RecordReplay<RequestKey, RecordedResponse>>> {
+        &self.store
+    }
+
+    fn response_body_key(resp: &owned::http::Response) -> usize {
+        Arc::as_ptr(&resp._body).cast::<()>() as usize
+    }
+}
+
+impl IoClassHttpResponse for ReplayHttp {
+    fn text(
+        &self,
+        heap: &Arc<BexHeap>,
+        call_id: CallId,
+        response: owned::http::Response,
+        ctx: &SysOpContext,
+    ) -> SysOpOutput<String> {
+        // Try replay downcast first.
+        if let Some(replay_body) = response._body.downcast_ref::<ReplayResponseBody>() {
+            let text = replay_body.0.lock().unwrap().take();
+            return match text {
+                Some(t) => SysOpOutput::ok(t),
+                None => SysOpOutput::err(OpErrorKind::Other(
+                    "Replayed response body has already been consumed".into(),
+                )),
+            };
+        }
+
+        // Look up correlation from `send()`.
+        let body_ptr = Self::response_body_key(&response);
+        let request_key = self.pending_recordings.lock().unwrap().remove(&body_ptr);
+
+        // Capture response metadata before delegating.
+        let resp_status = response.status_code;
+        let resp_headers = response.headers.clone();
+        let resp_url = response.url.clone();
+
+        let inner_result = self.inner.text(heap, call_id, response, ctx);
+        let store = self.store.clone();
+        let fetch_id_alloc = self.fetch_id_allocator.clone();
+
+        match request_key {
+            Some(key) => match inner_result {
+                SysOpOutput::Async(fut) => SysOpOutput::async_op(async move {
+                    let text = fut.await?;
+                    let fetch_id = fetch_id_alloc.load(Ordering::Relaxed) - 1;
+                    store.write().unwrap().record(
+                        key,
+                        fetch_id,
+                        RecordedResponse {
+                            status: resp_status,
+                            headers: resp_headers,
+                            body: text.clone(),
+                            url: resp_url,
+                        },
+                    );
+                    Ok(text)
+                }),
+                other @ SysOpOutput::Ready(_) => other,
+            },
+            None => inner_result,
+        }
+    }
+}
+
+impl IoNamespaceHttp for ReplayHttp {
+    fn send(
+        &self,
+        heap: &Arc<BexHeap>,
+        call_id: CallId,
+        request: owned::http::Request,
+        ctx: &SysOpContext,
+    ) -> SysOpOutput<owned::http::Response> {
+        let request_key = RequestKey::from_request(&request);
+
+        // Phase 2 will add: check `store.get_pinned(&request_key)` here.
+
+        // Delegate to inner (`PlaygroundHttp`).
+        let inner_result = self.inner.send(heap, call_id, request, ctx);
+        let pending = self.pending_recordings.clone();
+        let key = request_key;
+
+        match inner_result {
+            SysOpOutput::Async(fut) => SysOpOutput::async_op(async move {
+                let resp = fut.await?;
+                let body_ptr = Arc::as_ptr(&resp._body).cast::<()>() as usize;
+                pending.lock().unwrap().insert(body_ptr, key);
+                Ok(resp)
+            }),
+            SysOpOutput::Ready(Ok(resp)) => {
+                let body_ptr = Arc::as_ptr(&resp._body).cast::<()>() as usize;
+                self.pending_recordings
+                    .lock()
+                    .unwrap()
+                    .insert(body_ptr, key);
+                SysOpOutput::Ready(Ok(resp))
+            }
+            other @ SysOpOutput::Ready(Err(_)) => other,
+        }
+    }
+
+    fn fetch(
+        &self,
+        heap: &Arc<BexHeap>,
+        call_id: CallId,
+        url: String,
+        ctx: &SysOpContext,
+    ) -> SysOpOutput<owned::http::Response> {
+        let req = owned::http::Request {
+            method: "GET".to_string(),
+            url,
+            headers: indexmap::IndexMap::new(),
+            body: String::new(),
+        };
+        self.send(heap, call_id, req, ctx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_record_and_lookup() {
+        let mut store = RecordReplay::new();
+        let key = RequestKey([0u8; 32]);
+        store.record(key.clone(), 1, "response body".to_string());
+
+        assert!(store.get_pinned(&key).is_none());
+
+        assert!(store.set_pinned(1, true));
+        let pinned = store.get_pinned(&key).unwrap();
+        assert_eq!(pinned.value, "response body");
+        assert_eq!(pinned.fetch_id, 1);
+
+        assert!(store.set_pinned(1, false));
+        assert!(store.get_pinned(&key).is_none());
+    }
+
+    #[test]
+    fn test_multiple_recordings_per_key() {
+        let mut store = RecordReplay::new();
+        let key = RequestKey([0u8; 32]);
+        store.record(key.clone(), 1, "first".to_string());
+        store.record(key.clone(), 2, "second".to_string());
+
+        assert!(store.set_pinned(2, true));
+        let pinned = store.get_pinned(&key).unwrap();
+        assert_eq!(pinned.value, "second");
+
+        assert!(store.set_pinned(1, true));
+        let pinned = store.get_pinned(&key).unwrap();
+        assert_eq!(pinned.value, "first");
+    }
+
+    #[test]
+    fn test_request_key_deterministic() {
+        let req = owned::http::Request {
+            method: "POST".to_string(),
+            url: "https://api.openai.com/v1/chat".to_string(),
+            headers: indexmap::IndexMap::from([
+                ("content-type".to_string(), "application/json".to_string()),
+                ("authorization".to_string(), "Bearer sk-xxx".to_string()),
+            ]),
+            body: r#"{"model":"gpt-4","messages":[]}"#.to_string(),
+        };
+        let key1 = RequestKey::from_request(&req);
+        let key2 = RequestKey::from_request(&req);
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn test_request_key_header_order_independent() {
+        let req1 = owned::http::Request {
+            method: "POST".to_string(),
+            url: "https://api.example.com".to_string(),
+            headers: indexmap::IndexMap::from([
+                ("a".to_string(), "1".to_string()),
+                ("b".to_string(), "2".to_string()),
+            ]),
+            body: "body".to_string(),
+        };
+        let req2 = owned::http::Request {
+            method: "POST".to_string(),
+            url: "https://api.example.com".to_string(),
+            headers: indexmap::IndexMap::from([
+                ("b".to_string(), "2".to_string()),
+                ("a".to_string(), "1".to_string()),
+            ]),
+            body: "body".to_string(),
+        };
+        assert_eq!(
+            RequestKey::from_request(&req1),
+            RequestKey::from_request(&req2)
+        );
+    }
+
+    #[test]
+    fn test_request_key_different_body() {
+        let req1 = owned::http::Request {
+            method: "POST".to_string(),
+            url: "https://api.example.com".to_string(),
+            headers: indexmap::IndexMap::new(),
+            body: "body1".to_string(),
+        };
+        let req2 = owned::http::Request {
+            method: "POST".to_string(),
+            url: "https://api.example.com".to_string(),
+            headers: indexmap::IndexMap::new(),
+            body: "body2".to_string(),
+        };
+        assert_ne!(
+            RequestKey::from_request(&req1),
+            RequestKey::from_request(&req2)
+        );
+    }
+
+    #[test]
+    fn test_set_pinned_unknown_fetch_id() {
+        let mut store: RecordReplay<RequestKey, String> = RecordReplay::new();
+        assert!(!store.set_pinned(999, true));
+    }
+}

--- a/baml_language/crates/sys_ops/src/replay.rs
+++ b/baml_language/crates/sys_ops/src/replay.rs
@@ -27,7 +27,7 @@ use crate::io::{IoClassHttpResponse, IoNamespaceHttp, owned};
 pub struct RequestDisplayInfo {
     pub method: String,
     pub url: String,
-    pub body_preview: String,
+    pub body: String,
 }
 
 /// Snapshot of a single request group for the popover.
@@ -44,7 +44,7 @@ pub struct ReplayGroupSnapshot {
 pub struct RecordingSnapshot {
     pub fetch_id: u64,
     pub status: i64,
-    pub body_preview: String,
+    pub body: String,
     /// Seconds since UNIX epoch when the recording was captured.
     pub recorded_at: u64,
 }
@@ -143,7 +143,7 @@ impl RecordReplay<RequestKey, RecordedResponse> {
                     .map(|e| RecordingSnapshot {
                         fetch_id: e.fetch_id,
                         status: e.value.status,
-                        body_preview: e.value.body.chars().take(1000).collect(),
+                        body: e.value.body.clone(),
                         recorded_at: e.recorded_at,
                     })
                     .collect();
@@ -300,7 +300,21 @@ impl IoClassHttpResponse for ReplayHttp {
                     );
                     Ok(text)
                 }),
-                other @ SysOpOutput::Ready(_) => other,
+                SysOpOutput::Ready(Ok(text)) => {
+                    store.write().unwrap().record(
+                        key,
+                        fetch_id,
+                        RecordedResponse {
+                            status: resp_status,
+                            headers: resp_headers,
+                            body: text.clone(),
+                            url: resp_url,
+                        },
+                        display,
+                    );
+                    SysOpOutput::ok(text)
+                }
+                SysOpOutput::Ready(Err(err)) => SysOpOutput::Ready(Err(err)),
             },
             None => inner_result,
         }
@@ -357,7 +371,7 @@ impl IoNamespaceHttp for ReplayHttp {
         let display = RequestDisplayInfo {
             method: request.method.clone(),
             url: request.url.clone(),
-            body_preview: request.body.chars().take(1000).collect(),
+            body: request.body.clone(),
         };
         // Pre-allocate a unique fetch_id now so it's deterministic (not racy).
         let fetch_id = self.fetch_id_allocator.fetch_add(1, Ordering::Relaxed);
@@ -412,7 +426,7 @@ mod tests {
         RequestDisplayInfo {
             method: "GET".to_string(),
             url: "https://example.com".to_string(),
-            body_preview: String::new(),
+            body: String::new(),
         }
     }
 
@@ -531,7 +545,7 @@ mod tests {
         RequestDisplayInfo {
             method: method.to_string(),
             url: url.to_string(),
-            body_preview: String::new(),
+            body: String::new(),
         }
     }
 

--- a/baml_language/crates/sys_ops/src/replay.rs
+++ b/baml_language/crates/sys_ops/src/replay.rs
@@ -149,7 +149,6 @@ pub struct ReplayHttp {
     store: Arc<RwLock<RecordReplay<RequestKey, RecordedResponse>>>,
     fetch_id_allocator: Arc<AtomicU64>,
     /// Callback for replay-hit fetch log events.
-    #[allow(dead_code)]
     on_replay: Option<Arc<dyn Fn(ReplayFetchEvent) + Send + Sync>>,
     /// Correlates `send()` to `text()` via response body pointer identity.
     pending_recordings: Arc<Mutex<HashMap<usize, RequestKey>>>,
@@ -246,9 +245,43 @@ impl IoNamespaceHttp for ReplayHttp {
     ) -> SysOpOutput<owned::http::Response> {
         let request_key = RequestKey::from_request(&request);
 
-        // Phase 2 will add: check `store.get_pinned(&request_key)` here.
+        // Check for a pinned replay entry.
+        if let Some(entry) = self.store.read().unwrap().get_pinned(&request_key) {
+            let recorded = entry.value.clone();
+            let fetch_id = self.fetch_id_allocator.fetch_add(1, Ordering::Relaxed);
 
-        // Delegate to inner (`PlaygroundHttp`).
+            // Emit replay fetch log events via callback.
+            if let Some(ref on_replay) = self.on_replay {
+                on_replay(ReplayFetchEvent {
+                    call_id: call_id.0,
+                    fetch_id,
+                    method: request.method,
+                    url: request.url,
+                    request_headers: request.headers.into_iter().collect(),
+                    request_body: request.body,
+                    status: recorded.status,
+                    response_headers: recorded
+                        .headers
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                    response_body: recorded.body.clone(),
+                    duration_ms: 0,
+                });
+            }
+
+            // Return synthetic response with ReplayResponseBody.
+            let body: Arc<dyn std::any::Any + Send + Sync> =
+                Arc::new(ReplayResponseBody(Mutex::new(Some(recorded.body.clone()))));
+            return SysOpOutput::ok(owned::http::Response {
+                status_code: recorded.status,
+                headers: recorded.headers,
+                url: recorded.url,
+                _body: body,
+            });
+        }
+
+        // No replay hit — delegate to inner.
         let inner_result = self.inner.send(heap, call_id, request, ctx);
         let pending = self.pending_recordings.clone();
         let key = request_key;

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -684,12 +684,12 @@ self.onmessage = async (event: MessageEvent) => {
           display: {
             method: e.display.method,
             url: e.display.url,
-            bodyPreview: e.display.body_preview,
+            body: e.display.body,
           },
           recordings: (e.recordings ?? []).map((r: any) => ({
             fetchId: r.fetch_id,
             status: r.status,
-            bodyPreview: r.body_preview,
+            body: r.body,
             recordedAt: r.recorded_at ?? 0,
           })),
           pinnedFetchId: e.pinned_fetch_id ?? null,

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -384,6 +384,40 @@ self.onmessage = async (event: MessageEvent) => {
           notification = mapsToRecordsDeep(notification);
           onPlaygroundNotification(notification);
         },
+        replay_notify: (
+          callId: number,
+          fetchId: number,
+          method: string,
+          url: string,
+          requestHeadersJson: string,
+          requestBody: string,
+          status: number,
+          responseHeadersJson: string,
+          responseBody: string,
+        ) => {
+          let requestHeaders: Record<string, string> = {};
+          let responseHeaders: Record<string, string> = {};
+          try { requestHeaders = JSON.parse(requestHeadersJson); } catch {}
+          try { responseHeaders = JSON.parse(responseHeadersJson); } catch {}
+          postOut({
+            type: "fetchLogNew",
+            entry: {
+              id: fetchId,
+              callId,
+              timestamp: Date.now(),
+              method,
+              url,
+              requestHeaders,
+              requestBody,
+              status,
+              responseBody,
+              error: null,
+              durationMs: 0,
+              responseHeaders,
+              replayed: true,
+            },
+          });
+        },
       },
       vfs.wasmVfs,
     );
@@ -637,7 +671,9 @@ self.onmessage = async (event: MessageEvent) => {
       return;
 
     case "toggleReplay":
-      // WASM replay support added in Phase 4.
+      if (runtime) {
+        runtime.toggleReplay(msg.fetchId, msg.pinned);
+      }
       return;
   }
   msg satisfies never;

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -635,6 +635,10 @@ self.onmessage = async (event: MessageEvent) => {
     case "dispose":
       dispose();
       return;
+
+    case "toggleReplay":
+      // WASM replay support added in Phase 4.
+      return;
   }
   msg satisfies never;
 };

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -675,6 +675,28 @@ self.onmessage = async (event: MessageEvent) => {
         runtime.toggleReplay(msg.fetchId, msg.pinned);
       }
       return;
+
+    case "requestReplayState":
+      if (runtime) {
+        const rawEntries = runtime.replayState();
+        const entries = (Array.isArray(rawEntries) ? rawEntries : []).map((e: any) => ({
+          key: e.key,
+          display: {
+            method: e.display.method,
+            url: e.display.url,
+            bodyPreview: e.display.body_preview,
+          },
+          recordings: (e.recordings ?? []).map((r: any) => ({
+            fetchId: r.fetch_id,
+            status: r.status,
+            bodyPreview: r.body_preview,
+            recordedAt: r.recorded_at ?? 0,
+          })),
+          pinnedFetchId: e.pinned_fetch_id ?? null,
+        }));
+        self.postMessage({ type: "replayState", entries });
+      }
+      return;
   }
   msg satisfies never;
 };

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -11,6 +11,8 @@
 
 import type { ChangeEvent, FC, RefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAtom } from 'jotai';
+import { envVarsAtom } from './atoms';
 import { encodeCallArgs } from '@b/pkg-proto';
 import { KeyRound, PanelLeft, RotateCcw, Square } from 'lucide-react';
 import { Button } from './components/ui/button';
@@ -222,7 +224,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
   const [diagsExpanded, setDiagsExpanded] = useState(false);
   const [buildTime, setBuildTime] = useState<number | null>(null);
-  const [envVars, setEnvVarsState] = useState<Record<string, string>>({});
+  const [envVars, setEnvVarsState] = useAtom(envVarsAtom);
   // Keys the project is known to need — accumulated from envVarRequests, never shrunk.
   const [knownRequiredKeys, setKnownRequiredKeys] = useState<Set<string>>(new Set());
   // In-flight worker requests waiting for a value: id → variable name. Ref because it doesn't drive renders.
@@ -886,6 +888,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
               <Button
                 variant="ghost"
                 size="icon"
+                aria-label="Record / Replay"
                 className="relative h-7 w-7"
                 onClick={() => setShowReplayManager((prev) => !prev)}
               >

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -12,7 +12,7 @@
 import type { ChangeEvent, FC, RefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { encodeCallArgs } from '@b/pkg-proto';
-import { KeyRound, PanelLeft, Pin, PinOff, Square } from 'lucide-react';
+import { KeyRound, PanelLeft, RotateCcw, Square } from 'lucide-react';
 import { Button } from './components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
 import { Input } from './components/ui/input';
@@ -42,6 +42,8 @@ import { ResultDisplay } from './ResultDisplay';
 import { registerBuiltinResultRenderers } from './renderers/registerBuiltins';
 import { GraphView } from './graph/GraphView';
 import { FunctionSidebar } from './FunctionSidebar';
+import { ReplayManagerDialog } from './ReplayManagerPopover';
+import type { ReplayGroup } from './worker-protocol';
 
 registerBuiltinResultRenderers();
 
@@ -95,10 +97,9 @@ interface CollectionRunViewProps {
   run: RunEntry;
   expandedLogId: number | null;
   setExpandedLogId: (id: number | null) => void;
-  onTogglePin?: (fetchId: number, pinned: boolean) => void;
 }
 
-const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, setExpandedLogId, onTogglePin }) => {
+const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, setExpandedLogId }) => {
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {/* Header */}
@@ -135,23 +136,6 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
                 <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
                 <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
                 {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
-                {onTogglePin && (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-5 w-5 shrink-0 text-vsc-text-muted hover:text-vsc-text"
-                          onClick={(e) => { e.stopPropagation(); onTogglePin(log.id, !log.pinned); }}
-                        >
-                          {log.pinned ? <PinOff size={11} /> : <Pin size={11} />}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>{log.pinned ? 'Unpin (allow live call)' : 'Pin (replay this response)'}</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
                 <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
               </div>
               {isExp && (
@@ -233,6 +217,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
   const [showApiKeysDialog, setShowApiKeysDialog] = useState(false);
   const showApiKeysDialogRef = useRef(false);
+  const [showReplayManager, setShowReplayManager] = useState(false);
+  const [replayEntries, setReplayEntries] = useState<ReplayGroup[]>([]);
 
   const [diagsExpanded, setDiagsExpanded] = useState(false);
   const [buildTime, setBuildTime] = useState<number | null>(null);
@@ -513,6 +499,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
           handleCursorContext(data.context);
           break;
 
+        case "replayState":
+          setReplayEntries(data.entries);
+          break;
+
         default:
           data satisfies never;
       }
@@ -667,27 +657,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       [runId]: (prev[runId] ?? 'parsed') === 'parsed' ? 'raw' : 'parsed',
     }));
   }, []);
-
-  const onTogglePin = useCallback((fetchId: number, pinned: boolean) => {
-    // Update pinned state locally across all runs
-    setRuns((prev) =>
-      prev.map((r) => ({
-        ...r,
-        fetchLogs: r.fetchLogs.map((l) => (l.id === fetchId ? { ...l, pinned } : l)),
-      })),
-    );
-    // Also update in collection run
-    setCollectionRun((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        fetchLogs: prev.fetchLogs.map((l) => (l.id === fetchId ? { ...l, pinned } : l)),
-      };
-    });
-    if (selectedProject) {
-      port.postMessage({ type: 'toggleReplay', fetchId, pinned, project: selectedProject });
-    }
-  }, [port, selectedProject]);
 
   const onResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -914,6 +883,21 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="relative h-7 w-7"
+                onClick={() => setShowReplayManager((prev) => !prev)}
+              >
+                <RotateCcw size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Record / Replay</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
               <Button variant="ghost" size="icon" className="relative h-7 w-7" onClick={() => setShowApiKeysDialog(true)}>
                 <KeyRound size={14} />
                 {hasMissingKeys && (
@@ -1087,7 +1071,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
               run={collectionRun}
               expandedLogId={expandedLogId}
               setExpandedLogId={setExpandedLogId}
-              onTogglePin={onTogglePin}
             />
           ) : viewingTestRun ? (
             <div ref={outputRef} className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg">
@@ -1150,21 +1133,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                             <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
                             <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
                             {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
-                            <TooltipProvider>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="h-5 w-5 shrink-0 text-vsc-text-muted hover:text-vsc-text"
-                                    onClick={(e) => { e.stopPropagation(); onTogglePin(log.id, !log.pinned); }}
-                                  >
-                                    {log.pinned ? <PinOff size={11} /> : <Pin size={11} />}
-                                  </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>{log.pinned ? 'Unpin (allow live call)' : 'Pin (replay this response)'}</TooltipContent>
-                              </Tooltip>
-                            </TooltipProvider>
                             <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
                           </div>
                           {isExp && (
@@ -1400,21 +1368,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                                 <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
                                 <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
                                 {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
-                                <TooltipProvider>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-5 w-5 shrink-0 text-vsc-text-muted hover:text-vsc-text"
-                                        onClick={(e) => { e.stopPropagation(); onTogglePin(log.id, !log.pinned); }}
-                                      >
-                                        {log.pinned ? <PinOff size={11} /> : <Pin size={11} />}
-                                      </Button>
-                                    </TooltipTrigger>
-                                    <TooltipContent>{log.pinned ? 'Unpin (allow live call)' : 'Pin (replay this response)'}</TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
                                 <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
                               </div>
                               {isExp && (
@@ -1519,6 +1472,26 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
         onSetEnvVar={addEnvVar}
         onDeleteEnvVar={removeEnvVar}
         onImportEnvVars={handleImportEnvVars}
+      />
+      <ReplayManagerDialog
+        open={showReplayManager}
+        onOpenChange={setShowReplayManager}
+        entries={replayEntries}
+        onToggleReplay={(fetchId, pinned) => {
+          port.postMessage({
+            type: 'toggleReplay',
+            fetchId,
+            pinned,
+            project: selectedProject ?? '',
+          });
+          // Refresh state after toggle.
+          setTimeout(() => {
+            port.postMessage({ type: 'requestReplayState', project: selectedProject ?? '' });
+          }, 50);
+        }}
+        onRequestState={() => {
+          port.postMessage({ type: 'requestReplayState', project: selectedProject ?? '' });
+        }}
       />
     </>
   );

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -12,7 +12,7 @@
 import type { ChangeEvent, FC, RefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { encodeCallArgs } from '@b/pkg-proto';
-import { KeyRound, PanelLeft, Square } from 'lucide-react';
+import { KeyRound, PanelLeft, Pin, PinOff, Square } from 'lucide-react';
 import { Button } from './components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
 import { Input } from './components/ui/input';
@@ -95,9 +95,10 @@ interface CollectionRunViewProps {
   run: RunEntry;
   expandedLogId: number | null;
   setExpandedLogId: (id: number | null) => void;
+  onTogglePin?: (fetchId: number, pinned: boolean) => void;
 }
 
-const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, setExpandedLogId }) => {
+const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, setExpandedLogId, onTogglePin }) => {
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {/* Header */}
@@ -126,9 +127,31 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
                 className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
               >
                 <span className={`${statusColorCls} font-semibold text-[11px]`}>{log.status ?? '...'}</span>
+                {log.replayed && (
+                  <span className="px-1 py-0 rounded text-[9px] font-semibold" style={{ backgroundColor: '#1e1528', color: '#7c3aed', border: '1px solid #7c3aed' }}>
+                    REPLAYED
+                  </span>
+                )}
                 <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
                 <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
                 {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
+                {onTogglePin && (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-5 w-5 shrink-0 text-vsc-text-muted hover:text-vsc-text"
+                          onClick={(e) => { e.stopPropagation(); onTogglePin(log.id, !log.pinned); }}
+                        >
+                          {log.pinned ? <PinOff size={11} /> : <Pin size={11} />}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{log.pinned ? 'Unpin (allow live call)' : 'Pin (replay this response)'}</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
                 <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
               </div>
               {isExp && (
@@ -645,6 +668,27 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     }));
   }, []);
 
+  const onTogglePin = useCallback((fetchId: number, pinned: boolean) => {
+    // Update pinned state locally across all runs
+    setRuns((prev) =>
+      prev.map((r) => ({
+        ...r,
+        fetchLogs: r.fetchLogs.map((l) => (l.id === fetchId ? { ...l, pinned } : l)),
+      })),
+    );
+    // Also update in collection run
+    setCollectionRun((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        fetchLogs: prev.fetchLogs.map((l) => (l.id === fetchId ? { ...l, pinned } : l)),
+      };
+    });
+    if (selectedProject) {
+      port.postMessage({ type: 'toggleReplay', fetchId, pinned, project: selectedProject });
+    }
+  }, [port, selectedProject]);
+
   const onResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     resizingRef.current = true;
@@ -1043,6 +1087,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
               run={collectionRun}
               expandedLogId={expandedLogId}
               setExpandedLogId={setExpandedLogId}
+              onTogglePin={onTogglePin}
             />
           ) : viewingTestRun ? (
             <div ref={outputRef} className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg">
@@ -1097,9 +1142,29 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                             className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
                           >
                             <span className={`${statusColorCls} font-semibold text-[11px]`}>{log.status ?? '...'}</span>
+                            {log.replayed && (
+                              <span className="px-1 py-0 rounded text-[9px] font-semibold" style={{ backgroundColor: '#1e1528', color: '#7c3aed', border: '1px solid #7c3aed' }}>
+                                REPLAYED
+                              </span>
+                            )}
                             <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
                             <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
                             {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-5 w-5 shrink-0 text-vsc-text-muted hover:text-vsc-text"
+                                    onClick={(e) => { e.stopPropagation(); onTogglePin(log.id, !log.pinned); }}
+                                  >
+                                    {log.pinned ? <PinOff size={11} /> : <Pin size={11} />}
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>{log.pinned ? 'Unpin (allow live call)' : 'Pin (replay this response)'}</TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
                             <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
                           </div>
                           {isExp && (
@@ -1327,9 +1392,29 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                                 className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
                               >
                                 <span className={`${statusColorCls} font-semibold text-[11px]`}>{log.status ?? '...'}</span>
+                                {log.replayed && (
+                                  <span className="px-1 py-0 rounded text-[9px] font-semibold" style={{ backgroundColor: '#1e1528', color: '#7c3aed', border: '1px solid #7c3aed' }}>
+                                    REPLAYED
+                                  </span>
+                                )}
                                 <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
                                 <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
                                 {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-5 w-5 shrink-0 text-vsc-text-muted hover:text-vsc-text"
+                                        onClick={(e) => { e.stopPropagation(); onTogglePin(log.id, !log.pinned); }}
+                                      >
+                                        {log.pinned ? <PinOff size={11} /> : <Pin size={11} />}
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>{log.pinned ? 'Unpin (allow live call)' : 'Pin (replay this response)'}</TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
                                 <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
                               </div>
                               {isExp && (

--- a/typescript2/pkg-playground/src/ReplayManagerPopover.tsx
+++ b/typescript2/pkg-playground/src/ReplayManagerPopover.tsx
@@ -133,7 +133,7 @@ function RequestNavItem({
       ) : (
         <Circle size={10} className="text-vsc-text-faint shrink-0" />
       )}
-      <span className="truncate">{trim(group.display.bodyPreview, 40)}</span>
+      <span className="truncate">{trim(group.display.body, 40)}</span>
       <span className="text-[9px] text-vsc-text-faint shrink-0 ml-auto tabular-nums">
         {group.recordings.length}
       </span>
@@ -280,7 +280,7 @@ function RightPanel({
                 )}
                 <StatusBadge status={rec.status} />
                 <span className="text-[10px] text-vsc-text-muted truncate flex-1">
-                  {trim(rec.bodyPreview, 40)}
+                  {trim(rec.body, 40)}
                 </span>
                 {rec.recordedAt > 0 && (
                   <span className="text-[9px] text-vsc-text-faint shrink-0">{timeAgo(rec.recordedAt)}</span>
@@ -313,8 +313,8 @@ function RightPanel({
       <div className="flex-1 min-h-0 px-3 pb-3 pt-1">
         <pre className="text-[10px] font-mono text-vsc-text bg-vsc-background rounded p-2 overflow-auto h-full whitespace-pre-wrap break-all border border-vsc-border">
           {activeTab === "request"
-            ? tryPrettyJson(group.display.bodyPreview)
-            : selectedRec ? tryPrettyJson(selectedRec.bodyPreview) : "(no response selected)"}
+            ? tryPrettyJson(group.display.body)
+            : selectedRec ? tryPrettyJson(selectedRec.body) : "(no response selected)"}
         </pre>
       </div>
     </div>
@@ -351,7 +351,7 @@ export function ReplayManagerDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="!max-w-[900px] w-[900px] h-[70vh] !flex !flex-col overflow-hidden">
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-[900px] h-[70vh] !flex !flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <RotateCcw size={14} className="text-vsc-text-muted" />

--- a/typescript2/pkg-playground/src/ReplayManagerPopover.tsx
+++ b/typescript2/pkg-playground/src/ReplayManagerPopover.tsx
@@ -1,0 +1,397 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "./components/ui/dialog";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./components/ui/collapsible";
+import { ChevronRight, RotateCcw, Circle, CheckCircle2, Globe } from "lucide-react";
+import { cn } from "./lib/utils";
+import { Switch } from "./components/ui/switch";
+import type { ReplayGroup } from "./worker-protocol";
+
+interface ReplayManagerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entries: ReplayGroup[];
+  onToggleReplay: (fetchId: number, pinned: boolean) => void;
+  onRequestState: () => void;
+}
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: "bg-emerald-500/15 text-emerald-400 border-emerald-500/30",
+  POST: "bg-blue-500/15 text-blue-400 border-blue-500/30",
+  PUT: "bg-amber-500/15 text-amber-400 border-amber-500/30",
+  DELETE: "bg-red-500/15 text-red-400 border-red-500/30",
+  PATCH: "bg-purple-500/15 text-purple-400 border-purple-500/30",
+};
+
+function MethodBadge({ method }: { method: string }) {
+  return (
+    <span className={cn("text-[9px] font-bold font-mono px-1.5 py-0.5 rounded border", METHOD_COLORS[method] ?? "bg-zinc-500/15 text-zinc-400 border-zinc-500/30")}>
+      {method}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: number }) {
+  return (
+    <span className={cn("text-[10px] font-mono font-semibold px-1.5 py-0.5 rounded", status >= 400 ? "bg-red-500/15 text-red-400" : "bg-emerald-500/15 text-emerald-400")}>
+      {status}
+    </span>
+  );
+}
+
+function trim(s: string, len: number): string {
+  if (!s) return "(empty)";
+  if (s.length <= len) return s;
+  return s.slice(0, len) + "…";
+}
+
+function tryPrettyJson(s: string): string {
+  try { return JSON.stringify(JSON.parse(s), null, 2); } catch { return s; }
+}
+
+function timeAgo(epochSecs: number): string {
+  if (!epochSecs) return "";
+  const delta = Math.floor(Date.now() / 1000) - epochSecs;
+  if (delta < 5) return "just now";
+  if (delta < 60) return `${delta}s ago`;
+  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+  if (delta < 86400) return `${Math.floor(delta / 3600)}h ago`;
+  return `${Math.floor(delta / 86400)}d ago`;
+}
+
+function parseUrl(url: string): { domain: string; path: string } {
+  try { const u = new URL(url); return { domain: u.host, path: u.pathname }; }
+  catch { return { domain: url, path: "/" }; }
+}
+
+// ── Tree data model ────────────────────────────────────────────
+
+interface EndpointNode {
+  method: string;
+  url: string;
+  path: string;
+  requests: ReplayGroup[];
+  activeCount: number;
+}
+
+interface DomainNode {
+  domain: string;
+  endpoints: EndpointNode[];
+  activeCount: number;
+}
+
+function buildTree(entries: ReplayGroup[]): DomainNode[] {
+  const endpointMap = new Map<string, EndpointNode>();
+  for (const g of entries) {
+    const epKey = `${g.display.method} ${g.display.url}`;
+    let ep = endpointMap.get(epKey);
+    if (!ep) {
+      const { path } = parseUrl(g.display.url);
+      ep = { method: g.display.method, url: g.display.url, path, requests: [], activeCount: 0 };
+      endpointMap.set(epKey, ep);
+    }
+    ep.requests.push(g);
+    if (g.pinnedFetchId != null) ep.activeCount++;
+  }
+  const domainMap = new Map<string, EndpointNode[]>();
+  for (const ep of endpointMap.values()) {
+    const { domain } = parseUrl(ep.url);
+    const list = domainMap.get(domain);
+    if (list) list.push(ep); else domainMap.set(domain, [ep]);
+  }
+  return Array.from(domainMap.entries()).map(([domain, endpoints]) => ({
+    domain, endpoints, activeCount: endpoints.reduce((n, ep) => n + ep.activeCount, 0),
+  }));
+}
+
+// ── Left panel: nav tree (domain → endpoint → request) ─────────
+
+function RequestNavItem({
+  group,
+  isActive,
+  onSelect,
+}: {
+  group: ReplayGroup;
+  isActive: boolean;
+  onSelect: () => void;
+}) {
+  const hasPinned = group.pinnedFetchId != null;
+  return (
+    <button
+      onClick={onSelect}
+      className={cn(
+        "flex items-center gap-1.5 w-full py-1 pl-8 pr-2 rounded text-left text-[10px] cursor-pointer",
+        isActive ? "bg-[#1e1528] ring-1 ring-[#7c3aed]/50 text-vsc-text" : "text-vsc-text-muted hover:bg-vsc-hover",
+      )}
+    >
+      {hasPinned ? (
+        <CheckCircle2 size={10} className="text-[#7c3aed] shrink-0" />
+      ) : (
+        <Circle size={10} className="text-vsc-text-faint shrink-0" />
+      )}
+      <span className="truncate">{trim(group.display.bodyPreview, 40)}</span>
+      <span className="text-[9px] text-vsc-text-faint shrink-0 ml-auto tabular-nums">
+        {group.recordings.length}
+      </span>
+    </button>
+  );
+}
+
+function EndpointNavNode({
+  endpoint,
+  selectedGroupKey,
+  onSelectGroup,
+}: {
+  endpoint: EndpointNode;
+  selectedGroupKey: string | null;
+  onSelectGroup: (group: ReplayGroup) => void;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 py-1 pl-4 pr-2">
+        <MethodBadge method={endpoint.method} />
+        <span className="text-[11px] text-vsc-text font-mono truncate" title={endpoint.url}>{endpoint.path}</span>
+        {endpoint.activeCount > 0 && (
+          <span className="text-[9px] font-semibold text-[#7c3aed] bg-[#7c3aed]/15 px-1.5 py-0.5 rounded-full shrink-0 ml-auto">{endpoint.activeCount}</span>
+        )}
+      </div>
+      {endpoint.requests.map((group) => (
+        <RequestNavItem
+          key={group.key}
+          group={group}
+          isActive={group.key === selectedGroupKey}
+          onSelect={() => onSelectGroup(group)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function DomainNavNode({
+  node,
+  selectedGroupKey,
+  onSelectGroup,
+  defaultOpen,
+}: {
+  node: DomainNode;
+  selectedGroupKey: string | null;
+  onSelectGroup: (group: ReplayGroup) => void;
+  defaultOpen: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultOpen);
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded}>
+      <CollapsibleTrigger className="flex items-center gap-2 w-full px-2 py-1.5 hover:bg-vsc-hover rounded cursor-pointer">
+        <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 text-vsc-text-faint transition-transform", expanded && "rotate-90")} />
+        <Globe size={12} className="shrink-0 text-vsc-text-muted" />
+        <span className="text-[11px] font-medium text-vsc-text truncate">{node.domain}</span>
+        {node.activeCount > 0 && (
+          <span className="text-[9px] font-semibold text-[#7c3aed] bg-[#7c3aed]/15 px-1.5 py-0.5 rounded-full shrink-0 ml-auto">{node.activeCount} active</span>
+        )}
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="pb-1">
+          {node.endpoints.map((ep) => (
+            <EndpointNavNode key={`${ep.method} ${ep.url}`} endpoint={ep} selectedGroupKey={selectedGroupKey} onSelectGroup={onSelectGroup} />
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+// ── Right panel: selected request's responses + detail ──────────
+
+function RightPanel({
+  group,
+  onToggleReplay,
+}: {
+  group: ReplayGroup;
+  onToggleReplay: (fetchId: number, pinned: boolean) => void;
+}) {
+  const [selectedRecFetchId, setSelectedRecFetchId] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState<"request" | "response">("request");
+  const isEnabled = group.pinnedFetchId != null;
+
+  const effectiveSelectedId = selectedRecFetchId
+    ?? group.pinnedFetchId
+    ?? group.recordings[0]?.fetchId
+    ?? null;
+
+  const selectedRec = group.recordings.find((r) => r.fetchId === effectiveSelectedId) ?? null;
+
+  const handleToggle = (checked: boolean) => {
+    if (!checked) {
+      if (group.pinnedFetchId != null) onToggleReplay(group.pinnedFetchId, false);
+    } else if (effectiveSelectedId != null) {
+      onToggleReplay(effectiveSelectedId, true);
+    }
+  };
+
+  const handleSelectAndPin = (fetchId: number) => {
+    setSelectedRecFetchId(fetchId);
+    if (isEnabled) onToggleReplay(fetchId, true);
+  };
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 min-w-0">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-vsc-border shrink-0">
+        <MethodBadge method={group.display.method} />
+        <span className="text-[11px] font-mono text-vsc-text truncate" title={group.display.url}>
+          {parseUrl(group.display.url).path}
+        </span>
+        <div className="ml-auto flex items-center gap-2 shrink-0">
+          <span className={cn("text-[10px] font-medium", isEnabled ? "text-[#7c3aed]" : "text-vsc-text-faint")}>
+            {isEnabled ? "Replaying" : "Replay off"}
+          </span>
+          <Switch checked={isEnabled} onCheckedChange={handleToggle} size="sm" />
+        </div>
+      </div>
+
+      {/* Response list */}
+      <div className="shrink-0 border-b border-vsc-border">
+        <div className="px-3 py-1.5">
+          <span className="text-[9px] font-semibold text-vsc-text-faint uppercase tracking-wider">
+            Responses ({group.recordings.length})
+          </span>
+        </div>
+        <div className="px-2 pb-2 space-y-0.5 max-h-[120px] overflow-auto">
+          {group.recordings.map((rec) => {
+            const isActive = rec.fetchId === effectiveSelectedId;
+            const isPinned = rec.fetchId === group.pinnedFetchId;
+            return (
+              <button
+                key={rec.fetchId}
+                onClick={() => handleSelectAndPin(rec.fetchId)}
+                className={cn(
+                  "flex items-center gap-2 w-full px-2 py-1 rounded text-left cursor-pointer",
+                  isActive ? "bg-[#1e1528] ring-1 ring-[#7c3aed]/50" : "hover:bg-vsc-hover",
+                )}
+              >
+                {isPinned ? (
+                  <CheckCircle2 size={12} className="text-[#7c3aed] shrink-0" />
+                ) : (
+                  <Circle size={12} className="text-vsc-text-faint shrink-0" />
+                )}
+                <StatusBadge status={rec.status} />
+                <span className="text-[10px] text-vsc-text-muted truncate flex-1">
+                  {trim(rec.bodyPreview, 40)}
+                </span>
+                {rec.recordedAt > 0 && (
+                  <span className="text-[9px] text-vsc-text-faint shrink-0">{timeAgo(rec.recordedAt)}</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Simple tab bar (no Radix) */}
+      <div className="flex gap-0 border-b border-vsc-border shrink-0 mx-3 mt-1">
+        {(["request", "response"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={cn(
+              "px-3 py-1.5 text-[11px] font-mono border-b-2 cursor-pointer",
+              activeTab === tab
+                ? "border-vsc-accent text-vsc-text font-semibold"
+                : "border-transparent text-vsc-text-faint hover:text-vsc-text",
+            )}
+          >
+            {tab === "request" ? "Request Body" : "Response Body"}
+          </button>
+        ))}
+      </div>
+
+      {/* Body content */}
+      <div className="flex-1 min-h-0 px-3 pb-3 pt-1">
+        <pre className="text-[10px] font-mono text-vsc-text bg-vsc-background rounded p-2 overflow-auto h-full whitespace-pre-wrap break-all border border-vsc-border">
+          {activeTab === "request"
+            ? tryPrettyJson(group.display.bodyPreview)
+            : selectedRec ? tryPrettyJson(selectedRec.bodyPreview) : "(no response selected)"}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+// ── Main dialog ────────────────────────────────────────────────
+
+export function ReplayManagerDialog({
+  open,
+  onOpenChange,
+  entries,
+  onToggleReplay,
+  onRequestState,
+}: ReplayManagerDialogProps) {
+  const [selectedGroupKey, setSelectedGroupKey] = useState<string | null>(null);
+
+  // Request fresh state only when dialog opens (not on every render).
+  const onRequestStateRef = React.useRef(onRequestState);
+  onRequestStateRef.current = onRequestState;
+  useEffect(() => {
+    if (open) {
+      onRequestStateRef.current();
+      setSelectedGroupKey(null);
+    }
+  }, [open]);
+
+  const domainNodes = useMemo(() => buildTree(entries), [entries]);
+
+  // Find the currently selected group from entries
+  const selectedGroup = selectedGroupKey
+    ? entries.find((g) => g.key === selectedGroupKey) ?? null
+    : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="!max-w-[900px] w-[900px] h-[70vh] !flex !flex-col overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <RotateCcw size={14} className="text-vsc-text-muted" />
+            Record / Replay
+          </DialogTitle>
+        </DialogHeader>
+        <p className="text-[11px] text-vsc-text-faint px-4 -mt-2 leading-relaxed">
+          HTTP calls are recorded automatically. Select a request to manage its cached responses.
+        </p>
+        <div className="flex flex-1 min-h-0 pb-4">
+          {/* Left: nav tree */}
+          <div className="w-[300px] flex-shrink-0 overflow-auto py-2 px-2 space-y-1 border-r border-vsc-border">
+            {entries.length === 0 ? (
+              <div className="py-8 text-xs text-vsc-text-faint text-center">
+                No recorded requests yet.
+                <br />
+                Run a function to start recording.
+              </div>
+            ) : (
+              domainNodes.map((node) => (
+                <DomainNavNode
+                  key={node.domain}
+                  node={node}
+                  selectedGroupKey={selectedGroupKey}
+                  onSelectGroup={(g) => setSelectedGroupKey(g.key)}
+                  defaultOpen={domainNodes.length <= 3}
+                />
+              ))
+            )}
+          </div>
+          {/* Right: selected request detail */}
+          {selectedGroup ? (
+            <RightPanel group={selectedGroup} onToggleReplay={onToggleReplay} />
+          ) : (
+            <div className="flex-1 flex items-center justify-center">
+              <p className="text-xs text-vsc-text-faint">Select a request to view responses</p>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/typescript2/pkg-playground/src/components/ApiKeysDialog.tsx
+++ b/typescript2/pkg-playground/src/components/ApiKeysDialog.tsx
@@ -77,7 +77,7 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[480px] max-h-[80vh] flex flex-col overflow-hidden">
+      <DialogContent className="w-[480px] max-h-[80vh] flex flex-col overflow-hidden" data-1p-ignore data-lpignore="true">
         <DialogHeader>
           <DialogTitle>API Keys</DialogTitle>
         </DialogHeader>
@@ -98,6 +98,10 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
                   onChange={(e) => handleInlineEdit(key, e.target.value)}
                   placeholder={isMissing ? 'Required' : ''}
                   className="flex-1 text-[11px] font-vsc-mono"
+                  autoComplete="off"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-form-type="other"
                 />
                 <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => toggleShow(key)}>
                   {showValues.has(key) ? <EyeOff size={12} /> : <Eye size={12} />}
@@ -116,12 +120,20 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
               value={newKey}
               onChange={(e) => setNewKey(e.target.value)}
               className="w-[140px] text-[11px] font-vsc-mono"
+              autoComplete="off"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
             />
             <Input
               placeholder="Value"
               value={newValue}
               onChange={(e) => setNewValue(e.target.value)}
               className="flex-1 text-[11px] font-vsc-mono"
+              autoComplete="off"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
             />
             <Button variant="default" size="sm" onClick={handleAdd}>
               <Plus size={12} />

--- a/typescript2/pkg-playground/src/components/ui/switch.tsx
+++ b/typescript2/pkg-playground/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "../../lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -12,7 +12,7 @@
  */
 
 import type { RuntimePort } from '../runtime-port';
-import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification } from '../worker-protocol';
+import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification, ReplayGroup } from '../worker-protocol';
 import { decodeCallResult } from '@b/pkg-proto';
 
 /** Server → Client message shapes (must match playground_ws.rs WsOutMessage) */
@@ -25,7 +25,8 @@ type WsOutMessage =
   | { type: 'fetchLogNew'; callId: number; id: number; method: string; url: string; requestHeaders: Record<string, string>; requestBody: string; replayed?: boolean }
   | { type: 'fetchLogUpdate'; callId: number; logId: number; status?: number; durationMs?: number; responseBody?: string; error?: string; responseHeaders?: Record<string, string> }
   | { type: 'controlFlowGraphResult'; functionName: string; graph: unknown | null }
-  | { type: 'cursorContext'; context: unknown };
+  | { type: 'cursorContext'; context: unknown }
+  | { type: 'replayState'; entries: unknown[] };
 
 /** Client → Server message shapes (must match playground_ws.rs WsInMessage) */
 type WsInMessage =
@@ -38,7 +39,8 @@ type WsInMessage =
   | { type: 'requestCollectTests'; project: string }
   | { type: 'requestControlFlowGraph'; project: string; functionName: string }
   | { type: 'cursorPosition'; file: string; line: number; column: number }
-  | { type: 'toggleReplay'; project: string; fetchId: number; pinned: boolean };
+  | { type: 'toggleReplay'; project: string; fetchId: number; pinned: boolean }
+  | { type: 'requestReplayState'; project: string };
 
 const MAX_RECONNECT_DELAY = 5000;
 
@@ -226,6 +228,8 @@ export class WebSocketRuntimePort implements RuntimePort {
           fetchId: msg.fetchId,
           pinned: msg.pinned,
         };
+      case 'requestReplayState':
+        return { type: 'requestReplayState', project: msg.project };
       case 'clearHandles':
         return null; // handles live in the Rust process; no TS-side cleanup needed
       case 'dispose':
@@ -314,6 +318,25 @@ export class WebSocketRuntimePort implements RuntimePort {
         return {
           type: 'cursorContext',
           context: raw.context as import('../worker-protocol').CursorContext,
+        };
+      case 'replayState':
+        return {
+          type: 'replayState',
+          entries: (raw.entries ?? []).map((e: any) => ({
+            key: e.key,
+            display: {
+              method: e.display.method,
+              url: e.display.url,
+              bodyPreview: e.display.body_preview,
+            },
+            recordings: (e.recordings ?? []).map((r: any) => ({
+              fetchId: r.fetch_id,
+              status: r.status,
+              bodyPreview: r.body_preview,
+              recordedAt: r.recorded_at ?? 0,
+            })),
+            pinnedFetchId: e.pinned_fetch_id ?? null,
+          })) as ReplayGroup[],
         };
       default:
         return null;

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -327,12 +327,12 @@ export class WebSocketRuntimePort implements RuntimePort {
             display: {
               method: e.display.method,
               url: e.display.url,
-              bodyPreview: e.display.body_preview,
+              body: e.display.body,
             },
             recordings: (e.recordings ?? []).map((r: any) => ({
               fetchId: r.fetch_id,
               status: r.status,
-              bodyPreview: r.body_preview,
+              body: r.body,
               recordedAt: r.recorded_at ?? 0,
             })),
             pinnedFetchId: e.pinned_fetch_id ?? null,

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -22,7 +22,7 @@ type WsOutMessage =
   | { type: 'callFunctionResult'; id: number; result: string }
   | { type: 'callFunctionError'; id: number; error: string; cancelled?: boolean }
   | { type: 'envVarRequest'; id: number; variable: string }
-  | { type: 'fetchLogNew'; callId: number; id: number; method: string; url: string; requestHeaders: Record<string, string>; requestBody: string }
+  | { type: 'fetchLogNew'; callId: number; id: number; method: string; url: string; requestHeaders: Record<string, string>; requestBody: string; replayed?: boolean }
   | { type: 'fetchLogUpdate'; callId: number; logId: number; status?: number; durationMs?: number; responseBody?: string; error?: string; responseHeaders?: Record<string, string> }
   | { type: 'controlFlowGraphResult'; functionName: string; graph: unknown | null }
   | { type: 'cursorContext'; context: unknown };
@@ -37,7 +37,8 @@ type WsInMessage =
   | { type: 'requestState' }
   | { type: 'requestCollectTests'; project: string }
   | { type: 'requestControlFlowGraph'; project: string; functionName: string }
-  | { type: 'cursorPosition'; file: string; line: number; column: number };
+  | { type: 'cursorPosition'; file: string; line: number; column: number }
+  | { type: 'toggleReplay'; project: string; fetchId: number; pinned: boolean };
 
 const MAX_RECONNECT_DELAY = 5000;
 
@@ -218,6 +219,13 @@ export class WebSocketRuntimePort implements RuntimePort {
           generation: msg.generation,
           testsetName: msg.testsetName,
         };
+      case 'toggleReplay':
+        return {
+          type: 'toggleReplay',
+          project: msg.project,
+          fetchId: msg.fetchId,
+          pinned: msg.pinned,
+        };
       case 'clearHandles':
         return null; // handles live in the Rust process; no TS-side cleanup needed
       case 'dispose':
@@ -281,6 +289,7 @@ export class WebSocketRuntimePort implements RuntimePort {
             error: null,
             durationMs: null,
             responseHeaders: null,
+            replayed: raw.replayed ?? undefined,
           },
         };
       case 'fetchLogUpdate':

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -124,6 +124,24 @@ export interface FetchLogEntry {
   pinned?: boolean;
 }
 
+export interface ReplayRecording {
+  fetchId: number;
+  status: number;
+  bodyPreview: string;
+  recordedAt: number;
+}
+
+export interface ReplayGroup {
+  key: string;
+  display: {
+    method: string;
+    url: string;
+    bodyPreview: string;
+  };
+  recordings: ReplayRecording[];
+  pinnedFetchId: number | null;
+}
+
 export interface EnvVarRequest {
   id: number;
   variable: string;
@@ -160,7 +178,8 @@ export type WorkerOutMessage =
   | { type: 'vfsFileDeleted'; path: string }
   | { type: 'buildTime'; value: string }
   | { type: 'controlFlowGraphResult'; functionName: string; graph: ControlFlowGraph | null }
-  | { type: 'cursorContext'; context: CursorContext };
+  | { type: 'cursorContext'; context: CursorContext }
+  | { type: 'replayState'; entries: ReplayGroup[] };
 
 // ---------------------------------------------------------------------------
 // Main thread → Worker messages
@@ -181,6 +200,7 @@ export type WorkerInMessage =
   | { type: 'callTestFunction'; id: number; project: string; generation: number; testName: string }
   | { type: 'expandTestSet'; project: string; generation: number; testsetName: string }
   | { type: 'toggleReplay'; fetchId: number; pinned: boolean; project: string }
+  | { type: 'requestReplayState'; project: string }
   | { type: 'filesChanged'; files: Record<string, string> }
   | { type: 'dispose' };
 

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -120,6 +120,8 @@ export interface FetchLogEntry {
   error: string | null;
   durationMs: number | null;
   responseHeaders: Record<string, string> | null;
+  replayed?: boolean;
+  pinned?: boolean;
 }
 
 export interface EnvVarRequest {
@@ -178,6 +180,7 @@ export type WorkerInMessage =
   | { type: 'requestCollectTests'; project: string }
   | { type: 'callTestFunction'; id: number; project: string; generation: number; testName: string }
   | { type: 'expandTestSet'; project: string; generation: number; testsetName: string }
+  | { type: 'toggleReplay'; fetchId: number; pinned: boolean; project: string }
   | { type: 'filesChanged'; files: Record<string, string> }
   | { type: 'dispose' };
 

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -127,7 +127,7 @@ export interface FetchLogEntry {
 export interface ReplayRecording {
   fetchId: number;
   status: number;
-  bodyPreview: string;
+  body: string;
   recordedAt: number;
 }
 
@@ -136,7 +136,7 @@ export interface ReplayGroup {
   display: {
     method: string;
     url: string;
-    bodyPreview: string;
+    body: string;
   };
   recordings: ReplayRecording[];
   pinnedFetchId: number | null;


### PR DESCRIPTION
[Record-Replay System](https://cloud.codelayer.cloud/artifacts/019d660d-68a2-733a-80b9-f335940245a6) | [Artifacts](https://cloud.codelayer.cloud/tasks/019d660d-655a-77a4-b01a-b83e384b1076/artifacts) | [Task](https://cloud.codelayer.cloud/deep/tasks/019d660d-655a-77a4-b01a-b83e384b1076)

## What problems was I solving

When iterating on BAML functions that make multiple LLM calls (chains, retries, conditional branches), every click of "Run" re-executes all HTTP fetches from scratch. If the user is only changing the prompt for one call in a chain, they still wait for every other call to complete. There's no way to "pin" a previous response and skip the network round-trip.

This PR adds automatic HTTP response recording and user-controlled replay to the BAML playground. After running a function once, users can pin any recorded response so that subsequent runs with the same request key return instantly — eliminating redundant LLM calls during prompt iteration.

## What user-facing changes did I ship

- **Automatic recording**: Every HTTP response flowing through the runtime is recorded transparently (no user action needed)
- **REPLAYED badge**: Fetch log rows that were served from cache show a purple "REPLAYED" badge with near-zero duration
- **Replay Manager dialog**: A new toolbar button (rotate icon) opens a dialog where users can browse recorded requests organized by domain/endpoint, inspect request/response bodies, and toggle replay on/off per request
- **Toggle replay**: Selecting a recorded response and enabling its switch causes all future matching requests (same method + URL + headers + body) to be served instantly from cache
- **Both runtime paths**: Works identically in VS Code (LSP/WebSocket path) and promptfiddle.com (WASM/Web Worker path)

## How I implemented it

### Core Infrastructure (Rust — `sys_ops/src/replay.rs`)

New 635-line module with:
- `RecordReplay<K, V>` — generic recording/pinning/lookup store with `record()`, `get_pinned()`, `set_pinned()`, and `snapshot()` methods
- `RequestKey` — SHA-256 hash of `(method, url, sorted_headers, body)` for content-addressable request matching
- `RecordedResponse` — stores status, headers, body, and URL
- `ReplayHttp` — wraps any `dyn IoNamespaceHttp` to intercept `send()` (checks for pinned replay hit) and `text()` (records response after successful fetch). Uses `ReplayResponseBody` marker in `_body` for replay hits and `pending_recordings` map for `send()`→`text()` correlation via `Arc::as_ptr`
- `ReplayFetchEvent` + `on_replay` callback — notifies the UI when a replay hit occurs
- 10 unit tests covering record/lookup, multiple recordings per key, header-order independence, snapshot, and pin/unpin

### LSP Path Wiring (`baml_lsp_server/`)

- `lib.rs` — `ReplayStoreMap` type alias for per-project replay stores; `build_playground_sys_ops()` now takes a `replay_store` and wraps `PlaygroundHttp` in `ReplayHttp` with an `on_replay` callback that broadcasts `FetchLogNew` + `FetchLogUpdate` events
- `playground_http.rs` — `next_fetch_id` changed from owned `AtomicU64` to shared `Arc<AtomicU64>` so `ReplayHttp` can allocate IDs for replayed calls without collision
- `playground_server.rs` — `WsState` gains `replay_stores` field; new `ToggleReplay` and `RequestReplayState` WebSocket message handlers
- `playground_ws.rs` — New `WsInMessage::ToggleReplay` and `WsInMessage::RequestReplayState` variants; `FetchLogNew` gains optional `replayed` field; new `WsOutMessage::ReplayState`

### WASM Path Wiring (`bridge_wasm/src/lib.rs`)

- `BamlWasmRuntime` gains `replay_store` field
- Constructor wraps `WasmHttp` in `ReplayHttp` with a `replay_notify` JS callback that posts replay events to the main thread via `js_sys::Array`
- New `toggleReplay()` and `replayState()` methods exposed to JS via `#[wasm_bindgen]`

### Frontend (TypeScript)

- `worker-protocol.ts` — New `ReplayGroup`, `ReplayRecording` types; `FetchLogEntry` gains `replayed` and `pinned` fields; new `toggleReplay` and `requestReplayState` worker messages
- `baml-lsp-worker.ts` — `replay_notify` callback in WASM callbacks; `toggleReplay` and `requestReplayState` message handlers
- `WebSocketRuntimePort.ts` — Maps `toggleReplay`/`requestReplayState` to/from WebSocket; transforms `replayState` and `fetchLogNew.replayed` in both directions
- `ExecutionPanel.tsx` — Purple "REPLAYED" badge on fetch log rows (all 3 render sites); Replay Manager button in toolbar; state management for `replayEntries`
- `ReplayManagerPopover.tsx` (new, 397 lines) — Full Replay Manager dialog with domain→endpoint→request tree navigation (left panel) and response inspector with replay toggle (right panel)
- `components/ui/switch.tsx` (new) — Radix-based Switch component for replay toggle
- `ApiKeysDialog.tsx` — Suppresses password manager autofill on API key inputs (quality-of-life fix)

## Deviations from the plan

### Implemented as planned
- Phase 1: Core `RecordReplay<K,V>` store, `RequestKey` (SHA-256), `RecordedResponse`, `ReplayResponseBody`, `ReplayHttp` wrapper in `sys_ops`
- Phase 1: LSP path wiring with shared `Arc<AtomicU64>` fetch ID allocator
- Phase 2: `set_pinned()`/`get_pinned()`, replay-hit path in `send()`, `ToggleReplay`/`RequestReplayState` WebSocket protocol
- Phase 3: REPLAYED badge on fetch log rows with purple `#7c3aed` styling at all 3 render sites
- Phase 4: WASM path — `ReplayHttp` wrapping `WasmHttp`, `toggleReplay`/`replayState` on `BamlWasmRuntime`, `replay_notify` callback

### Deviations/surprises
- Plan called for **pin icons on each fetch log row**; implementation uses a **separate Replay Manager dialog** instead — provides richer browsing/inspection UX without cluttering the compact fetch log rows
- `RecordedEntry` has a `recorded_at` timestamp (using `web-time` for WASM compat) — not in plan but needed for the "time ago" display in the Replay Manager
- `on_replay` callback pattern for broadcasting replay-hit fetch log events — plan didn't specify how replay hits would appear in the fetch log, this approach keeps `ReplayHttp` decoupled from any specific transport

### Additions not in plan
- Full **Replay Manager dialog** with tree navigation (domain → endpoint → request) and request/response body inspector
- `RequestDisplayInfo` and snapshot types (`ReplayGroupSnapshot`, `RecordingSnapshot`) for the popover data model
- `Switch` UI component
- `ApiKeysDialog.tsx` password-manager suppression (unrelated fix)

### Items planned but not implemented
- **Pin icon on fetch log rows** — replaced by the Replay Manager dialog approach
- **Shared `FetchLogRow` component extraction** — plan called for refactoring the 3 identical fetch log render sites into a shared component; this was deferred (REPLAYED badge was added inline at all 3 sites)

## How to verify it

### Setup
```bash
git fetch
git checkout vbv/record-replay-system-for-playground-http-calls
```

### Manual Testing (VS Code / LSP path)
- [ ] Open a BAML project in VS Code with a multi-step function
- [ ] Run the function — observe fetch log rows appear normally
- [ ] Click the rotate (↺) icon in the toolbar to open the Replay Manager
- [ ] Verify recorded requests appear organized by domain/endpoint
- [ ] Select a request, enable the replay toggle, close the dialog
- [ ] Re-run the same function — pinned fetches should show "REPLAYED" badge with ~0ms duration
- [ ] Open Replay Manager, disable the toggle, re-run — fetch should go live again

### Manual Testing (promptfiddle.com / WASM path)
- [ ] Same workflow as above but on promptfiddle.com
- [ ] Verify `toggleReplay` and `replayState` work through the Web Worker

### Automated Tests
```bash
cd baml_language
cargo test -p sys_ops replay
```

## Description for the changelog

Add record-replay system to the playground: HTTP responses are automatically recorded during function runs, and users can pin recorded responses via the new Replay Manager dialog for instant replay on subsequent runs — eliminating redundant LLM calls during prompt iteration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP request recording and per-project replay with pin/unpin controls.
  * "Record / Replay" manager UI and dialog from the execution panel to view, pin, and replay recordings.
  * Live replay notifications to the UI when pinned responses are served.
  * Fetch logs now mark replayed requests.

* **Improvements**
  * API Keys dialog: added browser autofill suppression attributes for improved privacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->