### PR TITLE
refactor(bex_vm): extract instruction dispatch into step method

### DIFF
--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1471,1558 +1471,7 @@ impl BexVm {
                 eprintln!("{instruction} {metadata}");
             }
 
-            let step_result: Result<Option<VmExecState>, VmError> = (|| {
-                match function.bytecode.instructions[instruction_ptr] {
-                    Instruction::NotifyBlock(block_index) => {
-                        // Get the notification from the function's storage
-                        let notification = &function.block_notifications[block_index];
-
-                        // Create a copy with the function name populated
-                        let full_notification = bytecode::BlockNotification {
-                            function_name: function.name.clone(),
-                            block_name: notification.block_name.clone(),
-                            level: notification.level,
-                            block_type: notification.block_type,
-                            is_enter: notification.is_enter,
-                        };
-
-                        return Ok(Some(VmExecState::Notify(WatchNotification::Block(
-                            full_notification,
-                        ))));
-                    }
-
-                    Instruction::VizEnter(index) | Instruction::VizExit(index) => {
-                        let instruction = &function.bytecode.instructions[instruction_ptr];
-                        let delta = match instruction {
-                            Instruction::VizEnter(_) => bytecode::VizExecDelta::Enter,
-                            Instruction::VizExit(_) => bytecode::VizExecDelta::Exit,
-                            _ => unreachable!("matched on viz instruction"),
-                        };
-
-                        #[allow(clippy::cast_possible_wrap)]
-                        let node = function.viz_nodes.get(index).ok_or({
-                            VmPanic::IndexOutOfBounds {
-                                index: index as i64,
-                                length: function.viz_nodes.len(),
-                            }
-                        })?;
-
-                        let event = bytecode::VizExecEvent {
-                            delta,
-                            node_id: node.node_id,
-                            node_type: node.node_type,
-                            label: node.label.clone(),
-                            header_level: node.header_level,
-                        };
-
-                        return Ok(Some(VmExecState::Notify(WatchNotification::Viz {
-                            function_name: function.name.clone(),
-                            event,
-                        })));
-                    }
-
-                    Instruction::LoadConst(index) => {
-                        // Use pre-resolved constants (resolved at load time)
-                        let value = function.bytecode.resolved_constants[index];
-                        self.stack.push(value);
-                    }
-
-                    Instruction::LoadVar(index) => {
-                        let slot = Self::local_slot_stack_index(
-                            self.frames[frame_idx].locals_offset,
-                            index,
-                        );
-                        let value = self.stack[slot];
-                        self.stack.push(value);
-                    }
-
-                    Instruction::StoreVar(index) => {
-                        // Absolute index of the local variable.
-                        let local_var_index = Self::local_slot_stack_index(
-                            self.frames[frame_idx].locals_offset,
-                            index,
-                        );
-
-                        // New value.
-                        let value = self.stack.ensure_pop()?;
-
-                        // Old value being replaced.
-                        let old_value = std::mem::replace(&mut self.stack[local_var_index], value);
-
-                        // If this local is watched, update the watch graph.
-                        //
-                        // A watched local is a root in the watch graph. When
-                        // reassigned (e.g. `v = new_val`), three things happen:
-                        //
-                        // 1. `update_watched_node` handles edge topology: unlinks
-                        //    the old binding (so mutations to the old object no
-                        //    longer trigger notifications), links the new one, and
-                        //    deep-copies the previous root state into
-                        //    `last_assigned` so the notification filter can diff
-                        //    old vs new.
-                        //
-                        // 2. `state.value` is updated to the new value. This is
-                        //    specific to `StoreVar` — for field/array/map stores
-                        //    the root's top-level binding hasn't changed, but here
-                        //    the root itself is being rebound.
-                        //
-                        // 3. `process_notifications` walks all roots reaching this
-                        //    node (just itself, since it IS a root) and applies
-                        //    the watch filter to decide whether to notify.
-                        if self.watched_vars.contains_key(&local_var_index) {
-                            let watched_node = NodeId::LocalVar(local_var_index);
-
-                            self.update_watched_node(
-                                watched_node,
-                                watch::Path::Binding,
-                                old_value,
-                                value,
-                            );
-
-                            if let Some(state) = self.watch.root_state_mut(watched_node) {
-                                state.value = value;
-                            }
-
-                            let notifications = self.process_notifications(watched_node)?;
-
-                            if !notifications.is_empty() {
-                                return Ok(Some(VmExecState::Notify(
-                                    WatchNotification::Variables(notifications),
-                                )));
-                            }
-                        }
-                    }
-
-                    Instruction::LoadGlobal(index) => {
-                        let value = &self.globals[index];
-                        self.stack.push(*value);
-                    }
-
-                    Instruction::StoreGlobal(index) => {
-                        // Consume the value. Read impl of Instruction::StoreVar.
-                        let value = self.stack.ensure_pop()?;
-
-                        self.globals[index] = value;
-                    }
-
-                    Instruction::LoadField(index) => {
-                        let top = self.stack.ensure_pop()?;
-
-                        let reference = self.as_object_ptr(&top, ObjectType::Instance)?;
-
-                        // Extract the field value before pushing to stack
-                        let field_value = {
-                            let Object::Instance(instance) = self.get_object(reference) else {
-                                return Err(VmError::TypeError {
-                                    expected: ObjectType::Instance.into(),
-                                    got: ObjectType::of(self.get_object(reference)).into(),
-                                });
-                            };
-                            instance.fields[index]
-                        };
-
-                        // Push the value on top of the stack.
-                        self.stack.push(field_value);
-                    }
-
-                    Instruction::StoreField(index) => {
-                        // Consume the new value to be set from the stack.
-                        let new_value = self.stack.ensure_pop()?;
-
-                        // Consume the instance value from the stack.
-                        let instance_value = self.stack.ensure_pop()?;
-                        let instance_index =
-                            self.as_object_ptr(&instance_value, ObjectType::Instance)?;
-
-                        // Read old value (and typecheck).
-                        let old_value = match self.get_object(instance_index) {
-                            Object::Instance(instance) => instance.fields[index],
-
-                            other => {
-                                return Err(VmError::TypeError {
-                                    expected: ObjectType::Instance.into(),
-                                    got: ObjectType::of(other).into(),
-                                });
-                            }
-                        };
-
-                        // Change graph topology.
-                        let watched_node = NodeId::HeapObject(instance_index);
-
-                        self.update_watched_node(
-                            watched_node,
-                            watch::Path::InstanceField(index),
-                            old_value,
-                            new_value,
-                        );
-
-                        // Set the new value.
-                        if let Object::Instance(instance) = self.get_object_mut(instance_index) {
-                            instance.fields[index] = new_value;
-                        }
-
-                        let notifications = self.process_notifications(watched_node)?;
-
-                        if !notifications.is_empty() {
-                            return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
-                                notifications,
-                            ))));
-                        }
-                    }
-
-                    Instruction::Pop(n) => {
-                        let drain_start = self.stack.len() - n;
-                        let drain_range = StackIndex::from_raw(drain_start)..;
-                        self.stack.drain(drain_range);
-                    }
-
-                    Instruction::Copy(offset) => {
-                        let index = self.stack.ensure_slot_from_top(offset)?;
-                        let value = self.stack[index];
-                        self.stack.push(value);
-                    }
-
-                    Instruction::Jump(offset) => {
-                        // Offset can be negative (backward jumps for loops).
-                        // NOTE: checked_add_signed has a branch on overflow. If this
-                        // becomes a bottleneck on hot loops, it can be replaced with
-                        // wrapping_add_signed — the array bounds check on the next
-                        // iteration will catch invalid pointers anyway.
-                        self.frames[frame_idx].instruction_ptr = instruction_ptr
-                            .checked_add_signed(offset)
-                            .ok_or(VmError::InvalidJump)?;
-                    }
-
-                    Instruction::PopJumpIfFalse(offset) => {
-                        // Pop the condition from the stack (don't leave it there).
-                        let condition = self.stack.ensure_pop()?;
-
-                        match condition {
-                            // Reassign only if the condition is false.
-                            Value::Bool(value) => {
-                                if !value {
-                                    self.frames[frame_idx].instruction_ptr = instruction_ptr
-                                        .checked_add_signed(offset)
-                                        .ok_or(VmError::InvalidJump)?;
-                                }
-                            }
-
-                            // Type error, we don't have "falsey" values in the language
-                            // so we should always check booleans.
-                            other => {
-                                return Err(VmError::TypeError {
-                                    expected: Type::Bool,
-                                    got: self.type_of(&other),
-                                });
-                            }
-                        }
-                    }
-
-                    Instruction::Throw => {
-                        let value = self.stack.ensure_pop()?;
-                        self.try_unwind_exception(&mut frame_idx, &mut function, value)?;
-                    }
-
-                    Instruction::BinOp(op) => {
-                        let right = self.stack.ensure_pop()?;
-                        let left = self.stack.ensure_pop()?;
-
-                        let result = match (left, right) {
-                            (Value::Int(left), Value::Int(right)) => Value::Int(match op {
-                                BinOp::Div if right == 0 => {
-                                    return Err(VmPanic::DivisionByZero {
-                                        left: Value::Int(left),
-                                        right: Value::Int(right),
-                                    }
-                                    .into());
-                                }
-
-                                BinOp::Add => left + right,
-                                BinOp::Sub => left - right,
-                                BinOp::Mul => left * right,
-                                BinOp::Div => left / right,
-                                BinOp::Mod => left % right,
-
-                                BinOp::BitAnd => left & right,
-                                BinOp::BitOr => left | right,
-                                BinOp::BitXor => left ^ right,
-                                BinOp::Shl => left << right,
-                                BinOp::Shr => left >> right,
-                            }),
-
-                            (Value::Float(left), Value::Float(right)) => {
-                                Value::Float(match op {
-                                    BinOp::Div if right == 0.0 => {
-                                        return Err(VmPanic::DivisionByZero {
-                                            left: Value::Float(left),
-                                            right: Value::Float(right),
-                                        }
-                                        .into());
-                                    }
-
-                                    BinOp::Add => left + right,
-                                    BinOp::Sub => left - right,
-                                    BinOp::Mul => left * right,
-                                    BinOp::Div => left / right,
-                                    BinOp::Mod => left % right,
-
-                                    // Bitwise ops not applicable to floats.
-                                    BinOp::BitAnd
-                                    | BinOp::BitOr
-                                    | BinOp::BitXor
-                                    | BinOp::Shl
-                                    | BinOp::Shr => {
-                                        return Err(VmError::CannotApplyBinOp {
-                                            left: Type::Float,
-                                            right: Type::Float,
-                                            op,
-                                        });
-                                    }
-                                })
-                            }
-
-                            // Mixed int/float: promote int to float.
-                            #[allow(clippy::cast_precision_loss)]
-                            (Value::Int(left), Value::Float(right)) => {
-                                let left = left as f64;
-                                Value::Float(match op {
-                                    BinOp::Div if right == 0.0 => {
-                                        return Err(VmPanic::DivisionByZero {
-                                            left: Value::Float(left),
-                                            right: Value::Float(right),
-                                        }
-                                        .into());
-                                    }
-
-                                    BinOp::Add => left + right,
-                                    BinOp::Sub => left - right,
-                                    BinOp::Mul => left * right,
-                                    BinOp::Div => left / right,
-                                    BinOp::Mod => left % right,
-
-                                    BinOp::BitAnd
-                                    | BinOp::BitOr
-                                    | BinOp::BitXor
-                                    | BinOp::Shl
-                                    | BinOp::Shr => {
-                                        return Err(VmError::CannotApplyBinOp {
-                                            left: Type::Int,
-                                            right: Type::Float,
-                                            op,
-                                        });
-                                    }
-                                })
-                            }
-
-                            #[allow(clippy::cast_precision_loss)]
-                            (Value::Float(left), Value::Int(right)) => {
-                                let right = right as f64;
-                                Value::Float(match op {
-                                    BinOp::Div if right == 0.0 => {
-                                        return Err(VmPanic::DivisionByZero {
-                                            left: Value::Float(left),
-                                            right: Value::Float(right),
-                                        }
-                                        .into());
-                                    }
-
-                                    BinOp::Add => left + right,
-                                    BinOp::Sub => left - right,
-                                    BinOp::Mul => left * right,
-                                    BinOp::Div => left / right,
-                                    BinOp::Mod => left % right,
-
-                                    BinOp::BitAnd
-                                    | BinOp::BitOr
-                                    | BinOp::BitXor
-                                    | BinOp::Shl
-                                    | BinOp::Shr => {
-                                        return Err(VmError::CannotApplyBinOp {
-                                            left: Type::Float,
-                                            right: Type::Int,
-                                            op,
-                                        });
-                                    }
-                                })
-                            }
-
-                            (Value::Object(_), Value::Object(_)) if op == BinOp::Add => {
-                                let left = self.as_string(&left)?;
-                                let right = self.as_string(&right)?;
-
-                                let mut concat = left.clone();
-                                concat.push_str(right);
-
-                                self.alloc_string(concat)
-                            }
-
-                            _ => {
-                                return Err(VmError::CannotApplyBinOp {
-                                    left: self.type_of(&left),
-                                    right: self.type_of(&right),
-                                    op,
-                                });
-                            }
-                        };
-
-                        self.stack.push(result);
-                    }
-
-                    Instruction::CmpOp(op) => {
-                        let right = self.stack.ensure_pop()?;
-                        let left = self.stack.ensure_pop()?;
-
-                        let result = match (left, right) {
-                            (Value::Int(left), Value::Int(right)) => Value::Bool(match op {
-                                CmpOp::Eq => left == right,
-                                CmpOp::NotEq => left != right,
-                                CmpOp::Lt => left < right,
-                                CmpOp::LtEq => left <= right,
-                                CmpOp::Gt => left > right,
-                                CmpOp::GtEq => left >= right,
-
-                                CmpOp::InstanceOf => {
-                                    return Err(VmError::CannotApplyCmpOp {
-                                        left: Type::Int,
-                                        right: Type::Int,
-                                        op,
-                                    });
-                                }
-                            }),
-
-                            #[allow(clippy::float_cmp)]
-                            // intentional exact comparison for equality operators
-                            (Value::Float(left), Value::Float(right)) => Value::Bool(match op {
-                                CmpOp::Eq => left == right,
-                                CmpOp::NotEq => left != right,
-                                CmpOp::Lt => left < right,
-                                CmpOp::LtEq => left <= right,
-                                CmpOp::Gt => left > right,
-                                CmpOp::GtEq => left >= right,
-
-                                CmpOp::InstanceOf => {
-                                    return Err(VmError::CannotApplyCmpOp {
-                                        left: Type::Float,
-                                        right: Type::Float,
-                                        op,
-                                    });
-                                }
-                            }),
-
-                            // Mixed int/float comparisons: promote int to float.
-                            #[allow(clippy::cast_precision_loss, clippy::float_cmp)]
-                            (Value::Int(left), Value::Float(right)) => {
-                                let left = left as f64;
-                                Value::Bool(match op {
-                                    CmpOp::Eq => left == right,
-                                    CmpOp::NotEq => left != right,
-                                    CmpOp::Lt => left < right,
-                                    CmpOp::LtEq => left <= right,
-                                    CmpOp::Gt => left > right,
-                                    CmpOp::GtEq => left >= right,
-
-                                    CmpOp::InstanceOf => {
-                                        return Err(VmError::CannotApplyCmpOp {
-                                            left: Type::Int,
-                                            right: Type::Float,
-                                            op,
-                                        });
-                                    }
-                                })
-                            }
-
-                            #[allow(clippy::cast_precision_loss, clippy::float_cmp)]
-                            (Value::Float(left), Value::Int(right)) => {
-                                let right = right as f64;
-                                Value::Bool(match op {
-                                    CmpOp::Eq => left == right,
-                                    CmpOp::NotEq => left != right,
-                                    CmpOp::Lt => left < right,
-                                    CmpOp::LtEq => left <= right,
-                                    CmpOp::Gt => left > right,
-                                    CmpOp::GtEq => left >= right,
-
-                                    CmpOp::InstanceOf => {
-                                        return Err(VmError::CannotApplyCmpOp {
-                                            left: Type::Float,
-                                            right: Type::Int,
-                                            op,
-                                        });
-                                    }
-                                })
-                            }
-
-                            (Value::Object(left_index), Value::Object(right_index))
-                                if matches!(self.get_object(left_index), Object::String(_))
-                                    && matches!(
-                                        self.get_object(right_index),
-                                        Object::String(_)
-                                    ) =>
-                            {
-                                let left = self.as_string(&left)?;
-                                let right = self.as_string(&right)?;
-
-                                Value::Bool(match op {
-                                    CmpOp::Eq => left == right,
-                                    CmpOp::NotEq => left != right,
-                                    CmpOp::Lt => left < right,
-                                    CmpOp::LtEq => left <= right,
-                                    CmpOp::Gt => left > right,
-                                    CmpOp::GtEq => left >= right,
-                                    CmpOp::InstanceOf => {
-                                        return Err(VmError::CannotApplyCmpOp {
-                                            left: Type::Object(ObjectType::String),
-                                            right: Type::Object(ObjectType::String),
-                                            op,
-                                        });
-                                    }
-                                })
-                            }
-
-                            // Uint8Array comparison: compare by content
-                            (Value::Object(left_index), Value::Object(right_index))
-                                if matches!(self.get_object(left_index), Object::Uint8Array(_))
-                                    && matches!(
-                                        self.get_object(right_index),
-                                        Object::Uint8Array(_)
-                                    ) =>
-                            {
-                                let left = self.as_uint8array(&left)?;
-                                let right = self.as_uint8array(&right)?;
-
-                                Value::Bool(match op {
-                                    CmpOp::Eq => left == right,
-                                    CmpOp::NotEq => left != right,
-                                    _ => {
-                                        return Err(VmError::CannotApplyCmpOp {
-                                            left: Type::Object(ObjectType::Uint8Array),
-                                            right: Type::Object(ObjectType::Uint8Array),
-                                            op,
-                                        });
-                                    }
-                                })
-                            }
-
-                            // Variant comparison: compare by enum type and variant index
-                            (Value::Object(left_index), Value::Object(right_index))
-                                if matches!(self.get_object(left_index), Object::Variant(_))
-                                    && matches!(
-                                        self.get_object(right_index),
-                                        Object::Variant(_)
-                                    ) =>
-                            {
-                                let Object::Variant(left_var) = self.get_object(left_index) else {
-                                    unreachable!()
-                                };
-                                let Object::Variant(right_var) = self.get_object(right_index)
-                                else {
-                                    unreachable!()
-                                };
-
-                                Value::Bool(match op {
-                                    CmpOp::Eq => {
-                                        left_var.enm == right_var.enm
-                                            && left_var.index == right_var.index
-                                    }
-                                    CmpOp::NotEq => {
-                                        left_var.enm != right_var.enm
-                                            || left_var.index != right_var.index
-                                    }
-                                    _ => {
-                                        return Err(VmError::CannotApplyCmpOp {
-                                            left: Type::Object(ObjectType::Variant),
-                                            right: Type::Object(ObjectType::Variant),
-                                            op,
-                                        });
-                                    }
-                                })
-                            }
-
-                            _ => Value::Bool(match op {
-                                CmpOp::Eq => left == right,
-                                CmpOp::NotEq => left != right,
-
-                                CmpOp::InstanceOf => {
-                                    // null/non-object is never an instance of anything.
-                                    match left {
-                                        Value::Object(left_ptr) => {
-                                            match self.get_object(left_ptr) {
-                                                Object::Instance(instance) => {
-                                                    let right_ptr = self
-                                                        .as_object_ptr(&right, ObjectType::Class)?;
-                                                    instance.class == right_ptr
-                                                }
-                                                _ => false,
-                                            }
-                                        }
-                                        _ => false,
-                                    }
-                                }
-
-                                _ => {
-                                    return Err(VmError::CannotApplyCmpOp {
-                                        left: self.type_of(&left),
-                                        right: self.type_of(&right),
-                                        op,
-                                    });
-                                }
-                            }),
-                        };
-
-                        self.stack.push(result);
-                    }
-
-                    Instruction::UnaryOp(op) => {
-                        let value = self.stack.ensure_pop()?;
-
-                        let result = match (op, value) {
-                            (UnaryOp::Not, Value::Bool(value)) => Value::Bool(!value),
-                            (UnaryOp::Neg, Value::Int(value)) => Value::Int(-value),
-                            (UnaryOp::Neg, Value::Float(value)) => Value::Float(-value),
-                            _ => {
-                                return Err(VmError::CannotApplyUnaryOp {
-                                    op,
-                                    value: self.type_of(&value),
-                                });
-                            }
-                        };
-
-                        self.stack.push(result);
-                    }
-
-                    Instruction::AllocArray(size) => {
-                        // Pop all the elements from the stack and create an array.
-                        let drain_range = StackIndex::from_raw(self.stack.len() - size)..;
-                        let array = self.stack.drain(drain_range).collect();
-
-                        // Allocate it on the heap.
-                        let array_index = self.tlab.alloc(Object::Array(array));
-
-                        // Push the array object on top of the stack.
-                        self.stack.push(Value::Object(array_index));
-                    }
-
-                    Instruction::LoadArrayElement => {
-                        // Stack should contain [array, index]
-                        // Pop the index first, then the array
-                        let index_value = self.stack.ensure_pop()?;
-                        let array_value = self.stack.ensure_pop()?;
-
-                        let array_obj_index =
-                            self.as_object_ptr(&array_value, ObjectType::Array)?;
-
-                        // Get the array length for bounds checking.
-                        let array_len = match self.get_object(array_obj_index) {
-                            Object::Array(arr) => arr.len(),
-                            Object::Uint8Array(bytes) => bytes.len(),
-                            other => {
-                                return Err(VmError::TypeError {
-                                    expected: ObjectType::Array.into(),
-                                    got: ObjectType::of(other).into(),
-                                });
-                            }
-                        };
-
-                        // Get the index
-                        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                        // bounds checked below
-                        let index = match index_value {
-                            Value::Int(i) => {
-                                if i < 0 || i as usize >= array_len {
-                                    return Err(VmPanic::IndexOutOfBounds {
-                                        index: i,
-                                        length: array_len,
-                                    }
-                                    .into());
-                                }
-                                i as usize
-                            }
-                            _ => {
-                                return Err(VmError::TypeError {
-                                    expected: Type::Int,
-                                    got: self.type_of(&index_value),
-                                });
-                            }
-                        };
-
-                        // Extract the array element before pushing to stack
-                        #[allow(clippy::cast_possible_wrap)]
-                        let element = {
-                            match self.get_object(array_obj_index) {
-                                Object::Array(array) => {
-                                    if index >= array.len() {
-                                        return Err(VmPanic::IndexOutOfBounds {
-                                            index: index as i64,
-                                            length: array.len(),
-                                        }
-                                        .into());
-                                    }
-                                    array[index]
-                                }
-                                Object::Uint8Array(bytes) => {
-                                    if index >= bytes.len() {
-                                        return Err(VmPanic::IndexOutOfBounds {
-                                            index: index as i64,
-                                            length: bytes.len(),
-                                        }
-                                        .into());
-                                    }
-                                    Value::Int(i64::from(bytes[index]))
-                                }
-                                _ => {
-                                    return Err(VmError::TypeError {
-                                        expected: ObjectType::Array.into(),
-                                        got: ObjectType::of(self.get_object(array_obj_index))
-                                            .into(),
-                                    });
-                                }
-                            }
-                        };
-
-                        // Push the element onto the stack
-                        self.stack.push(element);
-                    }
-
-                    Instruction::LoadMapElement => {
-                        // LoadMapElement Instruction
-                        //
-                        // Stack before: [map, key]
-                        // Stack after: [value]
-                        //
-                        // Interpretation steps:
-                        // 1. Pop key from stack (top element)
-                        // 2. Pop map reference from stack (bottom element)
-                        // 3. Validate that the popped map reference is indeed a map object
-                        // 4. Get the key as a string from the objects pool (maps use string keys)
-                        //    - Validate key_value is an object reference to a String
-                        //    - Get the string reference from the objects pool
-                        // 5. Look up the value at map[key]
-                        // 6. Handle the case where key doesn't exist in the map
-                        //    - Return a runtime error NoSuchKeyInMap if key not found
-                        // 7. Push the found value onto the stack
-
-                        let key_value = self.stack.ensure_pop()?;
-                        let map_value = self.stack.ensure_pop()?;
-
-                        let map_index = self.as_object_ptr(&map_value, ObjectType::Map)?;
-
-                        let Object::Map(map) = self.get_object(map_index) else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Map.into(),
-                                got: ObjectType::of(self.get_object(map_index)).into(),
-                            });
-                        };
-
-                        // Get the string key from the objects pool
-                        let key_index = self.as_object_ptr(&key_value, ObjectType::String)?;
-                        let key = self.get_object(key_index).as_string()?;
-
-                        // Look up the value in the map
-                        let value = map.get(key).copied().ok_or(VmPanic::MapKeyNotFound)?;
-
-                        // Push the value onto the stack
-                        self.stack.push(value);
-                    }
-
-                    Instruction::StoreArrayElement => {
-                        // Instruction args.
-                        let new_value = self.stack.ensure_pop()?;
-                        let index_value = self.stack.ensure_pop()?;
-                        let array_value = self.stack.ensure_pop()?;
-                        let array_object_index =
-                            self.as_object_ptr(&array_value, ObjectType::Array)?;
-
-                        // Get the array length for bounds checking.
-                        let array_len = match self.get_object(array_object_index) {
-                            Object::Array(arr) => arr.len(),
-                            Object::Uint8Array(bytes) => bytes.len(),
-                            other => {
-                                return Err(VmError::TypeError {
-                                    expected: ObjectType::Array.into(),
-                                    got: ObjectType::of(other).into(),
-                                });
-                            }
-                        };
-
-                        // Verify index.
-                        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                        // bounds checked below
-                        let index = match index_value {
-                            Value::Int(i) => {
-                                if i < 0 || i as usize >= array_len {
-                                    return Err(VmPanic::IndexOutOfBounds {
-                                        index: i,
-                                        length: array_len,
-                                    }
-                                    .into());
-                                }
-                                i as usize
-                            }
-                            other => {
-                                return Err(VmError::TypeError {
-                                    expected: Type::Int,
-                                    got: self.type_of(&other),
-                                });
-                            }
-                        };
-
-                        // Read old value (and typecheck).
-                        #[allow(clippy::cast_possible_wrap)]
-                        let old_value = match self.get_object(array_object_index) {
-                            Object::Array(array) => {
-                                if index >= array.len() {
-                                    return Err(VmPanic::IndexOutOfBounds {
-                                        index: index as i64,
-                                        length: array.len(),
-                                    }
-                                    .into());
-                                }
-                                array[index]
-                            }
-                            Object::Uint8Array(bytes) => {
-                                if index >= bytes.len() {
-                                    return Err(VmPanic::IndexOutOfBounds {
-                                        index: index as i64,
-                                        length: bytes.len(),
-                                    }
-                                    .into());
-                                }
-                                Value::Int(i64::from(bytes[index]))
-                            }
-                            other => {
-                                return Err(VmError::TypeError {
-                                    expected: ObjectType::Array.into(),
-                                    got: ObjectType::of(other).into(),
-                                });
-                            }
-                        };
-
-                        // Change graph topology
-                        let watched_node = NodeId::HeapObject(array_object_index);
-                        self.update_watched_node(
-                            watched_node,
-                            watch::Path::ArrayIndex(index),
-                            old_value,
-                            new_value,
-                        );
-
-                        // Set the new value.
-                        match self.get_object_mut(array_object_index) {
-                            Object::Array(array) => {
-                                array[index] = new_value;
-                            }
-                            Object::Uint8Array(bytes) => {
-                                let Value::Int(i) = new_value else {
-                                    return Err(VmError::TypeError {
-                                        expected: Type::Int,
-                                        got: self.type_of(&new_value),
-                                    });
-                                };
-                                let Ok(i) = u8::try_from(i) else {
-                                    return Err(VmError::InternalError(format!(
-                                        "uint8array store: value {i} out of range 0..=255"
-                                    )));
-                                };
-                                bytes[index] = i;
-                            }
-                            _ => {
-                                unreachable!(
-                                    "We already checked earlier that we are operating on an array-like type"
-                                );
-                            }
-                        }
-
-                        let notifications = self.process_notifications(watched_node)?;
-
-                        if !notifications.is_empty() {
-                            return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
-                                notifications,
-                            ))));
-                        }
-                    }
-
-                    Instruction::StoreMapElement => {
-                        // Instruction args.
-                        let new_value = self.stack.ensure_pop()?;
-                        let key_value = self.stack.ensure_pop()?;
-                        let map_value = self.stack.ensure_pop()?;
-
-                        // Get the string key from the objects pool.
-                        let key_index = self.as_object_ptr(&key_value, ObjectType::String)?;
-                        let key = self.get_object(key_index).as_string()?.clone();
-
-                        let map_index = self.as_object_ptr(&map_value, ObjectType::Map)?;
-
-                        // Read old value (and typecheck).
-                        //
-                        // If the map didn't contain any value we'll use null so
-                        // there's not watch graph edge to update.
-                        let old_value = match self.get_object(map_index) {
-                            Object::Map(map) => map.get(&key).copied().unwrap_or(Value::Null),
-
-                            other => {
-                                return Err(VmError::TypeError {
-                                    expected: ObjectType::Map.into(),
-                                    got: ObjectType::of(other).into(),
-                                });
-                            }
-                        };
-
-                        // Change graph topology
-                        let watched_node = NodeId::HeapObject(map_index);
-
-                        self.update_watched_node(
-                            watched_node,
-                            watch::Path::MapKey(key.clone()),
-                            old_value,
-                            new_value,
-                        );
-
-                        // Set the new value.
-                        if let Object::Map(map) = self.get_object_mut(map_index) {
-                            map.insert(key, new_value);
-                        }
-
-                        let notifications = self.process_notifications(watched_node)?;
-
-                        if !notifications.is_empty() {
-                            return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
-                                notifications,
-                            ))));
-                        }
-                    }
-
-                    Instruction::AllocInstance(index) => {
-                        // Convert compile-time ObjectIndex to HeapPtr
-                        let class_ptr = self.idx_to_ptr(index);
-                        let Object::Class(class) = self.get_object(class_ptr) else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Class.into(),
-                                got: ObjectType::of(self.get_object(class_ptr)).into(),
-                            });
-                        };
-
-                        // Allocate the fields.
-                        let mut fields = Vec::with_capacity(class.fields.len());
-                        fields.resize(class.fields.len(), Value::Null);
-
-                        // Allocate an instance of the class.
-                        let instance_ptr = self.tlab.alloc(Object::Instance(Instance {
-                            class: class_ptr,
-                            fields,
-                        }));
-
-                        // Push the instance object on top of the stack.
-                        self.stack.push(Value::Object(instance_ptr));
-                    }
-
-                    // TODO: Contains a lot of typechecking, we know at compile time
-                    // that all this stuff is right. Should do something about it.
-                    Instruction::AllocVariant(enum_index) => {
-                        // Convert compile-time ObjectIndex to HeapPtr
-                        let enum_ptr = self.idx_to_ptr(enum_index);
-                        // Extract the variant count before popping from stack to avoid borrow conflicts
-                        let variant_count = {
-                            let Object::Enum(enm) = self.get_object(enum_ptr) else {
-                                return Err(VmError::TypeError {
-                                    expected: ObjectType::Enum.into(),
-                                    got: ObjectType::of(self.get_object(enum_ptr)).into(),
-                                });
-                            };
-                            enm.variants.len()
-                        };
-
-                        let variant = self.stack.ensure_pop()?;
-
-                        let Value::Int(variant_index) = variant else {
-                            return Err(VmError::TypeError {
-                                expected: Type::Int,
-                                got: self.type_of(&variant),
-                            });
-                        };
-
-                        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                        // Safe: we check variant_index < 0 first, so the cast
-                        // only executes for non-negative values.
-                        if variant_index < 0 || variant_index as usize >= variant_count {
-                            return Err(VmPanic::IndexOutOfBounds {
-                                index: variant_index,
-                                length: variant_count,
-                            }
-                            .into());
-                        }
-
-                        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                        // checked non-negative above
-                        let variant_usize = variant_index as usize;
-
-                        let variant_ptr = self.tlab.alloc(Object::Variant(Variant {
-                            enm: enum_ptr,
-                            index: variant_usize,
-                        }));
-
-                        // Push the variant object on top of the stack.
-                        self.stack.push(Value::Object(variant_ptr));
-                    }
-
-                    Instruction::DispatchFuture(callee) => {
-                        let callee_value = self.globals[callee];
-                        let expected_type = FunctionType::SysOp;
-                        let callee_ptr = self.as_object_ptr(&callee_value, expected_type.into())?;
-
-                        // Can't dispatch if it's not a function
-                        let Object::Function(callable_future) = self.get_object(callee_ptr) else {
-                            return Err(VmError::TypeError {
-                                expected: expected_type.into(),
-                                got: ObjectType::of(self.get_object(callee_ptr)).into(),
-                            });
-                        };
-
-                        // Must be a sys_op - extract the SysOp.
-                        let FunctionKind::SysOp(sys_op) = callable_future.kind else {
-                            return Err(VmError::TypeError {
-                                expected: FunctionType::SysOp.into(),
-                                got: FunctionType::from(&callable_future.kind).into(),
-                            });
-                        };
-
-                        let args_offset = self
-                            .stack
-                            .len()
-                            .checked_sub(callable_future.arity)
-                            .ok_or(VmError::NotEnoughItemsOnStack(callable_future.arity))?;
-                        let args_offset = StackIndex::from_raw(args_offset);
-
-                        // Collect function call args and cleanup consumed stack.
-                        let future_args: Vec<Value> = self.stack.drain(args_offset..).collect();
-
-                        // Create the pending future with the SysOp enum.
-                        let pending_future = PendingFuture {
-                            operation: sys_op,
-                            args: future_args,
-                        };
-
-                        // Allocate the future.
-                        let future_value = self.alloc_future(Future::Pending(pending_future));
-
-                        // Extract the index
-                        let Value::Object(object_index) = future_value else {
-                            unreachable!("alloc_future returns Value::Object")
-                        };
-
-                        // Now leave the future on top of the stack.
-                        self.stack.push(future_value);
-
-                        // Yield control flow back to the embedder.
-                        return Ok(Some(VmExecState::ScheduleFuture(object_index)));
-                    }
-
-                    Instruction::Await => {
-                        let value = self.stack.ensure_stack_top()?;
-
-                        let wanted_type = FutureType::Any;
-
-                        let index = self.as_object_ptr(&self.stack[value], wanted_type.into())?;
-
-                        // Check if future is ready and extract value if so
-                        let ready_value = {
-                            let Object::Future(awaiting) = self.get_object(index) else {
-                                return Err(VmError::TypeError {
-                                    expected: wanted_type.into(),
-                                    got: ObjectType::of(self.get_object(index)).into(),
-                                });
-                            };
-
-                            match awaiting {
-                                // Can't do nothing, handle control flow back to embedder.
-                                Future::Pending(_) => {
-                                    return Ok(Some(VmExecState::Await(index)));
-                                }
-
-                                // Return the ready value
-                                Future::Ready(value) => *value,
-                            }
-                        };
-
-                        // Replace the future on the eval stack with the ready value
-                        self.stack.pop();
-                        self.stack.push(ready_value);
-                    }
-
-                    Instruction::Watch(index) => {
-                        // Stack contains: [channel, filter]
-
-                        // Consume filter.
-                        let filter = match self.stack.ensure_pop()? {
-                            Value::Null => WatchFilter::Default,
-                            Value::Object(object_index) => match self.get_object(object_index) {
-                                Object::Function(_) => WatchFilter::Function(object_index),
-                                Object::String(mode) if mode == "manual" => WatchFilter::Manual,
-                                Object::String(mode) if mode == "never" => WatchFilter::Paused,
-                                _ => {
-                                    return Err(VmError::InternalError(
-                                        "Invalid filter".to_string(),
-                                    ));
-                                }
-                            },
-                            _ => {
-                                return Err(VmError::InternalError("Invalid filter".to_string()));
-                            }
-                        };
-
-                        // Consume channel.
-                        let channel_value = self.stack.ensure_pop()?;
-                        let channel = self.as_string(&channel_value)?.to_owned();
-
-                        let local_var_index = Self::local_slot_stack_index(
-                            self.frames[frame_idx].locals_offset,
-                            index,
-                        );
-                        let value = self.stack[local_var_index];
-
-                        // The variable index should be the same as where the value is stored
-                        let var_node = NodeId::LocalVar(local_var_index);
-
-                        // Register this variable as an emittable root.
-                        self.watch.register_root(
-                            var_node,
-                            RootState {
-                                channel,
-                                value,
-                                filter,
-                                last_notified: None,
-                                last_assigned: None,
-                            },
-                        );
-
-                        let watched_var_name = &function.local_names[index];
-                        // Track this so we can unregister on scope exit
-                        self.watched_vars.insert(
-                            local_var_index,
-                            (watched_var_name.clone(), function.name.clone()),
-                        );
-
-                        // If it's an object, build the entire dependency graph
-                        if let Value::Object(object_index) = value {
-                            watch::track_watch_dependencies(
-                                &mut self.watch,
-                                var_node,
-                                watch::Path::Binding,
-                                object_index,
-                            );
-                        }
-                    }
-
-                    Instruction::Unwatch(index) => {
-                        let local_var_index = Self::local_slot_stack_index(
-                            self.frames[frame_idx].locals_offset,
-                            index,
-                        );
-
-                        // Remove from watched_vars tracking
-                        if self.watched_vars.remove(&local_var_index).is_some() {
-                            let var_node = NodeId::LocalVar(local_var_index);
-                            // Unregister this variable as a root
-                            self.watch.unregister_root(var_node);
-
-                            // If it was linked to an object, unlink it
-                            let value = self.stack[local_var_index];
-                            if let Value::Object(object_index) = value {
-                                self.watch.unlink_edge(
-                                    var_node,
-                                    watch::Path::Binding,
-                                    NodeId::HeapObject(object_index),
-                                );
-                            }
-                        }
-                    }
-
-                    Instruction::Notify(index) => {
-                        let local_var_index = Self::local_slot_stack_index(
-                            self.frames[frame_idx].locals_offset,
-                            index,
-                        );
-                        let var_node = NodeId::LocalVar(local_var_index);
-
-                        let notifications = self.watch.copy_roots_reaching(var_node);
-
-                        if notifications.len() != 1 && notifications.first() != Some(&var_node) {
-                            return Err(VmError::InternalError(
-                                "Invalid manual notify".to_string(),
-                            ));
-                        }
-
-                        return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
-                            notifications,
-                        ))));
-                    }
-
-                    Instruction::Call(callee) => {
-                        let callee_value = self.globals[callee];
-                        let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
-                        let args_offset = self
-                            .stack
-                            .len()
-                            .checked_sub(arg_count)
-                            .ok_or(VmError::NotEnoughItemsOnStack(arg_count))?;
-                        let locals_offset = StackIndex::from_raw(args_offset);
-
-                        if let Some(state) = self.execute_call_from_locals_offset(
-                            callee_ptr,
-                            locals_offset,
-                            arg_count,
-                            &mut frame_idx,
-                            &mut function,
-                        )? {
-                            return Ok(Some(state));
-                        }
-                    }
-
-                    Instruction::CallIndirect => {
-                        // Stack layout: [arg1, arg2, ..., argN, callee]
-                        let callee_slot = self.stack.ensure_stack_top()?;
-                        let callee_value = self.stack[callee_slot];
-                        let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
-                        let args_offset = self
-                            .stack
-                            .len()
-                            .checked_sub(arg_count + 1)
-                            .ok_or(VmError::NotEnoughItemsOnStack(arg_count + 1))?;
-                        let _popped_callee = self.stack.ensure_pop()?;
-                        let locals_offset = StackIndex::from_raw(args_offset);
-
-                        if let Some(state) = self.execute_call_from_locals_offset(
-                            callee_ptr,
-                            locals_offset,
-                            arg_count,
-                            &mut frame_idx,
-                            &mut function,
-                        )? {
-                            return Ok(Some(state));
-                        }
-                    }
-
-                    Instruction::Return => {
-                        // Pop the result from the eval stack.
-                        let result = self.stack.ensure_pop()?;
-
-                        // Check if this frame was traced.
-                        // Capture function name before popping the frame.
-                        let span_exit = if self.traced_frames.last() == Some(&frame_idx) {
-                            let func_name = self
-                                .get_object(self.frames[frame_idx].function)
-                                .as_function()
-                                .map(|f| f.name.clone())
-                                .ok();
-                            self.traced_frames.pop();
-                            func_name
-                        } else {
-                            None
-                        };
-
-                        // Restore the eval stack to the state before the function
-                        // was called and leave the result on top.
-                        self.stack.drain(self.frames[frame_idx].locals_offset..);
-                        self.stack.push(result);
-
-                        // Pop from the call stack.
-                        self.frames.pop();
-
-                        // Return from interrupt.
-                        if Some(self.frames.len()) == self.interrupt_frame {
-                            self.interrupt_frame = None;
-                            return self.stack.ensure_pop().map(VmExecState::Complete).map(Some);
-                        }
-
-                        // If there are no more frames, we're done.
-                        if self.frames.is_empty() {
-                            return self.stack.ensure_pop().map(VmExecState::Complete).map(Some);
-                        }
-
-                        // Yield FunctionExit for traced frames (with result value).
-                        if let Some(name) = span_exit {
-                            return Ok(Some(VmExecState::SpanNotify(
-                                SpanNotification::FunctionExit {
-                                    function_name: name,
-                                    result,
-                                },
-                            )));
-                        }
-
-                        // Resume previous frame execution.
-                        frame_idx = self.frames.len() - 1;
-
-                        // SAFETY: See `load_function` doc comment.
-                        function = unsafe { self.load_function(frame_idx)? };
-                    }
-
-                    Instruction::AllocMap(n) => {
-                        let map = if n > 0 {
-                            let end_of_values = self.stack.ensure_slot_from_top(2 * n - 1)?;
-                            let end_of_keys = self.stack.ensure_slot_from_top(n - 1)?;
-                            let idx_of_last_key = self.stack.ensure_slot_from_top(n - 1)?;
-
-                            // We can safely copy the objects that act as values so there's no problem
-                            // with not draining them.
-                            let values = self.stack[end_of_values..end_of_keys].iter().copied();
-
-                            // We cannot copy key references since we aren't interning yet, so we
-                            // must clone the strings.
-                            // Here we'll also double-check that the keys are strings. This adds `n`
-                            // branches which is not ideal for performance. Might want to consider this
-                            // in map accesses.
-                            let keys = self.stack[idx_of_last_key..].iter().map(|k| {
-                                let obj_index = self.as_object_ptr(k, ObjectType::String)?;
-
-                                self.get_object(obj_index).as_string().cloned()
-                            });
-
-                            let pairs = values
-                                .zip(keys)
-                                .map(|(val, key_res)| key_res.map(|k| (k, val)));
-
-                            let map = pairs.collect::<Result<IndexMap<_, _>, _>>()?;
-
-                            // drain & drop the drain so that vec is empty.
-                            self.stack.drain(end_of_values..);
-
-                            map
-                        } else {
-                            // nothing to pop.
-                            IndexMap::new()
-                        };
-
-                        let obj_index = self.tlab.alloc(Object::Map(map));
-
-                        self.stack.push(Value::Object(obj_index));
-                    }
-
-                    // ============================================================
-                    // Jump Table Instructions
-                    // ============================================================
-                    Instruction::JumpTable { table_idx, default } => {
-                        // Pop discriminant from stack
-                        let discriminant = self.stack.ensure_pop()?;
-
-                        // Must be an integer
-                        let Value::Int(value) = discriminant else {
-                            return Err(VmError::TypeError {
-                                expected: Type::Int,
-                                got: self.type_of(&discriminant),
-                            });
-                        };
-
-                        // Lookup in jump table
-                        let table = &function.bytecode.jump_tables[table_idx];
-                        let offset = table.lookup(value).unwrap_or(default);
-
-                        // Jump
-                        self.frames[frame_idx].instruction_ptr = instruction_ptr
-                            .checked_add_signed(offset)
-                            .ok_or(VmError::InvalidJump)?;
-                    }
-
-                    Instruction::Discriminant => {
-                        // Pop value from stack
-                        let value = self.stack.ensure_pop()?;
-
-                        // Must be an object (variants are heap-allocated)
-                        let Value::Object(object_idx) = value else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Variant.into(),
-                                got: self.type_of(&value),
-                            });
-                        };
-
-                        // Must be a Variant object
-                        let variant_index = {
-                            let Object::Variant(variant) = self.get_object(object_idx) else {
-                                return Err(VmError::TypeError {
-                                    expected: ObjectType::Variant.into(),
-                                    got: ObjectType::of(self.get_object(object_idx)).into(),
-                                });
-                            };
-                            variant.index
-                        };
-
-                        // Variant.index is the discriminant we need
-                        #[allow(clippy::cast_possible_wrap)]
-                        self.stack.push(Value::Int(variant_index as i64));
-                    }
-
-                    Instruction::TypeTag => {
-                        let value = self.stack.ensure_pop()?;
-                        let tag = value_type_tag(&value);
-                        self.stack.push(Value::Int(tag));
-                    }
-
-                    Instruction::ThrowIfPanic => {
-                        let value = self.stack.ensure_pop()?;
-                        let is_panic = match value {
-                            Value::Object(ptr) => match self.get_object(ptr) {
-                                Object::Instance(instance) => {
-                                    self.panic_class_ptrs.contains(&instance.class)
-                                }
-                                _ => false,
-                            },
-                            _ => false,
-                        };
-                        if is_panic {
-                            self.try_unwind_exception(&mut frame_idx, &mut function, value)?;
-                        }
-                    }
-
-                    Instruction::Unreachable => {
-                        // This instruction should never be executed. If we reach it,
-                        // there's a bug in the compiler or type system.
-                        return Err(VmPanic::Unreachable.into());
-                    }
-
-                    Instruction::MakeCell => {
-                        let value = self.stack.ensure_pop()?;
-                        let cell = Object::Cell(Cell { value });
-                        let ptr = self.tlab.alloc(cell);
-                        self.stack.push(Value::Object(ptr));
-                    }
-
-                    Instruction::MakeClosure(obj_idx, capture_count) => {
-                        let mut captures = Vec::with_capacity(capture_count);
-                        for _ in 0..capture_count {
-                            captures.push(self.stack.ensure_pop()?);
-                        }
-                        // Captures were pushed left-to-right, popped right-to-left.
-                        captures.reverse();
-                        let function_ptr = self.idx_to_ptr(obj_idx);
-                        let closure = Object::Closure(Closure {
-                            function: function_ptr,
-                            captures,
-                        });
-                        let ptr = self.tlab.alloc(closure);
-                        self.stack.push(Value::Object(ptr));
-                    }
-
-                    Instruction::LoadDeref(slot) => {
-                        let locals_offset = self.frames[frame_idx].locals_offset;
-                        let cell_value =
-                            self.stack[Self::local_slot_stack_index(locals_offset, slot)];
-                        let Value::Object(cell_ptr) = cell_value else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Cell.into(),
-                                got: self.type_of(&cell_value),
-                            });
-                        };
-                        // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
-                        let obj = unsafe { cell_ptr.get() };
-                        let Object::Cell(cell) = obj else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Cell.into(),
-                                got: ObjectType::of(obj).into(),
-                            });
-                        };
-                        self.stack.push(cell.value);
-                    }
-
-                    Instruction::StoreDeref(slot) => {
-                        let value = self.stack.ensure_pop()?;
-                        let locals_offset = self.frames[frame_idx].locals_offset;
-                        let cell_value =
-                            self.stack[Self::local_slot_stack_index(locals_offset, slot)];
-                        let Value::Object(cell_ptr) = cell_value else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Cell.into(),
-                                got: self.type_of(&cell_value),
-                            });
-                        };
-                        // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
-                        let obj = unsafe { cell_ptr.get_mut() };
-                        let Object::Cell(cell) = obj else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Cell.into(),
-                                got: ObjectType::of(obj).into(),
-                            });
-                        };
-                        cell.value = value;
-                    }
-
-                    Instruction::LoadCapture(idx) => {
-                        let closure_ptr = self.frames[frame_idx].function;
-                        // SAFETY: closure_ptr is the frame's function, valid for
-                        // the duration of this frame.
-                        let obj = unsafe { closure_ptr.get() };
-                        let Object::Closure(closure) = obj else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Closure.into(),
-                                got: ObjectType::of(obj).into(),
-                            });
-                        };
-                        let cell_value = closure.captures[idx];
-                        let Value::Object(cell_ptr) = cell_value else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Cell.into(),
-                                got: self.type_of(&cell_value),
-                            });
-                        };
-                        // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
-                        let cell_obj = unsafe { cell_ptr.get() };
-                        let Object::Cell(cell) = cell_obj else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Cell.into(),
-                                got: ObjectType::of(cell_obj).into(),
-                            });
-                        };
-                        self.stack.push(cell.value);
-                    }
-
-                    Instruction::StoreCapture(idx) => {
-                        let value = self.stack.ensure_pop()?;
-                        let closure_ptr = self.frames[frame_idx].function;
-                        // SAFETY: closure_ptr is the frame's function, valid for
-                        // the duration of this frame.
-                        let obj = unsafe { closure_ptr.get() };
-                        let Object::Closure(closure) = obj else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Closure.into(),
-                                got: ObjectType::of(obj).into(),
-                            });
-                        };
-                        let cell_value = closure.captures[idx];
-                        let Value::Object(cell_ptr) = cell_value else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Cell.into(),
-                                got: self.type_of(&cell_value),
-                            });
-                        };
-                        // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
-                        let cell_obj = unsafe { cell_ptr.get_mut() };
-                        let Object::Cell(cell) = cell_obj else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Cell.into(),
-                                got: ObjectType::of(cell_obj).into(),
-                            });
-                        };
-                        cell.value = value;
-                    }
-
-                    Instruction::CaptureRef(idx) => {
-                        // Push the raw cell pointer from captures[idx] without
-                        // reading through the cell.  Used by nested closures to
-                        // forward a shared cell to an inner closure.
-                        let closure_ptr = self.frames[frame_idx].function;
-                        // SAFETY: closure_ptr is the frame's function, valid for
-                        // the duration of this frame.
-                        let obj = unsafe { closure_ptr.get() };
-                        let Object::Closure(closure) = obj else {
-                            return Err(VmError::TypeError {
-                                expected: ObjectType::Closure.into(),
-                                got: ObjectType::of(obj).into(),
-                            });
-                        };
-                        self.stack.push(closure.captures[idx]);
-                    }
-                }
-
-                Ok(None)
-            })();
+            let step_result = self.step(&mut frame_idx, &mut function, instruction_ptr);
 
             match step_result {
                 Ok(Some(state)) => return Ok(state),
@@ -3033,5 +1482,1529 @@ impl BexVm {
                 }
             }
         }
