### PR TITLE
baml_language: baml-cli test discovers and runs testsets

### DIFF
--- a/baml_language/crates/baml_cli/src/main.rs
+++ b/baml_language/crates/baml_cli/src/main.rs
@@ -10,14 +10,6 @@ fn main() -> Result<()> {
 
     let argv: Vec<String> = std::env::args().collect();
 
-    baml_cli::run_cli(argv)?;
-
-    // TODO: Original code with RuntimeCliDefaults
-    // baml_cli::run_cli(
-    //     argv,
-    //     RuntimeCliDefaults {
-    //         output_type: baml_types::GeneratorOutputType::OpenApi,
-    //     },
-    // )?;
-    Ok(())
+    let exit_code = baml_cli::run_cli(argv)?;
+    std::process::exit(exit_code.into());
 }

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -1,11 +1,14 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result, anyhow};
 use baml_db::{baml_compiler_diagnostics::Severity, baml_compiler2_emit};
 use baml_project::ProjectDatabase;
-use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder, test_arg_to_external};
+use bex_engine::{
+    BexEngine, BexExternalValue, CancellationToken, FunctionCallContextBuilder,
+    test_arg_to_external,
+};
 use clap::Args;
 use sys_native::{CallId, SysOpsExt};
 
@@ -41,15 +44,53 @@ pub struct TestArgs {
     pub exclude: Vec<String>,
 }
 
-/// A discovered test: a (function_name, test_name) pair with its source location.
+/// Source of a discovered test — determines how it's executed.
+enum TestKind {
+    /// Old-style `test "name" { functions [Foo] args {…} }` attached to an LLM
+    /// function. Executed by calling the function directly with test args.
+    Legacy { file_path: PathBuf },
+    /// New-style test inside a `testset "name" { test "name" { … } }` block.
+    /// Executed via `testing.TestRegistry.run_test(registry, full_path)`.
+    Testset {
+        /// Slash-separated path as the testing runtime knows it, e.g.
+        /// `"tictactoe/x wins row"` or `"outer/inner/foo"`.
+        full_path: String,
+    },
+}
+
 struct DiscoveredTest {
+    /// First segment shown to the filter as `FunctionName` — for legacy tests
+    /// this is the user function under test; for testset tests it's the
+    /// top-level testset name.
     function_name: String,
+    /// Second segment shown to the filter as `TestName` — for legacy tests
+    /// this is the test-block name; for testset tests it's the remainder of
+    /// the slash-separated path after the first segment.
     test_name: String,
-    file_path: PathBuf,
+    kind: TestKind,
+}
+
+impl DiscoveredTest {
+    fn display_location(&self) -> String {
+        match &self.kind {
+            TestKind::Legacy { file_path } => file_path.display().to_string(),
+            TestKind::Testset { .. } => "<testset>".to_string(),
+        }
+    }
+}
+
+/// Bundle of the engine + tokio runtime + cancellation token shared by every
+/// test invocation. Kept as a struct rather than separate arguments so the
+/// helper functions don't trip `clippy::too_many_arguments`.
+struct RunCtx<'a> {
+    engine: &'a Arc<BexEngine>,
+    rt: &'a tokio::runtime::Runtime,
+    cancel: &'a CancellationToken,
 }
 
 impl TestArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
