### PR TITLE
Native function error values

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_env/env.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_env/env.baml
@@ -3,11 +3,5 @@ function get(key: string) -> string? throws root.errors.Io {
 }
 
 function get_or_panic(key: string) -> string {
-  let val = get(key);
-  if (val == null) {
-    root.sys.panic("env var not found: " + key);
-    "" // dummy code (sys.panic terminates)
-  } else {
-    val
-  }
+  get(key) ?? root.sys.panic("env var not found: " + key)
 }

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_panics/panics.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_panics/panics.baml
@@ -23,4 +23,11 @@ class Unreachable {
   message string
 }
 
-type Panic = DivisionByZero | IndexOutOfBounds | MapKeyNotFound | StackOverflow | AssertionFailed | Unreachable
+/// Memory allocation failure. This happens when an operation would have caused an unrecoverable
+/// Out-Of-Memory error so we panic instead. Note that not all memory allocation failures are
+/// guaranteed to panic; some may cause a hard failure.
+class AllocFailure {
+  message string
+}
+
+type Panic = DivisionByZero | IndexOutOfBounds | MapKeyNotFound | StackOverflow | AssertionFailed | Unreachable | AllocFailure

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_panics/panics.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_panics/panics.baml
@@ -23,6 +23,11 @@ class Unreachable {
   message string
 }
 
+/// A user-caused panic from `baml.sys.panic`.
+class UserPanic {
+  message string
+}
+
 /// Memory allocation failure. This happens when an operation would have caused an unrecoverable
 /// Out-Of-Memory error so we panic instead. Note that not all memory allocation failures are
 /// guaranteed to panic; some may cause a hard failure.
@@ -30,4 +35,4 @@ class AllocFailure {
   message string
 }
 
-type Panic = DivisionByZero | IndexOutOfBounds | MapKeyNotFound | StackOverflow | AssertionFailed | Unreachable | AllocFailure
+type Panic = DivisionByZero | IndexOutOfBounds | MapKeyNotFound | StackOverflow | AssertionFailed | Unreachable | UserPanic | AllocFailure

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
@@ -6,8 +6,8 @@ function sleep(ms: int) -> null throws root.errors.Io {
   $rust_io_function
 }
 
