### PR TITLE
fix(lsp): advertise codeActionProvider in server capabilities

### DIFF
--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -1,5 +1,6 @@
 use lsp_types::{
-    CodeLens, CodeLensOptions, CompletionOptions, HoverProviderCapability, InlayHintOptions,
+    CodeActionProviderCapability, CodeLens, CodeLensOptions, CompletionOptions,
+    HoverProviderCapability, InlayHintOptions,
     InlayHintServerCapabilities, SaveOptions, SemanticTokensFullOptions, SemanticTokensLegend,
     SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
@@ -28,7 +29,7 @@ pub(super) fn server_capabilities() -> ServerCapabilities {
         code_lens_provider: Some(CodeLensOptions {
             resolve_provider: Some(true),
         }),
-        code_action_provider: None,
+        code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         execute_command_provider: Some(lsp_types::ExecuteCommandOptions {
             commands: vec![commands::OpenBamlPanel::COMMAND_ID.to_string()],
             work_done_progress_options: lsp_types::WorkDoneProgressOptions::default(),


### PR DESCRIPTION
## Issue
The LSP server implements `textDocument/codeAction` but `initialize` did not set `code_action_provider`, so spec-compliant clients (e.g. Neovim) never send `textDocument/codeAction` requests.

## Changes
- Set `code_action_provider: Some(CodeActionProviderCapability::Simple(true))` in `server_capabilities()`.
- Import `CodeActionProviderCapability` from `lsp_types`.

## Testing
- [ ] `cargo check -p bex_project` (or full engine build) — not run in this session due to long dependency fetch.

Closes: _(add issue number if you open one)_

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The language server now advertises support for code actions, enabling compatible IDE integrations and editors to discover and utilize code action capabilities for inline code improvement suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->