+    }
+
+    /// Execute a single instruction.
+    ///
+    /// Returns `Ok(Some(state))` when the VM must yield control flow to the
+    /// embedder (await, schedule, complete, notify). Returns `Ok(None)` when
+    /// execution should continue to the next instruction.
+    fn step(
+        &mut self,
+        frame_idx: &mut usize,
+        function: &mut &'static Function,
+        instruction_ptr: usize,
+    ) -> Result<Option<VmExecState>, VmError> {
+        match function.bytecode.instructions[instruction_ptr] {
+            Instruction::NotifyBlock(block_index) => {
+                // Get the notification from the function's storage
+                let notification = &function.block_notifications[block_index];
+
+                // Create a copy with the function name populated
+                let full_notification = bytecode::BlockNotification {
+                    function_name: function.name.clone(),
+                    block_name: notification.block_name.clone(),
+                    level: notification.level,
+                    block_type: notification.block_type,
+                    is_enter: notification.is_enter,
+                };
+
+                return Ok(Some(VmExecState::Notify(WatchNotification::Block(
+                    full_notification,
+                ))));
+            }
+
+            Instruction::VizEnter(index) | Instruction::VizExit(index) => {
+                let instruction = &function.bytecode.instructions[instruction_ptr];
+                let delta = match instruction {
+                    Instruction::VizEnter(_) => bytecode::VizExecDelta::Enter,
+                    Instruction::VizExit(_) => bytecode::VizExecDelta::Exit,
+                    _ => unreachable!("matched on viz instruction"),
+                };
+
+                #[allow(clippy::cast_possible_wrap)]
+                let node = function.viz_nodes.get(index).ok_or({
+                    VmPanic::IndexOutOfBounds {
+                        index: index as i64,
+                        length: function.viz_nodes.len(),
+                    }
+                })?;
+
+                let event = bytecode::VizExecEvent {
+                    delta,
+                    node_id: node.node_id,
+                    node_type: node.node_type,
+                    label: node.label.clone(),
+                    header_level: node.header_level,
+                };
+
+                return Ok(Some(VmExecState::Notify(WatchNotification::Viz {
+                    function_name: function.name.clone(),
+                    event,
+                })));
+            }
+
+            Instruction::LoadConst(index) => {
+                // Use pre-resolved constants (resolved at load time)
+                let value = function.bytecode.resolved_constants[index];
+                self.stack.push(value);
+            }
+
+            Instruction::LoadVar(index) => {
+                let slot =
+                    Self::local_slot_stack_index(self.frames[*frame_idx].locals_offset, index);
+                let value = self.stack[slot];
+                self.stack.push(value);
+            }
+
+            Instruction::StoreVar(index) => {
+                // Absolute index of the local variable.
+                let local_var_index =
+                    Self::local_slot_stack_index(self.frames[*frame_idx].locals_offset, index);
+
+                // New value.
+                let value = self.stack.ensure_pop()?;
+
+                // Old value being replaced.
+                let old_value = std::mem::replace(&mut self.stack[local_var_index], value);
+
+                // If this local is watched, update the watch graph.
+                //
+                // A watched local is a root in the watch graph. When
+                // reassigned (e.g. `v = new_val`), three things happen:
+                //
+                // 1. `update_watched_node` handles edge topology: unlinks
+                //    the old binding (so mutations to the old object no
+                //    longer trigger notifications), links the new one, and
+                //    deep-copies the previous root state into
+                //    `last_assigned` so the notification filter can diff
+                //    old vs new.
+                //
+                // 2. `state.value` is updated to the new value. This is
+                //    specific to `StoreVar` — for field/array/map stores
+                //    the root's top-level binding hasn't changed, but here
+                //    the root itself is being rebound.
+                //
+                // 3. `process_notifications` walks all roots reaching this
+                //    node (just itself, since it IS a root) and applies
+                //    the watch filter to decide whether to notify.
+                if self.watched_vars.contains_key(&local_var_index) {
+                    let watched_node = NodeId::LocalVar(local_var_index);
+
+                    self.update_watched_node(watched_node, watch::Path::Binding, old_value, value);
+
+                    if let Some(state) = self.watch.root_state_mut(watched_node) {
+                        state.value = value;
+                    }
+
+                    let notifications = self.process_notifications(watched_node)?;
+
+                    if !notifications.is_empty() {
+                        return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
+                            notifications,
+                        ))));
+                    }
+                }
+            }
+
+            Instruction::LoadGlobal(index) => {
+                let value = &self.globals[index];
+                self.stack.push(*value);
+            }
+
+            Instruction::StoreGlobal(index) => {
+                // Consume the value. Read impl of Instruction::StoreVar.
+                let value = self.stack.ensure_pop()?;
+
+                self.globals[index] = value;
+            }
+
+            Instruction::LoadField(index) => {
+                let top = self.stack.ensure_pop()?;
+
+                let reference = self.as_object_ptr(&top, ObjectType::Instance)?;
+
+                // Extract the field value before pushing to stack
+                let field_value = {
+                    let Object::Instance(instance) = self.get_object(reference) else {
+                        return Err(VmError::TypeError {
+                            expected: ObjectType::Instance.into(),
+                            got: ObjectType::of(self.get_object(reference)).into(),
+                        });
+                    };
+                    instance.fields[index]
+                };
+
+                // Push the value on top of the stack.
+                self.stack.push(field_value);
+            }
+
+            Instruction::StoreField(index) => {
+                // Consume the new value to be set from the stack.
+                let new_value = self.stack.ensure_pop()?;
+
+                // Consume the instance value from the stack.
+                let instance_value = self.stack.ensure_pop()?;
+                let instance_index = self.as_object_ptr(&instance_value, ObjectType::Instance)?;
+
+                // Read old value (and typecheck).
+                let old_value = match self.get_object(instance_index) {
+                    Object::Instance(instance) => instance.fields[index],
+
+                    other => {
+                        return Err(VmError::TypeError {
+                            expected: ObjectType::Instance.into(),
+                            got: ObjectType::of(other).into(),
+                        });
+                    }
+                };
+
+                // Change graph topology.
+                let watched_node = NodeId::HeapObject(instance_index);
+
+                self.update_watched_node(
+                    watched_node,
+                    watch::Path::InstanceField(index),
+                    old_value,
+                    new_value,
+                );
+
+                // Set the new value.
+                if let Object::Instance(instance) = self.get_object_mut(instance_index) {
+                    instance.fields[index] = new_value;
+                }
+
+                let notifications = self.process_notifications(watched_node)?;
+
+                if !notifications.is_empty() {
+                    return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
+                        notifications,
+                    ))));
+                }
+            }
+
+            Instruction::Pop(n) => {
+                let drain_start = self.stack.len() - n;
+                let drain_range = StackIndex::from_raw(drain_start)..;
+                self.stack.drain(drain_range);
+            }
+
+            Instruction::Copy(offset) => {
+                let index = self.stack.ensure_slot_from_top(offset)?;
+                let value = self.stack[index];
+                self.stack.push(value);
+            }
+
+            Instruction::Jump(offset) => {
+                // Offset can be negative (backward jumps for loops).
+                // NOTE: checked_add_signed has a branch on overflow. If this
+                // becomes a bottleneck on hot loops, it can be replaced with
+                // wrapping_add_signed — the array bounds check on the next
+                // iteration will catch invalid pointers anyway.
+                self.frames[*frame_idx].instruction_ptr = instruction_ptr
+                    .checked_add_signed(offset)
+                    .ok_or(VmError::InvalidJump)?;
+            }
+
+            Instruction::PopJumpIfFalse(offset) => {
+                // Pop the condition from the stack (don't leave it there).
+                let condition = self.stack.ensure_pop()?;
+
+                match condition {
+                    // Reassign only if the condition is false.
+                    Value::Bool(value) => {
+                        if !value {
+                            self.frames[*frame_idx].instruction_ptr = instruction_ptr
+                                .checked_add_signed(offset)
+                                .ok_or(VmError::InvalidJump)?;
+                        }
+                    }
+
+                    // Type error, we don't have "falsey" values in the language
+                    // so we should always check booleans.
+                    other => {
+                        return Err(VmError::TypeError {
+                            expected: Type::Bool,
+                            got: self.type_of(&other),
+                        });
+                    }
+                }
+            }
+
+            Instruction::Throw => {
+                let value = self.stack.ensure_pop()?;
+                self.try_unwind_exception(frame_idx, function, value)?;
+            }
+
+            Instruction::BinOp(op) => {
+                let right = self.stack.ensure_pop()?;
+                let left = self.stack.ensure_pop()?;
+
+                let result = match (left, right) {
+                    (Value::Int(left), Value::Int(right)) => Value::Int(match op {
+                        BinOp::Div if right == 0 => {
+                            return Err(VmPanic::DivisionByZero {
+                                left: Value::Int(left),
+                                right: Value::Int(right),
+                            }
+                            .into());
+                        }
+
+                        BinOp::Add => left + right,
+                        BinOp::Sub => left - right,
+                        BinOp::Mul => left * right,
+                        BinOp::Div => left / right,
+                        BinOp::Mod => left % right,
+
+                        BinOp::BitAnd => left & right,
+                        BinOp::BitOr => left | right,
+                        BinOp::BitXor => left ^ right,
+                        BinOp::Shl => left << right,
+                        BinOp::Shr => left >> right,
+                    }),
+
+                    (Value::Float(left), Value::Float(right)) => {
+                        Value::Float(match op {
+                            BinOp::Div if right == 0.0 => {
+                                return Err(VmPanic::DivisionByZero {
+                                    left: Value::Float(left),
+                                    right: Value::Float(right),
+                                }
+                                .into());
+                            }
+
+                            BinOp::Add => left + right,
+                            BinOp::Sub => left - right,
+                            BinOp::Mul => left * right,
+                            BinOp::Div => left / right,
+                            BinOp::Mod => left % right,
+
+                            // Bitwise ops not applicable to floats.
+                            BinOp::BitAnd
+                            | BinOp::BitOr
+                            | BinOp::BitXor
+                            | BinOp::Shl
+                            | BinOp::Shr => {
+                                return Err(VmError::CannotApplyBinOp {
+                                    left: Type::Float,
+                                    right: Type::Float,
+                                    op,
+                                });
+                            }
+                        })
+                    }
+
+                    // Mixed int/float: promote int to float.
+                    #[allow(clippy::cast_precision_loss)]
+                    (Value::Int(left), Value::Float(right)) => {
+                        let left = left as f64;
+                        Value::Float(match op {
+                            BinOp::Div if right == 0.0 => {
+                                return Err(VmPanic::DivisionByZero {
+                                    left: Value::Float(left),
+                                    right: Value::Float(right),
+                                }
+                                .into());
+                            }
+
+                            BinOp::Add => left + right,
+                            BinOp::Sub => left - right,
+                            BinOp::Mul => left * right,
+                            BinOp::Div => left / right,
+                            BinOp::Mod => left % right,
+
+                            BinOp::BitAnd
+                            | BinOp::BitOr
+                            | BinOp::BitXor
+                            | BinOp::Shl
+                            | BinOp::Shr => {
+                                return Err(VmError::CannotApplyBinOp {
+                                    left: Type::Int,
+                                    right: Type::Float,
+                                    op,
+                                });
+                            }
+                        })
+                    }
+
+                    #[allow(clippy::cast_precision_loss)]
+                    (Value::Float(left), Value::Int(right)) => {
+                        let right = right as f64;
+                        Value::Float(match op {
+                            BinOp::Div if right == 0.0 => {
+                                return Err(VmPanic::DivisionByZero {
+                                    left: Value::Float(left),
+                                    right: Value::Float(right),
+                                }
+                                .into());
+                            }
+
+                            BinOp::Add => left + right,
+                            BinOp::Sub => left - right,
+                            BinOp::Mul => left * right,
+                            BinOp::Div => left / right,
+                            BinOp::Mod => left % right,
+
+                            BinOp::BitAnd
+                            | BinOp::BitOr
+                            | BinOp::BitXor
+                            | BinOp::Shl
+                            | BinOp::Shr => {
+                                return Err(VmError::CannotApplyBinOp {
+                                    left: Type::Float,
+                                    right: Type::Int,
+                                    op,
+                                });
+                            }
+                        })
+                    }
+
+                    (Value::Object(_), Value::Object(_)) if op == BinOp::Add => {
+                        let left = self.as_string(&left)?;
+                        let right = self.as_string(&right)?;
+
+                        let mut concat = left.clone();
+                        concat.push_str(right);
+
+                        self.alloc_string(concat)
+                    }
+
+                    _ => {
+                        return Err(VmError::CannotApplyBinOp {
+                            left: self.type_of(&left),
+                            right: self.type_of(&right),
+                            op,
+                        });
+                    }
+                };
+
+                self.stack.push(result);
+            }
+
+            Instruction::CmpOp(op) => {
+                let right = self.stack.ensure_pop()?;
+                let left = self.stack.ensure_pop()?;
+
+                let result = match (left, right) {
+                    (Value::Int(left), Value::Int(right)) => Value::Bool(match op {
+                        CmpOp::Eq => left == right,
+                        CmpOp::NotEq => left != right,
+                        CmpOp::Lt => left < right,
+                        CmpOp::LtEq => left <= right,
+                        CmpOp::Gt => left > right,
+                        CmpOp::GtEq => left >= right,
+
+                        CmpOp::InstanceOf => {
+                            return Err(VmError::CannotApplyCmpOp {
+                                left: Type::Int,
+                                right: Type::Int,
+                                op,
+                            });
+                        }
+                    }),
+
+                    #[allow(clippy::float_cmp)]
+                    // intentional exact comparison for equality operators
+                    (Value::Float(left), Value::Float(right)) => Value::Bool(match op {
+                        CmpOp::Eq => left == right,
+                        CmpOp::NotEq => left != right,
+                        CmpOp::Lt => left < right,
+                        CmpOp::LtEq => left <= right,
+                        CmpOp::Gt => left > right,
+                        CmpOp::GtEq => left >= right,
+
+                        CmpOp::InstanceOf => {
+                            return Err(VmError::CannotApplyCmpOp {
+                                left: Type::Float,
+                                right: Type::Float,
+                                op,
+                            });
+                        }
+                    }),
+
+                    // Mixed int/float comparisons: promote int to float.
+                    #[allow(clippy::cast_precision_loss, clippy::float_cmp)]
+                    (Value::Int(left), Value::Float(right)) => {
+                        let left = left as f64;
+                        Value::Bool(match op {
+                            CmpOp::Eq => left == right,
+                            CmpOp::NotEq => left != right,
+                            CmpOp::Lt => left < right,
+                            CmpOp::LtEq => left <= right,
+                            CmpOp::Gt => left > right,
+                            CmpOp::GtEq => left >= right,
+
+                            CmpOp::InstanceOf => {
+                                return Err(VmError::CannotApplyCmpOp {
+                                    left: Type::Int,
+                                    right: Type::Float,
+                                    op,
+                                });
+                            }
+                        })
+                    }
+
+                    #[allow(clippy::cast_precision_loss, clippy::float_cmp)]
+                    (Value::Float(left), Value::Int(right)) => {
+                        let right = right as f64;
+                        Value::Bool(match op {
+                            CmpOp::Eq => left == right,
+                            CmpOp::NotEq => left != right,
+                            CmpOp::Lt => left < right,
+                            CmpOp::LtEq => left <= right,
+                            CmpOp::Gt => left > right,
+                            CmpOp::GtEq => left >= right,
+
+                            CmpOp::InstanceOf => {
+                                return Err(VmError::CannotApplyCmpOp {
+                                    left: Type::Float,
+                                    right: Type::Int,
+                                    op,
+                                });
+                            }
+                        })
+                    }
+
+                    (Value::Object(left_index), Value::Object(right_index))
+                        if matches!(self.get_object(left_index), Object::String(_))
+                            && matches!(self.get_object(right_index), Object::String(_)) =>
+                    {
+                        let left = self.as_string(&left)?;
+                        let right = self.as_string(&right)?;
+
+                        Value::Bool(match op {
+                            CmpOp::Eq => left == right,
+                            CmpOp::NotEq => left != right,
+                            CmpOp::Lt => left < right,
+                            CmpOp::LtEq => left <= right,
+                            CmpOp::Gt => left > right,
+                            CmpOp::GtEq => left >= right,
+                            CmpOp::InstanceOf => {
+                                return Err(VmError::CannotApplyCmpOp {
+                                    left: Type::Object(ObjectType::String),
+                                    right: Type::Object(ObjectType::String),
+                                    op,
+                                });
+                            }
+                        })
+                    }
+
+                    // Uint8Array comparison: compare by content
+                    (Value::Object(left_index), Value::Object(right_index))
+                        if matches!(self.get_object(left_index), Object::Uint8Array(_))
+                            && matches!(self.get_object(right_index), Object::Uint8Array(_)) =>
+                    {
+                        let left = self.as_uint8array(&left)?;
+                        let right = self.as_uint8array(&right)?;
+
+                        Value::Bool(match op {
+                            CmpOp::Eq => left == right,
+                            CmpOp::NotEq => left != right,
+                            _ => {
+                                return Err(VmError::CannotApplyCmpOp {
+                                    left: Type::Object(ObjectType::Uint8Array),
+                                    right: Type::Object(ObjectType::Uint8Array),
+                                    op,
+                                });
+                            }
+                        })
+                    }
+
+                    // Variant comparison: compare by enum type and variant index
+                    (Value::Object(left_index), Value::Object(right_index))
+                        if matches!(self.get_object(left_index), Object::Variant(_))
+                            && matches!(self.get_object(right_index), Object::Variant(_)) =>
+                    {
+                        let Object::Variant(left_var) = self.get_object(left_index) else {
+                            unreachable!()
+                        };
+                        let Object::Variant(right_var) = self.get_object(right_index) else {
+                            unreachable!()
+                        };
+
+                        Value::Bool(match op {
+                            CmpOp::Eq => {
+                                left_var.enm == right_var.enm && left_var.index == right_var.index
+                            }
+                            CmpOp::NotEq => {
+                                left_var.enm != right_var.enm || left_var.index != right_var.index
+                            }
+                            _ => {
+                                return Err(VmError::CannotApplyCmpOp {
+                                    left: Type::Object(ObjectType::Variant),
+                                    right: Type::Object(ObjectType::Variant),
+                                    op,
+                                });
+                            }
+                        })
+                    }
+
+                    _ => Value::Bool(match op {
+                        CmpOp::Eq => left == right,
+                        CmpOp::NotEq => left != right,
+
+                        CmpOp::InstanceOf => {
+                            // null/non-object is never an instance of anything.
+                            match left {
+                                Value::Object(left_ptr) => match self.get_object(left_ptr) {
+                                    Object::Instance(instance) => {
+                                        let right_ptr =
+                                            self.as_object_ptr(&right, ObjectType::Class)?;
+                                        instance.class == right_ptr
+                                    }
+                                    _ => false,
+                                },
+                                _ => false,
+                            }
+                        }
+
+                        _ => {
+                            return Err(VmError::CannotApplyCmpOp {
+                                left: self.type_of(&left),
+                                right: self.type_of(&right),
+                                op,
+                            });
+                        }
+                    }),
+                };
+
+                self.stack.push(result);
+            }
+
+            Instruction::UnaryOp(op) => {
+                let value = self.stack.ensure_pop()?;
+
+                let result = match (op, value) {
+                    (UnaryOp::Not, Value::Bool(value)) => Value::Bool(!value),
+                    (UnaryOp::Neg, Value::Int(value)) => Value::Int(-value),
+                    (UnaryOp::Neg, Value::Float(value)) => Value::Float(-value),
+                    _ => {
+                        return Err(VmError::CannotApplyUnaryOp {
+                            op,
+                            value: self.type_of(&value),
+                        });
+                    }
+                };
+
+                self.stack.push(result);
+            }
+
+            Instruction::AllocArray(size) => {
+                // Pop all the elements from the stack and create an array.
+                let drain_range = StackIndex::from_raw(self.stack.len() - size)..;
+                let array = self.stack.drain(drain_range).collect();
+
+                // Allocate it on the heap.
+                let array_index = self.tlab.alloc(Object::Array(array));
+
+                // Push the array object on top of the stack.
+                self.stack.push(Value::Object(array_index));
+            }
+
+            Instruction::LoadArrayElement => {
+                // Stack should contain [array, index]
+                // Pop the index first, then the array
+                let index_value = self.stack.ensure_pop()?;
+                let array_value = self.stack.ensure_pop()?;
+
+                let array_obj_index = self.as_object_ptr(&array_value, ObjectType::Array)?;
+
+                // Get the array length for bounds checking.
+                let array_len = match self.get_object(array_obj_index) {
+                    Object::Array(arr) => arr.len(),
+                    Object::Uint8Array(bytes) => bytes.len(),
+                    other => {
+                        return Err(VmError::TypeError {
+                            expected: ObjectType::Array.into(),
+                            got: ObjectType::of(other).into(),
+                        });
+                    }
+                };
+
+                // Get the index
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                // bounds checked below
+                let index = match index_value {
+                    Value::Int(i) => {
+                        if i < 0 || i as usize >= array_len {
+                            return Err(VmPanic::IndexOutOfBounds {
+                                index: i,
+                                length: array_len,
+                            }
+                            .into());
+                        }
+                        i as usize
+                    }
+                    _ => {
+                        return Err(VmError::TypeError {
+                            expected: Type::Int,
+                            got: self.type_of(&index_value),
+                        });
+                    }
+                };
+
+                // Extract the array element before pushing to stack
+                #[allow(clippy::cast_possible_wrap)]
+                let element = {
+                    match self.get_object(array_obj_index) {
+                        Object::Array(array) => {
+                            if index >= array.len() {
+                                return Err(VmPanic::IndexOutOfBounds {
+                                    index: index as i64,
+                                    length: array.len(),
+                                }
+                                .into());
+                            }
+                            array[index]
+                        }
+                        Object::Uint8Array(bytes) => {
+                            if index >= bytes.len() {
+                                return Err(VmPanic::IndexOutOfBounds {
+                                    index: index as i64,
+                                    length: bytes.len(),
+                                }
+                                .into());
+                            }
+                            Value::Int(i64::from(bytes[index]))
+                        }
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: ObjectType::Array.into(),
+                                got: ObjectType::of(self.get_object(array_obj_index)).into(),
+                            });
+                        }
+                    }
+                };
+
+                // Push the element onto the stack
+                self.stack.push(element);
+            }
+
+            Instruction::LoadMapElement => {
+                // LoadMapElement Instruction
+                //
+                // Stack before: [map, key]
+                // Stack after: [value]
+                //
+                // Interpretation steps:
+                // 1. Pop key from stack (top element)
+                // 2. Pop map reference from stack (bottom element)
+                // 3. Validate that the popped map reference is indeed a map object
+                // 4. Get the key as a string from the objects pool (maps use string keys)
+                //    - Validate key_value is an object reference to a String
+                //    - Get the string reference from the objects pool
+                // 5. Look up the value at map[key]
+                // 6. Handle the case where key doesn't exist in the map
+                //    - Return a runtime error NoSuchKeyInMap if key not found
+                // 7. Push the found value onto the stack
+
+                let key_value = self.stack.ensure_pop()?;
+                let map_value = self.stack.ensure_pop()?;
+
+                let map_index = self.as_object_ptr(&map_value, ObjectType::Map)?;
+
+                let Object::Map(map) = self.get_object(map_index) else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Map.into(),
+                        got: ObjectType::of(self.get_object(map_index)).into(),
+                    });
+                };
+
+                // Get the string key from the objects pool
+                let key_index = self.as_object_ptr(&key_value, ObjectType::String)?;
+                let key = self.get_object(key_index).as_string()?;
+
+                // Look up the value in the map
+                let value = map.get(key).copied().ok_or(VmPanic::MapKeyNotFound)?;
+
+                // Push the value onto the stack
+                self.stack.push(value);
+            }
+
+            Instruction::StoreArrayElement => {
+                // Instruction args.
+                let new_value = self.stack.ensure_pop()?;
+                let index_value = self.stack.ensure_pop()?;
+                let array_value = self.stack.ensure_pop()?;
+                let array_object_index = self.as_object_ptr(&array_value, ObjectType::Array)?;
+
+                // Get the array length for bounds checking.
+                let array_len = match self.get_object(array_object_index) {
+                    Object::Array(arr) => arr.len(),
+                    Object::Uint8Array(bytes) => bytes.len(),
+                    other => {
+                        return Err(VmError::TypeError {
+                            expected: ObjectType::Array.into(),
+                            got: ObjectType::of(other).into(),
+                        });
+                    }
+                };
+
+                // Verify index.
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                // bounds checked below
+                let index = match index_value {
+                    Value::Int(i) => {
+                        if i < 0 || i as usize >= array_len {
+                            return Err(VmPanic::IndexOutOfBounds {
+                                index: i,
+                                length: array_len,
+                            }
+                            .into());
+                        }
+                        i as usize
+                    }
+                    other => {
+                        return Err(VmError::TypeError {
+                            expected: Type::Int,
+                            got: self.type_of(&other),
+                        });
+                    }
+                };
+
+                // Read old value (and typecheck).
+                #[allow(clippy::cast_possible_wrap)]
+                let old_value = match self.get_object(array_object_index) {
+                    Object::Array(array) => {
+                        if index >= array.len() {
+                            return Err(VmPanic::IndexOutOfBounds {
+                                index: index as i64,
+                                length: array.len(),
+                            }
+                            .into());
+                        }
+                        array[index]
+                    }
+                    Object::Uint8Array(bytes) => {
+                        if index >= bytes.len() {
+                            return Err(VmPanic::IndexOutOfBounds {
+                                index: index as i64,
+                                length: bytes.len(),
+                            }
+                            .into());
+                        }
+                        Value::Int(i64::from(bytes[index]))
+                    }
+                    other => {
+                        return Err(VmError::TypeError {
+                            expected: ObjectType::Array.into(),
+                            got: ObjectType::of(other).into(),
+                        });
+                    }
+                };
+
+                // Change graph topology
+                let watched_node = NodeId::HeapObject(array_object_index);
+                self.update_watched_node(
+                    watched_node,
+                    watch::Path::ArrayIndex(index),
+                    old_value,
+                    new_value,
+                );
+
+                // Set the new value.
+                match self.get_object_mut(array_object_index) {
+                    Object::Array(array) => {
+                        array[index] = new_value;
+                    }
+                    Object::Uint8Array(bytes) => {
+                        let Value::Int(i) = new_value else {
+                            return Err(VmError::TypeError {
+                                expected: Type::Int,
+                                got: self.type_of(&new_value),
+                            });
+                        };
+                        let Ok(i) = u8::try_from(i) else {
+                            return Err(VmError::InternalError(format!(
+                                "uint8array store: value {i} out of range 0..=255"
+                            )));
+                        };
+                        bytes[index] = i;
+                    }
+                    _ => {
+                        unreachable!(
+                            "We already checked earlier that we are operating on an array-like type"
+                        );
+                    }
+                }
+
+                let notifications = self.process_notifications(watched_node)?;
+
+                if !notifications.is_empty() {
+                    return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
+                        notifications,
+                    ))));
+                }
+            }
+
+            Instruction::StoreMapElement => {
+                // Instruction args.
+                let new_value = self.stack.ensure_pop()?;
+                let key_value = self.stack.ensure_pop()?;
+                let map_value = self.stack.ensure_pop()?;
+
+                // Get the string key from the objects pool.
+                let key_index = self.as_object_ptr(&key_value, ObjectType::String)?;
+                let key = self.get_object(key_index).as_string()?.clone();
+
+                let map_index = self.as_object_ptr(&map_value, ObjectType::Map)?;
+
+                // Read old value (and typecheck).
+                //
+                // If the map didn't contain any value we'll use null so
+                // there's not watch graph edge to update.
+                let old_value = match self.get_object(map_index) {
+                    Object::Map(map) => map.get(&key).copied().unwrap_or(Value::Null),
+
+                    other => {
+                        return Err(VmError::TypeError {
+                            expected: ObjectType::Map.into(),
+                            got: ObjectType::of(other).into(),
+                        });
+                    }
+                };
+
+                // Change graph topology
+                let watched_node = NodeId::HeapObject(map_index);
+
+                self.update_watched_node(
+                    watched_node,
+                    watch::Path::MapKey(key.clone()),
+                    old_value,
+                    new_value,
+                );
+
+                // Set the new value.
+                if let Object::Map(map) = self.get_object_mut(map_index) {
+                    map.insert(key, new_value);
+                }
+
+                let notifications = self.process_notifications(watched_node)?;
+
+                if !notifications.is_empty() {
+                    return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
+                        notifications,
+                    ))));
+                }
+            }
+
+            Instruction::AllocInstance(index) => {
+                // Convert compile-time ObjectIndex to HeapPtr
+                let class_ptr = self.idx_to_ptr(index);
+                let Object::Class(class) = self.get_object(class_ptr) else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Class.into(),
+                        got: ObjectType::of(self.get_object(class_ptr)).into(),
+                    });
+                };
+
+                // Allocate the fields.
+                let mut fields = Vec::with_capacity(class.fields.len());
+                fields.resize(class.fields.len(), Value::Null);
+
+                // Allocate an instance of the class.
+                let instance_ptr = self.tlab.alloc(Object::Instance(Instance {
+                    class: class_ptr,
+                    fields,
+                }));
+
+                // Push the instance object on top of the stack.
+                self.stack.push(Value::Object(instance_ptr));
+            }
+
+            // TODO: Contains a lot of typechecking, we know at compile time
+            // that all this stuff is right. Should do something about it.
+            Instruction::AllocVariant(enum_index) => {
+                // Convert compile-time ObjectIndex to HeapPtr
+                let enum_ptr = self.idx_to_ptr(enum_index);
+                // Extract the variant count before popping from stack to avoid borrow conflicts
+                let variant_count = {
+                    let Object::Enum(enm) = self.get_object(enum_ptr) else {
+                        return Err(VmError::TypeError {
+                            expected: ObjectType::Enum.into(),
+                            got: ObjectType::of(self.get_object(enum_ptr)).into(),
+                        });
+                    };
+                    enm.variants.len()
+                };
+
+                let variant = self.stack.ensure_pop()?;
+
+                let Value::Int(variant_index) = variant else {
+                    return Err(VmError::TypeError {
+                        expected: Type::Int,
+                        got: self.type_of(&variant),
+                    });
+                };
+
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                // Safe: we check variant_index < 0 first, so the cast
+                // only executes for non-negative values.
+                if variant_index < 0 || variant_index as usize >= variant_count {
+                    return Err(VmPanic::IndexOutOfBounds {
+                        index: variant_index,
+                        length: variant_count,
+                    }
+                    .into());
+                }
+
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                // checked non-negative above
+                let variant_usize = variant_index as usize;
+
+                let variant_ptr = self.tlab.alloc(Object::Variant(Variant {
+                    enm: enum_ptr,
+                    index: variant_usize,
+                }));
+
+                // Push the variant object on top of the stack.
+                self.stack.push(Value::Object(variant_ptr));
+            }
+
+            Instruction::DispatchFuture(callee) => {
+                let callee_value = self.globals[callee];
+                let expected_type = FunctionType::SysOp;
+                let callee_ptr = self.as_object_ptr(&callee_value, expected_type.into())?;
+
+                // Can't dispatch if it's not a function
+                let Object::Function(callable_future) = self.get_object(callee_ptr) else {
+                    return Err(VmError::TypeError {
+                        expected: expected_type.into(),
+                        got: ObjectType::of(self.get_object(callee_ptr)).into(),
+                    });
+                };
+
+                // Must be a sys_op - extract the SysOp.
+                let FunctionKind::SysOp(sys_op) = callable_future.kind else {
+                    return Err(VmError::TypeError {
+                        expected: FunctionType::SysOp.into(),
+                        got: FunctionType::from(&callable_future.kind).into(),
+                    });
+                };
+
+                let args_offset = self
+                    .stack
+                    .len()
+                    .checked_sub(callable_future.arity)
+                    .ok_or(VmError::NotEnoughItemsOnStack(callable_future.arity))?;
+                let args_offset = StackIndex::from_raw(args_offset);
+
+                // Collect function call args and cleanup consumed stack.
+                let future_args: Vec<Value> = self.stack.drain(args_offset..).collect();
+
+                // Create the pending future with the SysOp enum.
+                let pending_future = PendingFuture {
+                    operation: sys_op,
+                    args: future_args,
+                };
+
+                // Allocate the future.
+                let future_value = self.alloc_future(Future::Pending(pending_future));
+
+                // Extract the index
+                let Value::Object(object_index) = future_value else {
+                    unreachable!("alloc_future returns Value::Object")
+                };
+
+                // Now leave the future on top of the stack.
+                self.stack.push(future_value);
+
+                // Yield control flow back to the embedder.
+                return Ok(Some(VmExecState::ScheduleFuture(object_index)));
+            }
+
+            Instruction::Await => {
+                let value = self.stack.ensure_stack_top()?;
+
+                let wanted_type = FutureType::Any;
+
+                let index = self.as_object_ptr(&self.stack[value], wanted_type.into())?;
+
+                // Check if future is ready and extract value if so
+                let ready_value = {
+                    let Object::Future(awaiting) = self.get_object(index) else {
+                        return Err(VmError::TypeError {
+                            expected: wanted_type.into(),
+                            got: ObjectType::of(self.get_object(index)).into(),
+                        });
+                    };
+
+                    match awaiting {
+                        // Can't do nothing, handle control flow back to embedder.
+                        Future::Pending(_) => {
+                            return Ok(Some(VmExecState::Await(index)));
+                        }
+
+                        // Return the ready value
+                        Future::Ready(value) => *value,
+                    }
+                };
+
+                // Replace the future on the eval stack with the ready value
+                self.stack.pop();
+                self.stack.push(ready_value);
+            }
+
+            Instruction::Watch(index) => {
+                // Stack contains: [channel, filter]
+
+                // Consume filter.
+                let filter = match self.stack.ensure_pop()? {
+                    Value::Null => WatchFilter::Default,
+                    Value::Object(object_index) => match self.get_object(object_index) {
+                        Object::Function(_) => WatchFilter::Function(object_index),
+                        Object::String(mode) if mode == "manual" => WatchFilter::Manual,
+                        Object::String(mode) if mode == "never" => WatchFilter::Paused,
+                        _ => {
+                            return Err(VmError::InternalError("Invalid filter".to_string()));
+                        }
+                    },
+                    _ => {
+                        return Err(VmError::InternalError("Invalid filter".to_string()));
+                    }
+                };
+
+                // Consume channel.
+                let channel_value = self.stack.ensure_pop()?;
+                let channel = self.as_string(&channel_value)?.to_owned();
+
+                let local_var_index =
+                    Self::local_slot_stack_index(self.frames[*frame_idx].locals_offset, index);
+                let value = self.stack[local_var_index];
+
+                // The variable index should be the same as where the value is stored
+                let var_node = NodeId::LocalVar(local_var_index);
+
+                // Register this variable as an emittable root.
+                self.watch.register_root(
+                    var_node,
+                    RootState {
+                        channel,
+                        value,
+                        filter,
+                        last_notified: None,
+                        last_assigned: None,
+                    },
+                );
+
+                let watched_var_name = &function.local_names[index];
+                // Track this so we can unregister on scope exit
+                self.watched_vars.insert(
+                    local_var_index,
+                    (watched_var_name.clone(), function.name.clone()),
+                );
+
+                // If it's an object, build the entire dependency graph
+                if let Value::Object(object_index) = value {
+                    watch::track_watch_dependencies(
+                        &mut self.watch,
+                        var_node,
+                        watch::Path::Binding,
+                        object_index,
+                    );
+                }
+            }
+
+            Instruction::Unwatch(index) => {
+                let local_var_index =
+                    Self::local_slot_stack_index(self.frames[*frame_idx].locals_offset, index);
+
+                // Remove from watched_vars tracking
+                if self.watched_vars.remove(&local_var_index).is_some() {
+                    let var_node = NodeId::LocalVar(local_var_index);
+                    // Unregister this variable as a root
+                    self.watch.unregister_root(var_node);
+
+                    // If it was linked to an object, unlink it
+                    let value = self.stack[local_var_index];
+                    if let Value::Object(object_index) = value {
+                        self.watch.unlink_edge(
+                            var_node,
+                            watch::Path::Binding,
+                            NodeId::HeapObject(object_index),
+                        );
+                    }
+                }
+            }
+
+            Instruction::Notify(index) => {
+                let local_var_index =
+                    Self::local_slot_stack_index(self.frames[*frame_idx].locals_offset, index);
+                let var_node = NodeId::LocalVar(local_var_index);
+
+                let notifications = self.watch.copy_roots_reaching(var_node);
+
+                if notifications.len() != 1 && notifications.first() != Some(&var_node) {
+                    return Err(VmError::InternalError("Invalid manual notify".to_string()));
+                }
+
+                return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
+                    notifications,
+                ))));
+            }
+
+            Instruction::Call(callee) => {
+                let callee_value = self.globals[callee];
+                let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
+                let args_offset = self
+                    .stack
+                    .len()
+                    .checked_sub(arg_count)
+                    .ok_or(VmError::NotEnoughItemsOnStack(arg_count))?;
+                let locals_offset = StackIndex::from_raw(args_offset);
+
+                if let Some(state) = self.execute_call_from_locals_offset(
+                    callee_ptr,
+                    locals_offset,
+                    arg_count,
+                    frame_idx,
+                    function,
+                )? {
+                    return Ok(Some(state));
+                }
+            }
+
+            Instruction::CallIndirect => {
+                // Stack layout: [arg1, arg2, ..., argN, callee]
+                let callee_slot = self.stack.ensure_stack_top()?;
+                let callee_value = self.stack[callee_slot];
+                let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
+                let args_offset = self
+                    .stack
+                    .len()
+                    .checked_sub(arg_count + 1)
+                    .ok_or(VmError::NotEnoughItemsOnStack(arg_count + 1))?;
+                let _popped_callee = self.stack.ensure_pop()?;
+                let locals_offset = StackIndex::from_raw(args_offset);
+
+                if let Some(state) = self.execute_call_from_locals_offset(
+                    callee_ptr,
+                    locals_offset,
+                    arg_count,
+                    frame_idx,
+                    function,
+                )? {
+                    return Ok(Some(state));
+                }
+            }
+
+            Instruction::Return => {
+                // Pop the result from the eval stack.
+                let result = self.stack.ensure_pop()?;
+
+                // Check if this frame was traced.
+                // Capture function name before popping the frame.
+                let span_exit = if self.traced_frames.last() == Some(frame_idx) {
+                    let func_name = self
+                        .get_object(self.frames[*frame_idx].function)
+                        .as_function()
+                        .map(|f| f.name.clone())
+                        .ok();
+                    self.traced_frames.pop();
+                    func_name
+                } else {
+                    None
+                };
+
+                // Restore the eval stack to the state before the function
+                // was called and leave the result on top.
+                self.stack.drain(self.frames[*frame_idx].locals_offset..);
+                self.stack.push(result);
+
+                // Pop from the call stack.
+                self.frames.pop();
+
+                // Return from interrupt.
+                if Some(self.frames.len()) == self.interrupt_frame {
+                    self.interrupt_frame = None;
+                    return self.stack.ensure_pop().map(VmExecState::Complete).map(Some);
+                }
+
+                // If there are no more frames, we're done.
+                if self.frames.is_empty() {
+                    return self.stack.ensure_pop().map(VmExecState::Complete).map(Some);
+                }
+
+                // Yield FunctionExit for traced frames (with result value).
+                if let Some(name) = span_exit {
+                    return Ok(Some(VmExecState::SpanNotify(
+                        SpanNotification::FunctionExit {
+                            function_name: name,
+                            result,
+                        },
+                    )));
+                }
+
+                // Resume previous frame execution.
+                *frame_idx = self.frames.len() - 1;
+
+                // SAFETY: See `load_function` doc comment.
+                *function = unsafe { self.load_function(*frame_idx)? };
+            }
+
+            Instruction::AllocMap(n) => {
+                let map = if n > 0 {
+                    let end_of_values = self.stack.ensure_slot_from_top(2 * n - 1)?;
+                    let end_of_keys = self.stack.ensure_slot_from_top(n - 1)?;
+                    let idx_of_last_key = self.stack.ensure_slot_from_top(n - 1)?;
+
+                    // We can safely copy the objects that act as values so there's no problem
+                    // with not draining them.
+                    let values = self.stack[end_of_values..end_of_keys].iter().copied();
+
+                    // We cannot copy key references since we aren't interning yet, so we
+                    // must clone the strings.
+                    // Here we'll also double-check that the keys are strings. This adds `n`
+                    // branches which is not ideal for performance. Might want to consider this
+                    // in map accesses.
+                    let keys = self.stack[idx_of_last_key..].iter().map(|k| {
+                        let obj_index = self.as_object_ptr(k, ObjectType::String)?;
+
+                        self.get_object(obj_index).as_string().cloned()
+                    });
+
+                    let pairs = values
+                        .zip(keys)
+                        .map(|(val, key_res)| key_res.map(|k| (k, val)));
+
+                    let map = pairs.collect::<Result<IndexMap<_, _>, _>>()?;
+
+                    // drain & drop the drain so that vec is empty.
+                    self.stack.drain(end_of_values..);
+
+                    map
+                } else {
+                    // nothing to pop.
+                    IndexMap::new()
+                };
+
+                let obj_index = self.tlab.alloc(Object::Map(map));
+
+                self.stack.push(Value::Object(obj_index));
+            }
+
+            // ============================================================
+            // Jump Table Instructions
+            // ============================================================
+            Instruction::JumpTable { table_idx, default } => {
+                // Pop discriminant from stack
+                let discriminant = self.stack.ensure_pop()?;
+
+                // Must be an integer
+                let Value::Int(value) = discriminant else {
+                    return Err(VmError::TypeError {
+                        expected: Type::Int,
+                        got: self.type_of(&discriminant),
+                    });
+                };
+
+                // Lookup in jump table
+                let table = &function.bytecode.jump_tables[table_idx];
+                let offset = table.lookup(value).unwrap_or(default);
+
+                // Jump
+                self.frames[*frame_idx].instruction_ptr = instruction_ptr
+                    .checked_add_signed(offset)
+                    .ok_or(VmError::InvalidJump)?;
+            }
+
+            Instruction::Discriminant => {
+                // Pop value from stack
+                let value = self.stack.ensure_pop()?;
+
+                // Must be an object (variants are heap-allocated)
+                let Value::Object(object_idx) = value else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Variant.into(),
+                        got: self.type_of(&value),
+                    });
+                };
+
+                // Must be a Variant object
+                let variant_index = {
+                    let Object::Variant(variant) = self.get_object(object_idx) else {
+                        return Err(VmError::TypeError {
+                            expected: ObjectType::Variant.into(),
+                            got: ObjectType::of(self.get_object(object_idx)).into(),
+                        });
+                    };
+                    variant.index
+                };
+
+                // Variant.index is the discriminant we need
+                #[allow(clippy::cast_possible_wrap)]
+                self.stack.push(Value::Int(variant_index as i64));
+            }
+
+            Instruction::TypeTag => {
+                let value = self.stack.ensure_pop()?;
+                let tag = value_type_tag(&value);
+                self.stack.push(Value::Int(tag));
+            }
+
+            Instruction::ThrowIfPanic => {
+                let value = self.stack.ensure_pop()?;
+                let is_panic = match value {
+                    Value::Object(ptr) => match self.get_object(ptr) {
+                        Object::Instance(instance) => {
+                            self.panic_class_ptrs.contains(&instance.class)
+                        }
+                        _ => false,
+                    },
+                    _ => false,
+                };
+                if is_panic {
+                    self.try_unwind_exception(frame_idx, function, value)?;
+                }
+            }
+
+            Instruction::Unreachable => {
+                // This instruction should never be executed. If we reach it,
+                // there's a bug in the compiler or type system.
+                return Err(VmPanic::Unreachable.into());
+            }
+
+            Instruction::MakeCell => {
+                let value = self.stack.ensure_pop()?;
+                let cell = Object::Cell(Cell { value });
+                let ptr = self.tlab.alloc(cell);
+                self.stack.push(Value::Object(ptr));
+            }
+
+            Instruction::MakeClosure(obj_idx, capture_count) => {
+                let mut captures = Vec::with_capacity(capture_count);
+                for _ in 0..capture_count {
+                    captures.push(self.stack.ensure_pop()?);
+                }
+                // Captures were pushed left-to-right, popped right-to-left.
+                captures.reverse();
+                let function_ptr = self.idx_to_ptr(obj_idx);
+                let closure = Object::Closure(Closure {
+                    function: function_ptr,
+                    captures,
+                });
+                let ptr = self.tlab.alloc(closure);
+                self.stack.push(Value::Object(ptr));
+            }
+
+            Instruction::LoadDeref(slot) => {
+                let locals_offset = self.frames[*frame_idx].locals_offset;
+                let cell_value = self.stack[Self::local_slot_stack_index(locals_offset, slot)];
+                let Value::Object(cell_ptr) = cell_value else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Cell.into(),
+                        got: self.type_of(&cell_value),
+                    });
+                };
+                // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
+                let obj = unsafe { cell_ptr.get() };
+                let Object::Cell(cell) = obj else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Cell.into(),
+                        got: ObjectType::of(obj).into(),
+                    });
+                };
+                self.stack.push(cell.value);
+            }
+
+            Instruction::StoreDeref(slot) => {
+                let value = self.stack.ensure_pop()?;
+                let locals_offset = self.frames[*frame_idx].locals_offset;
+                let cell_value = self.stack[Self::local_slot_stack_index(locals_offset, slot)];
+                let Value::Object(cell_ptr) = cell_value else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Cell.into(),
+                        got: self.type_of(&cell_value),
+                    });
+                };
+                // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
+                let obj = unsafe { cell_ptr.get_mut() };
+                let Object::Cell(cell) = obj else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Cell.into(),
+                        got: ObjectType::of(obj).into(),
+                    });
+                };
+                cell.value = value;
+            }
+
+            Instruction::LoadCapture(idx) => {
+                let closure_ptr = self.frames[*frame_idx].function;
+                // SAFETY: closure_ptr is the frame's function, valid for
+                // the duration of this frame.
+                let obj = unsafe { closure_ptr.get() };
+                let Object::Closure(closure) = obj else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Closure.into(),
+                        got: ObjectType::of(obj).into(),
+                    });
+                };
+                let cell_value = closure.captures[idx];
+                let Value::Object(cell_ptr) = cell_value else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Cell.into(),
+                        got: self.type_of(&cell_value),
+                    });
+                };
+                // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
+                let cell_obj = unsafe { cell_ptr.get() };
+                let Object::Cell(cell) = cell_obj else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Cell.into(),
+                        got: ObjectType::of(cell_obj).into(),
+                    });
+                };
+                self.stack.push(cell.value);
+            }
+
+            Instruction::StoreCapture(idx) => {
+                let value = self.stack.ensure_pop()?;
+                let closure_ptr = self.frames[*frame_idx].function;
+                // SAFETY: closure_ptr is the frame's function, valid for
+                // the duration of this frame.
+                let obj = unsafe { closure_ptr.get() };
+                let Object::Closure(closure) = obj else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Closure.into(),
+                        got: ObjectType::of(obj).into(),
+                    });
+                };
+                let cell_value = closure.captures[idx];
+                let Value::Object(cell_ptr) = cell_value else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Cell.into(),
+                        got: self.type_of(&cell_value),
+                    });
+                };
+                // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
+                let cell_obj = unsafe { cell_ptr.get_mut() };
+                let Object::Cell(cell) = cell_obj else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Cell.into(),
+                        got: ObjectType::of(cell_obj).into(),
+                    });
+                };
+                cell.value = value;
+            }
+
+            Instruction::CaptureRef(idx) => {
+                // Push the raw cell pointer from captures[idx] without
+                // reading through the cell.  Used by nested closures to
+                // forward a shared cell to an inner closure.
+                let closure_ptr = self.frames[*frame_idx].function;
+                // SAFETY: closure_ptr is the frame's function, valid for
+                // the duration of this frame.
+                let obj = unsafe { closure_ptr.get() };
+                let Object::Closure(closure) = obj else {
+                    return Err(VmError::TypeError {
+                        expected: ObjectType::Closure.into(),
+                        got: ObjectType::of(obj).into(),
+                    });
+                };
+                self.stack.push(closure.captures[idx]);
+            }
+        }
+
+        Ok(None)
     }
 }


### PR DESCRIPTION
## Summary
- Extract the ~1500-line immediately-invoked closure in `exec()` into a named `step()` method
- No behavioral change — the closure was only used as a try-block pattern and maps 1:1 to a method call
- The `'static` lifetime on `Function` (from the unsafe `load_function` escape hatch) means `&mut self` and `&mut &'static Function` create no aliasing conflict

## Test plan
- [x] `cargo check -p bex_vm` passes
- [x] Full `cargo test` suite passes (3 runs)
- [x] `cargo fmt` and `cargo clippy` clean