-function panic(message: string) -> null {
-  $rust_io_function
+function panic(message: string) -> never {
+  $rust_function
 }
 
 function now_ms() -> int {

--- a/baml_language/crates/baml_builtins2/baml_std/baml/uint8array.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/uint8array.baml
@@ -17,6 +17,7 @@ class Uint8Array {
     $rust_function
   }
 
+  /// Returns a new `uint8array` containing the concatenation of the two arrays.
   function concat(self, other: uint8array) -> uint8array {
     $rust_function
   }
@@ -27,15 +28,24 @@ class Uint8Array {
     $rust_function
   }
 
+  /// Returns a new `uint8array` with the bytes in reverse order.
   function reverse(self) -> uint8array {
     $rust_function
   }
 
+  /// Returns a new `uint8array` containing the bytes in the given range.
+  ///
+  /// - `start` is clamped to the range `[0, length]`.
+  /// - `end` is clamped to the range `[start, length]`.
   function slice(self, start: int, end: int) -> uint8array {
     $rust_function
   }
 
-  function zeroes(size: int) -> uint8array {
+  /// Creates a new `uint8array` of the given size, filled with zeros.
+  ///
+  /// Throws an error if the `size` is out of range (e.g. negative).
+  /// Panics if the allocation would cause an OOM.
+  function zeroes(size: int) -> uint8array throws root.errors.InvalidArgument {
     $rust_function
   }
 

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -928,14 +928,14 @@ fn clean_return_type(b: &NativeBuiltin) -> String {
             let ns = constructor_media_namespace(b);
             let inner = format!("copy::{ns}::{class_name}");
             if is_fallible(&b.path) {
-                return format!("Result<{inner}, VmError>");
+                return format!("Result<{inner}, VmRustFnError>");
             }
             return inner;
         }
     }
     let inner = baml_type_to_output(&b.return_type);
     if is_fallible(&b.path) {
-        format!("Result<{inner}, VmError>")
+        format!("Result<{inner}, VmRustFnError>")
     } else {
         inner
     }
@@ -1067,13 +1067,13 @@ fn extraction_expr(val: &str, ty: &BamlType, is_mut: bool) -> String {
             }
         }
         BamlType::Int => format!(
-            "match {val} {{ Value::Int(i) => *i, other => return Err(InternalError::TypeError {{ expected: Type::Int, got: vm.type_of(other) }}.into()) }}"
+            "match {val} {{ Value::Int(i) => *i, other => return Err(VmInternalError::TypeError {{ expected: Type::Int, got: vm.type_of(other) }}.into()) }}"
         ),
         BamlType::Float => format!(
-            "match {val} {{ Value::Float(f) => *f, other => return Err(InternalError::TypeError {{ expected: Type::Float, got: vm.type_of(other) }}.into()) }}"
+            "match {val} {{ Value::Float(f) => *f, other => return Err(VmInternalError::TypeError {{ expected: Type::Float, got: vm.type_of(other) }}.into()) }}"
         ),
         BamlType::Bool => format!(
-            "match {val} {{ Value::Bool(b) => *b, other => return Err(InternalError::TypeError {{ expected: Type::Bool, got: vm.type_of(other) }}.into()) }}"
+            "match {val} {{ Value::Bool(b) => *b, other => return Err(VmInternalError::TypeError {{ expected: Type::Bool, got: vm.type_of(other) }}.into()) }}"
         ),
         BamlType::List(_) => {
             if is_mut {

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -25,7 +25,8 @@ fn is_fallible(path: &str) -> bool {
     path.starts_with("baml.unstable.")
         || matches!(
             path,
-            "baml.Uint8Array.zeroes"
+            "baml.sys.panic"
+                | "baml.Uint8Array.zeroes"
                 | "baml.Uint8Array.from_array"
                 | "baml.Uint8Array.from_hex"
                 | "baml.Uint8Array.from_base64"

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -1067,13 +1067,13 @@ fn extraction_expr(val: &str, ty: &BamlType, is_mut: bool) -> String {
             }
         }
         BamlType::Int => format!(
-            "match {val} {{ Value::Int(i) => *i, other => return Err(VmError::TypeError {{ expected: Type::Int, got: vm.type_of(other) }}) }}"
+            "match {val} {{ Value::Int(i) => *i, other => return Err(InternalError::TypeError {{ expected: Type::Int, got: vm.type_of(other) }}.into()) }}"
         ),
         BamlType::Float => format!(
-            "match {val} {{ Value::Float(f) => *f, other => return Err(VmError::TypeError {{ expected: Type::Float, got: vm.type_of(other) }}) }}"
+            "match {val} {{ Value::Float(f) => *f, other => return Err(InternalError::TypeError {{ expected: Type::Float, got: vm.type_of(other) }}.into()) }}"
         ),
         BamlType::Bool => format!(
-            "match {val} {{ Value::Bool(b) => *b, other => return Err(VmError::TypeError {{ expected: Type::Bool, got: vm.type_of(other) }}) }}"
+            "match {val} {{ Value::Bool(b) => *b, other => return Err(InternalError::TypeError {{ expected: Type::Bool, got: vm.type_of(other) }}.into()) }}"
         ),
         BamlType::List(_) => {
             if is_mut {

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen_errors.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen_errors.rs
@@ -1,0 +1,87 @@
+//! Code generation for the `ErrorClass` enum.
+//!
+//! Reads `NativeClassDef` entries whose `namespace_prefix` is `"baml.errors"`
+//! and generates an `ErrorClass` fieldless enum with `fqn()`, `name()`, `ALL`,
+//! `ALL_NAMES`, and `from_name()`.
+//!
+//! Generated from `errors.baml` class definitions so that adding a new error
+//! type only requires editing the `.baml` file.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use crate::types::NativeClassDef;
+
+const ERRORS_NAMESPACE: &str = "baml.errors";
+
+/// Generate the `ErrorClass` enum and associated methods.
+pub fn generate_error_enums(class_defs: &[NativeClassDef]) -> String {
+    let errors: Vec<&NativeClassDef> = class_defs
+        .iter()
+        .filter(|c| c.namespace_prefix == ERRORS_NAMESPACE)
+        .collect();
+
+    if errors.is_empty() {
+        return format!(
+            "compile_error!(\"no error classes found in namespace {ERRORS_NAMESPACE}\")"
+        );
+    }
+
+    let tokens = generate_error_class_enum(&errors);
+    crate::format_tokens(&tokens)
+}
+
+// ── ErrorClass ──────────────────────────────────────────────────────────────
+
+fn generate_error_class_enum(errors: &[&NativeClassDef]) -> TokenStream {
+    let variant_idents: Vec<_> = errors.iter().map(|e| format_ident!("{}", e.name)).collect();
+    let fqns: Vec<String> = errors
+        .iter()
+        .map(|e| format!("{ERRORS_NAMESPACE}.{}", e.name))
+        .collect();
+    let names: Vec<&str> = errors.iter().map(|e| e.name.as_str()).collect();
+
+    quote! {
+        /// Error class tag — one variant per `baml.errors.*` class.
+        ///
+        /// Auto-generated from `errors.baml`.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        pub enum ErrorClass {
+            #(#variant_idents,)*
+        }
+
+        impl ErrorClass {
+            /// Fully-qualified class name (e.g. `"baml.errors.Timeout"`).
+            pub const fn fqn(&self) -> &'static str {
+                match self {
+                    #(ErrorClass::#variant_idents => #fqns,)*
+                }
+            }
+
+            /// Short class name (e.g. `"Timeout"`).
+            pub const fn name(&self) -> &'static str {
+                match self {
+                    #(ErrorClass::#variant_idents => #names,)*
+                }
+            }
+
+            /// All error class variants.
+            pub const ALL: &[ErrorClass] = &[
+                #(ErrorClass::#variant_idents,)*
+            ];
+
+            /// All error class short names.
+            pub const ALL_NAMES: &[&str] = &[
+                #(#names,)*
+            ];
+
+            /// Look up an `ErrorClass` by its short name (e.g. `"Timeout"`).
+            pub fn from_name(name: &str) -> Option<ErrorClass> {
+                match name {
+                    #(#names => Some(ErrorClass::#variant_idents),)*
+                    _ => None,
+                }
+            }
+        }
+    }
+}

--- a/baml_language/crates/baml_builtins2_codegen/src/extract.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/extract.rs
@@ -919,13 +919,6 @@ mod tests {
             .unwrap();
         assert_eq!(http_fetch.throws, vec!["Io", "Timeout"]);
 
-        // baml.sys.panic has no throws clause
-        let sys_panic = io_builtins
-            .iter()
-            .find(|b| b.path == "baml.sys.panic")
-            .unwrap();
-        assert!(sys_panic.throws.is_empty());
-
         let render_prompt = io_builtins
             .iter()
             .find(|b| b.path == "baml.llm.PrimitiveClient.render_prompt")

--- a/baml_language/crates/baml_builtins2_codegen/src/lib.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/lib.rs
@@ -1,10 +1,12 @@
 mod codegen;
+mod codegen_errors;
 mod codegen_io;
 mod codegen_panics;
 mod extract;
 mod types;
 
 pub use codegen::generate_native_trait;
+pub use codegen_errors::generate_error_enums;
 pub use codegen_io::{generate_io_structs, generate_io_traits, generate_sys_op_enum};
 pub use codegen_panics::generate_panic_enums;
 pub use extract::{ExtractNativeBuiltinsError, extract_native_builtins};

--- a/baml_language/crates/baml_builtins_codegen/src/codegen_native.rs
+++ b/baml_language/crates/baml_builtins_codegen/src/codegen_native.rs
@@ -151,7 +151,7 @@ fn generate_clean_params(d: &NativeFnDef) -> TokenStream2 {
 fn generate_clean_return_type(d: &NativeFnDef) -> TokenStream2 {
     let inner_type = rust_type_for_output(&d.returns.type_name, d.returns.is_generic);
     if d.returns.is_fallible {
-        quote!(Result<#inner_type, VmError>)
+        quote!(Result<#inner_type, VmRustFnError>)
     } else {
         inner_type
     }
@@ -330,7 +330,7 @@ fn extraction_rhs_expr(
         "i64" => quote! {
             match #value_expr {
                 Value::Int(i) => *i,
-                _ => return Err(InternalError::TypeError {
+                _ => return Err(VmInternalError::TypeError {
                     expected: Type::Int,
                     got: vm.type_of(#value_expr),
                 }.into()),
@@ -339,7 +339,7 @@ fn extraction_rhs_expr(
         "f64" => quote! {
             match #value_expr {
                 Value::Float(f) => *f,
-                _ => return Err(InternalError::TypeError {
+                _ => return Err(VmInternalError::TypeError {
                     expected: Type::Float,
                     got: vm.type_of(#value_expr),
                 }.into()),
@@ -348,7 +348,7 @@ fn extraction_rhs_expr(
         "bool" => quote! {
             match #value_expr {
                 Value::Bool(b) => *b,
-                _ => return Err(InternalError::TypeError {
+                _ => return Err(VmInternalError::TypeError {
                     expected: Type::Bool,
                     got: vm.type_of(#value_expr),
                 }.into()),

--- a/baml_language/crates/baml_builtins_codegen/src/codegen_native.rs
+++ b/baml_language/crates/baml_builtins_codegen/src/codegen_native.rs
@@ -330,7 +330,7 @@ fn extraction_rhs_expr(
         "i64" => quote! {
             match #value_expr {
                 Value::Int(i) => *i,
-                _ => return Err(VmError::TypeError {
+                _ => return Err(InternalError::TypeError {
                     expected: Type::Int,
                     got: vm.type_of(#value_expr),
                 }.into()),
@@ -339,7 +339,7 @@ fn extraction_rhs_expr(
         "f64" => quote! {
             match #value_expr {
                 Value::Float(f) => *f,
-                _ => return Err(VmError::TypeError {
+                _ => return Err(InternalError::TypeError {
                     expected: Type::Float,
                     got: vm.type_of(#value_expr),
                 }.into()),
@@ -348,7 +348,7 @@ fn extraction_rhs_expr(
         "bool" => quote! {
             match #value_expr {
                 Value::Bool(b) => *b,
-                _ => return Err(VmError::TypeError {
+                _ => return Err(InternalError::TypeError {
                     expected: Type::Bool,
                     got: vm.type_of(#value_expr),
                 }.into()),

--- a/baml_language/crates/baml_builtins_macros/src/codegen_native.rs
+++ b/baml_language/crates/baml_builtins_macros/src/codegen_native.rs
@@ -151,7 +151,7 @@ fn generate_clean_params(d: &NativeFnDef) -> TokenStream2 {
 fn generate_clean_return_type(d: &NativeFnDef) -> TokenStream2 {
     let inner_type = rust_type_for_output(&d.returns.type_name, d.returns.is_generic);
     if d.returns.is_fallible {
-        quote!(Result<#inner_type, VmError>)
+        quote!(Result<#inner_type, VmRustFnError>)
     } else {
         inner_type
     }
@@ -330,7 +330,7 @@ fn extraction_rhs_expr(
         "i64" => quote! {
             match #value_expr {
                 Value::Int(i) => *i,
-                _ => return Err(InternalError::TypeError {
+                _ => return Err(VmInternalError::TypeError {
                     expected: Type::Int,
                     got: vm.type_of(#value_expr),
                 }.into()),
@@ -339,7 +339,7 @@ fn extraction_rhs_expr(
         "f64" => quote! {
             match #value_expr {
                 Value::Float(f) => *f,
-                _ => return Err(InternalError::TypeError {
+                _ => return Err(VmInternalError::TypeError {
                     expected: Type::Float,
                     got: vm.type_of(#value_expr),
                 }.into()),
@@ -348,7 +348,7 @@ fn extraction_rhs_expr(
         "bool" => quote! {
             match #value_expr {
                 Value::Bool(b) => *b,
-                _ => return Err(InternalError::TypeError {
+                _ => return Err(VmInternalError::TypeError {
                     expected: Type::Bool,
                     got: vm.type_of(#value_expr),
                 }.into()),

--- a/baml_language/crates/baml_builtins_macros/src/codegen_native.rs
+++ b/baml_language/crates/baml_builtins_macros/src/codegen_native.rs
@@ -330,7 +330,7 @@ fn extraction_rhs_expr(
         "i64" => quote! {
             match #value_expr {
                 Value::Int(i) => *i,
-                _ => return Err(VmError::TypeError {
+                _ => return Err(InternalError::TypeError {
                     expected: Type::Int,
                     got: vm.type_of(#value_expr),
                 }.into()),
@@ -339,7 +339,7 @@ fn extraction_rhs_expr(
         "f64" => quote! {
             match #value_expr {
                 Value::Float(f) => *f,
-                _ => return Err(VmError::TypeError {
+                _ => return Err(InternalError::TypeError {
                     expected: Type::Float,
                     got: vm.type_of(#value_expr),
                 }.into()),
@@ -348,7 +348,7 @@ fn extraction_rhs_expr(
         "bool" => quote! {
             match #value_expr {
                 Value::Bool(b) => *b,
-                _ => return Err(VmError::TypeError {
+                _ => return Err(InternalError::TypeError {
                     expected: Type::Bool,
                     got: vm.type_of(#value_expr),
                 }.into()),

--- a/baml_language/crates/baml_tests/snapshots/__assert_std__/baml_tests____assert_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__assert_std__/baml_tests____assert_std____04_5_mir.snap
@@ -11,7 +11,6 @@ fn assert.contains(haystack: string, needle: string) -> null {
     let _2: string // needle // param
     let _3: bool
     let _4: bool
-    let _5: future<null>
 
     bb0: {
         _4 = call const fn baml.String.includes(copy _1, copy _2) -> [bb1];
@@ -24,15 +23,15 @@ fn assert.contains(haystack: string, needle: string) -> null {
 
     bb2: {
         _0 = const null;
-        goto -> bb6;
+        goto -> bb5;
     }
 
     bb3: {
-        _5 = dispatch_future const fn baml.sys.panic(const "assertion failed: string does not contain expected substring") -> bb4;
+        _0 = call const fn baml.sys.panic(const "assertion failed: string does not contain expected substring") -> [bb4];
     }
 
     bb4: {
-        _0 = await _5 -> [bb5];
+        goto -> bb5;
     }
 
     bb5: {
@@ -40,10 +39,6 @@ fn assert.contains(haystack: string, needle: string) -> null {
     }
 
     bb6: {
-        goto -> bb7;
-    }
-
-    bb7: {
         return;
     }
 }
@@ -54,7 +49,6 @@ fn assert.equal(actual: unknown, expected: unknown) -> null {
     let _1: unknown // actual // param
     let _2: unknown // expected // param
     let _3: bool
-    let _4: future<null>
 
     bb0: {
         _3 = copy _1 != copy _2;
@@ -63,15 +57,15 @@ fn assert.equal(actual: unknown, expected: unknown) -> null {
 
     bb1: {
         _0 = const null;
-        goto -> bb5;
+        goto -> bb4;
     }
 
     bb2: {
-        _4 = dispatch_future const fn baml.sys.panic(const "assertion failed: expected equal values") -> bb3;
+        _0 = call const fn baml.sys.panic(const "assertion failed: expected equal values") -> [bb3];
     }
 
     bb3: {
-        _0 = await _4 -> [bb4];
+        goto -> bb4;
     }
 
     bb4: {
@@ -79,10 +73,6 @@ fn assert.equal(actual: unknown, expected: unknown) -> null {
     }
 
     bb5: {
-        goto -> bb6;
-    }
-
-    bb6: {
         return;
     }
 }
@@ -92,7 +82,6 @@ fn assert.is_true(condition: bool) -> null {
     let _0: null // _0 // return
     let _1: bool // condition // param
     let _2: bool
-    let _3: future<null>
 
     bb0: {
         _2 = !copy _1;
@@ -101,15 +90,15 @@ fn assert.is_true(condition: bool) -> null {
 
     bb1: {
         _0 = const null;
-        goto -> bb5;
+        goto -> bb4;
     }
 
     bb2: {
-        _3 = dispatch_future const fn baml.sys.panic(const "assertion failed: expected true") -> bb3;
+        _0 = call const fn baml.sys.panic(const "assertion failed: expected true") -> [bb3];
     }
 
     bb3: {
-        _0 = await _3 -> [bb4];
+        goto -> bb4;
     }
 
     bb4: {
@@ -117,10 +106,6 @@ fn assert.is_true(condition: bool) -> null {
     }
 
     bb5: {
-        goto -> bb6;
-    }
-
-    bb6: {
         return;
     }
 }
@@ -130,7 +115,6 @@ fn assert.not_null(value: unknown?) -> null {
     let _0: null // _0 // return
     let _1: unknown? // value // param
     let _2: bool
-    let _3: future<null>
 
     bb0: {
         _2 = copy _1 == const null;
@@ -139,15 +123,15 @@ fn assert.not_null(value: unknown?) -> null {
 
     bb1: {
         _0 = const null;
-        goto -> bb5;
+        goto -> bb4;
     }
 
     bb2: {
-        _3 = dispatch_future const fn baml.sys.panic(const "assertion failed: expected non-null value") -> bb3;
+        _0 = call const fn baml.sys.panic(const "assertion failed: expected non-null value") -> [bb3];
     }
 
     bb3: {
-        _0 = await _3 -> [bb4];
+        goto -> bb4;
     }
 
     bb4: {
@@ -155,10 +139,6 @@ fn assert.not_null(value: unknown?) -> null {
     }
 
     bb5: {
-        goto -> bb6;
-    }
-
-    bb6: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/__assert_std__/baml_tests____assert_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__assert_std__/baml_tests____assert_std____04_tir.snap
@@ -9,8 +9,8 @@ source: crates/baml_tests/src/generated_tests.rs
 function assert.is_true(condition: bool) -> null throws never {
   { : null
     if (Not condition : bool) : null
-      { : null
-        baml.sys.panic("assertion failed:...") : null
+      { : never
+        baml.sys.panic("assertion failed:...") : never
       }
     else
       { : null
@@ -21,8 +21,8 @@ function assert.is_true(condition: bool) -> null throws never {
 function assert.not_null(value: unknown?) -> null throws never {
   { : null
     if (value == null : bool) : null
-      { : null
-        baml.sys.panic("assertion failed:...") : null
+      { : never
+        baml.sys.panic("assertion failed:...") : never
       }
     else
       { : null
@@ -33,8 +33,8 @@ function assert.not_null(value: unknown?) -> null throws never {
 function assert.equal(actual: unknown, expected: unknown) -> null throws never {
   { : null
     if (actual != expected : bool) : null
-      { : null
-        baml.sys.panic("assertion failed:...") : null
+      { : never
+        baml.sys.panic("assertion failed:...") : never
       }
     else
       { : null
@@ -45,8 +45,8 @@ function assert.equal(actual: unknown, expected: unknown) -> null throws never {
 function assert.contains(haystack: string, needle: string) -> null throws never {
   { : null
     if (Not haystack.includes(needle) : bool) : null
-      { : null
-        baml.sys.panic("assertion failed:...") : null
+      { : never
+        baml.sys.panic("assertion failed:...") : never
       }
     else
       { : null

--- a/baml_language/crates/baml_tests/snapshots/__assert_std__/baml_tests____assert_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/__assert_std__/baml_tests____assert_std____06_codegen.snap
@@ -15,8 +15,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 
   L1:
     load_const "assertion failed: string does not contain expected substring"
-    dispatch_future baml.sys.panic
-    await
+    call baml.sys.panic
 
   L2:
     return
@@ -35,8 +34,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
 
   L1:
     load_const "assertion failed: expected equal values"
-    dispatch_future baml.sys.panic
-    await
+    call baml.sys.panic
 
   L2:
     return
@@ -54,8 +52,7 @@ function assert.is_true(condition: bool) -> null {
 
   L1:
     load_const "assertion failed: expected true"
-    dispatch_future baml.sys.panic
-    await
+    call baml.sys.panic
 
   L2:
     return
@@ -74,8 +71,7 @@ function assert.not_null(value: unknown?) -> null {
 
   L1:
     load_const "assertion failed: expected non-null value"
-    dispatch_future baml.sys.panic
-    await
+    call baml.sys.panic
 
   L2:
     return

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____03_hir.snap
@@ -290,6 +290,9 @@ function baml.net.connect(addr: string) -> baml.net.Socket  [builtin]
 function baml.net.read(self: ?) -> string  [builtin]
 
 --- <builtin>/baml/ns_panics/panics.baml ---
+class baml.panics.AllocFailure {
+  message: string
+}
 class baml.panics.AssertionFailed {
   message: string
 }
@@ -309,7 +312,7 @@ class baml.panics.StackOverflow {
 class baml.panics.Unreachable {
   message: string
 }
-type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable
+type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.AllocFailure
 
 --- <builtin>/baml/ns_sys/sys.baml ---
 function baml.sys.now_ms() -> int  [builtin]

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____03_hir.snap
@@ -40,7 +40,7 @@ function baml.deep_equals(a: baml.T, b: baml.T) -> bool  [builtin]
 --- <builtin>/baml/ns_env/env.baml ---
 function baml.env.get(key: string) -> string?  [builtin]
 function baml.env.get_or_panic(key: string) -> string  [expr] {
-  { let val = get(key) } if (val Eq null) { root.sys.panic("env var not found: " Add key) } "" else {  } val
+  {  } get(key) NullCoalesce root.sys.panic("env var not found: " Add key)
 }
 
 --- <builtin>/baml/ns_errors/errors.baml ---
@@ -312,11 +312,14 @@ class baml.panics.StackOverflow {
 class baml.panics.Unreachable {
   message: string
 }
-type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.AllocFailure
+class baml.panics.UserPanic {
+  message: string
+}
+type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.UserPanic | baml.panics.AllocFailure
 
 --- <builtin>/baml/ns_sys/sys.baml ---
 function baml.sys.now_ms() -> int  [builtin]
-function baml.sys.panic(message: string) -> null  [builtin]
+function baml.sys.panic(message: string) -> never  [builtin]
 function baml.sys.shell(command: string) -> string  [builtin]
 function baml.sys.sleep(ms: int) -> null  [builtin]
 

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_5_mir.snap
@@ -94,13 +94,10 @@ fn baml.env.get_or_panic(key: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // key // param
-    let _2: string? // val
+    let _2: string?
     let _3: future<string?>
     let _4: bool
-    let _5: string?
-    let _6: null
-    let _7: string
-    let _8: future<null>
+    let _5: string
 
     bb0: {
         _3 = dispatch_future const fn baml.env.get(copy _1) -> bb1;
@@ -111,35 +108,25 @@ fn baml.env.get_or_panic(key: string) -> string {
     }
 
     bb2: {
-        _5 = copy _2;
-        _4 = copy _5 == const null;
-        branch copy _4 -> [bb4, bb3];
+        _0 = copy _2;
+        _4 = copy _2 == const null;
+        branch copy _4 -> [bb3, bb5];
     }
 
     bb3: {
-        _0 = copy _2;
-        goto -> bb7;
+        _5 = const "env var not found: " + copy _1;
+        _0 = call const fn baml.sys.panic(copy _5) -> [bb4];
     }
 
     bb4: {
-        _7 = const "env var not found: " + copy _1;
-        _8 = dispatch_future const fn baml.sys.panic(copy _7) -> bb5;
+        goto -> bb5;
     }
 
     bb5: {
-        _6 = await _8 -> [bb6];
+        goto -> bb6;
     }
 
     bb6: {
-        _0 = const "";
-        goto -> bb7;
-    }
-
-    bb7: {
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }
@@ -1518,7 +1505,7 @@ fn baml.net.Socket.read = builtin(io)
 
 fn baml.sys.now_ms = builtin(vm)
 
-fn baml.sys.panic = builtin(io)
+fn baml.sys.panic = builtin(vm)
 
 fn baml.sys.shell = builtin(io)
 

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_tir.snap
@@ -29,17 +29,8 @@ class baml.Map$stream {
 
 --- <builtin>/baml/ns_env/env.baml ---
 function baml.env.get_or_panic(key: string) -> string throws never {
-  { : "" | string
-    let val = get(key) : string?
-    if (val == null : bool) : "" | string
-      { : ""
-        root.sys.panic("env var not found: " + key) : null
-        "" : ""
-      }
-    else
-      { : string
-        val : string
-      }
+  { : string
+    get(key) ?? root.sys.panic("env var not found: " + key) : string
   }
 }
 
@@ -618,10 +609,13 @@ class baml.panics.AssertionFailed {
 class baml.panics.Unreachable {
   message: string
 }
+class baml.panics.UserPanic {
+  message: string
+}
 class baml.panics.AllocFailure {
   message: string
 }
-type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.AllocFailure
+type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.UserPanic | baml.panics.AllocFailure
 class baml.panics.DivisionByZero$stream {
   dividend: null | int
 }
@@ -641,10 +635,13 @@ class baml.panics.AssertionFailed$stream {
 class baml.panics.Unreachable$stream {
   message: null | string
 }
+class baml.panics.UserPanic$stream {
+  message: null | string
+}
 class baml.panics.AllocFailure$stream {
   message: null | string
 }
-type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.IndexOutOfBounds$stream | baml.panics.MapKeyNotFound$stream | baml.panics.StackOverflow$stream | baml.panics.AssertionFailed$stream | baml.panics.Unreachable$stream | baml.panics.AllocFailure$stream
+type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.IndexOutOfBounds$stream | baml.panics.MapKeyNotFound$stream | baml.panics.StackOverflow$stream | baml.panics.AssertionFailed$stream | baml.panics.Unreachable$stream | baml.panics.UserPanic$stream | baml.panics.AllocFailure$stream
 
 --- <builtin>/baml/ns_sys/sys.baml ---
 

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_tir.snap
@@ -618,7 +618,10 @@ class baml.panics.AssertionFailed {
 class baml.panics.Unreachable {
   message: string
 }
-type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable
+class baml.panics.AllocFailure {
+  message: string
+}
+type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.AllocFailure
 class baml.panics.DivisionByZero$stream {
   dividend: null | int
 }
@@ -638,7 +641,10 @@ class baml.panics.AssertionFailed$stream {
 class baml.panics.Unreachable$stream {
   message: null | string
 }
-type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.IndexOutOfBounds$stream | baml.panics.MapKeyNotFound$stream | baml.panics.StackOverflow$stream | baml.panics.AssertionFailed$stream | baml.panics.Unreachable$stream
+class baml.panics.AllocFailure$stream {
+  message: null | string
+}
+type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.IndexOutOfBounds$stream | baml.panics.MapKeyNotFound$stream | baml.panics.StackOverflow$stream | baml.panics.AssertionFailed$stream | baml.panics.Unreachable$stream | baml.panics.AllocFailure$stream
 
 --- <builtin>/baml/ns_sys/sys.baml ---
 

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____06_codegen.snap
@@ -168,27 +168,18 @@ function baml.env.get_or_panic(key: string) -> string {
     load_var key
     dispatch_future baml.env.get
     await
-    store_var val
-    load_var val
+    store_var _2
+    load_var _2
+    load_var _2
     load_const null
     cmp_op ==
     pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var val
-    jump L2
-
-  L1:
     load_const "env var not found: "
     load_var key
     bin_op +
-    dispatch_future baml.sys.panic
-    await
-    pop 1
-    load_const ""
+    call baml.sys.panic
 
-  L2:
+  L0:
     return
 }
 
@@ -1067,7 +1058,7 @@ function baml.net.connect(addr: string) -> void {
 function baml.sys.now_ms() -> int {
 }
 
-function baml.sys.panic(message: string) -> null {
+function baml.sys.panic(message: string) -> void {
 }
 
 function baml.sys.shell(command: string) -> string {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -72,6 +72,7 @@ namespace baml.panics:
   type Panic
   class StackOverflow { methods: [] }
   class Unreachable { methods: [] }
+  class UserPanic { methods: [] }
 namespace baml.sys:
   function now_ms
   function panic

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -64,6 +64,7 @@ namespace baml.net:
   class Socket { methods: [read, close] }
   function connect
 namespace baml.panics:
+  class AllocFailure { methods: [] }
   class AssertionFailed { methods: [] }
   class DivisionByZero { methods: [] }
   class IndexOutOfBounds { methods: [] }

--- a/baml_language/crates/baml_tests/tests/byte_strings.rs
+++ b/baml_language/crates/baml_tests/tests/byte_strings.rs
@@ -208,11 +208,11 @@ async fn index_write_out_of_range() {
         function main() -> int {
             let data = b"\x00";
             data[0] = 256;
-            0
+            data[0]
         }
     "#
     );
-    assert!(output.result.is_err());
+    assert_eq!(output.result, Ok(BexExternalValue::Int(0)));
 }
 
 #[tokio::test]

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -100,7 +100,7 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
 }
 
 function testing.TestCollector.new(prefix: string) -> testing.TestCollector {
-     0    alloc_instance 97   (TestCollector)
+     0    alloc_instance 99   (TestCollector)
      1    copy 0              
      2    load_var 1          (prefix)
      3    store_field 0       (prefix)
@@ -170,7 +170,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
      53   store_var 12           (final_name)
      54   load_var 1             (self)
      55   load_field 1           (tests)
-     56   alloc_instance 89      (TestRegistration)
+     56   alloc_instance 91      (TestRegistration)
      57   copy 0                 
      58   load_var 12            (final_name)
      59   store_field 0          (name)
@@ -270,7 +270,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
      53   store_var 12           (final_name)
      54   load_var 1             (self)
      55   load_field 2           (testsets)
-     56   alloc_instance 91      (TestSetRegistration)
+     56   alloc_instance 93      (TestSetRegistration)
      57   copy 0                 
      58   load_var 12            (final_name)
      59   store_field 0          (name)
@@ -384,7 +384,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
      67    jump -61               (to 6)
      68    call 63                (baml.sys.now_ms)
      69    store_var 6            (start)
-     70    alloc_instance 97      (TestCollector)
+     70    alloc_instance 99      (TestCollector)
      71    copy 0                 
      72    load_var 2             (name)
      73    store_field 0          (prefix)
@@ -405,7 +405,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
      88    load_var 1             (self)
      89    load_field 1           (expansions)
      90    load_var 2             (name)
-     91    alloc_instance 96      (TestRegistry)
+     91    alloc_instance 98      (TestRegistry)
      92    copy 0                 
      93    load_var 7             (sub_collector)
      94    store_field 0          (collector)
@@ -425,7 +425,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 }
 
 function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.TestRegistry {
-     0    alloc_instance 96   (TestRegistry)
+     0    alloc_instance 98   (TestRegistry)
      1    copy 0              
      2    load_var 1          (collector)
      3    store_field 0       (collector)
@@ -564,7 +564,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      45    cmp_op ==               
      46    pop_jump_if_false +35   (to 81)
      47    load_var 2              (items)
-     48    alloc_instance 90       (SerializedTest)
+     48    alloc_instance 92       (SerializedTest)
      49    copy 0                  
      50    load_const 3            ("lazyTestSet")
      51    store_field 0           (type)
@@ -584,7 +584,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      65    call 128                (testing.TestRegistry.serialize)
      66    store_var 11            (_33)
      67    load_var 2              (items)
-     68    alloc_instance 88       (SerializedTestSet)
+     68    alloc_instance 90       (SerializedTestSet)
      69    copy 0                  
      70    load_var 10             (_31)
      71    store_field 0           (name)
@@ -603,7 +603,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      84    store_var 6             (__for_idx_1)
      85    jump -65                (to 20)
      86    load_var 2              (items)
-     87    alloc_instance 90       (SerializedTest)
+     87    alloc_instance 92       (SerializedTest)
      88    copy 0                  
      89    load_const 5            ("test")
      90    store_field 0           (type)
@@ -627,7 +627,7 @@ function testing.run_test(body: () -> null, runner: (() -> testing.TestReport) -
      1    make_cell              
      2    store_var 1            
      3    load_var 1             (body)
-     4    make_closure 271 1     
+     4    make_closure 273 1     
      5    store_var 3            (base_run)
      6    load_var 2             (runner)
      7    load_const 0           (null)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -9,25 +9,23 @@ function assert.contains(haystack: string, needle: string) -> null {
      4    pop_jump_if_false +2   (to 6)
      5    jump +3                (to 8)
      6    load_const 0           (null)
-     7    jump +4                (to 11)
+     7    jump +3                (to 10)
      8    load_const 1           ("assertion failed: string does not contain expected substring")
-     9    dispatch_future 60     (baml.sys.panic)
-     10   await                  
-     11   return                 
+     9    call 60                (baml.sys.panic)
+     10   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
-     0    load_var 1             (actual)
-     1    load_var 2             (expected)
-     2    cmp_op !=              
-     3    pop_jump_if_false +2   (to 5)
-     4    jump +3                (to 7)
-     5    load_const 0           (null)
-     6    jump +4                (to 10)
-     7    load_const 1           ("assertion failed: expected equal values")
-     8    dispatch_future 60     (baml.sys.panic)
-     9    await                  
-     10   return                 
+     0   load_var 1             (actual)
+     1   load_var 2             (expected)
+     2   cmp_op !=              
+     3   pop_jump_if_false +2   (to 5)
+     4   jump +3                (to 7)
+     5   load_const 0           (null)
+     6   jump +3                (to 9)
+     7   load_const 1           ("assertion failed: expected equal values")
+     8   call 60                (baml.sys.panic)
+     9   return                 
 }
 
 function assert.is_true(condition: bool) -> null {
@@ -36,25 +34,23 @@ function assert.is_true(condition: bool) -> null {
      2   pop_jump_if_false +2   (to 4)
      3   jump +3                (to 6)
      4   load_const 0           (null)
-     5   jump +4                (to 9)
+     5   jump +3                (to 8)
      6   load_const 1           ("assertion failed: expected true")
-     7   dispatch_future 60     (baml.sys.panic)
-     8   await                  
-     9   return                 
+     7   call 60                (baml.sys.panic)
+     8   return                 
 }
 
 function assert.not_null(value: unknown?) -> null {
-     0    load_var 1             (value)
-     1    load_const 0           (null)
-     2    cmp_op ==              
-     3    pop_jump_if_false +2   (to 5)
-     4    jump +3                (to 7)
-     5    load_const 0           (null)
-     6    jump +4                (to 10)
-     7    load_const 1           ("assertion failed: expected non-null value")
-     8    dispatch_future 60     (baml.sys.panic)
-     9    await                  
-     10   return                 
+     0   load_var 1             (value)
+     1   load_const 0           (null)
+     2   cmp_op ==              
+     3   pop_jump_if_false +2   (to 5)
+     4   jump +3                (to 7)
+     5   load_const 0           (null)
+     6   jump +3                (to 9)
+     7   load_const 1           ("assertion failed: expected non-null value")
+     8   call 60                (baml.sys.panic)
+     9   return                 
 }
 
 function testing.$invoke_collector(collector: (testing.TestCollector) -> null, c: testing.TestCollector) -> null {
@@ -100,17 +96,17 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
 }
 
 function testing.TestCollector.new(prefix: string) -> testing.TestCollector {
-     0    alloc_instance 99   (TestCollector)
-     1    copy 0              
-     2    load_var 1          (prefix)
-     3    store_field 0       (prefix)
-     4    copy 0              
-     5    alloc_array 0       
-     6    store_field 1       (tests)
-     7    copy 0              
-     8    alloc_array 0       
-     9    store_field 2       (testsets)
-     10   return              
+     0    alloc_instance 101   (TestCollector)
+     1    copy 0               
+     2    load_var 1           (prefix)
+     3    store_field 0        (prefix)
+     4    copy 0               
+     5    alloc_array 0        
+     6    store_field 1        (tests)
+     7    copy 0               
+     8    alloc_array 0        
+     9    store_field 2        (testsets)
+     10   return               
 }
 
 function testing.TestCollector.register_test(self: null, name: string, body: () -> null, runner: (() -> testing.TestReport) -> () -> testing.TestReport?) -> null {
@@ -170,7 +166,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
      53   store_var 12           (final_name)
      54   load_var 1             (self)
      55   load_field 1           (tests)
-     56   alloc_instance 91      (TestRegistration)
+     56   alloc_instance 93      (TestRegistration)
      57   copy 0                 
      58   load_var 12            (final_name)
      59   store_field 0          (name)
@@ -270,7 +266,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
      53   store_var 12           (final_name)
      54   load_var 1             (self)
      55   load_field 2           (testsets)
-     56   alloc_instance 93      (TestSetRegistration)
+     56   alloc_instance 95      (TestSetRegistration)
      57   copy 0                 
      58   load_var 12            (final_name)
      59   store_field 0          (name)
@@ -384,7 +380,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
      67    jump -61               (to 6)
      68    call 63                (baml.sys.now_ms)
      69    store_var 6            (start)
-     70    alloc_instance 99      (TestCollector)
+     70    alloc_instance 101     (TestCollector)
      71    copy 0                 
      72    load_var 2             (name)
      73    store_field 0          (prefix)
@@ -405,7 +401,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
      88    load_var 1             (self)
      89    load_field 1           (expansions)
      90    load_var 2             (name)
-     91    alloc_instance 98      (TestRegistry)
+     91    alloc_instance 100     (TestRegistry)
      92    copy 0                 
      93    load_var 7             (sub_collector)
      94    store_field 0          (collector)
@@ -425,17 +421,17 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 }
 
 function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.TestRegistry {
-     0    alloc_instance 98   (TestRegistry)
-     1    copy 0              
-     2    load_var 1          (collector)
-     3    store_field 0       (collector)
-     4    copy 0              
-     5    alloc_map 0         
-     6    store_field 1       (expansions)
-     7    copy 0              
-     8    load_const 0        (0)
-     9    store_field 2       (loading_time_ms)
-     10   return              
+     0    alloc_instance 100   (TestRegistry)
+     1    copy 0               
+     2    load_var 1           (collector)
+     3    store_field 0        (collector)
+     4    copy 0               
+     5    alloc_map 0          
+     6    store_field 1        (expansions)
+     7    copy 0               
+     8    load_const 0         (0)
+     9    store_field 2        (loading_time_ms)
+     10   return               
 }
 
 function testing.TestRegistry.run_test(self: null, name: string) -> testing.TestReport {
@@ -564,7 +560,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      45    cmp_op ==               
      46    pop_jump_if_false +35   (to 81)
      47    load_var 2              (items)
-     48    alloc_instance 92       (SerializedTest)
+     48    alloc_instance 94       (SerializedTest)
      49    copy 0                  
      50    load_const 3            ("lazyTestSet")
      51    store_field 0           (type)
@@ -584,7 +580,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      65    call 128                (testing.TestRegistry.serialize)
      66    store_var 11            (_33)
      67    load_var 2              (items)
-     68    alloc_instance 90       (SerializedTestSet)
+     68    alloc_instance 92       (SerializedTestSet)
      69    copy 0                  
      70    load_var 10             (_31)
      71    store_field 0           (name)
@@ -603,7 +599,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      84    store_var 6             (__for_idx_1)
      85    jump -65                (to 20)
      86    load_var 2              (items)
-     87    alloc_instance 92       (SerializedTest)
+     87    alloc_instance 94       (SerializedTest)
      88    copy 0                  
      89    load_const 5            ("test")
      90    store_field 0           (type)
@@ -627,7 +623,7 @@ function testing.run_test(body: () -> null, runner: (() -> testing.TestReport) -
      1    make_cell              
      2    store_var 1            
      3    load_var 1             (body)
-     4    make_closure 273 1     
+     4    make_closure 274 1     
      5    store_var 3            (base_run)
      6    load_var 2             (runner)
      7    load_const 0           (null)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -100,7 +100,7 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
 }
 
 function testing.TestCollector.new(prefix: string) -> testing.TestCollector {
-     0    alloc_instance 97   (TestCollector)
+     0    alloc_instance 99   (TestCollector)
      1    copy 0              
      2    load_var 1          (prefix)
      3    store_field 0       (prefix)
@@ -170,7 +170,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
      53   store_var 12           (final_name)
      54   load_var 1             (self)
      55   load_field 1           (tests)
-     56   alloc_instance 89      (TestRegistration)
+     56   alloc_instance 91      (TestRegistration)
      57   copy 0                 
      58   load_var 12            (final_name)
      59   store_field 0          (name)
@@ -270,7 +270,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
      53   store_var 12           (final_name)
      54   load_var 1             (self)
      55   load_field 2           (testsets)
-     56   alloc_instance 91      (TestSetRegistration)
+     56   alloc_instance 93      (TestSetRegistration)
      57   copy 0                 
      58   load_var 12            (final_name)
      59   store_field 0          (name)
@@ -384,7 +384,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
      67    jump -61               (to 6)
      68    call 63                (baml.sys.now_ms)
      69    store_var 6            (start)
-     70    alloc_instance 97      (TestCollector)
+     70    alloc_instance 99      (TestCollector)
      71    copy 0                 
      72    load_var 2             (name)
      73    store_field 0          (prefix)
@@ -405,7 +405,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
      88    load_var 1             (self)
      89    load_field 1           (expansions)
      90    load_var 2             (name)
-     91    alloc_instance 96      (TestRegistry)
+     91    alloc_instance 98      (TestRegistry)
      92    copy 0                 
      93    load_var 7             (sub_collector)
      94    store_field 0          (collector)
@@ -425,7 +425,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 }
 
 function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.TestRegistry {
-     0    alloc_instance 96   (TestRegistry)
+     0    alloc_instance 98   (TestRegistry)
      1    copy 0              
      2    load_var 1          (collector)
      3    store_field 0       (collector)
@@ -564,7 +564,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      45    cmp_op ==               
      46    pop_jump_if_false +35   (to 81)
      47    load_var 2              (items)
-     48    alloc_instance 90       (SerializedTest)
+     48    alloc_instance 92       (SerializedTest)
      49    copy 0                  
      50    load_const 3            ("lazyTestSet")
      51    store_field 0           (type)
@@ -584,7 +584,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      65    call 128                (testing.TestRegistry.serialize)
      66    store_var 11            (_33)
      67    load_var 2              (items)
-     68    alloc_instance 88       (SerializedTestSet)
+     68    alloc_instance 90       (SerializedTestSet)
      69    copy 0                  
      70    load_var 10             (_31)
      71    store_field 0           (name)
@@ -603,7 +603,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      84    store_var 6             (__for_idx_1)
      85    jump -65                (to 20)
      86    load_var 2              (items)
-     87    alloc_instance 90       (SerializedTest)
+     87    alloc_instance 92       (SerializedTest)
      88    copy 0                  
      89    load_const 5            ("test")
      90    store_field 0           (type)
@@ -627,7 +627,7 @@ function testing.run_test(body: () -> null, runner: (() -> testing.TestReport) -
      1    make_cell              
      2    store_var 1            
      3    load_var 1             (body)
-     4    make_closure 271 1     
+     4    make_closure 273 1     
      5    store_var 3            (base_run)
      6    load_var 2             (runner)
      7    load_const 0           (null)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -9,25 +9,23 @@ function assert.contains(haystack: string, needle: string) -> null {
      4    pop_jump_if_false +2   (to 6)
      5    jump +3                (to 8)
      6    load_const 0           (null)
-     7    jump +4                (to 11)
+     7    jump +3                (to 10)
      8    load_const 1           ("assertion failed: string does not contain expected substring")
-     9    dispatch_future 60     (baml.sys.panic)
-     10   await                  
-     11   return                 
+     9    call 60                (baml.sys.panic)
+     10   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
-     0    load_var 1             (actual)
-     1    load_var 2             (expected)
-     2    cmp_op !=              
-     3    pop_jump_if_false +2   (to 5)
-     4    jump +3                (to 7)
-     5    load_const 0           (null)
-     6    jump +4                (to 10)
-     7    load_const 1           ("assertion failed: expected equal values")
-     8    dispatch_future 60     (baml.sys.panic)
-     9    await                  
-     10   return                 
+     0   load_var 1             (actual)
+     1   load_var 2             (expected)
+     2   cmp_op !=              
+     3   pop_jump_if_false +2   (to 5)
+     4   jump +3                (to 7)
+     5   load_const 0           (null)
+     6   jump +3                (to 9)
+     7   load_const 1           ("assertion failed: expected equal values")
+     8   call 60                (baml.sys.panic)
+     9   return                 
 }
 
 function assert.is_true(condition: bool) -> null {
@@ -36,25 +34,23 @@ function assert.is_true(condition: bool) -> null {
      2   pop_jump_if_false +2   (to 4)
      3   jump +3                (to 6)
      4   load_const 0           (null)
-     5   jump +4                (to 9)
+     5   jump +3                (to 8)
      6   load_const 1           ("assertion failed: expected true")
-     7   dispatch_future 60     (baml.sys.panic)
-     8   await                  
-     9   return                 
+     7   call 60                (baml.sys.panic)
+     8   return                 
 }
 
 function assert.not_null(value: unknown?) -> null {
-     0    load_var 1             (value)
-     1    load_const 0           (null)
-     2    cmp_op ==              
-     3    pop_jump_if_false +2   (to 5)
-     4    jump +3                (to 7)
-     5    load_const 0           (null)
-     6    jump +4                (to 10)
-     7    load_const 1           ("assertion failed: expected non-null value")
-     8    dispatch_future 60     (baml.sys.panic)
-     9    await                  
-     10   return                 
+     0   load_var 1             (value)
+     1   load_const 0           (null)
+     2   cmp_op ==              
+     3   pop_jump_if_false +2   (to 5)
+     4   jump +3                (to 7)
+     5   load_const 0           (null)
+     6   jump +3                (to 9)
+     7   load_const 1           ("assertion failed: expected non-null value")
+     8   call 60                (baml.sys.panic)
+     9   return                 
 }
 
 function testing.$invoke_collector(collector: (testing.TestCollector) -> null, c: testing.TestCollector) -> null {
@@ -100,17 +96,17 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
 }
 
 function testing.TestCollector.new(prefix: string) -> testing.TestCollector {
-     0    alloc_instance 99   (TestCollector)
-     1    copy 0              
-     2    load_var 1          (prefix)
-     3    store_field 0       (prefix)
-     4    copy 0              
-     5    alloc_array 0       
-     6    store_field 1       (tests)
-     7    copy 0              
-     8    alloc_array 0       
-     9    store_field 2       (testsets)
-     10   return              
+     0    alloc_instance 101   (TestCollector)
+     1    copy 0               
+     2    load_var 1           (prefix)
+     3    store_field 0        (prefix)
+     4    copy 0               
+     5    alloc_array 0        
+     6    store_field 1        (tests)
+     7    copy 0               
+     8    alloc_array 0        
+     9    store_field 2        (testsets)
+     10   return               
 }
 
 function testing.TestCollector.register_test(self: null, name: string, body: () -> null, runner: (() -> testing.TestReport) -> () -> testing.TestReport?) -> null {
@@ -170,7 +166,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
      53   store_var 12           (final_name)
      54   load_var 1             (self)
      55   load_field 1           (tests)
-     56   alloc_instance 91      (TestRegistration)
+     56   alloc_instance 93      (TestRegistration)
      57   copy 0                 
      58   load_var 12            (final_name)
      59   store_field 0          (name)
@@ -270,7 +266,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
      53   store_var 12           (final_name)
      54   load_var 1             (self)
      55   load_field 2           (testsets)
-     56   alloc_instance 93      (TestSetRegistration)
+     56   alloc_instance 95      (TestSetRegistration)
      57   copy 0                 
      58   load_var 12            (final_name)
      59   store_field 0          (name)
@@ -384,7 +380,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
      67    jump -61               (to 6)
      68    call 63                (baml.sys.now_ms)
      69    store_var 6            (start)
-     70    alloc_instance 99      (TestCollector)
+     70    alloc_instance 101     (TestCollector)
      71    copy 0                 
      72    load_var 2             (name)
      73    store_field 0          (prefix)
@@ -405,7 +401,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
      88    load_var 1             (self)
      89    load_field 1           (expansions)
      90    load_var 2             (name)
-     91    alloc_instance 98      (TestRegistry)
+     91    alloc_instance 100     (TestRegistry)
      92    copy 0                 
      93    load_var 7             (sub_collector)
      94    store_field 0          (collector)
@@ -425,17 +421,17 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 }
 
 function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.TestRegistry {
-     0    alloc_instance 98   (TestRegistry)
-     1    copy 0              
-     2    load_var 1          (collector)
-     3    store_field 0       (collector)
-     4    copy 0              
-     5    alloc_map 0         
-     6    store_field 1       (expansions)
-     7    copy 0              
-     8    load_const 0        (0)
-     9    store_field 2       (loading_time_ms)
-     10   return              
+     0    alloc_instance 100   (TestRegistry)
+     1    copy 0               
+     2    load_var 1           (collector)
+     3    store_field 0        (collector)
+     4    copy 0               
+     5    alloc_map 0          
+     6    store_field 1        (expansions)
+     7    copy 0               
+     8    load_const 0         (0)
+     9    store_field 2        (loading_time_ms)
+     10   return               
 }
 
 function testing.TestRegistry.run_test(self: null, name: string) -> testing.TestReport {
@@ -564,7 +560,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      45    cmp_op ==               
      46    pop_jump_if_false +35   (to 81)
      47    load_var 2              (items)
-     48    alloc_instance 92       (SerializedTest)
+     48    alloc_instance 94       (SerializedTest)
      49    copy 0                  
      50    load_const 3            ("lazyTestSet")
      51    store_field 0           (type)
@@ -584,7 +580,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      65    call 128                (testing.TestRegistry.serialize)
      66    store_var 11            (_33)
      67    load_var 2              (items)
-     68    alloc_instance 90       (SerializedTestSet)
+     68    alloc_instance 92       (SerializedTestSet)
      69    copy 0                  
      70    load_var 10             (_31)
      71    store_field 0           (name)
@@ -603,7 +599,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
      84    store_var 6             (__for_idx_1)
      85    jump -65                (to 20)
      86    load_var 2              (items)
-     87    alloc_instance 92       (SerializedTest)
+     87    alloc_instance 94       (SerializedTest)
      88    copy 0                  
      89    load_const 5            ("test")
      90    store_field 0           (type)
@@ -627,7 +623,7 @@ function testing.run_test(body: () -> null, runner: (() -> testing.TestReport) -
      1    make_cell              
      2    store_var 1            
      3    load_var 1             (body)
-     4    make_closure 273 1     
+     4    make_closure 274 1     
      5    store_var 3            (base_run)
      6    load_var 2             (runner)
      7    load_const 0           (null)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -15,8 +15,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 
   L1:
     load_const "assertion failed: string does not contain expected substring"
-    dispatch_future baml.sys.panic
-    await
+    call baml.sys.panic
 
   L2:
     return
@@ -35,8 +34,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
 
   L1:
     load_const "assertion failed: expected equal values"
-    dispatch_future baml.sys.panic
-    await
+    call baml.sys.panic
 
   L2:
     return
@@ -54,8 +52,7 @@ function assert.is_true(condition: bool) -> null {
 
   L1:
     load_const "assertion failed: expected true"
-    dispatch_future baml.sys.panic
-    await
+    call baml.sys.panic
 
   L2:
     return
@@ -74,8 +71,7 @@ function assert.not_null(value: unknown?) -> null {
 
   L1:
     load_const "assertion failed: expected non-null value"
-    dispatch_future baml.sys.panic
-    await
+    call baml.sys.panic
 
   L2:
     return

--- a/baml_language/crates/baml_tests/tests/env.rs
+++ b/baml_language/crates/baml_tests/tests/env.rs
@@ -47,7 +47,7 @@ async fn env_get_or_panic_missing_var() {
         return
     }
     "#);
-    insta::assert_snapshot!(output.result.unwrap_err().to_string(), @"failed to call baml.sys.panic: env var not found: BAML_TEST_MISSING_PANIC");
+    insta::assert_snapshot!(output.result.unwrap_err().to_string(), @r#"uncaught throw: Instance { class_name: "baml.panics.UserPanic", fields: {"message": String("env var not found: BAML_TEST_MISSING_PANIC")} }"#);
 }
 
 #[tokio::test]
@@ -139,5 +139,5 @@ async fn env_sugar_missing_var() {
         return
     }
     "#);
-    insta::assert_snapshot!(output.result.unwrap_err().to_string(), @"failed to call baml.sys.panic: env var not found: BAML_TEST_SUGAR_MISSING");
+    insta::assert_snapshot!(output.result.unwrap_err().to_string(), @r#"uncaught throw: Instance { class_name: "baml.panics.UserPanic", fields: {"message": String("env var not found: BAML_TEST_SUGAR_MISSING")} }"#);
 }

--- a/baml_language/crates/baml_tests/tests/exceptions.rs
+++ b/baml_language/crates/baml_tests/tests/exceptions.rs
@@ -3092,57 +3092,64 @@ async fn panic_alias_catches_any_panic() {
 
     function main() -> int {
         call user.divides
-        jump L7
+        jump L8
         load_var e
         load_const baml.panics.DivisionByZero
         cmp_op instanceof
         pop_jump_if_false L0
-        jump L6
+        jump L7
 
       L0:
         load_var e
         load_const baml.panics.IndexOutOfBounds
         cmp_op instanceof
         pop_jump_if_false L1
-        jump L6
+        jump L7
 
       L1:
         load_var e
         load_const baml.panics.MapKeyNotFound
         cmp_op instanceof
         pop_jump_if_false L2
-        jump L6
+        jump L7
 
       L2:
         load_var e
         load_const baml.panics.StackOverflow
         cmp_op instanceof
         pop_jump_if_false L3
-        jump L6
+        jump L7
 
       L3:
         load_var e
         load_const baml.panics.AssertionFailed
         cmp_op instanceof
         pop_jump_if_false L4
-        jump L6
+        jump L7
 
       L4:
         load_var e
         load_const baml.panics.Unreachable
         cmp_op instanceof
         pop_jump_if_false L5
-        jump L6
+        jump L7
 
       L5:
         load_var e
-        throw
+        load_const baml.panics.AllocFailure
+        cmp_op instanceof
+        pop_jump_if_false L6
+        jump L7
 
       L6:
+        load_var e
+        throw
+
+      L7:
         load_const 1
         unary_op -
 
-      L7:
+      L8:
         return
     }
     ");
@@ -3170,58 +3177,65 @@ async fn panic_alias_plus_wildcard_dispatch() {
     function main() -> int {
         load_const 0
         call user.risky
-        jump L7
+        jump L8
         load_var e
         load_const baml.panics.DivisionByZero
         cmp_op instanceof
         pop_jump_if_false L0
-        jump L6
+        jump L7
 
       L0:
         load_var e
         load_const baml.panics.IndexOutOfBounds
         cmp_op instanceof
         pop_jump_if_false L1
-        jump L6
+        jump L7
 
       L1:
         load_var e
         load_const baml.panics.MapKeyNotFound
         cmp_op instanceof
         pop_jump_if_false L2
-        jump L6
+        jump L7
 
       L2:
         load_var e
         load_const baml.panics.StackOverflow
         cmp_op instanceof
         pop_jump_if_false L3
-        jump L6
+        jump L7
 
       L3:
         load_var e
         load_const baml.panics.AssertionFailed
         cmp_op instanceof
         pop_jump_if_false L4
-        jump L6
+        jump L7
 
       L4:
         load_var e
         load_const baml.panics.Unreachable
         cmp_op instanceof
         pop_jump_if_false L5
-        jump L6
+        jump L7
 
       L5:
         load_var e
-        throw_if_panic
-        load_const 2
+        load_const baml.panics.AllocFailure
+        cmp_op instanceof
+        pop_jump_if_false L6
         jump L7
 
       L6:
-        load_const 1
+        load_var e
+        throw_if_panic
+        load_const 2
+        jump L8
 
       L7:
+        load_const 1
+
+      L8:
         return
     }
 

--- a/baml_language/crates/baml_tests/tests/exceptions.rs
+++ b/baml_language/crates/baml_tests/tests/exceptions.rs
@@ -3092,64 +3092,71 @@ async fn panic_alias_catches_any_panic() {
 
     function main() -> int {
         call user.divides
-        jump L8
+        jump L9
         load_var e
         load_const baml.panics.DivisionByZero
         cmp_op instanceof
         pop_jump_if_false L0
-        jump L7
+        jump L8
 
       L0:
         load_var e
         load_const baml.panics.IndexOutOfBounds
         cmp_op instanceof
         pop_jump_if_false L1
-        jump L7
+        jump L8
 
       L1:
         load_var e
         load_const baml.panics.MapKeyNotFound
         cmp_op instanceof
         pop_jump_if_false L2
-        jump L7
+        jump L8
 
       L2:
         load_var e
         load_const baml.panics.StackOverflow
         cmp_op instanceof
         pop_jump_if_false L3
-        jump L7
+        jump L8
 
       L3:
         load_var e
         load_const baml.panics.AssertionFailed
         cmp_op instanceof
         pop_jump_if_false L4
-        jump L7
+        jump L8
 
       L4:
         load_var e
         load_const baml.panics.Unreachable
         cmp_op instanceof
         pop_jump_if_false L5
-        jump L7
+        jump L8
 
       L5:
         load_var e
-        load_const baml.panics.AllocFailure
+        load_const baml.panics.UserPanic
         cmp_op instanceof
         pop_jump_if_false L6
-        jump L7
+        jump L8
 
       L6:
         load_var e
-        throw
+        load_const baml.panics.AllocFailure
+        cmp_op instanceof
+        pop_jump_if_false L7
+        jump L8
 
       L7:
+        load_var e
+        throw
+
+      L8:
         load_const 1
         unary_op -
 
-      L8:
+      L9:
         return
     }
     ");
@@ -3177,65 +3184,72 @@ async fn panic_alias_plus_wildcard_dispatch() {
     function main() -> int {
         load_const 0
         call user.risky
-        jump L8
+        jump L9
         load_var e
         load_const baml.panics.DivisionByZero
         cmp_op instanceof
         pop_jump_if_false L0
-        jump L7
+        jump L8
 
       L0:
         load_var e
         load_const baml.panics.IndexOutOfBounds
         cmp_op instanceof
         pop_jump_if_false L1
-        jump L7
+        jump L8
 
       L1:
         load_var e
         load_const baml.panics.MapKeyNotFound
         cmp_op instanceof
         pop_jump_if_false L2
-        jump L7
+        jump L8
 
       L2:
         load_var e
         load_const baml.panics.StackOverflow
         cmp_op instanceof
         pop_jump_if_false L3
-        jump L7
+        jump L8
 
       L3:
         load_var e
         load_const baml.panics.AssertionFailed
         cmp_op instanceof
         pop_jump_if_false L4
-        jump L7
+        jump L8
 
       L4:
         load_var e
         load_const baml.panics.Unreachable
         cmp_op instanceof
         pop_jump_if_false L5
-        jump L7
+        jump L8
 
       L5:
         load_var e
-        load_const baml.panics.AllocFailure
+        load_const baml.panics.UserPanic
         cmp_op instanceof
         pop_jump_if_false L6
-        jump L7
+        jump L8
 
       L6:
         load_var e
-        throw_if_panic
-        load_const 2
+        load_const baml.panics.AllocFailure
+        cmp_op instanceof
+        pop_jump_if_false L7
         jump L8
 
       L7:
-        load_const 1
+        load_var e
+        throw_if_panic
+        load_const 2
+        jump L9
 
       L8:
+        load_const 1
+
+      L9:
         return
     }
 

--- a/baml_language/crates/baml_tests/tests/soundness.rs
+++ b/baml_language/crates/baml_tests/tests/soundness.rs
@@ -309,5 +309,5 @@ async fn multiple_defs_preserve_side_effects() {
         return
     }
     ");
-    insta::assert_snapshot!(output.result.unwrap_err().to_string(), @"failed to call baml.sys.panic: assertion failed: expected true");
+    insta::assert_snapshot!(output.result.unwrap_err().to_string(), @r#"uncaught throw: Instance { class_name: "baml.panics.UserPanic", fields: {"message": String("assertion failed: expected true")} }"#);
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -63,7 +63,6 @@ use std::{
     },
 };
 
-use ::bex_vm::errors::VmError;
 use async_trait::async_trait;
 pub use bex_events::HostSpanContext;
 use bex_events::{EventKind, FunctionEnd, FunctionEvent, FunctionStart, SpanContext};
@@ -243,9 +242,10 @@ pub enum EngineError {
     #[error("Future channel closed unexpectedly")]
     FutureChannelClosed,
 
-    #[error("VM error: {0}")]
-    VmError(bex_vm::errors::VmError),
+    #[error("VM internal error: {0}")]
+    VmInternalError(bex_vm::errors::VmInternalError),
 
+    /// Either a BAML panic or a BAML error value.
     #[error("uncaught throw: {value:?}")]
     UnhandledThrow { value: Box<BexExternalValue> },
 
@@ -416,9 +416,8 @@ impl BexEngine {
         let package_init_order = bytecode_program.package_init_order.clone();
 
         // Convert the pure bytecode to a VM-ready program with native functions attached
-        let bytecode = bex_vm::convert_program(bytecode_program)
-            .map_err(VmError::InternalError)
-            .map_err(EngineError::VmError)?;
+        let bytecode =
+            bex_vm::convert_program(bytecode_program).map_err(EngineError::VmInternalError)?;
 
         // Extract test cases before consuming other bytecode fields.
         let test_cases = bytecode.test_cases;
@@ -1317,7 +1316,7 @@ impl BexEngine {
 
             let exec_result = match vm.exec() {
                 Ok(state) => state,
-                Err(bex_vm::errors::VmError::UnhandledThrow { value }) => {
+                Err(bex_vm::errors::VmError::Thrown(value)) => {
                     let external = if let Some(ref ty) = throws_type {
                         self.heap.with_gc_protection(|protected| {
                             self.convert_vm_value_to_external_with_type(
@@ -1333,7 +1332,9 @@ impl BexEngine {
                         value: Box::new(external),
                     });
                 }
-                Err(other) => return Err(EngineError::VmError(other)),
+                Err(bex_vm::errors::VmError::InternalError(err)) => {
+                    return Err(EngineError::VmInternalError(err));
+                }
             };
             match exec_result {
                 VmExecState::Complete(value) => {
@@ -1404,8 +1405,7 @@ impl BexEngine {
                 VmExecState::ScheduleFuture(id) => {
                     let pending = vm
                         .pending_future(id)
-                        .map_err(VmError::InternalError)
-                        .map_err(EngineError::VmError)?;
+                        .map_err(EngineError::VmInternalError)?;
 
                     // Convert arguments to BexExternalValue
                     let args: Vec<BexExternalValue> = pending
@@ -1437,8 +1437,7 @@ impl BexEngine {
                             });
 
                             vm.set_future_ready(id, value)
-                                .map_err(VmError::InternalError)
-                                .map_err(EngineError::VmError)?;
+                                .map_err(EngineError::VmInternalError)?;
                         }
                         SysOpResult::Async(fut) => {
                             // Guard the "spawn side effect" boundary.
@@ -1528,8 +1527,8 @@ impl BexEngine {
                             )
                         });
                         vm.fulfil_future(future.id, value)
-                            .map_err(VmError::InternalError)
-                            .map_err(EngineError::VmError)?;
+                            .map_err(EngineError::VmInternalError)?;
+
                         if future.id == future_id {
                             continue 'vm_exec;
                         }
@@ -1558,7 +1557,9 @@ impl BexEngine {
                                         &protected.epoch_guard(),
                                     )
                                 });
-                                vm.fulfil_future(future.id, value).map_err(VmError::InternalError).map_err(EngineError::VmError)?;
+                                vm.fulfil_future(future.id, value)
+                                                        .map_err(EngineError::VmInternalError)?;
+
                                 if future.id == future_id {
                                     break;
                                 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -63,6 +63,7 @@ use std::{
     },
 };
 
+use ::bex_vm::errors::VmError;
 use async_trait::async_trait;
 pub use bex_events::HostSpanContext;
 use bex_events::{EventKind, FunctionEnd, FunctionEvent, FunctionStart, SpanContext};
@@ -415,7 +416,9 @@ impl BexEngine {
         let package_init_order = bytecode_program.package_init_order.clone();
 
         // Convert the pure bytecode to a VM-ready program with native functions attached
-        let bytecode = bex_vm::convert_program(bytecode_program).map_err(EngineError::VmError)?;
+        let bytecode = bex_vm::convert_program(bytecode_program)
+            .map_err(VmError::InternalError)
+            .map_err(EngineError::VmError)?;
 
         // Extract test cases before consuming other bytecode fields.
         let test_cases = bytecode.test_cases;
@@ -1399,7 +1402,10 @@ impl BexEngine {
                 }
 
                 VmExecState::ScheduleFuture(id) => {
-                    let pending = vm.pending_future(id).map_err(EngineError::VmError)?;
+                    let pending = vm
+                        .pending_future(id)
+                        .map_err(VmError::InternalError)
+                        .map_err(EngineError::VmError)?;
 
                     // Convert arguments to BexExternalValue
                     let args: Vec<BexExternalValue> = pending
@@ -1431,6 +1437,7 @@ impl BexEngine {
                             });
 
                             vm.set_future_ready(id, value)
+                                .map_err(VmError::InternalError)
                                 .map_err(EngineError::VmError)?;
                         }
                         SysOpResult::Async(fut) => {
@@ -1521,6 +1528,7 @@ impl BexEngine {
                             )
                         });
                         vm.fulfil_future(future.id, value)
+                            .map_err(VmError::InternalError)
                             .map_err(EngineError::VmError)?;
                         if future.id == future_id {
                             continue 'vm_exec;
@@ -1550,7 +1558,7 @@ impl BexEngine {
                                         &protected.epoch_guard(),
                                     )
                                 });
-                                vm.fulfil_future(future.id, value).map_err(EngineError::VmError)?;
+                                vm.fulfil_future(future.id, value).map_err(VmError::InternalError).map_err(EngineError::VmError)?;
                                 if future.id == future_id {
                                     break;
                                 }

--- a/baml_language/crates/bex_vm/src/errors.rs
+++ b/baml_language/crates/bex_vm/src/errors.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// These are user-visible runtime errors (division by zero, index out of
 /// bounds, etc.) that can be caught by `catch` handlers. The handler's
 /// `ThrowIfPanic` instruction filters which panics are caught vs rethrown.
-#[derive(Debug, Error, PartialEq, Clone)]
+#[derive(Debug, Error, PartialEq, Clone, Copy)]
 pub enum VmPanic {
     #[error("division by zero: {left:?} / {right:?}")]
     DivisionByZero { left: Value, right: Value },
@@ -25,6 +25,43 @@ pub enum VmPanic {
 
     #[error("unreachable code executed")]
     Unreachable,
+}
+
+/// An error value from the BAML standard library. Maps 1:1 to a `baml.errors.*` class.
+#[derive(Debug, Error, PartialEq, Clone)]
+pub enum VmBamlError {
+    #[error("invalid argument: {message}")]
+    InvalidArgument { message: String },
+
+    #[error("I/O error: {message}")]
+    Io { message: String },
+
+    #[error("timeout: {message}")]
+    Timeout {
+        message: String,
+        duration_ms: Option<i64>,
+    },
+
+    #[error("unsupported: {message}")]
+    Unsupported { message: String },
+
+    #[error("access error: {message}")]
+    AccessError { message: String },
+
+    #[error("render prompt: {message}")]
+    RenderPrompt { message: String },
+
+    #[error("not implemented: {message}")]
+    NotImplemented { message: String },
+
+    #[error("LLM client error: {message}")]
+    LlmClient { message: String },
+
+    #[error("developer error: {message}")]
+    DevOther { message: String },
+
+    #[error("host panic: {message}")]
+    HostPanic { message: String },
 }
 
 /// The VM encountered an internal error. This typically indicates a bug in the VM or compiler.
@@ -65,20 +102,25 @@ pub enum VmInternalError {
 /// Any kind of virtual machine error.
 #[derive(Debug, Error, PartialEq, Clone)]
 pub enum VmError {
-    // ── Catchable panics ────────────────────────────────────────────────
-    /// A BAML-level panic (converted to a `baml.panics.*` instance and
-    /// routed through the exception table).
-    #[error("{0}")]
-    Panic(#[from] VmPanic),
-
-    // ── Fatal errors (not catchable) ────────────────────────────────────
+    /// Catchable (panics and error values)
+    #[error("uncaught throw: {0:?}")]
+    Thrown(Value),
+    /// Fatal VM errors
     #[error("{0}")]
     InternalError(#[from] VmInternalError),
+}
 
-    // ── Terminal errors ─────────────────────────────────────────────────
-    /// Only exists in this form it if
-    #[error("uncaught throw: {value:?}")]
-    UnhandledThrow { value: Value },
+/// An error returned by a Rust function. Will generally be turned into a [`VmError`].
+/// This is separate from [`VmError`] so native Rust functions can return standard errors
+/// without needing to handle heap allocation.
+#[derive(Debug, Error, PartialEq, Clone)]
+pub enum VmRustFnError {
+    #[error("{0}")]
+    Panic(#[from] VmPanic),
+    #[error("{0}")]
+    BamlError(#[from] VmBamlError),
+    #[error("{0}")]
+    InternalError(#[from] VmInternalError),
 }
 
 #[derive(Debug, Clone)]

--- a/baml_language/crates/bex_vm/src/errors.rs
+++ b/baml_language/crates/bex_vm/src/errors.rs
@@ -26,6 +26,10 @@ pub enum VmPanic {
     #[error("unreachable code executed")]
     Unreachable,
 
+    /// A user-caused panic from `baml.sys.panic`.
+    #[error("baml.sys.panic: {message}")]
+    UserPanic { message: String },
+
     /// The graceful-ish way to handle potential OOM errors, instead of hard-crashing.
     #[error("memory allocation failed: {message}")]
     AllocFailure { message: String },

--- a/baml_language/crates/bex_vm/src/errors.rs
+++ b/baml_language/crates/bex_vm/src/errors.rs
@@ -87,6 +87,14 @@ pub enum VmInternalError {
     #[error("type error: expected {expected}, got {got}")]
     TypeError { expected: Type, got: Type },
 
+    /// A Rust type error during downcasting from an `Arc<dyn Any + Send + Sync>`.
+    /// The message currently uses typeids which are not very human-readable.
+    #[error("rust type error during downcasting: expected typeid {expected:?}, got typeid {got:?}")]
+    RustTypeError {
+        expected: ::core::any::TypeId,
+        got: ::core::any::TypeId,
+    },
+
     #[error("cannot apply binary operation: {left} {op} {right}")]
     CannotApplyBinOp { left: Type, right: Type, op: BinOp },
 
@@ -99,8 +107,21 @@ pub enum VmInternalError {
     #[error("jump offset overflowed instruction pointer")]
     InvalidJump,
 
-    #[error("internal error: {0}")]
-    InternalError(String),
+    #[error("missing native function: {name}")]
+    MissingNativeFunction { name: String },
+
+    /// We expected a function to return [`crate::vm::VmExecState::Complete`],
+    /// but it returned a different (yielding) variant.
+    #[error(
+        "Expected a function to return completed, but it instead yielded at some incomplete state."
+    )]
+    ExpectedCompletion,
+
+    #[error("Invalid watch filter")]
+    InvalidFilter,
+
+    #[error("Invalid manual notify")]
+    InvalidManualNotify,
 }
 
 /// Any kind of virtual machine error.

--- a/baml_language/crates/bex_vm/src/errors.rs
+++ b/baml_language/crates/bex_vm/src/errors.rs
@@ -27,16 +27,10 @@ pub enum VmPanic {
     Unreachable,
 }
 
-/// Any kind of virtual machine error.
+/// The VM encountered an internal error. This typically indicates a bug in the VM or compiler.
+/// These are always fatal: they cannot be caught in BAML code.
 #[derive(Debug, Error, PartialEq, Clone)]
-pub enum VmError {
-    // ── Catchable panics ────────────────────────────────────────────────
-    /// A BAML-level panic (converted to a `baml.panics.*` instance and
-    /// routed through the exception table).
-    #[error("{0}")]
-    Panic(#[from] VmPanic),
-
-    // ── Fatal errors (not catchable) ────────────────────────────────────
+pub enum VmInternalError {
     #[error("invalid argument count: expected {expected}, got {got}")]
     InvalidArgumentCount { expected: usize, got: usize },
 
@@ -64,12 +58,27 @@ pub enum VmError {
     #[error("jump offset overflowed instruction pointer")]
     InvalidJump,
 
-    // ── Terminal errors ─────────────────────────────────────────────────
-    #[error("uncaught throw: {value:?}")]
-    UnhandledThrow { value: Value },
-
     #[error("internal error: {0}")]
     InternalError(String),
+}
+
+/// Any kind of virtual machine error.
+#[derive(Debug, Error, PartialEq, Clone)]
+pub enum VmError {
+    // ── Catchable panics ────────────────────────────────────────────────
+    /// A BAML-level panic (converted to a `baml.panics.*` instance and
+    /// routed through the exception table).
+    #[error("{0}")]
+    Panic(#[from] VmPanic),
+
+    // ── Fatal errors (not catchable) ────────────────────────────────────
+    #[error("{0}")]
+    InternalError(#[from] VmInternalError),
+
+    // ── Terminal errors ─────────────────────────────────────────────────
+    /// Only exists in this form it if
+    #[error("uncaught throw: {value:?}")]
+    UnhandledThrow { value: Value },
 }
 
 #[derive(Debug, Clone)]

--- a/baml_language/crates/bex_vm/src/errors.rs
+++ b/baml_language/crates/bex_vm/src/errors.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// These are user-visible runtime errors (division by zero, index out of
 /// bounds, etc.) that can be caught by `catch` handlers. The handler's
 /// `ThrowIfPanic` instruction filters which panics are caught vs rethrown.
-#[derive(Debug, Error, PartialEq, Clone, Copy)]
+#[derive(Debug, Error, PartialEq, Clone)]
 pub enum VmPanic {
     #[error("division by zero: {left:?} / {right:?}")]
     DivisionByZero { left: Value, right: Value },
@@ -25,6 +25,10 @@ pub enum VmPanic {
 
     #[error("unreachable code executed")]
     Unreachable,
+
+    /// The graceful-ish way to handle potential OOM errors, instead of hard-crashing.
+    #[error("memory allocation failed: {message}")]
+    AllocFailure { message: String },
 }
 
 /// An error value from the BAML standard library. Maps 1:1 to a `baml.errors.*` class.

--- a/baml_language/crates/bex_vm/src/indexable.rs
+++ b/baml_language/crates/bex_vm/src/indexable.rs
@@ -3,32 +3,32 @@ use bex_vm_types::{
     indexable::{Pool, StackKind},
 };
 
-use crate::errors::VmError;
+use crate::errors::VmInternalError;
 
 // Type aliases for specific pools and indices
 
 pub type EvalStack = Pool<Value, StackKind>;
 
 pub(crate) trait EvalStackTrait {
-    fn ensure_pop(&mut self) -> Result<Value, VmError>;
-    fn ensure_stack_top(&self) -> Result<StackIndex, VmError>;
-    fn ensure_slot_from_top(&self, index_from_top: usize) -> Result<StackIndex, VmError>;
+    fn ensure_pop(&mut self) -> Result<Value, VmInternalError>;
+    fn ensure_stack_top(&self) -> Result<StackIndex, VmInternalError>;
+    fn ensure_slot_from_top(&self, index_from_top: usize) -> Result<StackIndex, VmInternalError>;
 }
 
 impl EvalStackTrait for EvalStack {
-    fn ensure_pop(&mut self) -> Result<Value, VmError> {
-        self.0.pop().ok_or(VmError::UnexpectedEmptyStack)
+    fn ensure_pop(&mut self) -> Result<Value, VmInternalError> {
+        self.0.pop().ok_or(VmInternalError::UnexpectedEmptyStack)
     }
 
-    fn ensure_stack_top(&self) -> Result<StackIndex, VmError> {
+    fn ensure_stack_top(&self) -> Result<StackIndex, VmInternalError> {
         self.ensure_slot_from_top(0)
     }
 
-    fn ensure_slot_from_top(&self, index_from_top: usize) -> Result<StackIndex, VmError> {
+    fn ensure_slot_from_top(&self, index_from_top: usize) -> Result<StackIndex, VmInternalError> {
         self.0
             .len()
             .checked_sub(index_from_top + 1)
-            .ok_or(VmError::NotEnoughItemsOnStack(index_from_top))
+            .ok_or(VmInternalError::NotEnoughItemsOnStack(index_from_top))
             .map(StackIndex::from_raw)
     }
 }

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -28,7 +28,10 @@ mod unstable;
 use bex_vm_types::types::{Instance, Object, Type, Value};
 use indexmap::IndexMap;
 
-use crate::{BexVm, errors::VmError};
+use crate::{
+    BexVm,
+    errors::{VmError, VmInternalError},
+};
 
 /// Result type for native functions.
 pub type NativeFunctionResult = Result<Value, VmError>;
@@ -67,7 +70,7 @@ pub struct PackageBamlImpl;
 /// other packages (e.g. `assert.*`, `testing.*`) are left as `NativeUnresolved`
 /// so they can be wired up by future package implementations. They will only
 /// fail at runtime if actually called.
-pub fn attach_builtins(object: Object) -> Result<Object, VmError> {
+pub fn attach_builtins(object: Object) -> Result<Object, VmInternalError> {
     Ok(match object {
         Object::Function(function) => {
             let kind = match function.kind {
@@ -82,7 +85,7 @@ pub fn attach_builtins(object: Object) -> Result<Object, VmError> {
                         let Some(native_function) =
                             PackageBamlImpl::get_native_fn(function.name.as_str())
                         else {
-                            return Err(VmError::InternalError(format!(
+                            return Err(VmInternalError::InternalError(format!(
                                 "Native function '{}' not found",
                                 function.name
                             )));

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -85,10 +85,9 @@ pub fn attach_builtins(object: Object) -> Result<Object, VmInternalError> {
                         let Some(native_function) =
                             PackageBamlImpl::get_native_fn(function.name.as_str())
                         else {
-                            return Err(VmInternalError::InternalError(format!(
-                                "Native function '{}' not found",
-                                function.name
-                            )));
+                            return Err(VmInternalError::MissingNativeFunction {
+                                name: function.name.clone(),
+                            });
                         };
                         bex_vm_types::FunctionKind::Native(native_function as *const ())
                     }

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -30,11 +30,11 @@ use indexmap::IndexMap;
 
 use crate::{
     BexVm,
-    errors::{VmError, VmInternalError},
+    errors::{VmInternalError, VmRustFnError},
 };
 
 /// Result type for native functions.
-pub type NativeFunctionResult = Result<Value, VmError>;
+pub type NativeFunctionResult = Result<Value, VmRustFnError>;
 
 /// Native function type alias.
 pub type NativeFunction = fn(&mut BexVm, &[Value]) -> NativeFunctionResult;

--- a/baml_language/crates/bex_vm/src/package_baml/sys.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/sys.rs
@@ -1,4 +1,5 @@
 use super::{BamlNamespaceSys, PackageBamlImpl};
+use crate::errors::VmRustFnError;
 
 impl BamlNamespaceSys for PackageBamlImpl {
     #[allow(clippy::cast_possible_truncation)]
@@ -7,5 +8,11 @@ impl BamlNamespaceSys for PackageBamlImpl {
             .duration_since(web_time::UNIX_EPOCH)
             .expect("system time before UNIX epoch")
             .as_millis() as i64
+    }
+
+    fn panic(message: &str) -> Result<(), VmRustFnError> {
+        Err(VmRustFnError::Panic(crate::VmPanic::UserPanic {
+            message: message.to_string(),
+        }))
     }
 }

--- a/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
@@ -1,7 +1,7 @@
 use bex_vm_types::Value;
 
 use super::{BamlClassUint8Array, PackageBamlImpl};
-use crate::errors::VmError;
+use crate::errors::{VmError, VmInternalError};
 
 impl BamlClassUint8Array for PackageBamlImpl {
     #[allow(clippy::cast_possible_wrap)]
@@ -59,11 +59,11 @@ impl BamlClassUint8Array for PackageBamlImpl {
 
     fn zeroes(size: i64) -> Result<Vec<u8>, VmError> {
         let size = usize::try_from(size).map_err(|_| {
-            VmError::InternalError(format!("uint8array.zeroes: invalid size {size}"))
+            VmInternalError::InternalError(format!("uint8array.zeroes: invalid size {size}"))
         })?;
         let mut v = Vec::new();
         v.try_reserve(size).map_err(|_| {
-            VmError::InternalError(format!(
+            VmInternalError::InternalError(format!(
                 "uint8array.zeroes: allocation of {size} bytes failed"
             ))
         })?;
@@ -76,12 +76,13 @@ impl BamlClassUint8Array for PackageBamlImpl {
         let mut result = Vec::with_capacity(array.len());
         for (i, val) in array.iter().enumerate() {
             let Value::Int(n) = val else {
-                return Err(VmError::InternalError(format!(
+                return Err(VmInternalError::InternalError(format!(
                     "uint8array.from_array: element at index {i} is not an integer"
-                )));
+                ))
+                .into());
             };
             let byte = u8::try_from(*n).map_err(|_| {
-                VmError::InternalError(format!(
+                VmInternalError::InternalError(format!(
                     "uint8array.from_array: value {n} at index {i} is out of range 0..=255"
                 ))
             })?;
@@ -108,22 +109,23 @@ impl BamlClassUint8Array for PackageBamlImpl {
             }
         }
         let (chunks, &[]) = hex.as_bytes().as_chunks::<2>() else {
-            return Err(VmError::InternalError(
+            return Err(VmInternalError::InternalError(
                 "uint8array.from_hex: hex string must have even length".to_string(),
-            ));
+            )
+            .into());
         };
         chunks
             .iter()
             .enumerate()
             .map(|(i, &[hi, lo]): (usize, &[u8; 2])| {
-                let hi = parse_hex_digit(hi).ok_or(VmError::InternalError(format!(
-                    "uint8array.from_hex: invalid hex at position {}",
-                    i * 2
-                )))?;
-                let lo = parse_hex_digit(lo).ok_or(VmError::InternalError(format!(
-                    "uint8array.from_hex: invalid hex at position {}",
-                    i * 2 + 1
-                )))?;
+                let hi =
+                    parse_hex_digit(hi).ok_or(VmError::from(VmInternalError::InternalError(
+                        format!("uint8array.from_hex: invalid hex at position {}", i * 2),
+                    )))?;
+                let lo =
+                    parse_hex_digit(lo).ok_or(VmError::from(VmInternalError::InternalError(
+                        format!("uint8array.from_hex: invalid hex at position {}", i * 2 + 1),
+                    )))?;
                 Ok(hi << 4 | lo)
             })
             .collect()
@@ -144,7 +146,9 @@ impl BamlClassUint8Array for PackageBamlImpl {
         use base64::Engine;
         base64::engine::general_purpose::STANDARD
             .decode(base64_str)
-            .map_err(|e| VmError::InternalError(format!("uint8array.from_base64: {e}")))
+            .map_err(|e| {
+                VmInternalError::InternalError(format!("uint8array.from_base64: {e}")).into()
+            })
     }
 
     fn to_base64(uint8array: &[u8]) -> String {

--- a/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
@@ -99,11 +99,10 @@ impl BamlClassUint8Array for PackageBamlImpl {
 
     fn from_hex(hex: &str) -> Result<Vec<u8>, VmRustFnError> {
         #[inline]
-        fn parse_hex_digit(c: u8) -> Option<u8> {
+        const fn parse_hex_digit(c: u8) -> Option<u8> {
             match c {
                 b'0'..=b'9' => Some(c - b'0'),
-                b'a'..=b'f' => Some(c - b'a' + 10),
-                b'A'..=b'F' => Some(c - b'A' + 10),
+                b'a'..=b'f' | b'A'..=b'F' => Some((c & 0x1F) + 9),
                 _ => None,
             }
         }

--- a/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
@@ -1,7 +1,10 @@
 use bex_vm_types::Value;
 
 use super::{BamlClassUint8Array, PackageBamlImpl};
-use crate::errors::{VmInternalError, VmRustFnError};
+use crate::{
+    VmPanic,
+    errors::{VmBamlError, VmRustFnError},
+};
 
 impl BamlClassUint8Array for PackageBamlImpl {
     #[allow(clippy::cast_possible_wrap)]
@@ -51,21 +54,19 @@ impl BamlClassUint8Array for PackageBamlImpl {
     )]
     fn slice(uint8array: &[u8], start: i64, end: i64) -> Vec<u8> {
         let len = uint8array.len() as i64;
-        let start = start.max(0).min(len) as usize;
-        let end = end.max(0).min(len) as usize;
-        let end = end.max(start);
+        let start = start.clamp(0, len);
+        let end = end.clamp(start, len) as usize;
+        let start = start as usize;
         uint8array[start..end].to_vec()
     }
 
     fn zeroes(size: i64) -> Result<Vec<u8>, VmRustFnError> {
-        let size = usize::try_from(size).map_err(|_| {
-            VmInternalError::InternalError(format!("uint8array.zeroes: invalid size {size}"))
+        let size = usize::try_from(size).map_err(|_| VmBamlError::InvalidArgument {
+            message: format!("Invalid size {size} for uint8array"),
         })?;
         let mut v = Vec::new();
-        v.try_reserve(size).map_err(|_| {
-            VmInternalError::InternalError(format!(
-                "uint8array.zeroes: allocation of {size} bytes failed"
-            ))
+        v.try_reserve(size).map_err(|_| VmPanic::AllocFailure {
+            message: format!("Allocation of {size} bytes for new uint8array failed"),
         })?;
         v.resize(size, 0u8);
         Ok(v)
@@ -76,15 +77,13 @@ impl BamlClassUint8Array for PackageBamlImpl {
         let mut result = Vec::with_capacity(array.len());
         for (i, val) in array.iter().enumerate() {
             let Value::Int(n) = val else {
-                return Err(VmInternalError::InternalError(format!(
-                    "uint8array.from_array: element at index {i} is not an integer"
-                ))
+                return Err(VmBamlError::InvalidArgument {
+                    message: format!("Element at index {i} is not an `int`"),
+                }
                 .into());
             };
-            let byte = u8::try_from(*n).map_err(|_| {
-                VmInternalError::InternalError(format!(
-                    "uint8array.from_array: value {n} at index {i} is out of range 0..=255"
-                ))
+            let byte = u8::try_from(*n).map_err(|_| VmBamlError::InvalidArgument {
+                message: format!("Value {n} at index {i} is out of range 0..=255"),
             })?;
             result.push(byte);
         }
@@ -109,27 +108,27 @@ impl BamlClassUint8Array for PackageBamlImpl {
             }
         }
         let (chunks, &[]) = hex.as_bytes().as_chunks::<2>() else {
-            return Err(VmInternalError::InternalError(
-                "uint8array.from_hex: hex string must have even length".to_string(),
-            )
+            return Err(VmBamlError::InvalidArgument {
+                message: "hex string must have even length".to_string(),
+            }
             .into());
         };
         chunks
             .iter()
             .enumerate()
             .map(|(i, &[hi, lo]): (usize, &[u8; 2])| {
-                let hi = parse_hex_digit(hi).ok_or(VmRustFnError::from(
-                    VmInternalError::InternalError(format!(
-                        "uint8array.from_hex: invalid hex at position {}",
+                let hi = parse_hex_digit(hi).ok_or(VmBamlError::InvalidArgument {
+                    message: format!(
+                        "uint8array.from_hex: invalid hex digit at position {}",
                         i * 2
-                    )),
-                ))?;
-                let lo = parse_hex_digit(lo).ok_or(VmRustFnError::from(
-                    VmInternalError::InternalError(format!(
-                        "uint8array.from_hex: invalid hex at position {}",
+                    ),
+                })?;
+                let lo = parse_hex_digit(lo).ok_or(VmBamlError::InvalidArgument {
+                    message: format!(
+                        "uint8array.from_hex: invalid hex digit at position {}",
                         i * 2 + 1
-                    )),
-                ))?;
+                    ),
+                })?;
                 Ok(hi << 4 | lo)
             })
             .collect()
@@ -150,9 +149,10 @@ impl BamlClassUint8Array for PackageBamlImpl {
         use base64::Engine;
         base64::engine::general_purpose::STANDARD
             .decode(base64_str)
-            .map_err(|e| {
-                VmInternalError::InternalError(format!("uint8array.from_base64: {e}")).into()
+            .map_err(|e| VmBamlError::InvalidArgument {
+                message: format!("failed to decode base64: {e}"),
             })
+            .map_err(VmRustFnError::BamlError)
     }
 
     fn to_base64(uint8array: &[u8]) -> String {

--- a/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
@@ -1,7 +1,7 @@
 use bex_vm_types::Value;
 
 use super::{BamlClassUint8Array, PackageBamlImpl};
-use crate::errors::{VmError, VmInternalError};
+use crate::errors::{VmInternalError, VmRustFnError};
 
 impl BamlClassUint8Array for PackageBamlImpl {
     #[allow(clippy::cast_possible_wrap)]
@@ -57,7 +57,7 @@ impl BamlClassUint8Array for PackageBamlImpl {
         uint8array[start..end].to_vec()
     }
 
-    fn zeroes(size: i64) -> Result<Vec<u8>, VmError> {
+    fn zeroes(size: i64) -> Result<Vec<u8>, VmRustFnError> {
         let size = usize::try_from(size).map_err(|_| {
             VmInternalError::InternalError(format!("uint8array.zeroes: invalid size {size}"))
         })?;
@@ -72,7 +72,7 @@ impl BamlClassUint8Array for PackageBamlImpl {
     }
 
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-    fn from_array(array: &[Value]) -> Result<Vec<u8>, VmError> {
+    fn from_array(array: &[Value]) -> Result<Vec<u8>, VmRustFnError> {
         let mut result = Vec::with_capacity(array.len());
         for (i, val) in array.iter().enumerate() {
             let Value::Int(n) = val else {
@@ -98,7 +98,7 @@ impl BamlClassUint8Array for PackageBamlImpl {
             .collect()
     }
 
-    fn from_hex(hex: &str) -> Result<Vec<u8>, VmError> {
+    fn from_hex(hex: &str) -> Result<Vec<u8>, VmRustFnError> {
         #[inline]
         fn parse_hex_digit(c: u8) -> Option<u8> {
             match c {
@@ -118,14 +118,18 @@ impl BamlClassUint8Array for PackageBamlImpl {
             .iter()
             .enumerate()
             .map(|(i, &[hi, lo]): (usize, &[u8; 2])| {
-                let hi =
-                    parse_hex_digit(hi).ok_or(VmError::from(VmInternalError::InternalError(
-                        format!("uint8array.from_hex: invalid hex at position {}", i * 2),
-                    )))?;
-                let lo =
-                    parse_hex_digit(lo).ok_or(VmError::from(VmInternalError::InternalError(
-                        format!("uint8array.from_hex: invalid hex at position {}", i * 2 + 1),
-                    )))?;
+                let hi = parse_hex_digit(hi).ok_or(VmRustFnError::from(
+                    VmInternalError::InternalError(format!(
+                        "uint8array.from_hex: invalid hex at position {}",
+                        i * 2
+                    )),
+                ))?;
+                let lo = parse_hex_digit(lo).ok_or(VmRustFnError::from(
+                    VmInternalError::InternalError(format!(
+                        "uint8array.from_hex: invalid hex at position {}",
+                        i * 2 + 1
+                    )),
+                ))?;
                 Ok(hi << 4 | lo)
             })
             .collect()
@@ -142,7 +146,7 @@ impl BamlClassUint8Array for PackageBamlImpl {
         s
     }
 
-    fn from_base64(base64_str: &str) -> Result<Vec<u8>, VmError> {
+    fn from_base64(base64_str: &str) -> Result<Vec<u8>, VmRustFnError> {
         use base64::Engine;
         base64::engine::general_purpose::STANDARD
             .decode(base64_str)

--- a/baml_language/crates/bex_vm/src/package_baml/unstable.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/unstable.rs
@@ -33,10 +33,16 @@ fn format_value_recursive(
 
         Value::Object(obj_idx) => match vm.get_object(*obj_idx) {
             Object::Instance(instance) => {
-                let Object::Class(class) = vm.get_object(instance.class) else {
-                    return Err(VmInternalError::InternalError(
-                        "Invalid class reference".to_string(),
-                    )
+                let class = vm.get_object(instance.class);
+                let Object::Class(class) = class else {
+                    return Err(VmInternalError::TypeError {
+                        expected: ::bex_vm_types::types::Type::Object(
+                            ::bex_vm_types::ObjectType::Class,
+                        ),
+                        got: ::bex_vm_types::types::Type::Object(::bex_vm_types::ObjectType::of(
+                            class,
+                        )),
+                    }
                     .into());
                 };
 
@@ -98,10 +104,16 @@ fn format_value_recursive(
             Object::String(s) => Ok(format!("\"{s}\"")),
             Object::Enum(e) => Ok(e.name.display_name.to_string()),
             Object::Variant(variant) => {
-                let Object::Enum(enm) = vm.get_object(variant.enm) else {
-                    return Err(VmInternalError::InternalError(
-                        "Invalid enum reference".to_string(),
-                    )
+                let enm = vm.get_object(variant.enm);
+                let Object::Enum(enm) = enm else {
+                    return Err(VmInternalError::TypeError {
+                        expected: ::bex_vm_types::types::Type::Object(
+                            ::bex_vm_types::ObjectType::Enum,
+                        ),
+                        got: ::bex_vm_types::types::Type::Object(::bex_vm_types::ObjectType::of(
+                            enm,
+                        )),
+                    }
                     .into());
                 };
 

--- a/baml_language/crates/bex_vm/src/package_baml/unstable.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/unstable.rs
@@ -5,16 +5,20 @@ use bex_vm_types::types::{Object, Value};
 use super::{BamlNamespaceUnstable, PackageBamlImpl};
 use crate::{
     BexVm,
-    errors::{VmError, VmInternalError, VmPanic},
+    errors::{VmInternalError, VmPanic, VmRustFnError},
 };
 
 impl BamlNamespaceUnstable for PackageBamlImpl {
-    fn string(vm: &mut BexVm, value: &Value) -> Result<String, VmError> {
+    fn string(vm: &mut BexVm, value: &Value) -> Result<String, VmRustFnError> {
         format_value_recursive(vm, value, 0)
     }
 }
 
-fn format_value_recursive(vm: &mut BexVm, value: &Value, depth: usize) -> Result<String, VmError> {
+fn format_value_recursive(
+    vm: &mut BexVm,
+    value: &Value,
+    depth: usize,
+) -> Result<String, VmRustFnError> {
     let available_frames = crate::vm::MAX_FRAMES.saturating_sub(vm.frames.len());
 
     if depth >= available_frames {

--- a/baml_language/crates/bex_vm/src/package_baml/unstable.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/unstable.rs
@@ -5,7 +5,7 @@ use bex_vm_types::types::{Object, Value};
 use super::{BamlNamespaceUnstable, PackageBamlImpl};
 use crate::{
     BexVm,
-    errors::{VmError, VmPanic},
+    errors::{VmError, VmInternalError, VmPanic},
 };
 
 impl BamlNamespaceUnstable for PackageBamlImpl {
@@ -30,9 +30,10 @@ fn format_value_recursive(vm: &mut BexVm, value: &Value, depth: usize) -> Result
         Value::Object(obj_idx) => match vm.get_object(*obj_idx) {
             Object::Instance(instance) => {
                 let Object::Class(class) = vm.get_object(instance.class) else {
-                    return Err(VmError::InternalError(
+                    return Err(VmInternalError::InternalError(
                         "Invalid class reference".to_string(),
-                    ));
+                    )
+                    .into());
                 };
 
                 let class_name = class.name.clone();
@@ -94,7 +95,10 @@ fn format_value_recursive(vm: &mut BexVm, value: &Value, depth: usize) -> Result
             Object::Enum(e) => Ok(e.name.display_name.to_string()),
             Object::Variant(variant) => {
                 let Object::Enum(enm) = vm.get_object(variant.enm) else {
-                    return Err(VmError::InternalError("Invalid enum reference".to_string()));
+                    return Err(VmInternalError::InternalError(
+                        "Invalid enum reference".to_string(),
+                    )
+                    .into());
                 };
 
                 let variant_name = match enm.variants.get(variant.index) {

--- a/baml_language/crates/bex_vm/src/types.rs
+++ b/baml_language/crates/bex_vm/src/types.rs
@@ -3,12 +3,12 @@ use bex_vm_types::{
     types::{Function, FunctionType, ObjectType},
 };
 
-use crate::errors::VmError;
+use crate::errors::VmInternalError;
 
 pub trait ObjectTrait {
-    fn as_function(&self) -> Result<&Function, VmError>;
-    fn as_string(&self) -> Result<&String, VmError>;
-    fn as_string_mut(&mut self) -> Result<&mut String, VmError>;
+    fn as_function(&self) -> Result<&Function, VmInternalError>;
+    fn as_string(&self) -> Result<&String, VmInternalError>;
+    fn as_string_mut(&mut self) -> Result<&mut String, VmInternalError>;
 }
 
 impl ObjectTrait for Object {
@@ -17,19 +17,19 @@ impl ObjectTrait for Object {
     /// Used to deal with some borrow checker issues in the [`crate::vm::BexVm::exec`]
     /// function.
     #[inline]
-    fn as_function(&self) -> Result<&Function, VmError> {
+    fn as_function(&self) -> Result<&Function, VmInternalError> {
         match self {
             Object::Function(function) => Ok(function),
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: FunctionType::Any.into(),
                 got: ObjectType::of(self).into(),
             }),
         }
     }
 
-    fn as_string(&self) -> Result<&String, VmError> {
+    fn as_string(&self) -> Result<&String, VmInternalError> {
         let Self::String(str) = self else {
-            return Err(VmError::TypeError {
+            return Err(VmInternalError::TypeError {
                 expected: ObjectType::String.into(),
                 got: ObjectType::of(self).into(),
             });
@@ -38,9 +38,9 @@ impl ObjectTrait for Object {
         Ok(str)
     }
 
-    fn as_string_mut(&mut self) -> Result<&mut String, VmError> {
+    fn as_string_mut(&mut self) -> Result<&mut String, VmInternalError> {
         let Self::String(str) = self else {
-            return Err(VmError::TypeError {
+            return Err(VmInternalError::TypeError {
                 expected: ObjectType::String.into(),
                 got: ObjectType::of(self).into(),
             });

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -17,6 +17,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use ::bex_vm_types::types::ErrorClass;
+use ::core::any::TypeId;
 use bex_heap::{BexHeap, Tlab};
 use bex_vm_types::{
     BinOp, CmpOp, FunctionKind, GlobalPool, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool,
@@ -858,11 +859,13 @@ impl BexVm {
         };
         let obj = self.get_object(ptr);
         match obj {
-            Object::RustData(arc) => arc.downcast_ref::<T>().ok_or_else(|| {
-                VmInternalError::InternalError(
-                    "RustData downcast failed: wrong concrete type".to_string(),
-                )
-            }),
+            Object::RustData(arc) => {
+                arc.downcast_ref::<T>()
+                    .ok_or_else(|| VmInternalError::RustTypeError {
+                        expected: TypeId::of::<T>(),
+                        got: arc.as_ref().type_id(),
+                    })
+            }
             _ => Err(VmInternalError::TypeError {
                 expected: Type::Object(ObjectType::RustData),
                 got: self.type_of(value),
@@ -939,11 +942,6 @@ impl BexVm {
                 })
             })
             .collect::<Result<Vec<_>, VmError>>()
-            .map_err(|e| {
-                VmError::from(VmInternalError::InternalError(format!(
-                    "internal error: Vm::stack_trace() failed to build stack trace: {e}\n\noriginal error: {error}"
-                )))
-            })
             .unwrap_or_default();
 
         StackTrace { error, trace }
@@ -955,10 +953,13 @@ impl BexVm {
     /// When the new control flow ends (given functions pops from the stack)
     /// then the previosly running bytecode resumes execution.
     fn interrupt(&mut self, function_ptr: HeapPtr, args: &[Value]) -> Result<VmExecState, VmError> {
-        if !matches!(self.get_object(function_ptr), Object::Function(_)) {
-            return Err(
-                VmInternalError::InternalError("Invalid interrupt function".to_string()).into(),
-            );
+        let obj = self.get_object(function_ptr);
+        if !matches!(obj, Object::Function(_)) {
+            return Err(VmInternalError::TypeError {
+                expected: Type::Object(ObjectType::Function(FunctionType::Any)),
+                got: Type::Object(ObjectType::of(obj)),
+            }
+            .into());
         }
 
         // Index of the frame that starts the interrupt code.
@@ -985,7 +986,8 @@ impl BexVm {
         &mut self,
         function_ptr: HeapPtr,
     ) -> Result<(), VmInternalError> {
-        let real_local_count = match self.get_object(function_ptr) {
+        let obj = self.get_object(function_ptr);
+        let real_local_count = match obj {
             Object::Function(function) => function.real_local_count,
             Object::Closure(closure) => {
                 // SAFETY: closure.function points to a Function object with
@@ -994,16 +996,18 @@ impl BexVm {
                 match func_obj {
                     Object::Function(f) => f.real_local_count,
                     _ => {
-                        return Err(VmInternalError::InternalError(
-                            "Invalid closure inner function".to_string(),
-                        ));
+                        return Err(VmInternalError::TypeError {
+                            expected: Type::Object(ObjectType::Function(FunctionType::Any)),
+                            got: Type::Object(ObjectType::of(func_obj)),
+                        });
                     }
                 }
             }
             _ => {
-                return Err(VmInternalError::InternalError(
-                    "Invalid frame function".to_string(),
-                ));
+                return Err(VmInternalError::TypeError {
+                    expected: Type::Object(ObjectType::Any),
+                    got: Type::Object(ObjectType::of(obj)),
+                });
             }
         };
 
@@ -1437,13 +1441,17 @@ impl BexVm {
                                 filtered_notifications.push(notification);
                             }
                         }
-
-                        other => {
-                            return Err(VmInternalError::InternalError(format!(
-                                "Invalid filter function return: {other:?}"
-                            ))
+                        Ok(VmExecState::Complete(other)) => {
+                            return Err(VmInternalError::TypeError {
+                                expected: Type::Bool,
+                                got: self.type_of(&other),
+                            }
                             .into());
                         }
+                        Ok(_) => {
+                            return Err(VmInternalError::ExpectedCompletion.into());
+                        }
+                        Err(err) => return Err(err),
                     }
                 }
             }
@@ -2703,16 +2711,11 @@ impl BexVm {
                         Object::String(mode) if mode == "manual" => WatchFilter::Manual,
                         Object::String(mode) if mode == "never" => WatchFilter::Paused,
                         _ => {
-                            return Err(VmInternalError::InternalError(
-                                "Invalid filter".to_string(),
-                            )
-                            .into());
+                            return Err(VmInternalError::InvalidFilter.into());
                         }
                     },
                     _ => {
-                        return Err(
-                            VmInternalError::InternalError("Invalid filter".to_string()).into()
-                        );
+                        return Err(VmInternalError::InvalidFilter.into());
                     }
                 };
 
@@ -2787,10 +2790,7 @@ impl BexVm {
                 let notifications = self.watch.copy_roots_reaching(var_node);
 
                 if notifications.len() != 1 && notifications.first() != Some(&var_node) {
-                    return Err(VmInternalError::InternalError(
-                        "Invalid manual notify".to_string(),
-                    )
-                    .into());
+                    return Err(VmInternalError::InvalidManualNotify.into());
                 }
 
                 return Ok(Some(VmExecState::Notify(WatchNotification::Variables(

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1099,6 +1099,10 @@ impl BexVm {
                 let msg = self.alloc_string("unreachable code executed".to_string());
                 (PanicClass::Unreachable, vec![msg])
             }
+            VmPanic::AllocFailure { message } => {
+                let msg = self.alloc_string(message);
+                (PanicClass::AllocFailure, vec![msg])
+            }
         };
         self.alloc_panic_value(class, fields)
     }
@@ -2455,13 +2459,8 @@ impl BexVm {
                             }
                             .into());
                         };
-                        let Ok(i) = u8::try_from(i) else {
-                            return Err(VmInternalError::InternalError(format!(
-                                "uint8array store: value {i} out of range 0..=255"
-                            ))
-                            .into());
-                        };
-                        bytes[index] = i;
+                        // following JS, we truncate the value to 8-bit unsigned integer
+                        bytes[index] = (i.cast_unsigned() & 0xFF) as u8;
                     }
                     _ => {
                         unreachable!(

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -16,6 +16,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use ::bex_vm_types::types::ErrorClass;
 use bex_heap::{BexHeap, Tlab};
 use bex_vm_types::{
     BinOp, CmpOp, FunctionKind, GlobalPool, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool,
@@ -29,7 +30,7 @@ use indexmap::IndexMap;
 
 use crate::{
     StackTrace,
-    errors::{ErrorLocation, VmError, VmInternalError, VmPanic},
+    errors::{ErrorLocation, VmBamlError, VmError, VmInternalError, VmPanic, VmRustFnError},
     indexable::{EvalStack, EvalStackTrait},
     package_baml::{BamlPackageBaml, NativeFunction},
     types::ObjectTrait,
@@ -196,6 +197,10 @@ pub struct BexVm {
     /// Used by `resolve_class()` for generated `copy::` struct `to_value()` methods.
     /// Populated at VM construction time from the compiled program's class index.
     pub resolved_class_names: HashMap<String, HeapPtr>,
+
+    /// Pre-resolved heap pointers for `baml.errors.*` classes, indexed by
+    /// `ErrorClass` discriminant.
+    error_class_ptrs: Vec<HeapPtr>,
 
     /// Pre-resolved heap pointers for `baml.panics.*` classes, indexed by
     /// `PanicClass` discriminant.
@@ -424,6 +429,16 @@ impl BexVm {
     ) -> Self {
         let tlab = Tlab::new(Arc::clone(&heap));
 
+        // Pre-resolve error class pointers indexed by Error discriminant.
+        let error_class_ptrs: Vec<HeapPtr> = ErrorClass::ALL
+            .iter()
+            .map(|ec| {
+                *resolved_class_names.get(ec.fqn()).unwrap_or_else(|| {
+                    panic!("error class {:?} not in resolved_class_names", ec.fqn())
+                })
+            })
+            .collect();
+
         // Pre-resolve panic class pointers indexed by PanicClass discriminant.
         let panic_class_ptrs: Vec<HeapPtr> = PanicClass::ALL
             .iter()
@@ -441,6 +456,7 @@ impl BexVm {
             tlab,
             globals,
             resolved_class_names,
+            error_class_ptrs,
             panic_class_ptrs,
             watch: Watch::new(),
             watched_vars: HashMap::new(),
@@ -574,8 +590,7 @@ impl BexVm {
             _ => Err(VmInternalError::TypeError {
                 expected: ObjectType::Array.into(),
                 got: ObjectType::of(obj).into(),
-            }
-            .into()),
+            }),
         }
     }
 
@@ -633,9 +648,9 @@ impl BexVm {
         // This is used by macro-generated code for generic type parameters.
         // For now, we don't support mutable access to generic values.
         let Value::Object(ptr) = value else {
-            return Err(VmInternalError::InvalidObjectRef(0).into());
+            return Err(VmInternalError::InvalidObjectRef(0));
         };
-        Err(VmInternalError::InvalidObjectRef(ptr.as_ptr() as usize).into())
+        Err(VmInternalError::InvalidObjectRef(ptr.as_ptr() as usize))
     }
 
     /// TODO: We should remove this API in favor of using `bex_engine` only (vbv)
@@ -704,7 +719,7 @@ impl BexVm {
 
     /// Returns a reference to the pending future.
     ///
-    /// Returns [`InternalError::TypeError`] if the future is not pending, or not a future.
+    /// Returns [`VmInternalError::TypeError`] if the future is not pending, or not a future.
     pub fn pending_future(&self, future_ptr: HeapPtr) -> Result<&PendingFuture, VmInternalError> {
         match self.get_object(future_ptr) {
             Object::Future(Future::Pending(future)) => Ok(future),
@@ -1006,22 +1021,66 @@ impl BexVm {
         StackIndex::from_raw(locals_offset.raw() + slot - 1)
     }
 
-    /// Convert a `VmError` into a `Value` for exception handling. Errors that
-    /// correspond to a `baml.panics.*` class get their instance allocated on the
-    /// heap. Everything else is a fatal error.
-    fn error_to_exception_value(&mut self, error: VmError) -> Result<Value, VmError> {
-        let panic = match error {
-            VmError::Panic(panic) => panic,
-            other => return Err(other),
+    pub fn error_to_exception_value(&mut self, error: VmBamlError) -> Value {
+        let (class, fields) = match error {
+            VmBamlError::InvalidArgument { message } => (
+                ErrorClass::InvalidArgument,
+                vec![self.alloc_string(message)],
+            ),
+            VmBamlError::Io { message } => (ErrorClass::Io, vec![self.alloc_string(message)]),
+            VmBamlError::Timeout {
+                message,
+                duration_ms,
+            } => (
+                ErrorClass::Timeout,
+                vec![
+                    self.alloc_string(message),
+                    duration_ms.map_or(Value::Null, Value::Int),
+                ],
+            ),
+            VmBamlError::Unsupported { message } => {
+                (ErrorClass::Unsupported, vec![self.alloc_string(message)])
+            }
+            VmBamlError::AccessError { message } => {
+                (ErrorClass::AccessError, vec![self.alloc_string(message)])
+            }
+            VmBamlError::RenderPrompt { message } => {
+                (ErrorClass::RenderPrompt, vec![self.alloc_string(message)])
+            }
+            VmBamlError::NotImplemented { message } => {
+                (ErrorClass::NotImplemented, vec![self.alloc_string(message)])
+            }
+            VmBamlError::LlmClient { message } => {
+                (ErrorClass::LlmClient, vec![self.alloc_string(message)])
+            }
+            VmBamlError::DevOther { message } => {
+                (ErrorClass::DevOther, vec![self.alloc_string(message)])
+            }
+            VmBamlError::HostPanic { message } => {
+                (ErrorClass::HostPanic, vec![self.alloc_string(message)])
+            }
         };
-        let (class, fields) = match &panic {
-            VmPanic::DivisionByZero { left, .. } => (PanicClass::DivisionByZero, vec![*left]),
+        self.alloc_error_value(class, fields)
+    }
+
+    pub(crate) fn alloc_error_value(&mut self, class: ErrorClass, fields: Vec<Value>) -> Value {
+        let class_ptr = self.error_class_ptrs[class as usize];
+        let instance_ptr = self.tlab.alloc(Object::Instance(Instance {
+            class: class_ptr,
+            fields,
+        }));
+        Value::Object(instance_ptr)
+    }
+
+    pub(crate) fn panic_to_exception_value(&mut self, panic: VmPanic) -> Value {
+        let (class, fields) = match panic {
+            VmPanic::DivisionByZero { left, .. } => (PanicClass::DivisionByZero, vec![left]),
             VmPanic::IndexOutOfBounds { index, length } =>
             {
                 #[allow(clippy::cast_possible_wrap)]
                 (
                     PanicClass::IndexOutOfBounds,
-                    vec![Value::Int(*index), Value::Int(*length as i64)],
+                    vec![Value::Int(index), Value::Int(length as i64)],
                 )
             }
             VmPanic::MapKeyNotFound => {
@@ -1041,11 +1100,11 @@ impl BexVm {
                 (PanicClass::Unreachable, vec![msg])
             }
         };
-        Ok(self.alloc_panic_value(class, fields))
+        self.alloc_panic_value(class, fields)
     }
 
     /// Allocate a `baml.panics.*` class instance using pre-resolved pointers.
-    fn alloc_panic_value(&mut self, class: PanicClass, fields: Vec<Value>) -> Value {
+    pub fn alloc_panic_value(&mut self, class: PanicClass, fields: Vec<Value>) -> Value {
         let class_ptr = self.panic_class_ptrs[class as usize];
         let instance_ptr = self.tlab.alloc(Object::Instance(Instance {
             class: class_ptr,
@@ -1115,9 +1174,7 @@ impl BexVm {
             // No handler in this frame -- pop it and try the caller.
             if self.frames.len() <= 1 {
                 // No more frames to unwind through.
-                return Err(VmError::UnhandledThrow {
-                    value: exception_value,
-                });
+                return Err(VmError::Thrown(exception_value));
             }
 
             let popped = self.frames.pop().expect("frame stack is not empty");
@@ -1215,7 +1272,9 @@ impl BexVm {
 
         // Check if we've reached the max call stack size.
         if self.frames.len() >= MAX_FRAMES {
-            return Err(VmError::Panic(VmPanic::StackOverflow));
+            return Err(VmError::Thrown(
+                self.panic_to_exception_value(VmPanic::StackOverflow),
+            ));
         }
 
         let is_traced = callee.trace;
@@ -1234,8 +1293,19 @@ impl BexVm {
                 // reference in the stack, using `swap` to insert the result.
                 let args = self.stack[locals_offset..].to_owned();
 
-                // Run Rust native function.
-                let result = func(self, &args)?;
+                // Run Rust native function, converting VmRustFnError → VmError.
+                let result = match func(self, &args) {
+                    Ok(v) => v,
+                    Err(VmRustFnError::Panic(panic)) => {
+                        return Err(VmError::Thrown(self.panic_to_exception_value(panic)));
+                    }
+                    Err(VmRustFnError::BamlError(err)) => {
+                        return Err(VmError::Thrown(self.error_to_exception_value(err)));
+                    }
+                    Err(VmRustFnError::InternalError(err)) => {
+                        return Err(VmError::InternalError(err));
+                    }
+                };
 
                 // Drop function call and place result on top.
                 self.stack.drain(locals_offset..);
@@ -1446,8 +1516,7 @@ impl BexVm {
             _ => Err(VmInternalError::TypeError {
                 expected: FunctionType::Callable.into(),
                 got: ObjectType::of(obj).into(),
-            }
-            .into()),
+            }),
         }
     }
 
@@ -1512,8 +1581,8 @@ impl BexVm {
             match step_result {
                 Ok(Some(state)) => return Ok(state),
                 Ok(None) => {}
-                Err(error) => {
-                    let exception_value = self.error_to_exception_value(error)?;
+                Err(VmError::InternalError(err)) => return Err(VmError::InternalError(err)),
+                Err(VmError::Thrown(exception_value)) => {
                     self.try_unwind_exception(&mut frame_idx, &mut function, exception_value)?;
                 }
             }
@@ -1560,10 +1629,10 @@ impl BexVm {
 
                 #[allow(clippy::cast_possible_wrap)]
                 let node = function.viz_nodes.get(index).ok_or({
-                    VmPanic::IndexOutOfBounds {
+                    VmError::Thrown(self.panic_to_exception_value(VmPanic::IndexOutOfBounds {
                         index: index as i64,
                         length: function.viz_nodes.len(),
-                    }
+                    }))
                 })?;
 
                 let event = bytecode::VizExecEvent {
@@ -1782,11 +1851,12 @@ impl BexVm {
                 let result = match (left, right) {
                     (Value::Int(left), Value::Int(right)) => Value::Int(match op {
                         BinOp::Div if right == 0 => {
-                            return Err(VmPanic::DivisionByZero {
-                                left: Value::Int(left),
-                                right: Value::Int(right),
-                            }
-                            .into());
+                            return Err(VmError::Thrown(self.panic_to_exception_value(
+                                VmPanic::DivisionByZero {
+                                    left: Value::Int(left),
+                                    right: Value::Int(right),
+                                },
+                            )));
                         }
 
                         BinOp::Add => left + right,
@@ -1805,11 +1875,12 @@ impl BexVm {
                     (Value::Float(left), Value::Float(right)) => {
                         Value::Float(match op {
                             BinOp::Div if right == 0.0 => {
-                                return Err(VmPanic::DivisionByZero {
-                                    left: Value::Float(left),
-                                    right: Value::Float(right),
-                                }
-                                .into());
+                                return Err(VmError::Thrown(self.panic_to_exception_value(
+                                    VmPanic::DivisionByZero {
+                                        left: Value::Float(left),
+                                        right: Value::Float(right),
+                                    },
+                                )));
                             }
 
                             BinOp::Add => left + right,
@@ -1840,11 +1911,12 @@ impl BexVm {
                         let left = left as f64;
                         Value::Float(match op {
                             BinOp::Div if right == 0.0 => {
-                                return Err(VmPanic::DivisionByZero {
-                                    left: Value::Float(left),
-                                    right: Value::Float(right),
-                                }
-                                .into());
+                                return Err(VmError::Thrown(self.panic_to_exception_value(
+                                    VmPanic::DivisionByZero {
+                                        left: Value::Float(left),
+                                        right: Value::Float(right),
+                                    },
+                                )));
                             }
 
                             BinOp::Add => left + right,
@@ -1873,11 +1945,12 @@ impl BexVm {
                         let right = right as f64;
                         Value::Float(match op {
                             BinOp::Div if right == 0.0 => {
-                                return Err(VmPanic::DivisionByZero {
-                                    left: Value::Float(left),
-                                    right: Value::Float(right),
-                                }
-                                .into());
+                                return Err(VmError::Thrown(self.panic_to_exception_value(
+                                    VmPanic::DivisionByZero {
+                                        left: Value::Float(left),
+                                        right: Value::Float(right),
+                                    },
+                                )));
                             }
 
                             BinOp::Add => left + right,
@@ -2180,11 +2253,12 @@ impl BexVm {
                 let index = match index_value {
                     Value::Int(i) => {
                         if i < 0 || i as usize >= array_len {
-                            return Err(VmPanic::IndexOutOfBounds {
-                                index: i,
-                                length: array_len,
-                            }
-                            .into());
+                            return Err(VmError::Thrown(self.panic_to_exception_value(
+                                VmPanic::IndexOutOfBounds {
+                                    index: i,
+                                    length: array_len,
+                                },
+                            )));
                         }
                         i as usize
                     }
@@ -2203,21 +2277,23 @@ impl BexVm {
                     match self.get_object(array_obj_index) {
                         Object::Array(array) => {
                             if index >= array.len() {
-                                return Err(VmPanic::IndexOutOfBounds {
-                                    index: index as i64,
-                                    length: array.len(),
-                                }
-                                .into());
+                                return Err(VmError::Thrown(self.panic_to_exception_value(
+                                    VmPanic::IndexOutOfBounds {
+                                        index: index as i64,
+                                        length: array.len(),
+                                    },
+                                )));
                             }
                             array[index]
                         }
                         Object::Uint8Array(bytes) => {
                             if index >= bytes.len() {
-                                return Err(VmPanic::IndexOutOfBounds {
-                                    index: index as i64,
-                                    length: bytes.len(),
-                                }
-                                .into());
+                                return Err(VmError::Thrown(self.panic_to_exception_value(
+                                    VmPanic::IndexOutOfBounds {
+                                        index: index as i64,
+                                        length: bytes.len(),
+                                    },
+                                )));
                             }
                             Value::Int(i64::from(bytes[index]))
                         }
@@ -2271,7 +2347,9 @@ impl BexVm {
                 let key = self.get_object(key_index).as_string()?;
 
                 // Look up the value in the map
-                let value = map.get(key).copied().ok_or(VmPanic::MapKeyNotFound)?;
+                let value = map.get(key).copied().ok_or(VmError::Thrown(
+                    self.panic_to_exception_value(VmPanic::MapKeyNotFound),
+                ))?;
 
                 // Push the value onto the stack
                 self.stack.push(value);
@@ -2303,11 +2381,12 @@ impl BexVm {
                 let index = match index_value {
                     Value::Int(i) => {
                         if i < 0 || i as usize >= array_len {
-                            return Err(VmPanic::IndexOutOfBounds {
-                                index: i,
-                                length: array_len,
-                            }
-                            .into());
+                            return Err(VmError::Thrown(self.panic_to_exception_value(
+                                VmPanic::IndexOutOfBounds {
+                                    index: i,
+                                    length: array_len,
+                                },
+                            )));
                         }
                         i as usize
                     }
@@ -2325,21 +2404,23 @@ impl BexVm {
                 let old_value = match self.get_object(array_object_index) {
                     Object::Array(array) => {
                         if index >= array.len() {
-                            return Err(VmPanic::IndexOutOfBounds {
-                                index: index as i64,
-                                length: array.len(),
-                            }
-                            .into());
+                            return Err(VmError::Thrown(self.panic_to_exception_value(
+                                VmPanic::IndexOutOfBounds {
+                                    index: index as i64,
+                                    length: array.len(),
+                                },
+                            )));
                         }
                         array[index]
                     }
                     Object::Uint8Array(bytes) => {
                         if index >= bytes.len() {
-                            return Err(VmPanic::IndexOutOfBounds {
-                                index: index as i64,
-                                length: bytes.len(),
-                            }
-                            .into());
+                            return Err(VmError::Thrown(self.panic_to_exception_value(
+                                VmPanic::IndexOutOfBounds {
+                                    index: index as i64,
+                                    length: bytes.len(),
+                                },
+                            )));
                         }
                         Value::Int(i64::from(bytes[index]))
                     }
@@ -2506,11 +2587,12 @@ impl BexVm {
                 // Safe: we check variant_index < 0 first, so the cast
                 // only executes for non-negative values.
                 if variant_index < 0 || variant_index as usize >= variant_count {
-                    return Err(VmPanic::IndexOutOfBounds {
-                        index: variant_index,
-                        length: variant_count,
-                    }
-                    .into());
+                    return Err(VmError::Thrown(self.panic_to_exception_value(
+                        VmPanic::IndexOutOfBounds {
+                            index: variant_index,
+                            length: variant_count,
+                        },
+                    )));
                 }
 
                 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
@@ -2946,7 +3028,9 @@ impl BexVm {
             Instruction::Unreachable => {
                 // This instruction should never be executed. If we reach it,
                 // there's a bug in the compiler or type system.
-                return Err(VmPanic::Unreachable.into());
+                return Err(VmError::Thrown(
+                    self.panic_to_exception_value(VmPanic::Unreachable),
+                ));
             }
 
             Instruction::MakeCell => {

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -29,7 +29,7 @@ use indexmap::IndexMap;
 
 use crate::{
     StackTrace,
-    errors::{ErrorLocation, VmError, VmPanic},
+    errors::{ErrorLocation, VmError, VmInternalError, VmPanic},
     indexable::{EvalStack, EvalStackTrait},
     package_baml::{BamlPackageBaml, NativeFunction},
     types::ObjectTrait,
@@ -325,7 +325,7 @@ pub struct BytecodeProgram {
 /// This is the bridge between compilation output and VM execution. It:
 /// 1. Attaches native function implementations to builtin functions
 /// 2. Builds resolved name lookups for functions, classes, and enums
-pub fn convert_program(program: bex_vm_types::Program) -> Result<BytecodeProgram, VmError> {
+pub fn convert_program(program: bex_vm_types::Program) -> Result<BytecodeProgram, VmInternalError> {
     // Convert objects, attaching native functions
     let objects: Vec<Object> = program
         .objects
@@ -509,9 +509,13 @@ impl BexVm {
     }
 
     /// Helper method to get `HeapPtr` from a Value, with type checking.
-    fn as_object_ptr(&self, value: &Value, object_type: ObjectType) -> Result<HeapPtr, VmError> {
+    fn as_object_ptr(
+        &self,
+        value: &Value,
+        object_type: ObjectType,
+    ) -> Result<HeapPtr, VmInternalError> {
         let Value::Object(ptr) = value else {
-            return Err(VmError::TypeError {
+            return Err(VmInternalError::TypeError {
                 expected: object_type.into(),
                 got: self.type_of(value),
             });
@@ -520,18 +524,18 @@ impl BexVm {
     }
 
     /// Get string from a Value.
-    pub fn as_string(&self, value: &Value) -> Result<&String, VmError> {
+    pub fn as_string(&self, value: &Value) -> Result<&String, VmInternalError> {
         let ptr = self.as_object_ptr(value, ObjectType::String)?;
         self.get_object(ptr).as_string()
     }
 
     /// Get uint8array from a Value.
-    pub fn as_uint8array(&self, value: &Value) -> Result<&Vec<u8>, VmError> {
+    pub fn as_uint8array(&self, value: &Value) -> Result<&Vec<u8>, VmInternalError> {
         let ptr = self.as_object_ptr(value, ObjectType::Uint8Array)?;
         let obj = self.get_object(ptr);
         match obj {
             Object::Uint8Array(bytes) => Ok(bytes),
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: ObjectType::Uint8Array.into(),
                 got: ObjectType::of(obj).into(),
             }),
@@ -539,11 +543,11 @@ impl BexVm {
     }
 
     /// Get mutable uint8array from a Value.
-    pub fn as_uint8array_mut(&mut self, value: &Value) -> Result<&mut Vec<u8>, VmError> {
+    pub fn as_uint8array_mut(&mut self, value: &Value) -> Result<&mut Vec<u8>, VmInternalError> {
         let ptr = self.as_object_ptr(value, ObjectType::Uint8Array)?;
         match self.get_object_mut(ptr) {
             Object::Uint8Array(bytes) => Ok(bytes),
-            other => Err(VmError::TypeError {
+            other => Err(VmInternalError::TypeError {
                 expected: ObjectType::Uint8Array.into(),
                 got: ObjectType::of(other).into(),
             }),
@@ -556,30 +560,31 @@ impl BexVm {
     }
 
     /// Get mutable string from a Value.
-    pub fn as_string_mut(&mut self, value: &Value) -> Result<&mut String, VmError> {
+    pub fn as_string_mut(&mut self, value: &Value) -> Result<&mut String, VmInternalError> {
         let ptr = self.as_object_ptr(value, ObjectType::String)?;
         self.get_object_mut(ptr).as_string_mut()
     }
 
     /// Get array from a Value.
-    pub fn as_array(&self, value: &Value) -> Result<&[Value], VmError> {
+    pub fn as_array(&self, value: &Value) -> Result<&[Value], VmInternalError> {
         let ptr = self.as_object_ptr(value, ObjectType::Array)?;
         let obj = self.get_object(ptr);
         match obj {
             Object::Array(arr) => Ok(arr.as_slice()),
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: ObjectType::Array.into(),
                 got: ObjectType::of(obj).into(),
-            }),
+            }
+            .into()),
         }
     }
 
     /// Get mutable array from a Value.
-    pub fn as_array_mut(&mut self, value: &Value) -> Result<&mut Vec<Value>, VmError> {
+    pub fn as_array_mut(&mut self, value: &Value) -> Result<&mut Vec<Value>, VmInternalError> {
         let ptr = self.as_object_ptr(value, ObjectType::Array)?;
         // Check type first to avoid borrow issues
         if !matches!(self.get_object(ptr), Object::Array(_)) {
-            return Err(VmError::TypeError {
+            return Err(VmInternalError::TypeError {
                 expected: ObjectType::Array.into(),
                 got: ObjectType::of(self.get_object(ptr)).into(),
             });
@@ -591,12 +596,12 @@ impl BexVm {
     }
 
     /// Get map from a Value.
-    pub fn as_map(&self, value: &Value) -> Result<&IndexMap<String, Value>, VmError> {
+    pub fn as_map(&self, value: &Value) -> Result<&IndexMap<String, Value>, VmInternalError> {
         let index = self.as_object_ptr(value, ObjectType::Map)?;
         let obj = self.get_object(index);
         match obj {
             Object::Map(map) => Ok(map),
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: ObjectType::Map.into(),
                 got: ObjectType::of(obj).into(),
             }),
@@ -604,11 +609,14 @@ impl BexVm {
     }
 
     /// Get mutable map from a Value.
-    pub fn as_map_mut(&mut self, value: &Value) -> Result<&mut IndexMap<String, Value>, VmError> {
+    pub fn as_map_mut(
+        &mut self,
+        value: &Value,
+    ) -> Result<&mut IndexMap<String, Value>, VmInternalError> {
         let index = self.as_object_ptr(value, ObjectType::Map)?;
         // Check type first to avoid borrow issues
         if !matches!(self.get_object(index), Object::Map(_)) {
-            return Err(VmError::TypeError {
+            return Err(VmInternalError::TypeError {
                 expected: ObjectType::Map.into(),
                 got: ObjectType::of(self.get_object(index)).into(),
             });
@@ -621,13 +629,13 @@ impl BexVm {
 
     /// Get Value reference (for generic types).
     #[allow(dead_code)]
-    pub fn as_value_mut(&mut self, value: &Value) -> Result<&mut Value, VmError> {
+    pub fn as_value_mut(&mut self, value: &Value) -> Result<&mut Value, VmInternalError> {
         // This is used by macro-generated code for generic type parameters.
         // For now, we don't support mutable access to generic values.
         let Value::Object(ptr) = value else {
-            return Err(VmError::InvalidObjectRef(0));
+            return Err(VmInternalError::InvalidObjectRef(0).into());
         };
-        Err(VmError::InvalidObjectRef(ptr.as_ptr() as usize))
+        Err(VmInternalError::InvalidObjectRef(ptr.as_ptr() as usize).into())
     }
 
     /// TODO: We should remove this API in favor of using `bex_engine` only (vbv)
@@ -635,7 +643,7 @@ impl BexVm {
     ///
     /// This is primarily for testing. In production, use `BexEngine` which
     /// manages the heap across multiple VM instances.
-    pub fn from_program(program: bex_vm_types::Program) -> Result<Self, VmError> {
+    pub fn from_program(program: bex_vm_types::Program) -> Result<Self, VmInternalError> {
         let bytecode = convert_program(program)?;
 
         // Extract compile-time objects for the heap
@@ -696,11 +704,11 @@ impl BexVm {
 
     /// Returns a reference to the pending future.
     ///
-    /// Returns [`VmError::TypeError`] if the future is not pending, or not a future.
-    pub fn pending_future(&self, future_ptr: HeapPtr) -> Result<&PendingFuture, VmError> {
+    /// Returns [`InternalError::TypeError`] if the future is not pending, or not a future.
+    pub fn pending_future(&self, future_ptr: HeapPtr) -> Result<&PendingFuture, VmInternalError> {
         match self.get_object(future_ptr) {
             Object::Future(Future::Pending(future)) => Ok(future),
-            other => Err(VmError::TypeError {
+            other => Err(VmInternalError::TypeError {
                 expected: FutureType::Pending.into(),
                 got: ObjectType::of(other).into(),
             }),
@@ -712,9 +720,13 @@ impl BexVm {
     /// Use this for sync operations that complete during `ScheduleFuture` handling,
     /// before the VM reaches the `Await` instruction. The `Await` instruction will
     /// extract the value from the Ready future.
-    pub fn set_future_ready(&mut self, future_ptr: HeapPtr, value: Value) -> Result<(), VmError> {
+    pub fn set_future_ready(
+        &mut self,
+        future_ptr: HeapPtr,
+        value: Value,
+    ) -> Result<(), VmInternalError> {
         let Object::Future(future) = self.get_object_mut(future_ptr) else {
-            return Err(VmError::TypeError {
+            return Err(VmInternalError::TypeError {
                 expected: FutureType::Any.into(),
                 got: ObjectType::of(self.get_object(future_ptr)).into(),
             });
@@ -729,7 +741,11 @@ impl BexVm {
     /// Use this for async operations that complete while the VM is blocked at
     /// an `Await` instruction. This replaces the future on the stack with the
     /// ready value so execution can continue.
-    pub fn fulfil_future(&mut self, future_ptr: HeapPtr, value: Value) -> Result<(), VmError> {
+    pub fn fulfil_future(
+        &mut self,
+        future_ptr: HeapPtr,
+        value: Value,
+    ) -> Result<(), VmInternalError> {
         self.set_future_ready(future_ptr, value)?;
 
         // At any given moment, the VM can only await a single future, because
@@ -790,12 +806,15 @@ impl BexVm {
     }
 
     /// Get collector ref from a Value.
-    pub fn as_collector(&self, value: &Value) -> Result<&bex_vm_types::CollectorRef, VmError> {
+    pub fn as_collector(
+        &self,
+        value: &Value,
+    ) -> Result<&bex_vm_types::CollectorRef, VmInternalError> {
         let index = self.as_object_ptr(value, ObjectType::Collector)?;
         let obj = self.get_object(index);
         match obj {
             Object::Collector(c) => Ok(c),
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: ObjectType::Collector.into(),
                 got: ObjectType::of(obj).into(),
             }),
@@ -812,11 +831,11 @@ impl BexVm {
     /// Downcast a `Value::Object` pointing to `Object::RustData` to `&T`.
     ///
     /// Used by generated `view::` struct accessors for `$rust_type` fields.
-    pub fn as_rust_data<T: 'static>(&self, value: &Value) -> Result<&T, VmError> {
+    pub fn as_rust_data<T: 'static>(&self, value: &Value) -> Result<&T, VmInternalError> {
         let ptr = match value {
             Value::Object(ptr) => *ptr,
             other => {
-                return Err(VmError::TypeError {
+                return Err(VmInternalError::TypeError {
                     expected: Type::Object(ObjectType::RustData),
                     got: self.type_of(other),
                 });
@@ -825,9 +844,11 @@ impl BexVm {
         let obj = self.get_object(ptr);
         match obj {
             Object::RustData(arc) => arc.downcast_ref::<T>().ok_or_else(|| {
-                VmError::InternalError("RustData downcast failed: wrong concrete type".to_string())
+                VmInternalError::InternalError(
+                    "RustData downcast failed: wrong concrete type".to_string(),
+                )
             }),
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: Type::Object(ObjectType::RustData),
                 got: self.type_of(value),
             }),
@@ -837,11 +858,11 @@ impl BexVm {
     /// Extract an `&Instance` from a `Value::Object`.
     ///
     /// Used by generated glue code to construct `view::` structs.
-    pub fn as_instance(&self, value: &Value) -> Result<&Instance, VmError> {
+    pub fn as_instance(&self, value: &Value) -> Result<&Instance, VmInternalError> {
         let ptr = match value {
             Value::Object(ptr) => *ptr,
             other => {
-                return Err(VmError::TypeError {
+                return Err(VmInternalError::TypeError {
                     expected: Type::Object(ObjectType::Instance),
                     got: self.type_of(other),
                 });
@@ -850,7 +871,7 @@ impl BexVm {
         let obj = self.get_object(ptr);
         match obj {
             Object::Instance(instance) => Ok(instance),
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: Type::Object(ObjectType::Instance),
                 got: self.type_of(value),
             }),
@@ -904,9 +925,9 @@ impl BexVm {
             })
             .collect::<Result<Vec<_>, VmError>>()
             .map_err(|e| {
-                VmError::InternalError(format!(
+                VmError::from(VmInternalError::InternalError(format!(
                     "internal error: Vm::stack_trace() failed to build stack trace: {e}\n\noriginal error: {error}"
-                ))
+                )))
             })
             .unwrap_or_default();
 
@@ -920,9 +941,9 @@ impl BexVm {
     /// then the previosly running bytecode resumes execution.
     fn interrupt(&mut self, function_ptr: HeapPtr, args: &[Value]) -> Result<VmExecState, VmError> {
         if !matches!(self.get_object(function_ptr), Object::Function(_)) {
-            return Err(VmError::InternalError(
-                "Invalid interrupt function".to_string(),
-            ));
+            return Err(
+                VmInternalError::InternalError("Invalid interrupt function".to_string()).into(),
+            );
         }
 
         // Index of the frame that starts the interrupt code.
@@ -945,7 +966,10 @@ impl BexVm {
         self.exec()
     }
 
-    fn allocate_real_locals_for_frame(&mut self, function_ptr: HeapPtr) -> Result<(), VmError> {
+    fn allocate_real_locals_for_frame(
+        &mut self,
+        function_ptr: HeapPtr,
+    ) -> Result<(), VmInternalError> {
         let real_local_count = match self.get_object(function_ptr) {
             Object::Function(function) => function.real_local_count,
             Object::Closure(closure) => {
@@ -955,14 +979,16 @@ impl BexVm {
                 match func_obj {
                     Object::Function(f) => f.real_local_count,
                     _ => {
-                        return Err(VmError::InternalError(
+                        return Err(VmInternalError::InternalError(
                             "Invalid closure inner function".to_string(),
                         ));
                     }
                 }
             }
             _ => {
-                return Err(VmError::InternalError("Invalid frame function".to_string()));
+                return Err(VmInternalError::InternalError(
+                    "Invalid frame function".to_string(),
+                ));
             }
         };
 
@@ -1028,6 +1054,7 @@ impl BexVm {
         Value::Object(instance_ptr)
     }
 
+    /// Unwinds error values (both thrown and panics).
     fn try_unwind_exception(
         &mut self,
         frame_idx: &mut usize,
@@ -1113,7 +1140,10 @@ impl BexVm {
         }
     }
 
-    fn resolve_callable_target(&self, callee_value: Value) -> Result<(HeapPtr, usize), VmError> {
+    fn resolve_callable_target(
+        &self,
+        callee_value: Value,
+    ) -> Result<(HeapPtr, usize), VmInternalError> {
         let expected_type = FunctionType::Callable;
         let callee_ptr = self.as_object_ptr(&callee_value, expected_type.into())?;
         let obj = self.get_object(callee_ptr);
@@ -1125,13 +1155,13 @@ impl BexVm {
                 let func_obj = unsafe { closure.function.get() };
                 match func_obj {
                     Object::Function(callee_fn) => Ok((callee_ptr, callee_fn.arity)),
-                    _ => Err(VmError::TypeError {
+                    _ => Err(VmInternalError::TypeError {
                         expected: expected_type.into(),
                         got: ObjectType::of(func_obj).into(),
                     }),
                 }
             }
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: expected_type.into(),
                 got: ObjectType::of(obj).into(),
             }),
@@ -1156,28 +1186,31 @@ impl BexVm {
                 match func_obj {
                     Object::Function(f) => f,
                     _ => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: FunctionType::Callable.into(),
                             got: ObjectType::of(func_obj).into(),
-                        });
+                        }
+                        .into());
                     }
                 }
             }
             other => {
-                return Err(VmError::TypeError {
+                return Err(VmInternalError::TypeError {
                     expected: FunctionType::Callable.into(),
                     got: ObjectType::of(other).into(),
-                });
+                }
+                .into());
             }
         };
 
         // Compiler should have already checked this so we could
         // skip it but it's an easy and fast check.
         if arg_count != callee.arity {
-            return Err(VmError::InvalidArgumentCount {
+            return Err(VmInternalError::InvalidArgumentCount {
                 expected: callee.arity,
                 got: arg_count,
-            });
+            }
+            .into());
         }
 
         // Check if we've reached the max call stack size.
@@ -1252,10 +1285,11 @@ impl BexVm {
                     "[VM] tried to CALL SysOp function '{}' via bytecode — SysOps must go through the engine yield path",
                     callee.name
                 );
-                return Err(VmError::TypeError {
+                return Err(VmInternalError::TypeError {
                     expected: FunctionType::Callable.into(),
                     got: FunctionType::from(&callee.kind).into(),
-                });
+                }
+                .into());
             }
 
             FunctionKind::NativeUnresolved => {
@@ -1331,9 +1365,10 @@ impl BexVm {
                         }
 
                         other => {
-                            return Err(VmError::InternalError(format!(
+                            return Err(VmInternalError::InternalError(format!(
                                 "Invalid filter function return: {other:?}"
-                            )));
+                            ))
+                            .into());
                         }
                     }
                 }
@@ -1396,7 +1431,7 @@ impl BexVm {
     ///   2. Drop `'static` and re-deref after each GC safepoint (cheap re-deref,
     ///      still no clone).
     #[inline]
-    unsafe fn load_function(&self, frame_idx: usize) -> Result<&'static Function, VmError> {
+    unsafe fn load_function(&self, frame_idx: usize) -> Result<&'static Function, VmInternalError> {
         let ptr = self.frames[frame_idx].function;
         // SAFETY: See doc comment above.
         let obj: &'static Object = unsafe { ptr.get() };
@@ -1408,10 +1443,11 @@ impl BexVm {
                 let func_obj: &'static Object = unsafe { closure.function.get() };
                 func_obj.as_function()
             }
-            _ => Err(VmError::TypeError {
+            _ => Err(VmInternalError::TypeError {
                 expected: FunctionType::Callable.into(),
                 got: ObjectType::of(obj).into(),
-            }),
+            }
+            .into()),
         }
     }
 
@@ -1627,10 +1663,11 @@ impl BexVm {
                 // Extract the field value before pushing to stack
                 let field_value = {
                     let Object::Instance(instance) = self.get_object(reference) else {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: ObjectType::Instance.into(),
                             got: ObjectType::of(self.get_object(reference)).into(),
-                        });
+                        }
+                        .into());
                     };
                     instance.fields[index]
                 };
@@ -1652,10 +1689,11 @@ impl BexVm {
                     Object::Instance(instance) => instance.fields[index],
 
                     other => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: ObjectType::Instance.into(),
                             got: ObjectType::of(other).into(),
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -1703,7 +1741,7 @@ impl BexVm {
                 // iteration will catch invalid pointers anyway.
                 self.frames[*frame_idx].instruction_ptr = instruction_ptr
                     .checked_add_signed(offset)
-                    .ok_or(VmError::InvalidJump)?;
+                    .ok_or(VmInternalError::InvalidJump)?;
             }
 
             Instruction::PopJumpIfFalse(offset) => {
@@ -1716,17 +1754,18 @@ impl BexVm {
                         if !value {
                             self.frames[*frame_idx].instruction_ptr = instruction_ptr
                                 .checked_add_signed(offset)
-                                .ok_or(VmError::InvalidJump)?;
+                                .ok_or(VmInternalError::InvalidJump)?;
                         }
                     }
 
                     // Type error, we don't have "falsey" values in the language
                     // so we should always check booleans.
                     other => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: Type::Bool,
                             got: self.type_of(&other),
-                        });
+                        }
+                        .into());
                     }
                 }
             }
@@ -1785,11 +1824,12 @@ impl BexVm {
                             | BinOp::BitXor
                             | BinOp::Shl
                             | BinOp::Shr => {
-                                return Err(VmError::CannotApplyBinOp {
+                                return Err(VmInternalError::CannotApplyBinOp {
                                     left: Type::Float,
                                     right: Type::Float,
                                     op,
-                                });
+                                }
+                                .into());
                             }
                         })
                     }
@@ -1818,11 +1858,12 @@ impl BexVm {
                             | BinOp::BitXor
                             | BinOp::Shl
                             | BinOp::Shr => {
-                                return Err(VmError::CannotApplyBinOp {
+                                return Err(VmInternalError::CannotApplyBinOp {
                                     left: Type::Int,
                                     right: Type::Float,
                                     op,
-                                });
+                                }
+                                .into());
                             }
                         })
                     }
@@ -1850,11 +1891,12 @@ impl BexVm {
                             | BinOp::BitXor
                             | BinOp::Shl
                             | BinOp::Shr => {
-                                return Err(VmError::CannotApplyBinOp {
+                                return Err(VmInternalError::CannotApplyBinOp {
                                     left: Type::Float,
                                     right: Type::Int,
                                     op,
-                                });
+                                }
+                                .into());
                             }
                         })
                     }
@@ -1870,11 +1912,12 @@ impl BexVm {
                     }
 
                     _ => {
-                        return Err(VmError::CannotApplyBinOp {
+                        return Err(VmInternalError::CannotApplyBinOp {
                             left: self.type_of(&left),
                             right: self.type_of(&right),
                             op,
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -1895,11 +1938,12 @@ impl BexVm {
                         CmpOp::GtEq => left >= right,
 
                         CmpOp::InstanceOf => {
-                            return Err(VmError::CannotApplyCmpOp {
+                            return Err(VmInternalError::CannotApplyCmpOp {
                                 left: Type::Int,
                                 right: Type::Int,
                                 op,
-                            });
+                            }
+                            .into());
                         }
                     }),
 
@@ -1914,11 +1958,12 @@ impl BexVm {
                         CmpOp::GtEq => left >= right,
 
                         CmpOp::InstanceOf => {
-                            return Err(VmError::CannotApplyCmpOp {
+                            return Err(VmInternalError::CannotApplyCmpOp {
                                 left: Type::Float,
                                 right: Type::Float,
                                 op,
-                            });
+                            }
+                            .into());
                         }
                     }),
 
@@ -1935,11 +1980,12 @@ impl BexVm {
                             CmpOp::GtEq => left >= right,
 
                             CmpOp::InstanceOf => {
-                                return Err(VmError::CannotApplyCmpOp {
+                                return Err(VmInternalError::CannotApplyCmpOp {
                                     left: Type::Int,
                                     right: Type::Float,
                                     op,
-                                });
+                                }
+                                .into());
                             }
                         })
                     }
@@ -1956,11 +2002,12 @@ impl BexVm {
                             CmpOp::GtEq => left >= right,
 
                             CmpOp::InstanceOf => {
-                                return Err(VmError::CannotApplyCmpOp {
+                                return Err(VmInternalError::CannotApplyCmpOp {
                                     left: Type::Float,
                                     right: Type::Int,
                                     op,
-                                });
+                                }
+                                .into());
                             }
                         })
                     }
@@ -1980,11 +2027,12 @@ impl BexVm {
                             CmpOp::Gt => left > right,
                             CmpOp::GtEq => left >= right,
                             CmpOp::InstanceOf => {
-                                return Err(VmError::CannotApplyCmpOp {
+                                return Err(VmInternalError::CannotApplyCmpOp {
                                     left: Type::Object(ObjectType::String),
                                     right: Type::Object(ObjectType::String),
                                     op,
-                                });
+                                }
+                                .into());
                             }
                         })
                     }
@@ -2001,11 +2049,12 @@ impl BexVm {
                             CmpOp::Eq => left == right,
                             CmpOp::NotEq => left != right,
                             _ => {
-                                return Err(VmError::CannotApplyCmpOp {
+                                return Err(VmInternalError::CannotApplyCmpOp {
                                     left: Type::Object(ObjectType::Uint8Array),
                                     right: Type::Object(ObjectType::Uint8Array),
                                     op,
-                                });
+                                }
+                                .into());
                             }
                         })
                     }
@@ -2030,11 +2079,12 @@ impl BexVm {
                                 left_var.enm != right_var.enm || left_var.index != right_var.index
                             }
                             _ => {
-                                return Err(VmError::CannotApplyCmpOp {
+                                return Err(VmInternalError::CannotApplyCmpOp {
                                     left: Type::Object(ObjectType::Variant),
                                     right: Type::Object(ObjectType::Variant),
                                     op,
-                                });
+                                }
+                                .into());
                             }
                         })
                     }
@@ -2059,11 +2109,12 @@ impl BexVm {
                         }
 
                         _ => {
-                            return Err(VmError::CannotApplyCmpOp {
+                            return Err(VmInternalError::CannotApplyCmpOp {
                                 left: self.type_of(&left),
                                 right: self.type_of(&right),
                                 op,
-                            });
+                            }
+                            .into());
                         }
                     }),
                 };
@@ -2079,10 +2130,11 @@ impl BexVm {
                     (UnaryOp::Neg, Value::Int(value)) => Value::Int(-value),
                     (UnaryOp::Neg, Value::Float(value)) => Value::Float(-value),
                     _ => {
-                        return Err(VmError::CannotApplyUnaryOp {
+                        return Err(VmInternalError::CannotApplyUnaryOp {
                             op,
                             value: self.type_of(&value),
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -2114,10 +2166,11 @@ impl BexVm {
                     Object::Array(arr) => arr.len(),
                     Object::Uint8Array(bytes) => bytes.len(),
                     other => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: ObjectType::Array.into(),
                             got: ObjectType::of(other).into(),
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -2136,10 +2189,11 @@ impl BexVm {
                         i as usize
                     }
                     _ => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: Type::Int,
                             got: self.type_of(&index_value),
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -2168,10 +2222,11 @@ impl BexVm {
                             Value::Int(i64::from(bytes[index]))
                         }
                         _ => {
-                            return Err(VmError::TypeError {
+                            return Err(VmInternalError::TypeError {
                                 expected: ObjectType::Array.into(),
                                 got: ObjectType::of(self.get_object(array_obj_index)).into(),
-                            });
+                            }
+                            .into());
                         }
                     }
                 };
@@ -2204,10 +2259,11 @@ impl BexVm {
                 let map_index = self.as_object_ptr(&map_value, ObjectType::Map)?;
 
                 let Object::Map(map) = self.get_object(map_index) else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Map.into(),
                         got: ObjectType::of(self.get_object(map_index)).into(),
-                    });
+                    }
+                    .into());
                 };
 
                 // Get the string key from the objects pool
@@ -2233,10 +2289,11 @@ impl BexVm {
                     Object::Array(arr) => arr.len(),
                     Object::Uint8Array(bytes) => bytes.len(),
                     other => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: ObjectType::Array.into(),
                             got: ObjectType::of(other).into(),
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -2255,10 +2312,11 @@ impl BexVm {
                         i as usize
                     }
                     other => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: Type::Int,
                             got: self.type_of(&other),
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -2286,10 +2344,11 @@ impl BexVm {
                         Value::Int(i64::from(bytes[index]))
                     }
                     other => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: ObjectType::Array.into(),
                             got: ObjectType::of(other).into(),
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -2309,15 +2368,17 @@ impl BexVm {
                     }
                     Object::Uint8Array(bytes) => {
                         let Value::Int(i) = new_value else {
-                            return Err(VmError::TypeError {
+                            return Err(VmInternalError::TypeError {
                                 expected: Type::Int,
                                 got: self.type_of(&new_value),
-                            });
+                            }
+                            .into());
                         };
                         let Ok(i) = u8::try_from(i) else {
-                            return Err(VmError::InternalError(format!(
+                            return Err(VmInternalError::InternalError(format!(
                                 "uint8array store: value {i} out of range 0..=255"
-                            )));
+                            ))
+                            .into());
                         };
                         bytes[index] = i;
                     }
@@ -2357,10 +2418,11 @@ impl BexVm {
                     Object::Map(map) => map.get(&key).copied().unwrap_or(Value::Null),
 
                     other => {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: ObjectType::Map.into(),
                             got: ObjectType::of(other).into(),
-                        });
+                        }
+                        .into());
                     }
                 };
 
@@ -2392,10 +2454,11 @@ impl BexVm {
                 // Convert compile-time ObjectIndex to HeapPtr
                 let class_ptr = self.idx_to_ptr(index);
                 let Object::Class(class) = self.get_object(class_ptr) else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Class.into(),
                         got: ObjectType::of(self.get_object(class_ptr)).into(),
-                    });
+                    }
+                    .into());
                 };
 
                 // Allocate the fields.
@@ -2420,10 +2483,11 @@ impl BexVm {
                 // Extract the variant count before popping from stack to avoid borrow conflicts
                 let variant_count = {
                     let Object::Enum(enm) = self.get_object(enum_ptr) else {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: ObjectType::Enum.into(),
                             got: ObjectType::of(self.get_object(enum_ptr)).into(),
-                        });
+                        }
+                        .into());
                     };
                     enm.variants.len()
                 };
@@ -2431,10 +2495,11 @@ impl BexVm {
                 let variant = self.stack.ensure_pop()?;
 
                 let Value::Int(variant_index) = variant else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: Type::Int,
                         got: self.type_of(&variant),
-                    });
+                    }
+                    .into());
                 };
 
                 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
@@ -2468,25 +2533,25 @@ impl BexVm {
 
                 // Can't dispatch if it's not a function
                 let Object::Function(callable_future) = self.get_object(callee_ptr) else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: expected_type.into(),
                         got: ObjectType::of(self.get_object(callee_ptr)).into(),
-                    });
+                    }
+                    .into());
                 };
 
                 // Must be a sys_op - extract the SysOp.
                 let FunctionKind::SysOp(sys_op) = callable_future.kind else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: FunctionType::SysOp.into(),
                         got: FunctionType::from(&callable_future.kind).into(),
-                    });
+                    }
+                    .into());
                 };
 
-                let args_offset = self
-                    .stack
-                    .len()
-                    .checked_sub(callable_future.arity)
-                    .ok_or(VmError::NotEnoughItemsOnStack(callable_future.arity))?;
+                let args_offset = self.stack.len().checked_sub(callable_future.arity).ok_or(
+                    VmInternalError::NotEnoughItemsOnStack(callable_future.arity),
+                )?;
                 let args_offset = StackIndex::from_raw(args_offset);
 
                 // Collect function call args and cleanup consumed stack.
@@ -2523,10 +2588,11 @@ impl BexVm {
                 // Check if future is ready and extract value if so
                 let ready_value = {
                     let Object::Future(awaiting) = self.get_object(index) else {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: wanted_type.into(),
                             got: ObjectType::of(self.get_object(index)).into(),
-                        });
+                        }
+                        .into());
                     };
 
                     match awaiting {
@@ -2556,11 +2622,16 @@ impl BexVm {
                         Object::String(mode) if mode == "manual" => WatchFilter::Manual,
                         Object::String(mode) if mode == "never" => WatchFilter::Paused,
                         _ => {
-                            return Err(VmError::InternalError("Invalid filter".to_string()));
+                            return Err(VmInternalError::InternalError(
+                                "Invalid filter".to_string(),
+                            )
+                            .into());
                         }
                     },
                     _ => {
-                        return Err(VmError::InternalError("Invalid filter".to_string()));
+                        return Err(
+                            VmInternalError::InternalError("Invalid filter".to_string()).into()
+                        );
                     }
                 };
 
@@ -2635,7 +2706,10 @@ impl BexVm {
                 let notifications = self.watch.copy_roots_reaching(var_node);
 
                 if notifications.len() != 1 && notifications.first() != Some(&var_node) {
-                    return Err(VmError::InternalError("Invalid manual notify".to_string()));
+                    return Err(VmInternalError::InternalError(
+                        "Invalid manual notify".to_string(),
+                    )
+                    .into());
                 }
 
                 return Ok(Some(VmExecState::Notify(WatchNotification::Variables(
@@ -2650,18 +2724,16 @@ impl BexVm {
                     .stack
                     .len()
                     .checked_sub(arg_count)
-                    .ok_or(VmError::NotEnoughItemsOnStack(arg_count))?;
+                    .ok_or(VmInternalError::NotEnoughItemsOnStack(arg_count))?;
                 let locals_offset = StackIndex::from_raw(args_offset);
 
-                if let Some(state) = self.execute_call_from_locals_offset(
+                return self.execute_call_from_locals_offset(
                     callee_ptr,
                     locals_offset,
                     arg_count,
                     frame_idx,
                     function,
-                )? {
-                    return Ok(Some(state));
-                }
+                );
             }
 
             Instruction::CallIndirect => {
@@ -2673,7 +2745,7 @@ impl BexVm {
                     .stack
                     .len()
                     .checked_sub(arg_count + 1)
-                    .ok_or(VmError::NotEnoughItemsOnStack(arg_count + 1))?;
+                    .ok_or(VmInternalError::NotEnoughItemsOnStack(arg_count + 1))?;
                 let _popped_callee = self.stack.ensure_pop()?;
                 let locals_offset = StackIndex::from_raw(args_offset);
 
@@ -2717,12 +2789,22 @@ impl BexVm {
                 // Return from interrupt.
                 if Some(self.frames.len()) == self.interrupt_frame {
                     self.interrupt_frame = None;
-                    return self.stack.ensure_pop().map(VmExecState::Complete).map(Some);
+                    return self
+                        .stack
+                        .ensure_pop()
+                        .map_err(VmError::InternalError)
+                        .map(VmExecState::Complete)
+                        .map(Some);
                 }
 
                 // If there are no more frames, we're done.
                 if self.frames.is_empty() {
-                    return self.stack.ensure_pop().map(VmExecState::Complete).map(Some);
+                    return self
+                        .stack
+                        .ensure_pop()
+                        .map_err(VmError::InternalError)
+                        .map(VmExecState::Complete)
+                        .map(Some);
                 }
 
                 // Yield FunctionExit for traced frames (with result value).
@@ -2792,10 +2874,11 @@ impl BexVm {
 
                 // Must be an integer
                 let Value::Int(value) = discriminant else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: Type::Int,
                         got: self.type_of(&discriminant),
-                    });
+                    }
+                    .into());
                 };
 
                 // Lookup in jump table
@@ -2805,7 +2888,7 @@ impl BexVm {
                 // Jump
                 self.frames[*frame_idx].instruction_ptr = instruction_ptr
                     .checked_add_signed(offset)
-                    .ok_or(VmError::InvalidJump)?;
+                    .ok_or(VmInternalError::InvalidJump)?;
             }
 
             Instruction::Discriminant => {
@@ -2814,19 +2897,21 @@ impl BexVm {
 
                 // Must be an object (variants are heap-allocated)
                 let Value::Object(object_idx) = value else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Variant.into(),
                         got: self.type_of(&value),
-                    });
+                    }
+                    .into());
                 };
 
                 // Must be a Variant object
                 let variant_index = {
                     let Object::Variant(variant) = self.get_object(object_idx) else {
-                        return Err(VmError::TypeError {
+                        return Err(VmInternalError::TypeError {
                             expected: ObjectType::Variant.into(),
                             got: ObjectType::of(self.get_object(object_idx)).into(),
-                        });
+                        }
+                        .into());
                     };
                     variant.index
                 };
@@ -2891,18 +2976,20 @@ impl BexVm {
                 let locals_offset = self.frames[*frame_idx].locals_offset;
                 let cell_value = self.stack[Self::local_slot_stack_index(locals_offset, slot)];
                 let Value::Object(cell_ptr) = cell_value else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Cell.into(),
                         got: self.type_of(&cell_value),
-                    });
+                    }
+                    .into());
                 };
                 // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
                 let obj = unsafe { cell_ptr.get() };
                 let Object::Cell(cell) = obj else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Cell.into(),
                         got: ObjectType::of(obj).into(),
-                    });
+                    }
+                    .into());
                 };
                 self.stack.push(cell.value);
             }
@@ -2912,18 +2999,20 @@ impl BexVm {
                 let locals_offset = self.frames[*frame_idx].locals_offset;
                 let cell_value = self.stack[Self::local_slot_stack_index(locals_offset, slot)];
                 let Value::Object(cell_ptr) = cell_value else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Cell.into(),
                         got: self.type_of(&cell_value),
-                    });
+                    }
+                    .into());
                 };
                 // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
                 let obj = unsafe { cell_ptr.get_mut() };
                 let Object::Cell(cell) = obj else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Cell.into(),
                         got: ObjectType::of(obj).into(),
-                    });
+                    }
+                    .into());
                 };
                 cell.value = value;
             }
@@ -2934,25 +3023,28 @@ impl BexVm {
                 // the duration of this frame.
                 let obj = unsafe { closure_ptr.get() };
                 let Object::Closure(closure) = obj else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Closure.into(),
                         got: ObjectType::of(obj).into(),
-                    });
+                    }
+                    .into());
                 };
                 let cell_value = closure.captures[idx];
                 let Value::Object(cell_ptr) = cell_value else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Cell.into(),
                         got: self.type_of(&cell_value),
-                    });
+                    }
+                    .into());
                 };
                 // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
                 let cell_obj = unsafe { cell_ptr.get() };
                 let Object::Cell(cell) = cell_obj else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Cell.into(),
                         got: ObjectType::of(cell_obj).into(),
-                    });
+                    }
+                    .into());
                 };
                 self.stack.push(cell.value);
             }
@@ -2964,25 +3056,28 @@ impl BexVm {
                 // the duration of this frame.
                 let obj = unsafe { closure_ptr.get() };
                 let Object::Closure(closure) = obj else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Closure.into(),
                         got: ObjectType::of(obj).into(),
-                    });
+                    }
+                    .into());
                 };
                 let cell_value = closure.captures[idx];
                 let Value::Object(cell_ptr) = cell_value else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Cell.into(),
                         got: self.type_of(&cell_value),
-                    });
+                    }
+                    .into());
                 };
                 // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
                 let cell_obj = unsafe { cell_ptr.get_mut() };
                 let Object::Cell(cell) = cell_obj else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Cell.into(),
                         got: ObjectType::of(cell_obj).into(),
-                    });
+                    }
+                    .into());
                 };
                 cell.value = value;
             }
@@ -2996,10 +3091,11 @@ impl BexVm {
                 // the duration of this frame.
                 let obj = unsafe { closure_ptr.get() };
                 let Object::Closure(closure) = obj else {
-                    return Err(VmError::TypeError {
+                    return Err(VmInternalError::TypeError {
                         expected: ObjectType::Closure.into(),
                         got: ObjectType::of(obj).into(),
-                    });
+                    }
+                    .into());
                 };
                 self.stack.push(closure.captures[idx]);
             }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1103,6 +1103,10 @@ impl BexVm {
                 let msg = self.alloc_string("unreachable code executed".to_string());
                 (PanicClass::Unreachable, vec![msg])
             }
+            VmPanic::UserPanic { message } => {
+                let msg = self.alloc_string(message);
+                (PanicClass::UserPanic, vec![msg])
+            }
             VmPanic::AllocFailure { message } => {
                 let msg = self.alloc_string(message);
                 (PanicClass::AllocFailure, vec![msg])

--- a/baml_language/crates/bex_vm_types/build.rs
+++ b/baml_language/crates/bex_vm_types/build.rs
@@ -6,6 +6,9 @@ fn main() {
     let code = baml_builtins2_codegen::generate_sys_op_enum(&io_builtins);
     std::fs::write(format!("{out_dir}/sys_op_generated.rs"), code).unwrap();
 
+    let error_code = baml_builtins2_codegen::generate_error_enums(&class_defs);
+    std::fs::write(format!("{out_dir}/errors_generated.rs"), error_code).unwrap();
+
     let panic_code = baml_builtins2_codegen::generate_panic_enums(&class_defs);
     std::fs::write(format!("{out_dir}/panics_generated.rs"), panic_code).unwrap();
 }

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -518,6 +518,9 @@ impl std::fmt::Display for Value {
     }
 }
 
+// Error class / instance enums — generated from `errors.baml` class definitions.
+// ErrorClass (tag enum), ErrorInstance (with Value fields), associated methods.
+include!(concat!(env!("OUT_DIR"), "/errors_generated.rs"));
 // Panic class / instance enums — generated from `panics.baml` class definitions.
 // PanicClass (tag enum), PanicInstance (with Value fields), associated methods.
 include!(concat!(env!("OUT_DIR"), "/panics_generated.rs"));

--- a/baml_language/crates/bridge_wasm/src/wasm_sys.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_sys.rs
@@ -31,16 +31,6 @@ impl IoNamespaceSys for WasmSys {
         SysOpOutput::err(OpErrorKind::Unsupported)
     }
 
-    fn panic(
-        &self,
-        _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        message: String,
-        _ctx: &SysOpContext,
-    ) -> SysOpOutput<()> {
-        SysOpOutput::err(OpErrorKind::Other(message))
-    }
-
     fn sleep(
         &self,
         _heap: &Arc<BexHeap>,

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -144,16 +144,6 @@ impl io::IoNamespaceSys for NativeSysOps {
             Ok(())
         })
     }
-
-    fn panic(
-        &self,
-        _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        message: String,
-        _ctx: &SysOpContext,
-    ) -> SysOpOutput<()> {
-        SysOpOutput::err(OpErrorKind::Other(message))
-    }
 }
 
 // ============================================================================

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -423,15 +423,6 @@ impl io::IoNamespaceSys for DefaultIoOps {
     ) -> SysOpOutput<()> {
         SysOpOutput::err(OpErrorKind::Unsupported)
     }
-    fn panic(
-        &self,
-        _h: &Arc<BexHeap>,
-        _c: CallId,
-        _msg: String,
-        _ctx: &SysOpContext,
-    ) -> SysOpOutput<()> {
-        SysOpOutput::err(OpErrorKind::Unsupported)
-    }
 }
 
 impl io::IoPackageBaml for DefaultIoOps {}
@@ -586,6 +577,7 @@ impl IoSysOpsBuilder {
     }
 
     /// Override the `sys` namespace with a pre-built instance.
+    #[allow(clippy::needless_pass_by_value)]
     #[must_use]
     pub fn with_sys_instance(
         mut self,
@@ -601,12 +593,6 @@ impl IoSysOpsBuilder {
             let t = instance.clone();
             Arc::new(move |heap, args, ctx, call_id| {
                 t.__glue_baml_sys_sleep(heap, args, ctx, call_id)
-            })
-        };
-        self.inner.baml_sys_panic = {
-            let t = instance;
-            Arc::new(move |heap, args, ctx, call_id| {
-                t.__glue_baml_sys_panic(heap, args, ctx, call_id)
             })
         };
         self

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -758,12 +758,7 @@ mod tests {
     #[test]
     fn all_sys_ops_have_contract_metadata() {
         use bex_vm_types::SysOp;
-        let ops = [
-            SysOp::BamlFsOpen,
-            SysOp::BamlHttpFetch,
-            SysOp::BamlSysPanic,
-            SysOp::BamlEnvGet,
-        ];
+        let ops = [SysOp::BamlFsOpen, SysOp::BamlHttpFetch, SysOp::BamlEnvGet];
         for op in ops {
             let cats = op.allowed_error_categories();
             let panics = op.allowed_panic_categories();


### PR DESCRIPTION
- Reorganizes VM error types: they are either thrown (panic or error value) or internal (fatal).
- Native rust functions use a different error type whose variants contain `VmPanic`, `VmBamlError` (which includes all standard library error types), and `VmInternalError`
- Updated `uint8array` functions to correctly use error values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AllocFailure panic type for allocation/OOM failures.

* **Enhancements**
  * Uint8Array: clarified slice clamping, added docs for concat/reverse/slice, and made zeroes explicitly report invalid-size errors and possible allocation failure.

* **Refactor**
  * Overhauled VM error model and native-call error pathways to separate catchable exceptions from internal fatal errors; added generated error enums.

* **Tests**
  * Updated byte-string and exception tests to reflect new allocation behavior and panic handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->