+        // ── 1. Load project ────────────────────────────────────────────────
         let (db, from, baml_files) = load_project_from(&self.from)?;
         if baml_files.is_empty() {
             eprintln!("No .baml files found in {}", from.display());
@@ -59,35 +100,7 @@ impl TestArgs {
             .get_project()
             .ok_or_else(|| anyhow!("No project context"))?;
 
-        // Discover all (function, test) pairs from the HIR.
-        let discovered = discover_tests(&db, project);
-
-        // Apply include/exclude filters.
-        let filter = TestFilter::new(
-            self.include.iter().map(|s| s.as_str()),
-            self.exclude.iter().map(|s| s.as_str()),
-        );
-
-        let selected: BTreeMap<(String, String), PathBuf> = discovered
-            .into_iter()
-            .filter(|t| filter.includes(&t.function_name, &t.test_name))
-            .map(|t| ((t.function_name, t.test_name), t.file_path))
-            .collect();
-
-        if selected.is_empty() {
-            println!("No tests selected.");
-            return Ok(crate::ExitCode::NoTestsRun);
-        }
-
-        if self.list {
-            println!("Selected tests ({}):\n", selected.len());
-            for ((func, test), path) in &selected {
-                println!("  {func}::{test}  ({path})", path = path.display());
-            }
-            return Ok(crate::ExitCode::Success);
-        }
-
-        // Check for diagnostic errors before compiling.
+        // ── 2. Diagnostics ─────────────────────────────────────────────────
         let source_files = db.get_source_files();
         let diagnostics = baml_project::collect_diagnostics(&db, project, &source_files);
         let errors: Vec<_> = diagnostics
@@ -102,70 +115,96 @@ impl TestArgs {
             return Ok(crate::ExitCode::Other);
         }
 
-        // Compile to bytecode (with test cases included).
+        // ── 3. Discover legacy tests from HIR ──────────────────────────────
+        let mut discovered: Vec<DiscoveredTest> = discover_legacy_tests(&db, project);
+
+        // ── 4. Compile + engine + runtime (needed for testset discovery) ──
         let compile_options = baml_compiler2_emit::CompileOptions {
             emit_test_cases: true,
         };
         let bytecode = baml_compiler2_emit::generate_project_bytecode(&db, &compile_options)
             .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
 
-        // Create the engine with native (tokio-based) sys ops.
-        let engine = BexEngine::new(
-            bytecode,
-            Arc::new(sys_native::SysOps::native()),
-            None,
-            Vec::new(),
-        )
-        .map_err(|e| anyhow!("Failed to create engine: {e:?}"))?;
-        let engine = Arc::new(engine);
-
-        // Create a tokio runtime for async execution.
+        let engine = Arc::new(
+            BexEngine::new(
+                bytecode,
+                Arc::new(sys_native::SysOps::native()),
+                None,
+                Vec::new(),
+            )
+            .map_err(|e| anyhow!("Failed to create engine: {e:?}"))?,
+        );
         let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
+        let cancel = CancellationToken::new();
 
-        // Run tests sequentially.
+        // ── 5. Discover testset tests via the engine ───────────────────────
+        // Mirrors the LSP collection/expansion path in
+        // `bex_project::bex_lsp::multi_project` (mod.rs:609–911). See also
+        // `BexEngine::collect_tests` at bex_engine/src/lib.rs:1241.
+        let (registry_value, testset_discovered) =
+            match discover_testset_tests(&engine, &rt, cancel.clone()) {
+                Ok(x) => x,
+                Err(e) => {
+                    eprintln!("warning: testset discovery failed: {e}");
+                    (None, Vec::new())
+                }
+            };
+        discovered.extend(testset_discovered);
+
+        // ── 6. Filter ──────────────────────────────────────────────────────
+        let filter = TestFilter::new(
+            self.include.iter().map(|s| s.as_str()),
+            self.exclude.iter().map(|s| s.as_str()),
+        );
+        let selected: Vec<DiscoveredTest> = discovered
+            .into_iter()
+            .filter(|t| filter.includes(&t.function_name, &t.test_name))
+            .collect();
+
+        if selected.is_empty() {
+            println!("No tests selected.");
+            return Ok(crate::ExitCode::NoTestsRun);
+        }
+
+        if self.list {
+            println!("Selected tests ({}):\n", selected.len());
+            for t in &selected {
+                println!(
+                    "  {}::{}  ({})",
+                    t.function_name,
+                    t.test_name,
+                    t.display_location()
+                );
+            }
+            return Ok(crate::ExitCode::Success);
+        }
+
+        // ── 7. Execute ─────────────────────────────────────────────────────
         let total = selected.len();
         let mut passed = 0usize;
         let mut failed = 0usize;
 
-        for (func_name, test_name) in selected.keys() {
-            // Look up the compiled test case from the engine.
-            let test_case = match engine.test_case(func_name, test_name) {
-                Some(tc) => tc,
-                None => {
-                    eprintln!(
-                        "FAIL {func_name}::{test_name} - test case not found in compiled program"
-                    );
-                    failed += 1;
-                    continue;
-                }
-            };
+        let run_ctx = RunCtx {
+            engine: &engine,
+            rt: &rt,
+            cancel: &cancel,
+        };
 
-            // Convert TestArgValue -> BexExternalValue and order by function params.
-            let ordered_args = match build_ordered_args(&engine, func_name, test_case) {
-                Ok(args) => args,
-                Err(e) => {
-                    eprintln!("FAIL {func_name}::{test_name} - {e}");
-                    failed += 1;
-                    continue;
+        for t in &selected {
+            match &t.kind {
+                TestKind::Legacy { .. } => {
+                    run_legacy_test(&run_ctx, t, &mut passed, &mut failed);
                 }
-            };
-
-            // Execute the function.
-            match rt.block_on(engine.call_function(
-                func_name,
-                ordered_args,
-                FunctionCallContextBuilder::new(CallId::next()).build(),
-                true,
-            )) {
-                Ok(result) => {
-                    println!("PASS {func_name}::{test_name}");
-                    println!("  => {result:?}");
-                    passed += 1;
-                }
-                Err(e) => {
-                    eprintln!("FAIL {func_name}::{test_name}");
-                    eprintln!("  => {e:?}");
-                    failed += 1;
+                TestKind::Testset { full_path } => {
+                    let Some(reg_value) = registry_value.as_ref() else {
+                        eprintln!(
+                            "FAIL {}::{} - testset registry unavailable",
+                            t.function_name, t.test_name
+                        );
+                        failed += 1;
+                        continue;
+                    };
+                    run_testset_test(&run_ctx, reg_value, full_path, t, &mut passed, &mut failed);
                 }
             }
         }
@@ -180,7 +219,55 @@ impl TestArgs {
     }
 }
 
-/// Build ordered args Vec from a test case, matching the function's parameter order.
+// ---------------------------------------------------------------------------
+// Legacy test execution (unchanged from the original implementation)
+// ---------------------------------------------------------------------------
+
+fn run_legacy_test(ctx: &RunCtx, t: &DiscoveredTest, passed: &mut usize, failed: &mut usize) {
+    let test_case = match ctx.engine.test_case(&t.function_name, &t.test_name) {
+        Some(tc) => tc,
+        None => {
+            eprintln!(
+                "FAIL {}::{} - test case not found in compiled program",
+                t.function_name, t.test_name
+            );
+            *failed += 1;
+            return;
+        }
+    };
+
+    let ordered_args = match build_ordered_args(ctx.engine, &t.function_name, test_case) {
+        Ok(args) => args,
+        Err(e) => {
+            eprintln!("FAIL {}::{} - {e}", t.function_name, t.test_name);
+            *failed += 1;
+            return;
+        }
+    };
+
+    match ctx.rt.block_on(
+        ctx.engine.call_function(
+            &t.function_name,
+            ordered_args,
+            FunctionCallContextBuilder::new(CallId::next())
+                .with_cancel_token(ctx.cancel.clone())
+                .build(),
+            true,
+        ),
+    ) {
+        Ok(result) => {
+            println!("PASS {}::{}", t.function_name, t.test_name);
+            println!("  => {result:?}");
+            *passed += 1;
+        }
+        Err(e) => {
+            eprintln!("FAIL {}::{}", t.function_name, t.test_name);
+            eprintln!("  => {e:?}");
+            *failed += 1;
+        }
+    }
+}
+
 fn build_ordered_args(
     engine: &BexEngine,
     function_name: &str,
@@ -204,31 +291,295 @@ fn build_ordered_args(
     Ok(ordered)
 }
 
-/// Walk the compiler2 HIR to discover all (function_name, test_name) pairs.
-///
-/// NOTE: Stubbed — pending compiler2 `project_items` implementation.
-/// Returns empty until compiler2 has a cross-file test enumeration API.
+// ---------------------------------------------------------------------------
+// Legacy test discovery (unchanged, renamed from discover_tests)
+// ---------------------------------------------------------------------------
+
 #[allow(unused_variables)]
-fn discover_tests(db: &ProjectDatabase, project: baml_workspace::Project) -> Vec<DiscoveredTest> {
+fn discover_legacy_tests(
+    db: &ProjectDatabase,
+    project: baml_workspace::Project,
+) -> Vec<DiscoveredTest> {
     use baml_db::baml_compiler2_hir;
 
     let mut tests = Vec::new();
 
-    // Walk all source files in the project.
     for source_file in db.get_source_files() {
         let item_tree = baml_compiler2_hir::file_item_tree(db, source_file);
         let file_path = source_file.path(db);
 
-        for (id, test) in &item_tree.tests {
+        for test in item_tree.tests.values() {
             for func_ref in &test.function_refs {
                 tests.push(DiscoveredTest {
                     function_name: func_ref.to_string(),
                     test_name: test.name.to_string(),
-                    file_path: file_path.clone(),
+                    kind: TestKind::Legacy {
+                        file_path: file_path.clone(),
+                    },
                 });
             }
         }
     }
 
     tests
+}
+
+// ---------------------------------------------------------------------------
+// Testset discovery via BexEngine::collect_tests
+//
+// Mirrors what the LSP does when the playground asks for a project's test
+// tree (bex_project::bex_lsp::multi_project::mod.rs:609). The sequence:
+//
+//   1. engine.collect_tests("user", …)
+//        → `Handle` to a live `testing.TestRegistry`, or `Null` if the
+//          project has no `$init_test` (i.e. no tests at all).
+//   2. Repeatedly `serialize` + `expand_set` each encountered `lazyTestSet`
+//        until no lazies remain. The CLI has no interactive UI so we
+//        auto-expand eagerly; this executes any generator bodies (for-loops
+//        inside testsets etc.) once at discovery time.
+//   3. Final `serialize` → walk the tree and collect every leaf `type:"test"`
+//        node's `name` (already slash-prefixed by the runtime's
+//        register_test logic, see baml_std/testing/registry.baml:27).
+//
+// Execution then calls `TestRegistry.run_test(registry, full_path)` which
+// navigates through the expansions map and runs the test body.
+// ---------------------------------------------------------------------------
+
+fn discover_testset_tests(
+    engine: &Arc<BexEngine>,
+    rt: &tokio::runtime::Runtime,
+    cancel: CancellationToken,
+) -> Result<(Option<BexExternalValue>, Vec<DiscoveredTest>)> {
+    let registry = rt
+        .block_on(engine.collect_tests("user", CallId::next(), cancel.clone()))
+        .map_err(|e| anyhow!("collect_tests failed: {e:?}"))?;
+
+    match &registry {
+        BexExternalValue::Null => return Ok((None, Vec::new())),
+        BexExternalValue::Handle(_) => {}
+        other => {
+            return Err(anyhow!(
+                "unexpected collect_tests result type: {}",
+                other.type_name()
+            ));
+        }
+    }
+
+    // Keep expanding lazy testsets until the tree is fully realized.
+    // Each expansion may surface new lazies nested inside, so loop.
+    loop {
+        let serialized = serialize_registry(engine, rt, &cancel, &registry)?;
+        let lazies = collect_lazy_names(&serialized);
+        if lazies.is_empty() {
+            break;
+        }
+        for name in lazies {
+            let ctx = FunctionCallContextBuilder::new(CallId::next())
+                .with_cancel_token(cancel.clone())
+                .build();
+            rt.block_on(engine.call_function(
+                "testing.TestRegistry.expand_set",
+                vec![registry.clone(), BexExternalValue::String(name.clone())],
+                ctx,
+                true,
+            ))
+            .map_err(|e| anyhow!("expand_set({name:?}) failed: {e:?}"))?;
+        }
+    }
+
+    let final_tree = serialize_registry(engine, rt, &cancel, &registry)?;
+    let mut tests = Vec::new();
+    flatten_tree(&final_tree, &mut tests);
+    Ok((Some(registry), tests))
+}
+
+fn serialize_registry(
+    engine: &Arc<BexEngine>,
+    rt: &tokio::runtime::Runtime,
+    cancel: &CancellationToken,
+    registry: &BexExternalValue,
+) -> Result<BexExternalValue> {
+    let ctx = FunctionCallContextBuilder::new(CallId::next())
+        .with_cancel_token(cancel.clone())
+        .build();
+    rt.block_on(engine.call_function(
+        "testing.TestRegistry.serialize",
+        vec![registry.clone()],
+        ctx,
+        true,
+    ))
+    .map_err(|e| anyhow!("TestRegistry.serialize failed: {e:?}"))
+}
+
+// ---------------------------------------------------------------------------
+// Tree walkers over the `SerializedTestDef[]` shape produced by
+// `testing.TestRegistry.serialize`. See baml_std/testing/registry.baml:99.
+// ---------------------------------------------------------------------------
+
+fn flatten_tree(value: &BexExternalValue, out: &mut Vec<DiscoveredTest>) {
+    match unwrap_union(value) {
+        BexExternalValue::Array { items, .. } => {
+            for item in items {
+                flatten_tree(item, out);
+            }
+        }
+        BexExternalValue::Instance { class_name, fields } => {
+            if class_matches(class_name, "SerializedTest") {
+                let kind = fields.get("type").and_then(as_string).unwrap_or_default();
+                if kind == "test" {
+                    if let Some(name) = fields.get("name").and_then(as_string) {
+                        let (func, test) = split_top(name);
+                        out.push(DiscoveredTest {
+                            function_name: func,
+                            test_name: test,
+                            kind: TestKind::Testset {
+                                full_path: name.to_string(),
+                            },
+                        });
+                    }
+                }
+                // `lazyTestSet` entries are expected to have been expanded
+                // before flattening; they contribute no tests of their own.
+            } else if class_matches(class_name, "SerializedTestSet") {
+                if let Some(items) = fields.get("items") {
+                    flatten_tree(items, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_lazy_names(value: &BexExternalValue) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_lazy_names_inner(value, &mut out);
+    out
+}
+
+fn collect_lazy_names_inner(value: &BexExternalValue, out: &mut Vec<String>) {
+    match unwrap_union(value) {
+        BexExternalValue::Array { items, .. } => {
+            for item in items {
+                collect_lazy_names_inner(item, out);
+            }
+        }
+        BexExternalValue::Instance { class_name, fields } => {
+            if class_matches(class_name, "SerializedTest") {
+                let kind = fields.get("type").and_then(as_string).unwrap_or_default();
+                if kind == "lazyTestSet" {
+                    if let Some(name) = fields.get("name").and_then(as_string) {
+                        out.push(name.to_string());
+                    }
+                }
+            } else if class_matches(class_name, "SerializedTestSet") {
+                if let Some(items) = fields.get("items") {
+                    collect_lazy_names_inner(items, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Testset test execution
+// ---------------------------------------------------------------------------
+
+fn run_testset_test(
+    ctx: &RunCtx,
+    registry: &BexExternalValue,
+    full_path: &str,
+    t: &DiscoveredTest,
+    passed: &mut usize,
+    failed: &mut usize,
+) {
+    let call_ctx = FunctionCallContextBuilder::new(CallId::next())
+        .with_cancel_token(ctx.cancel.clone())
+        .build();
+    match ctx.rt.block_on(ctx.engine.call_function(
+        "testing.TestRegistry.run_test",
+        vec![
+            registry.clone(),
+            BexExternalValue::String(full_path.to_string()),
+        ],
+        call_ctx,
+        true,
+    )) {
+        Ok(report) => {
+            let outcome = extract_outcome(&report).unwrap_or_else(|| "unknown".to_string());
+            if outcome == "pass" {
+                println!("PASS {}::{}", t.function_name, t.test_name);
+                *passed += 1;
+            } else {
+                println!(
+                    "FAIL {}::{} [outcome={outcome}]",
+                    t.function_name, t.test_name
+                );
+                *failed += 1;
+            }
+        }
+        Err(e) => {
+            eprintln!("FAIL {}::{}", t.function_name, t.test_name);
+            eprintln!("  => {e:?}");
+            *failed += 1;
+        }
+    }
+}
+
+/// Pull `TestReport.outcome` out of the returned value.
+///
+/// The runtime's `run_test` (baml_std/testing/registry.baml:172) returns a
+/// `TestReport { outcome, runs }` where `outcome` is `"pass" | "fail" |
+/// "error"`. Union-literal types may arrive wrapped; unwrap defensively.
+fn extract_outcome(value: &BexExternalValue) -> Option<String> {
+    let v = unwrap_union(value);
+    if let BexExternalValue::Instance { fields, .. } = v {
+        if let Some(outcome) = fields.get("outcome") {
+            return as_string(unwrap_union(outcome)).map(str::to_string);
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Strip a leading `Union { value, … }` wrapper. Union-typed fields (e.g.
+/// `SerializedTestDef = SerializedTest | SerializedTestSet`) come back
+/// wrapped when deep-copied across the FFI boundary.
+fn unwrap_union(value: &BexExternalValue) -> &BexExternalValue {
+    match value {
+        BexExternalValue::Union { value, .. } => unwrap_union(value),
+        other => other,
+    }
+}
+
+fn as_string(value: &BexExternalValue) -> Option<&str> {
+    match value {
+        BexExternalValue::String(s) => Some(s.as_str()),
+        BexExternalValue::Union { value, .. } => as_string(value),
+        _ => None,
+    }
+}
+
+/// Match the last segment of a namespaced class name, ignoring any leading
+/// `testing.` / `user.` / similar prefix. `testing.SerializedTest` and
+/// `SerializedTest` both match `"SerializedTest"`.
+fn class_matches(class_name: &str, leaf: &str) -> bool {
+    class_name == leaf
+        || class_name
+            .rsplit_once('.')
+            .is_some_and(|(_, last)| last == leaf)
+}
+
+/// Split a testset's slash-separated path into (first-segment, rest). For
+/// `"tictactoe/x wins row"` → ("tictactoe", "x wins row"). For a path with
+/// no slash (shouldn't happen for testset tests but guard anyway) → ("",
+/// whole-thing).
+fn split_top(full_path: &str) -> (String, String) {
+    match full_path.split_once('/') {
+        Some((head, tail)) => (head.to_string(), tail.to_string()),
+        None => (String::new(), full_path.to_string()),
+    }
 }


### PR DESCRIPTION
## Summary

- `baml-cli test` now discovers tests defined with the new `testset "…" { test "…" { … } }` syntax, not just the legacy per-function form. Previously even `baml_tests/projects/testset_basic/` printed `No tests selected.`
- Adds a second discovery path that calls `BexEngine::collect_tests`, auto-expands every `lazyTestSet` via `TestRegistry.expand_set`, flattens the `TestRegistry.serialize` tree into `(testset_head, rest/of/path)` tuples the existing `TestFilter` already understands, and executes each selected test via `TestRegistry.run_test` — mirroring what the LSP already does at `bex_project/src/bex_lsp/multi_project/mod.rs:609–911`.
- Bonus fix: `baml_cli::main` was discarding the `ExitCode` returned by `run_cli` and always exiting 0 for every subcommand. Now `std::process::exit(exit_code.into())` so `TestFailure` → 2 and `NoTestsRun` → 5 actually reach the shell.

Legacy (per-function-args) test execution is untouched; the two discovery paths merge into one list before filtering and running.

## Test plan

Verified manually against a tic-tac-toe project with five testset tests:

- [x] `baml-cli test` — all 5 tests PASS, exit 0
- [x] `baml-cli test --list` — lists 5 tests labeled `<testset>`
- [x] `baml-cli test -i 'tictactoe::*wins*'` — wildcard filter, 3 matches
- [x] `baml-cli test -i 'tictactoe::'` — top-level filter, all 5
- [x] `baml-cli test -x 'tictactoe::draw game'` — exclude, 4 run
- [x] `baml-cli test --from /abs/path` — works
- [x] `baml-cli test -i 'doesnotexist::*'` — `No tests selected.`, exit 5
- [x] Nested testsets (`outer { inner { test "leaf" {…} } }`) → discovered and runnable as `outer::inner/leaf`; `-i 'outer::inner/*'` filters correctly
- [x] Dynamic testsets (`testset "dynamic" { for (let n in [1,2,3]) { test "generated " + ... } }`) → all 3 generated tests found and executed
- [x] Mixed pass/fail → FAIL line + stack trace shown, `Results: 6 passed, 1 failed, 7 total`, exit 2
- [x] `cargo clippy -p baml_cli` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test command now supports two test modes: discover and execute legacy function-attached tests and testset tests from registries with unified reporting.

* **Refactor**
  * Test execution pipeline improved with separate handling for legacy and testset tests; enhanced cancellation support across all execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->