### PR TITLE
Switch all publish-* jobs to GitHub-hosted runners (ubuntu-latest)

### DIFF
--- a/.github/workflows/publish-zed-release.reusable.yaml
+++ b/.github/workflows/publish-zed-release.reusable.yaml
@@ -13,7 +13,8 @@ permissions: {}
 
 jobs:
   publish-zed-release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout upstream zed extensions
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,8 @@ jobs:
     environment: release
     needs: [all-builds, determine-version]
     if: ${{ needs.determine-version.outputs.is_release_tag == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -145,7 +146,8 @@ jobs:
     environment: release
     needs: [all-builds, determine-version]
     if: ${{ needs.determine-version.outputs.is_release_tag == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -215,7 +217,8 @@ jobs:
     environment: release
     needs: [all-builds, determine-version]
     if: ${{ needs.determine-version.outputs.is_release_tag == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -244,7 +247,8 @@ jobs:
   publish-to-open-vsx:
     environment: release
     needs: [determine-version, all-builds]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
+    runs-on: ubuntu-latest
     if: ${{ (needs.determine-version.outputs.is_release_tag == 'true') || inputs.force_publish_vscode }}
     steps:
       - uses: actions/checkout@v4
@@ -272,7 +276,8 @@ jobs:
   publish-to-vscode-marketplace:
     environment: release
     needs: [determine-version, all-builds]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
+    runs-on: ubuntu-latest
     if: ${{ (needs.determine-version.outputs.is_release_tag == 'true') || inputs.force_publish_vscode }}
     steps:
       - uses: actions/checkout@v4
@@ -300,7 +305,8 @@ jobs:
   publish-to-jetbrains-marketplace:
     environment: release
     needs: [determine-version, all-builds]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
+    runs-on: ubuntu-latest
     if: ${{ needs.determine-version.outputs.is_release_tag == 'true' }}
     steps:
       - uses: actions/checkout@v4
@@ -326,7 +332,8 @@ jobs:
     permissions:
       contents: write
     needs: [all-builds, determine-version]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Download all baml-cli artifacts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

## Issue Reference
N/A - operational fix for CI/CD publish workflows.

## Changes
All `publish-*` jobs across the release workflows have been switched from `blacksmith-4vcpu-ubuntu-2404` (self-hosted) to `ubuntu-latest` (GitHub-hosted).

**Files changed:**
- `.github/workflows/release.yml` — Updated 8 publish jobs: `publish-to-pypi`, `publish-to-npm`, `publish-to-crates-io`, `publish-to-open-vsx`, `publish-to-vscode-marketplace`, `publish-to-jetbrains-marketplace`, `publish-to-github`, and the `publish-to-zed-extensions` (via reusable workflow).
- `.github/workflows/publish-zed-release.reusable.yaml` — Updated the `publish-zed-release` job.

Each job now includes a comment explaining why GitHub-hosted runners are required:
```yaml
# Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
runs-on: ubuntu-latest
```

Non-publish jobs (`determine-version`, `all-builds`) remain on `blacksmith-4vcpu-ubuntu-2404`.

## Testing
- [x] Manual review of YAML syntax and structure
- [x] Verified all publish-* jobs are updated and non-publish jobs are unchanged

## PR Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
This change is needed because OIDC trusted publishing (used by npm, PyPI, etc.) requires GitHub-hosted runners to properly issue and validate identity tokens. Self-hosted/Blacksmith runners do not have the correct permissions for this.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1776282761725169?thread_ts=1776282761.725169&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-c840ea29-5ff9-5251-a79f-dfdbe1b2cde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c840ea29-5ff9-5251-a79f-dfdbe1b2cde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow runner configuration for improved reliability and consistency across multiple publishing pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->