### PR TITLE
baml_language/fix: allow combining let+for in testset

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -1086,8 +1086,9 @@ fn synthesize_register_call(
 
             // Args: (name_expr, collector_lambda, runner_or_null)
             let name_arg = lower_expr_body::lower_runner_element(ctx, name_element);
-            // Use a unique synthetic span for the collector lambda.
-            let collector_lambda_span = ctx.next_lambda_span();
+            // Use the testset body's real CST range so HIR scope lookup works
+            // correctly for name resolution inside the collector lambda body.
+            let collector_lambda_span = body_node.text_range();
             let collector_arg =
                 ctx.alloc_expr(Expr::Lambda(Box::new(collector_def)), collector_lambda_span);
             let runner_arg = lower_runner_element(runner_element.as_ref(), ctx, span);

--- a/baml_language/crates/baml_tests/snapshots/testset_dynamic/baml_tests__testset_dynamic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/testset_dynamic/baml_tests__testset_dynamic__04_5_mir.snap
@@ -36,25 +36,27 @@ fn .<lambda($init_test_19, 0)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
-    let _2: string[]
-    let _3: int // __for_idx
-    let _4: int
-    let _5: bool
-    let _6: string
-    let _7: string // case [captured]
-    let _8: null
-    let _9: () -> null
+    let _2: string[] // cases
+    let _3: string[]
+    let _4: int // __for_idx
+    let _5: int
+    let _6: bool
+    let _7: string
+    let _8: string // case [captured]
+    let _9: null
+    let _10: () -> null
 
     bb0: {
-        _2 = const null;
-        _3 = const 0_i64;
+        _2 = [const "hello", const "world", const "foo"];
+        _3 = copy _2;
+        _4 = const 0_i64;
         goto -> bb1;
     }
 
     bb1: {
-        _4 = len(_2);
-        _5 = copy _3 < copy _4;
-        branch copy _5 -> [bb4, bb2];
+        _5 = len(_3);
+        _6 = copy _4 < copy _5;
+        branch copy _6 -> [bb4, bb2];
     }
 
     bb2: {
@@ -67,10 +69,10 @@ fn .<lambda($init_test_19, 0)>(testset: testing.TestCollector) -> null {
     }
 
     bb4: {
-        _6 = copy _2[_3];
-        _7 = copy _6;
-        _9 = make_closure lambda[0](copy _7);
-        _8 = call const fn testing.TestCollector.register_test(copy _1, const "check case", copy _9, const null) -> [bb5];
+        _7 = copy _3[_4];
+        _8 = copy _7;
+        _10 = make_closure lambda[0](copy _8);
+        _9 = call const fn testing.TestCollector.register_test(copy _1, const "check case", copy _10, const null) -> [bb5];
     }
 
     bb5: {
@@ -78,7 +80,7 @@ fn .<lambda($init_test_19, 0)>(testset: testing.TestCollector) -> null {
     }
 
     bb6: {
-        _3 = copy _3 + const 1_i64;
+        _4 = copy _4 + const 1_i64;
         goto -> bb1;
     }
 }
@@ -108,18 +110,22 @@ fn .<lambda($init_test_19, 2)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
-    let _2: null
-    let _3: () -> null
-    let _4: null
-    let _5: () -> null
+    let _2: bool // run_slow
+    let _3: null
+    let _4: () -> null
+    let _5: bool
+    let _6: null
+    let _7: () -> null
 
     bb0: {
-        _3 = make_closure lambda[0]();
-        _2 = call const fn testing.TestCollector.register_test(copy _1, const "always runs", copy _3, const null) -> [bb1];
+        _2 = const false;
+        _4 = make_closure lambda[0]();
+        _3 = call const fn testing.TestCollector.register_test(copy _1, const "always runs", copy _4, const null) -> [bb1];
     }
 
     bb1: {
-        branch const null -> [bb3, bb2];
+        _5 = copy _2;
+        branch copy _5 -> [bb3, bb2];
     }
 
     bb2: {
@@ -127,8 +133,8 @@ fn .<lambda($init_test_19, 2)>(testset: testing.TestCollector) -> null {
     }
 
     bb3: {
-        _5 = make_closure lambda[1]();
-        _4 = call const fn testing.TestCollector.register_test(copy _1, const "only when slow", copy _5, const null) -> [bb4];
+        _7 = make_closure lambda[1]();
+        _6 = call const fn testing.TestCollector.register_test(copy _1, const "only when slow", copy _7, const null) -> [bb4];
     }
 
     bb4: {

--- a/baml_language/crates/baml_tests/tests/for_loops.rs
+++ b/baml_language/crates/baml_tests/tests/for_loops.rs
@@ -501,3 +501,50 @@ async fn c_for_endless_break() {
 
     assert_eq!(output.result, Ok(BexExternalValue::Int(0)));
 }
+
+// ============================================================================
+// For-in loops over let-bound variables
+// ============================================================================
+
+/// Regression test: iterating over an array stored in a `let` variable
+/// should work the same as iterating over an inline array literal.
+#[tokio::test]
+async fn for_loop_over_let_variable() {
+    let output = baml_test!(
+        r#"
+        function main() -> int {
+            let xs = [1, 2, 3];
+            let sum = 0;
+
+            for (let x in xs) {
+                sum += x;
+            }
+
+            sum
+        }
+    "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Int(6)));
+}
+
+/// Same as above but without parenthesized syntax.
+#[tokio::test]
+async fn for_loop_over_let_variable_no_parens() {
+    let output = baml_test!(
+        r#"
+        function main() -> int {
+            let xs = [10, 20, 30];
+            let sum = 0;
+
+            for x in xs {
+                sum += x;
+            }
+
+            sum
+        }
+    "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Int(60)));
+}

--- a/baml_language/crates/bex_engine/tests/collect_tests.rs
+++ b/baml_language/crates/bex_engine/tests/collect_tests.rs
@@ -138,6 +138,236 @@ async fn collect_tests_dynamic_name_returns_handle() {
     );
 }
 
+/// Helper: expand a testset by name via the registry's `expand_set` method.
+async fn expand_testset(
+    engine: &Arc<BexEngine>,
+    registry: BexExternalValue,
+    name: &str,
+) -> Result<BexExternalValue, bex_engine::EngineError> {
+    engine
+        .call_function(
+            "testing.TestRegistry.expand_set",
+            vec![registry, BexExternalValue::String(name.to_string())],
+            bex_engine::FunctionCallContextBuilder::new(CallId::next()).build(),
+            true,
+        )
+        .await
+}
+
+/// A testset with an inline for loop should expand successfully and find tests.
+/// This is the "working" case from the bug report.
+#[tokio::test]
+async fn collect_tests_testset_inline_for_loop_expands() {
+    let source = r#"
+        testset "dynamic" {
+            for (case in ["a", "b", "c"]) {
+                test "check" {
+                    assert.not_null(case)
+                }
+            }
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    // Expanding the testset triggers the lambda body (the for loop).
+    // With an inline array this should work fine.
+    let result = expand_testset(&engine, registry, "dynamic")
+        .await
+        .expect("expand_set should succeed for inline for loop");
+    assert!(
+        !matches!(result, BexExternalValue::Null),
+        "expected non-null result after expanding testset with inline for loop, got: {result:?}"
+    );
+}
+
+/// A testset with `let` + `for` should expand successfully and find tests.
+/// Regression test: the let initializer is dropped to null during MIR lowering,
+/// causing the for loop to iterate zero times (no tests discovered).
+#[tokio::test]
+async fn collect_tests_testset_let_then_for_loop_expands() {
+    let source = r#"
+        testset "dynamic" {
+            let cases: string[] = ["a", "b", "c"];
+            for (case in cases) {
+                test "check" {
+                    assert.not_null(case)
+                }
+            }
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    // Expanding the testset triggers the lambda body (the let + for loop).
+    // BUG: The let initializer gets dropped to null during MIR lowering, so
+    // the for loop tries to call Array.length on null → TypeError.
+    //
+    // When this bug is fixed, change this to:
+    //   let result = expand_testset(&engine, registry, "dynamic")
+    //       .await.expect("expand_set should succeed");
+    //   assert!(!matches!(result, BexExternalValue::Null));
+    let err = expand_testset(&engine, registry, "dynamic")
+        .await
+        .expect_err("BUG: let+for in testset should work, but currently fails with TypeError");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("type error") || msg.contains("TypeError"),
+        "expected type error from null array iteration, got: {msg}"
+    );
+}
+
+/// Let-bound array indexing in testset body works — only `for` iteration over
+/// a let-bound variable fails (see `collect_tests_testset_let_then_for_loop_expands`).
+#[tokio::test]
+async fn collect_tests_testset_let_array_index_in_name_and_body() {
+    let source = r#"
+        testset "suite" {
+            let cases: string[] = ["a", "b", "c"];
+            test "case: " + cases[0] {
+                assert.is_true(cases[0] == "a")
+            }
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    let result = expand_testset(&engine, registry, "suite")
+        .await
+        .expect("expand_set should succeed for simple let string");
+    let repr = format!("{result:?}");
+    assert!(
+        repr.contains("suite/case: a"),
+        "test name should be 'suite/case: a': {repr}"
+    );
+}
+
+/// While loop over a let-bound variable in a testset body.
+/// Tests whether the while condition can read a let-bound variable.
+#[tokio::test]
+async fn collect_tests_testset_let_then_while_loop() {
+    let source = r#"
+        testset "whileloop" {
+            let names: string[] = ["x", "y", "z"];
+            let i = 0;
+            while (i < names.length) {
+                test "item" {
+                    assert.is_true(true)
+                }
+                i += 1;
+            }
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    // BUG: `let names` and `let i` both become null → `i < names.length` fails.
+    //
+    // When fixed, change to:
+    //   let result = expand_testset(&engine, registry, "whileloop")
+    //       .await.expect("should succeed");
+    //   // verify 3 tests registered
+    let err = expand_testset(&engine, registry, "whileloop")
+        .await
+        .expect_err("BUG: let+while in testset should work, but currently fails");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("comparison") || msg.contains("type error"),
+        "expected comparison/type error, got: {msg}"
+    );
+}
+
+/// Let-bound variable used in a string concatenation for test name.
+/// Tests whether let-bound values are available for expression evaluation
+/// in the testset body (not just indexing).
+#[tokio::test]
+async fn collect_tests_testset_let_used_in_test_name_concat() {
+    let source = r#"
+        testset "concat" {
+            let prefix = "hello";
+            let suffix = "world";
+            test prefix + "_" + suffix {
+                assert.is_true(true)
+            }
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    // BUG: `let prefix` and `let suffix` become null → concatenation produces
+    // "null_null" or fails. The test name should be "concat/hello_world".
+    //
+    // When fixed, change assertion to check for "concat/hello_world".
+    let result = expand_testset(&engine, registry, "concat")
+        .await
+        .expect("expand_set succeeds but with wrong name");
+    let repr = format!("{result:?}");
+    // Interestingly, let-bound variables used in expressions (string concat)
+    // work correctly — the bug only affects control flow constructs (for, while, if)
+    // that read let-bound variables.
+    assert!(
+        repr.contains("concat/hello_world"),
+        "expected 'concat/hello_world': {repr}"
+    );
+}
+
+/// If-condition reading a let-bound bool in a testset body.
+/// The testset_dynamic MIR snapshot shows `branch const null` for this pattern.
+#[tokio::test]
+async fn collect_tests_testset_let_then_if_condition() {
+    let source = r#"
+        testset "ifcond" {
+            let enabled = true;
+            if (enabled) {
+                test "gated" {
+                    assert.is_true(true)
+                }
+            }
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    // BUG: `let enabled = true` becomes null → `if(null)` is TypeError (expected Bool).
+    //
+    // When fixed, change to:
+    //   let result = expand_testset(&engine, registry, "ifcond")
+    //       .await.expect("should succeed");
+    //   assert!(format!("{result:?}").contains("ifcond/gated"));
+    let err = expand_testset(&engine, registry, "ifcond")
+        .await
+        .expect_err("BUG: let+if in testset should work, but currently fails with TypeError");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("type error") || msg.contains("TypeError"),
+        "expected type error from null bool, got: {msg}"
+    );
+}
+
 /// A project with multiple testsets should produce a non-null registry Handle.
 #[tokio::test]
 async fn collect_tests_multiple_testsets_returns_handle() {

--- a/baml_language/crates/bex_engine/tests/collect_tests.rs
+++ b/baml_language/crates/bex_engine/tests/collect_tests.rs
@@ -186,8 +186,6 @@ async fn collect_tests_testset_inline_for_loop_expands() {
 }
 
 /// A testset with `let` + `for` should expand successfully and find tests.
-/// Regression test: the let initializer is dropped to null during MIR lowering,
-/// causing the for loop to iterate zero times (no tests discovered).
 #[tokio::test]
 async fn collect_tests_testset_let_then_for_loop_expands() {
     let source = r#"
@@ -208,25 +206,16 @@ async fn collect_tests_testset_let_then_for_loop_expands() {
         .expect("collect_tests should succeed");
 
     // Expanding the testset triggers the lambda body (the let + for loop).
-    // BUG: The let initializer gets dropped to null during MIR lowering, so
-    // the for loop tries to call Array.length on null → TypeError.
-    //
-    // When this bug is fixed, change this to:
-    //   let result = expand_testset(&engine, registry, "dynamic")
-    //       .await.expect("expand_set should succeed");
-    //   assert!(!matches!(result, BexExternalValue::Null));
-    let err = expand_testset(&engine, registry, "dynamic")
+    let result = expand_testset(&engine, registry, "dynamic")
         .await
-        .expect_err("BUG: let+for in testset should work, but currently fails with TypeError");
-    let msg = err.to_string();
+        .expect("expand_set should succeed for let+for testset");
     assert!(
-        msg.contains("type error") || msg.contains("TypeError"),
-        "expected type error from null array iteration, got: {msg}"
+        !matches!(result, BexExternalValue::Null),
+        "expected non-null result after expanding testset with let+for loop"
     );
 }
 
-/// Let-bound array indexing in testset body works — only `for` iteration over
-/// a let-bound variable fails (see `collect_tests_testset_let_then_for_loop_expands`).
+/// Let-bound array indexing in testset body works.
 #[tokio::test]
 async fn collect_tests_testset_let_array_index_in_name_and_body() {
     let source = r#"
@@ -262,7 +251,7 @@ async fn collect_tests_testset_let_then_while_loop() {
         testset "whileloop" {
             let names: string[] = ["x", "y", "z"];
             let i = 0;
-            while (i < names.length) {
+            while (i < names.length()) {
                 test "item" {
                     assert.is_true(true)
                 }
@@ -277,19 +266,14 @@ async fn collect_tests_testset_let_then_while_loop() {
         .await
         .expect("collect_tests should succeed");
 
-    // BUG: `let names` and `let i` both become null → `i < names.length` fails.
-    //
-    // When fixed, change to:
-    //   let result = expand_testset(&engine, registry, "whileloop")
-    //       .await.expect("should succeed");
-    //   // verify 3 tests registered
-    let err = expand_testset(&engine, registry, "whileloop")
+    // Should have 3 tests registered (one per iteration: i=0,1,2)
+    let result = expand_testset(&engine, registry, "whileloop")
         .await
-        .expect_err("BUG: let+while in testset should work, but currently fails");
-    let msg = err.to_string();
+        .expect("expand_set should succeed for let+while testset");
+    let repr = format!("{result:?}");
     assert!(
-        msg.contains("comparison") || msg.contains("type error"),
-        "expected comparison/type error, got: {msg}"
+        repr.contains("whileloop/item"),
+        "expected tests registered from while loop: {repr}"
     );
 }
 
@@ -314,17 +298,10 @@ async fn collect_tests_testset_let_used_in_test_name_concat() {
         .await
         .expect("collect_tests should succeed");
 
-    // BUG: `let prefix` and `let suffix` become null → concatenation produces
-    // "null_null" or fails. The test name should be "concat/hello_world".
-    //
-    // When fixed, change assertion to check for "concat/hello_world".
     let result = expand_testset(&engine, registry, "concat")
         .await
-        .expect("expand_set succeeds but with wrong name");
+        .expect("expand_set should succeed for let+concat testset");
     let repr = format!("{result:?}");
-    // Interestingly, let-bound variables used in expressions (string concat)
-    // work correctly — the bug only affects control flow constructs (for, while, if)
-    // that read let-bound variables.
     assert!(
         repr.contains("concat/hello_world"),
         "expected 'concat/hello_world': {repr}"
@@ -332,7 +309,6 @@ async fn collect_tests_testset_let_used_in_test_name_concat() {
 }
 
 /// If-condition reading a let-bound bool in a testset body.
-/// The testset_dynamic MIR snapshot shows `branch const null` for this pattern.
 #[tokio::test]
 async fn collect_tests_testset_let_then_if_condition() {
     let source = r#"
@@ -352,19 +328,14 @@ async fn collect_tests_testset_let_then_if_condition() {
         .await
         .expect("collect_tests should succeed");
 
-    // BUG: `let enabled = true` becomes null → `if(null)` is TypeError (expected Bool).
-    //
-    // When fixed, change to:
-    //   let result = expand_testset(&engine, registry, "ifcond")
-    //       .await.expect("should succeed");
-    //   assert!(format!("{result:?}").contains("ifcond/gated"));
-    let err = expand_testset(&engine, registry, "ifcond")
+    // The test "gated" should be registered since enabled=true
+    let result = expand_testset(&engine, registry, "ifcond")
         .await
-        .expect_err("BUG: let+if in testset should work, but currently fails with TypeError");
-    let msg = err.to_string();
+        .expect("expand_set should succeed for let+if testset");
+    let repr = format!("{result:?}");
     assert!(
-        msg.contains("type error") || msg.contains("TypeError"),
-        "expected type error from null bool, got: {msg}"
+        repr.contains("ifcond/gated"),
+        "expected test 'ifcond/gated' to be registered (enabled=true): {repr}"
     );
 }
 


### PR DESCRIPTION
```
// works
testset "happy" {
  for (let ex in ["hi", "by"]) {
    test "sentiment" {
      let result = ClassifySentiment("hi");
      null
    }
  }
}

// hangs?
testset "happy" {
  let examples: string[] = ["hi", "by"];
  for (let ex in examples) {
    test "sentiment" {
      let result = ClassifySentiment("hi");
      null
    }
  }
}
```

The reason for this issue is because `for` during desugaring synthesizes a temporary loop variable. During MIR lowering, name resolution for the temporary fails because `resolve_name_at_in_scope()` calls `scope_at_offset(span, Some("$init_test_19"))`, which assumes that the CST span on the temporary is correct.

Claude wanted to devise a new entry point for name resolution (`resolve_name_in_scope`) but we instead went with attaching the correct CST span to the synthesized temporaries.

I like neither approach, but attaching the correct CST span is the more correct one. Part of the problem here, I think, is that we're not tracking lowering context correctly as we recurse into nested expressions, and `resolve_name_*` is an attempt to paper over that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for for-in loop iteration with let-bound variables.
  * Added integration tests for testset expansion covering arrays, variable bindings, indexing, loops, string operations, and conditionals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->