### PR TITLE
Treat underscore patterns as explicit discards

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -578,12 +578,28 @@ pub enum Stmt {
 /// Patterns — modeled after `Pattern` in `body.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Pattern {
+    Discard,
+    TypedDiscard { ty: TypeExpr },
     Binding(Name),
     TypedBinding { name: Name, ty: TypeExpr },
     Literal(Literal),
     Null,
     EnumVariant { enum_name: Name, variant: Name },
     Union(Vec<PatId>),
+}
+
+impl Pattern {
+    pub fn binding_name(&self) -> Option<&Name> {
+        match self {
+            Self::Binding(name) => Some(name),
+            Self::TypedBinding { name, .. } => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn is_discard(&self) -> bool {
+        matches!(self, Self::Discard | Self::TypedDiscard { .. })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
@@ -92,8 +92,11 @@ fn validate_expr_body(body: &ExprBody, diagnostics: &mut Vec<(String, text_size:
 
     // Check typed patterns (e.g. `let x: string @alias("n") = ...`).
     for (_, pat) in body.patterns.iter() {
-        if let Pattern::TypedBinding { ty, .. } = pat {
-            validate_type_expr_tree(ty, diagnostics);
+        match pat {
+            Pattern::TypedBinding { ty, .. } | Pattern::TypedDiscard { ty } => {
+                validate_type_expr_tree(ty, diagnostics);
+            }
+            _ => {}
         }
     }
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -1045,8 +1045,7 @@ impl LoweringContext {
         }
 
         let arm = MatchArm {
-            pattern: pattern
-                .unwrap_or_else(|| self.patterns.alloc(Pattern::Binding(Name::new("_")))),
+            pattern: pattern.unwrap_or_else(|| self.patterns.alloc(Pattern::Discard)),
             guard,
             body: body.unwrap_or_else(|| self.exprs.alloc(Expr::Missing)),
         };
@@ -1088,13 +1087,15 @@ impl LoweringContext {
                                 // After `name:`, we expect the type to be a node child (TYPE_EXPR),
                                 // but sometimes parser emits it as a WORD token directly.
                                 // Treat it as a named type.
-                                let pat = Pattern::TypedBinding {
-                                    name,
-                                    ty: crate::ast::TypeExpr::Path {
-                                        segments: vec![Name::new(&text)],
-                                        generic_args: vec![],
-                                        attrs: vec![],
-                                    },
+                                let ty = crate::ast::TypeExpr::Path {
+                                    segments: vec![Name::new(&text)],
+                                    generic_args: vec![],
+                                    attrs: vec![],
+                                };
+                                let pat = if name.as_str() == "_" {
+                                    Pattern::TypedDiscard { ty }
+                                } else {
+                                    Pattern::TypedBinding { name, ty }
                                 };
                                 elements.push(self.alloc_pattern(pat, token.text_range()));
                                 continue;
@@ -1206,7 +1207,11 @@ impl LoweringContext {
                                 {
                                     let ty =
                                         crate::lower_type_expr::lower_type_expr_node(&type_expr);
-                                    let pat = Pattern::TypedBinding { name, ty };
+                                    let pat = if name.as_str() == "_" {
+                                        Pattern::TypedDiscard { ty }
+                                    } else {
+                                        Pattern::TypedBinding { name, ty }
+                                    };
                                     elements.push(self.alloc_pattern(pat, child.text_range()));
                                 }
                             }
@@ -1244,7 +1249,7 @@ impl LoweringContext {
         let _ = pending_negation; // consumed above
 
         match elements.len() {
-            0 => self.alloc_pattern(Pattern::Binding(Name::new("_")), TextRange::default()),
+            0 => self.alloc_pattern(Pattern::Discard, TextRange::default()),
             1 => elements.remove(0),
             _ => {
                 let range = TextRange::default();
@@ -1259,9 +1264,15 @@ impl LoweringContext {
             PatternElement::Segments(segs, start) => {
                 let range = TextRange::new(start, start);
                 match segs.len() {
-                    0 => self.alloc_pattern(Pattern::Binding(Name::new("_")), range),
-                    1 => self
-                        .alloc_pattern(Pattern::Binding(segs.into_iter().next().unwrap()), range),
+                    0 => self.alloc_pattern(Pattern::Discard, range),
+                    1 => {
+                        let name = segs.into_iter().next().unwrap();
+                        if name.as_str() == "_" {
+                            self.alloc_pattern(Pattern::Discard, range)
+                        } else {
+                            self.alloc_pattern(Pattern::Binding(name), range)
+                        }
+                    }
                     _ => {
                         // Multi-segment: last is variant, rest form enum name
                         let iter = segs.into_iter();
@@ -1285,12 +1296,20 @@ impl LoweringContext {
                 // Incomplete dotted path (ended with a dot) — treat as binding
                 let range = TextRange::new(start, start);
                 let name = segs.last().cloned().unwrap_or(Name::new("_"));
-                self.alloc_pattern(Pattern::Binding(name), range)
+                if name.as_str() == "_" {
+                    self.alloc_pattern(Pattern::Discard, range)
+                } else {
+                    self.alloc_pattern(Pattern::Binding(name), range)
+                }
             }
             PatternElement::TypedBindingStart(name, start) => {
                 // `name:` with no type — treat as simple binding
                 let range = TextRange::new(start, start);
-                self.alloc_pattern(Pattern::Binding(name), range)
+                if name.as_str() == "_" {
+                    self.alloc_pattern(Pattern::Discard, range)
+                } else {
+                    self.alloc_pattern(Pattern::Binding(name), range)
+                }
             }
         }
     }
@@ -1350,8 +1369,12 @@ impl LoweringContext {
                                 _ => None,
                             })
                             .unwrap_or_else(|| Name::new("_"));
-                        stack_trace_binding =
-                            Some(self.alloc_pattern(Pattern::Binding(name), child.text_range()));
+                        let pat = if name.as_str() == "_" {
+                            Pattern::Discard
+                        } else {
+                            Pattern::Binding(name)
+                        };
+                        stack_trace_binding = Some(self.alloc_pattern(pat, child.text_range()));
                     }
                     SyntaxKind::CATCH_ARM => {
                         let arm = self.lower_catch_arm(&child);
@@ -1364,9 +1387,8 @@ impl LoweringContext {
 
         CatchClause {
             kind,
-            binding: binding.unwrap_or_else(|| {
-                self.alloc_pattern(Pattern::Binding(Name::new("_")), node.text_range())
-            }),
+            binding: binding
+                .unwrap_or_else(|| self.alloc_pattern(Pattern::Discard, node.text_range())),
             stack_trace_binding,
             arms,
         }
@@ -1433,7 +1455,7 @@ impl LoweringContext {
 
         let pattern = match pattern {
             Some(pattern) => pattern,
-            None => self.alloc_pattern(Pattern::Binding(Name::new("_")), node.text_range()),
+            None => self.alloc_pattern(Pattern::Discard, node.text_range()),
         };
         let body = match body {
             Some(body) => body,
@@ -2419,8 +2441,12 @@ impl LoweringContext {
                                     .map(|t| Name::new(t.text()))
                                     .unwrap_or(Name::new("_"));
                                 let range = child.text_range();
-                                pattern_id =
-                                    Some(self.alloc_pattern(Pattern::Binding(name), range));
+                                let pat = if name.as_str() == "_" {
+                                    Pattern::Discard
+                                } else {
+                                    Pattern::Binding(name)
+                                };
+                                pattern_id = Some(self.alloc_pattern(pat, range));
                             }
                         }
                     } else if initializer.is_none() {
@@ -2441,11 +2467,13 @@ impl LoweringContext {
                         }
                         k if is_ident_token(k) && seen_let_kw && pattern_id.is_none() => {
                             let range = token.text_range();
-                            pattern_id =
-                                Some(self.alloc_pattern(
-                                    Pattern::Binding(Name::new(token.text())),
-                                    range,
-                                ));
+                            let name = Name::new(token.text());
+                            let pat = if name.as_str() == "_" {
+                                Pattern::Discard
+                            } else {
+                                Pattern::Binding(name)
+                            };
+                            pattern_id = Some(self.alloc_pattern(pat, range));
                         }
                         SyntaxKind::EQUALS | SyntaxKind::COLON => break,
                         _ => {}
@@ -2454,9 +2482,8 @@ impl LoweringContext {
             }
         }
 
-        let pattern = pattern_id.unwrap_or_else(|| {
-            self.alloc_pattern(Pattern::Binding(Name::new("_")), TextRange::default())
-        });
+        let pattern = pattern_id
+            .unwrap_or_else(|| self.alloc_pattern(Pattern::Discard, TextRange::default()));
 
         let origin = if is_watched {
             // TODO: Handle watched let statements
@@ -2647,7 +2674,11 @@ impl LoweringContext {
 
         let collection = iter_expr_opt.unwrap_or_else(|| self.alloc_expr(Expr::Missing, range));
         let body = body_opt.unwrap_or_else(|| self.alloc_expr(Expr::Missing, range));
-        let binding = self.alloc_pattern(Pattern::Binding(iter_name), range);
+        let binding = if iter_name.as_str() == "_" {
+            self.alloc_pattern(Pattern::Discard, range)
+        } else {
+            self.alloc_pattern(Pattern::Binding(iter_name), range)
+        };
 
         self.alloc_stmt(
             Stmt::For {

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -251,7 +251,7 @@ impl<'db> SemanticIndexBuilder<'db> {
             };
             if let Some(pattern) = binding_pattern {
                 let scope_id = self.current_scope_id();
-                if let ast::Pattern::Binding(name) = &body.patterns[pattern] {
+                if let Some(name) = body.patterns[pattern].binding_name() {
                     let name_range = source_map.pattern_span(pattern);
 
                     seen.entry(name.clone()).or_default().push(MemberSite {
@@ -503,11 +503,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         patterns: &la_arena::Arena<ast::Pattern>,
         pat_id: ast::PatId,
     ) -> Option<&Name> {
-        match &patterns[pat_id] {
-            ast::Pattern::Binding(name) if name.as_str() != "_" => Some(name),
-            ast::Pattern::TypedBinding { name, .. } if name.as_str() != "_" => Some(name),
-            _ => None,
-        }
+        patterns[pat_id].binding_name()
     }
 
     /// Collect all single-segment `Expr::Path` names from an `ExprBody`.

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3472,11 +3472,19 @@ impl LoweringContext<'_> {
             } => {
                 // Extract binding name from pattern
                 let pat = self.body.patterns[pattern].clone();
-                let name = match &pat {
-                    AstPattern::Binding(n) => n.clone(),
-                    AstPattern::TypedBinding { name, .. } => name.clone(),
-                    _ => Name::new("_"),
-                };
+                if pat.is_discard() {
+                    if let Some(init) = initializer {
+                        let temp = self.builder.temp(self.expr_ty(init));
+                        self.lower_expr(init, Place::local(temp));
+                    }
+                    self.builder.current_source_span = prev_span;
+                    return;
+                }
+
+                let name = pat
+                    .binding_name()
+                    .cloned()
+                    .unwrap_or_else(|| Name::new("_"));
 
                 let local_ty = self.pat_ty(pattern);
                 let local =
@@ -3658,7 +3666,7 @@ impl LoweringContext<'_> {
                 {
                     let pat = self.body.patterns[binding].clone();
                     match pat {
-                        AstPattern::Binding(name) if name.as_str() != "_" => {
+                        AstPattern::Binding(name) => {
                             let ty = self
                                 .pat_types
                                 .get(&(self.current_scope, binding))
@@ -3674,7 +3682,7 @@ impl LoweringContext<'_> {
                             );
                             self.locals.insert(name, local);
                         }
-                        AstPattern::TypedBinding { name, ty, .. } if name.as_str() != "_" => {
+                        AstPattern::TypedBinding { name, ty, .. } => {
                             let resolved_ty = self.resolve_type_annotation(&ty);
                             let local = self.builder.declare_local(
                                 Some(name.clone()),
@@ -3689,6 +3697,7 @@ impl LoweringContext<'_> {
                             );
                             self.locals.insert(name, local);
                         }
+                        AstPattern::Discard | AstPattern::TypedDiscard { .. } => {}
                         _ => {}
                     }
                 }
@@ -4303,7 +4312,9 @@ impl LoweringContext<'_> {
                                     int_arms.push((disc, i));
                                 }
                             }
-                            AstPattern::Binding(_) | AstPattern::TypedBinding { .. } => {
+                            AstPattern::Binding(_)
+                            | AstPattern::TypedBinding { .. }
+                            | AstPattern::TypedDiscard { .. } => {
                                 // Type-pattern sub-arm: look up type tag via TIR.
                                 match &switch_kind {
                                     None => switch_kind = Some(SwitchKind::TypeTag),
@@ -4325,7 +4336,7 @@ impl LoweringContext<'_> {
                         }
                     }
                 }
-                AstPattern::TypedBinding { .. } => {
+                AstPattern::TypedBinding { .. } | AstPattern::TypedDiscard { .. } => {
                     // Type-annotated binding → classify as TypeTag
                     match &switch_kind {
                         None => switch_kind = Some(SwitchKind::TypeTag),
@@ -4343,7 +4354,7 @@ impl LoweringContext<'_> {
                         None => return false,
                     }
                 }
-                AstPattern::Binding(name) if name.as_str() != "_" => {
+                AstPattern::Binding(_) => {
                     // Bare name resolved to a type by TIR (e.g. `DivisionByZero =>`)
                     if self.pat_types.contains_key(&(self.current_scope, pattern)) {
                         match &switch_kind {
@@ -4369,7 +4380,7 @@ impl LoweringContext<'_> {
                         otherwise_idx = Some(i);
                     }
                 }
-                AstPattern::Binding(_) => {
+                AstPattern::Discard => {
                     // Wildcard `_` — must be last arm
                     if i != arms.len() - 1 {
                         return false;
@@ -4710,22 +4721,22 @@ impl LoweringContext<'_> {
     ) {
         let pat = self.body.patterns[pat_id].clone();
         match pat {
-            AstPattern::Binding(ref name) => {
+            AstPattern::Discard => {
+                self.builder.goto(success);
+            }
+            AstPattern::Binding(_) => {
                 // Bare type sugar: the TIR resolved this binding name to a
                 // type (e.g. `DivisionByZero =>` resolves to a class).
                 // Generate an IsType test instead of an unconditional match.
-                if name.as_str() != "_" {
-                    if let Some(tir_ty) = self.pat_types.get(&(self.current_scope, pat_id)).cloned()
-                    {
-                        let resolved = self.resolved_aliases.convert(&tir_ty);
-                        self.emit_is_type_branch(scrutinee, resolved, success, failure);
-                        return;
-                    }
+                if let Some(tir_ty) = self.pat_types.get(&(self.current_scope, pat_id)).cloned() {
+                    let resolved = self.resolved_aliases.convert(&tir_ty);
+                    self.emit_is_type_branch(scrutinee, resolved, success, failure);
+                    return;
                 }
                 // Regular binding — always matches
                 self.builder.goto(success);
             }
-            AstPattern::TypedBinding { .. } => {
+            AstPattern::TypedBinding { .. } | AstPattern::TypedDiscard { .. } => {
                 // TIR always resolves TypedBinding patterns via record_pattern_test_types.
                 let annotation_ty = self
                     .pat_types
@@ -4816,7 +4827,7 @@ impl LoweringContext<'_> {
     fn bind_pattern(&mut self, scrutinee: Local, pat_id: AstPatId) {
         let pat = self.body.patterns[pat_id].clone();
         match pat {
-            AstPattern::Binding(name) if name.as_str() != "_" => {
+            AstPattern::Binding(name) => {
                 // Prefer TIR-inferred type; fall back to the scrutinee's declared type
                 // rather than Null, so catch bindings get the error's type (unknown) not null.
                 let ty = self
@@ -4833,7 +4844,7 @@ impl LoweringContext<'_> {
                 );
                 self.locals.insert(name, local);
             }
-            AstPattern::TypedBinding { name, ty, .. } if name.as_str() != "_" => {
+            AstPattern::TypedBinding { name, ty, .. } => {
                 let resolved_ty = self.resolve_type_annotation(&ty);
                 let local =
                     self.builder
@@ -4845,7 +4856,7 @@ impl LoweringContext<'_> {
                 self.locals.insert(name, local);
             }
             _ => {
-                // Wildcard `_`, Literal, Null, EnumVariant, Union — no binding needed
+                // Discard, typed discard, Literal, Null, EnumVariant, Union — no binding needed
             }
         }
     }
@@ -4865,7 +4876,7 @@ impl LoweringContext<'_> {
     fn classify_pattern_type_tag(&self, pat_id: AstPatId) -> Option<Vec<i64>> {
         let pat = &self.body.patterns[pat_id];
         match pat {
-            AstPattern::Binding(name) if name.as_str() == "_" => {
+            AstPattern::Discard => {
                 // Pure wildcard — handled separately, not a type test
                 None
             }
@@ -4875,7 +4886,7 @@ impl LoweringContext<'_> {
                 let resolved = self.resolved_aliases.convert(tir_ty);
                 self.ty_to_type_tags(&resolved)
             }
-            AstPattern::TypedBinding { .. } => {
+            AstPattern::TypedBinding { .. } | AstPattern::TypedDiscard { .. } => {
                 // Type-annotated binding — always resolved by TIR
                 let tir_ty = self.pat_types.get(&(self.current_scope, pat_id))?;
                 let resolved = self.resolved_aliases.convert(tir_ty);
@@ -4949,10 +4960,7 @@ impl LoweringContext<'_> {
         // shows up in bytecode instead of an anonymous `_N` temp.
         let binding_name = clauses
             .first()
-            .and_then(|c| match &self.body.patterns[c.binding] {
-                AstPattern::Binding(name) if name.as_str() != "_" => Some(name.clone()),
-                _ => None,
-            });
+            .and_then(|c| self.body.patterns[c.binding].binding_name().cloned());
         let error_local = self.builder.declare_local(
             binding_name.clone(),
             Ty::BuiltinUnknown {
@@ -4968,10 +4976,7 @@ impl LoweringContext<'_> {
         // Declare stack trace local if the catch clause has a second binding.
         let stack_trace_local = clauses.first().and_then(|c| {
             c.stack_trace_binding.map(|st_pat| {
-                let st_name = match &self.body.patterns[st_pat] {
-                    AstPattern::Binding(name) if name.as_str() != "_" => Some(name.clone()),
-                    _ => None,
-                };
+                let st_name = self.body.patterns[st_pat].binding_name().cloned();
                 let local = self.builder.declare_local(
                     st_name.clone(),
                     Ty::BuiltinUnknown {
@@ -4992,10 +4997,7 @@ impl LoweringContext<'_> {
         for clause in clauses {
             for &arm_id in &clause.arms {
                 let arm = self.body.catch_arms[arm_id].clone();
-                let is_wildcard = matches!(
-                    self.body.patterns[arm.pattern],
-                    AstPattern::Binding(ref name) if name.as_str() == "_"
-                );
+                let is_wildcard = matches!(self.body.patterns[arm.pattern], AstPattern::Discard);
                 arms.push((arm, is_wildcard));
             }
         }

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2005,12 +2005,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 if let Some(ty) = init_ty {
                     self.bindings.insert(*pattern, ty.clone());
                     let pat = &body.patterns[*pattern];
-                    let name = match pat {
-                        baml_compiler2_ast::Pattern::Binding(name) => Some(name),
-                        baml_compiler2_ast::Pattern::TypedBinding { name, .. } => Some(name),
-                        _ => None,
-                    };
-                    if let Some(name) = name {
+                    if let Some(name) = pat.binding_name() {
                         self.let_binding_patterns.insert(name.clone(), *pattern);
                         self.locals.insert(name.clone(), ty);
                         // Record declared type only for annotated let-bindings.
@@ -2072,13 +2067,8 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                 // 3. Bind the loop variable to the element type
                 let pat = &body.patterns[*binding];
-                let name = match pat {
-                    baml_compiler2_ast::Pattern::Binding(name) => Some(name.clone()),
-                    baml_compiler2_ast::Pattern::TypedBinding { name, .. } => Some(name.clone()),
-                    _ => None,
-                };
                 self.bindings.insert(*binding, elem_ty.clone());
-                if let Some(name) = name {
+                if let Some(name) = pat.binding_name().cloned() {
                     self.locals.insert(name, elem_ty);
                 }
 
@@ -2438,9 +2428,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.bindings.insert(st_binding, st_ty.clone());
                 // Also insert into locals so name resolution finds it.
                 let st_name = match &body.patterns[st_binding] {
-                    baml_compiler2_ast::Pattern::Binding(name) => Some(name.clone()),
-                    baml_compiler2_ast::Pattern::TypedBinding { name, .. } => Some(name.clone()),
-                    _ => None,
+                    pat => pat.binding_name().cloned(),
                 };
                 if let Some(name) = st_name {
                     self.locals.insert(name, st_ty);
@@ -2448,7 +2436,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             let binding_name = match &body.patterns[clause.binding] {
-                baml_compiler2_ast::Pattern::Binding(name) => Some(name.clone()),
                 baml_compiler2_ast::Pattern::TypedBinding { name, ty } => {
                     if let Some(banned) = crate::throw_inference::is_banned_catch_binding_type(ty) {
                         self.context.report_simple(
@@ -2460,7 +2447,18 @@ impl<'db> TypeInferenceBuilder<'db> {
                     }
                     Some(name.clone())
                 }
-                _ => None,
+                baml_compiler2_ast::Pattern::TypedDiscard { ty } => {
+                    if let Some(banned) = crate::throw_inference::is_banned_catch_binding_type(ty) {
+                        self.context.report_simple(
+                            TirTypeError::InvalidCatchBindingType {
+                                type_name: banned.to_string(),
+                            },
+                            base_expr_id,
+                        );
+                    }
+                    None
+                }
+                pat => pat.binding_name().cloned(),
             };
 
             for &arm_id in &clause.arms {
@@ -2620,10 +2618,11 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) -> BTreeSet<String> {
         let pattern = &body.patterns[pattern_id];
         match pattern {
+            baml_compiler2_ast::Pattern::Discard => {
+                self.required_match_cases(scrutinee_ty).unwrap_or_default()
+            }
             baml_compiler2_ast::Pattern::Binding(name) => {
-                if name.as_str() == "_" {
-                    self.required_match_cases(scrutinee_ty).unwrap_or_default()
-                } else if self.is_bare_type_sugar_binding(name) {
+                if self.is_bare_type_sugar_binding(name) {
                     let narrowed =
                         self.pattern_narrowed_type(pattern_id, scrutinee_ty, body, at_expr);
                     self.required_match_cases(&narrowed).unwrap_or_default()
@@ -2631,7 +2630,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                     self.required_match_cases(scrutinee_ty).unwrap_or_default()
                 }
             }
-            baml_compiler2_ast::Pattern::TypedBinding { .. } => {
+            baml_compiler2_ast::Pattern::TypedBinding { .. }
+            | baml_compiler2_ast::Pattern::TypedDiscard { .. } => {
                 let narrowed = self.pattern_narrowed_type(pattern_id, scrutinee_ty, body, at_expr);
                 if self.is_subtype(scrutinee_ty, &narrowed) {
                     self.required_match_cases(scrutinee_ty).unwrap_or_default()
@@ -2672,10 +2672,10 @@ impl<'db> TypeInferenceBuilder<'db> {
         at_expr: ExprId,
     ) -> bool {
         match &body.patterns[pattern_id] {
-            baml_compiler2_ast::Pattern::Binding(name) => {
-                !self.is_bare_type_sugar_binding(name) || name.as_str() == "_"
-            }
-            baml_compiler2_ast::Pattern::TypedBinding { .. } => {
+            baml_compiler2_ast::Pattern::Discard => true,
+            baml_compiler2_ast::Pattern::Binding(name) => !self.is_bare_type_sugar_binding(name),
+            baml_compiler2_ast::Pattern::TypedBinding { .. }
+            | baml_compiler2_ast::Pattern::TypedDiscard { .. } => {
                 let narrowed = self.pattern_narrowed_type(pattern_id, scrutinee_ty, body, at_expr);
                 self.is_subtype(scrutinee_ty, &narrowed)
             }
@@ -2715,12 +2715,14 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) -> Option<(Name, Ty)> {
         match &body.patterns[pattern_id] {
             baml_compiler2_ast::Pattern::Binding(name) => {
-                if name.as_str() == "_" || self.is_bare_type_sugar_binding(name) {
+                if self.is_bare_type_sugar_binding(name) {
                     None
                 } else {
                     Some((name.clone(), scrutinee_ty.clone()))
                 }
             }
+            baml_compiler2_ast::Pattern::Discard
+            | baml_compiler2_ast::Pattern::TypedDiscard { .. } => None,
             baml_compiler2_ast::Pattern::TypedBinding { name, ty } => {
                 Some((name.clone(), self.resolve_type_expr(ty, at_expr)))
             }
@@ -2736,13 +2738,15 @@ impl<'db> TypeInferenceBuilder<'db> {
         at_expr: ExprId,
     ) {
         match &body.patterns[pattern_id] {
-            baml_compiler2_ast::Pattern::Binding(name)
-                if name.as_str() != "_" && self.is_bare_type_sugar_binding(name) =>
-            {
+            baml_compiler2_ast::Pattern::Binding(name) if self.is_bare_type_sugar_binding(name) => {
                 let ty = self.pattern_narrowed_type(pattern_id, scrutinee_ty, body, at_expr);
                 self.bindings.insert(pattern_id, ty);
             }
             baml_compiler2_ast::Pattern::TypedBinding { ty, .. } => {
+                let resolved = self.resolve_type_expr(ty, at_expr);
+                self.bindings.insert(pattern_id, resolved);
+            }
+            baml_compiler2_ast::Pattern::TypedDiscard { ty } => {
                 let resolved = self.resolve_type_expr(ty, at_expr);
                 self.bindings.insert(pattern_id, resolved);
             }
@@ -2777,6 +2781,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         at_expr: ExprId,
     ) -> Ty {
         match &body.patterns[pattern_id] {
+            baml_compiler2_ast::Pattern::Discard => scrutinee_ty.clone(),
             baml_compiler2_ast::Pattern::Binding(name) => {
                 if let Some(prim_ty) = bare_type_sugar_to_ty(name) {
                     prim_ty
@@ -2796,6 +2801,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             baml_compiler2_ast::Pattern::TypedBinding { ty, .. } => {
                 self.resolve_type_expr(ty, at_expr)
             }
+            baml_compiler2_ast::Pattern::TypedDiscard { ty } => self.resolve_type_expr(ty, at_expr),
             baml_compiler2_ast::Pattern::Literal(lit) => Ty::Literal(
                 lit.clone(),
                 crate::ty::Freshness::Regular,
@@ -2867,8 +2873,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         at_expr: ExprId,
     ) -> Option<Ty> {
         match &body.patterns[pattern_id] {
+            baml_compiler2_ast::Pattern::Discard => None,
             baml_compiler2_ast::Pattern::Binding(name) => {
-                if name.as_str() == "_" || !self.is_bare_type_sugar_binding(name) {
+                if !self.is_bare_type_sugar_binding(name) {
                     return None;
                 }
 
@@ -2887,6 +2894,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.ty_panic_subset(&narrowed)
             }
             baml_compiler2_ast::Pattern::TypedBinding { ty, .. } => {
+                let narrowed = self.resolve_type_expr(ty, at_expr);
+                self.ty_panic_subset(&narrowed)
+            }
+            baml_compiler2_ast::Pattern::TypedDiscard { ty } => {
                 let narrowed = self.resolve_type_expr(ty, at_expr);
                 self.ty_panic_subset(&narrowed)
             }
@@ -3079,6 +3090,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         );
         let pattern = &body.patterns[pattern_id];
         match pattern {
+            baml_compiler2_ast::Pattern::Discard => PatternMatchStrength::DefiniteMatch,
             baml_compiler2_ast::Pattern::Binding(name) => {
                 if self.is_bare_type_sugar_binding(name) {
                     let lowered = if let Some(prim_ty) = bare_type_sugar_to_ty(name) {
@@ -3105,6 +3117,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
             baml_compiler2_ast::Pattern::TypedBinding { ty, .. } => {
+                let lowered = self.lower_pattern_type_expr(ty, at_expr);
+                if Self::ty_covers_fact(&lowered, throw_fact) {
+                    PatternMatchStrength::DefiniteMatch
+                } else if is_unknown {
+                    PatternMatchStrength::MayMatch
+                } else {
+                    PatternMatchStrength::NoMatch
+                }
+            }
+            baml_compiler2_ast::Pattern::TypedDiscard { ty } => {
                 let lowered = self.lower_pattern_type_expr(ty, at_expr);
                 if Self::ty_covers_fact(&lowered, throw_fact) {
                     PatternMatchStrength::DefiniteMatch

--- a/baml_language/crates/baml_compiler2_tir/src/throw_inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throw_inference.rs
@@ -8,7 +8,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use baml_base::Name;
-use baml_compiler2_ast::{Expr, ExprBody, Literal, Pattern, TypeExpr};
+use baml_compiler2_ast::{Expr, ExprBody, Literal, TypeExpr};
 use baml_compiler2_hir::{
     contributions::Definition,
     package::{PackageId, PackageItems, package_dependencies},
@@ -460,11 +460,8 @@ fn collect_catch_binding_names(body: &ExprBody) -> HashSet<&str> {
     for (_, expr) in body.exprs.iter() {
         if let Expr::Catch { clauses, .. } = expr {
             for clause in clauses {
-                match &body.patterns[clause.binding] {
-                    Pattern::Binding(name) | Pattern::TypedBinding { name, .. } => {
-                        names.insert(name.as_str());
-                    }
-                    _ => {}
+                if let Some(name) = body.patterns[clause.binding].binding_name() {
+                    names.insert(name.as_str());
                 }
             }
         }

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
@@ -654,6 +654,8 @@ impl<'a> AstGraphBuilder<'a> {
     fn format_pattern(&self, pat_id: ast::PatId) -> String {
         let pat = &self.body.patterns[pat_id];
         match pat {
+            ast::Pattern::Discard => "_".to_string(),
+            ast::Pattern::TypedDiscard { .. } => "_".to_string(),
             ast::Pattern::Binding(name) => name.to_string(),
             ast::Pattern::TypedBinding { name, .. } => name.to_string(),
             ast::Pattern::Literal(lit) => format_literal_ast(lit),

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/discard_bindings.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/discard_bindings.baml
@@ -1,0 +1,58 @@
+function Repro() -> int {
+  let _ = 1;
+  let _ = 2;
+  return 3;
+}
+
+function TypedRepro() -> int {
+  let _: int = 1;
+  let _: int = 2;
+  return 3;
+}
+
+function ReadDiscard() -> int {
+  let _ = 1;
+  return _;
+}
+
+function MatchDoesNotBindUnderscore(x: int | string) -> int {
+  let y = match (x) {
+    _ => 1
+  };
+  return _;
+}
+
+function TypedDiscardMismatch() -> int {
+  let _: int = "bad";
+  return 0;
+}
+
+//----
+//- diagnostics
+// Error: unresolved name: _
+//     ╭─[ expr_discard_bindings.baml:15:10 ]
+//     │
+//  15 │   return _;
+//     │          ┬  
+//     │          ╰── unresolved name: _
+//     │ 
+//     │ Note: Error code: E0003
+// ────╯
+// Error: unresolved name: _
+//     ╭─[ expr_discard_bindings.baml:22:10 ]
+//     │
+//  22 │   return _;
+//     │          ┬  
+//     │          ╰── unresolved name: _
+//     │ 
+//     │ Note: Error code: E0003
+// ────╯
+// Error: type mismatch: expected int, got "bad"
+//     ╭─[ expr_discard_bindings.baml:26:16 ]
+//     │
+//  26 │   let _: int = "bad";
+//     │                ──┬──  
+//     │                  ╰──── type mismatch: expected int, got "bad"
+//     │ 
+//     │ Note: Error code: E0001
+// ────╯

--- a/baml_language/crates/baml_tests/src/compiler2_hir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_hir.rs
@@ -672,6 +672,105 @@ mod tests {
         assert!(sites.iter().all(|s| s.kind == DefinitionKind::Binding));
     }
 
+    #[test]
+    fn discard_let_bindings_do_not_duplicate_or_bind() {
+        use baml_compiler2_hir::{diagnostic::Hir2Diagnostic, scope::ScopeKind};
+
+        let mut db = make_db();
+        let file = db.add_file(
+            "discard_let.baml",
+            "function foo() -> int {\n  let _ = 1;\n  let _ = 2;\n  return 3;\n}",
+        );
+
+        let index = file_semantic_index(&db, file);
+        assert!(!index.diagnostics().iter().any(|d| {
+            matches!(d, Hir2Diagnostic::DuplicateDefinition { name, .. } if name == &Name::new("_"))
+        }));
+
+        let (scope_idx, _) = index
+            .scopes
+            .iter()
+            .enumerate()
+            .find(|(_, scope)| {
+                matches!(scope.kind, ScopeKind::Function)
+                    && scope.name.as_ref() == Some(&Name::new("foo"))
+            })
+            .expect("function scope exists");
+        assert!(
+            index.scope_bindings[scope_idx]
+                .bindings
+                .iter()
+                .all(|(name, _, _)| name != &Name::new("_")),
+            "discard binding should not be visible in HIR scope bindings"
+        );
+    }
+
+    #[test]
+    fn typed_discard_let_bindings_do_not_duplicate_or_bind() {
+        use baml_compiler2_hir::{diagnostic::Hir2Diagnostic, scope::ScopeKind};
+
+        let mut db = make_db();
+        let file = db.add_file(
+            "typed_discard_let.baml",
+            "function foo() -> int {\n  let _: int = 1;\n  let _: int = 2;\n  return 3;\n}",
+        );
+
+        let index = file_semantic_index(&db, file);
+        assert!(!index.diagnostics().iter().any(|d| {
+            matches!(d, Hir2Diagnostic::DuplicateDefinition { name, .. } if name == &Name::new("_"))
+        }));
+
+        let (scope_idx, _) = index
+            .scopes
+            .iter()
+            .enumerate()
+            .find(|(_, scope)| {
+                matches!(scope.kind, ScopeKind::Function)
+                    && scope.name.as_ref() == Some(&Name::new("foo"))
+            })
+            .expect("function scope exists");
+        assert!(
+            index.scope_bindings[scope_idx]
+                .bindings
+                .iter()
+                .all(|(name, _, _)| name != &Name::new("_")),
+            "typed discard binding should not be visible in HIR scope bindings"
+        );
+    }
+
+    #[test]
+    fn discard_for_bindings_do_not_duplicate_or_bind() {
+        use baml_compiler2_hir::{diagnostic::Hir2Diagnostic, scope::ScopeKind};
+
+        let mut db = make_db();
+        let file = db.add_file(
+            "discard_for.baml",
+            "function foo(xs: int[]) -> int {\n  for _ in xs {\n    let y = 1;\n  }\n  for _ in xs {\n    let z = 2;\n  }\n  return 3;\n}",
+        );
+
+        let index = file_semantic_index(&db, file);
+        assert!(!index.diagnostics().iter().any(|d| {
+            matches!(d, Hir2Diagnostic::DuplicateDefinition { name, .. } if name == &Name::new("_"))
+        }));
+
+        let (scope_idx, _) = index
+            .scopes
+            .iter()
+            .enumerate()
+            .find(|(_, scope)| {
+                matches!(scope.kind, ScopeKind::Function)
+                    && scope.name.as_ref() == Some(&Name::new("foo"))
+            })
+            .expect("function scope exists");
+        assert!(
+            index.scope_bindings[scope_idx]
+                .bindings
+                .iter()
+                .all(|(name, _, _)| name != &Name::new("_")),
+            "for discard binding should not be visible in HIR scope bindings"
+        );
+    }
+
     /// A field and a method with the same name in a class produce a cross-kind diagnostic.
     #[test]
     fn field_method_same_name_produces_cross_kind_diagnostic() {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -132,6 +132,10 @@ pub(crate) mod support {
     fn pat_desc(pat_id: PatId, body: &ExprBody) -> String {
         let pat = &body.patterns[pat_id];
         match pat {
+            Pattern::Discard => "_".into(),
+            Pattern::TypedDiscard { ty } => {
+                format!("_: {}", type_expr_to_string(ty))
+            }
             Pattern::Binding(n) => n.to_string(),
             Pattern::TypedBinding { name, ty } => {
                 format!("{name}: {}", type_expr_to_string(ty))
@@ -738,6 +742,10 @@ pub(crate) mod support {
                 ..
             } => {
                 let pat_name = match &body.patterns[*pattern] {
+                    Pattern::Discard => "_".to_string(),
+                    Pattern::TypedDiscard { ty } => {
+                        format!("_: {}", type_expr_to_string(ty))
+                    }
                     Pattern::Binding(n) => n.to_string(),
                     Pattern::TypedBinding { name, ty } => {
                         format!("{name}: {}", type_expr_to_string(ty))
@@ -803,6 +811,10 @@ pub(crate) mod support {
                 body: for_body,
             } => {
                 let bind_name = match &body.patterns[*binding] {
+                    Pattern::Discard => "_".to_string(),
+                    Pattern::TypedDiscard { ty } => {
+                        format!("_: {}", type_expr_to_string(ty))
+                    }
                     Pattern::Binding(n) => n.to_string(),
                     Pattern::TypedBinding { name, .. } => name.to_string(),
                     other => format!("{other:?}"),
@@ -1287,6 +1299,10 @@ pub(crate) mod support {
         ) -> String {
             let pat = &body.patterns[pat_id];
             match pat {
+                Pattern::Discard => "_".into(),
+                Pattern::TypedDiscard { ty } => {
+                    format!("_: {}", type_expr_to_string_hir(ty, prefix))
+                }
                 Pattern::Binding(n) => n.to_string(),
                 Pattern::TypedBinding { name, ty } => {
                     format!("{name}: {}", type_expr_to_string_hir(ty, prefix))


### PR DESCRIPTION
## Summary
- Introduce explicit discard pattern variants for `_` and typed `_`, instead of modeling them as bindings named `_`.
- Update AST lowering, HIR, MIR, and TIR to treat discard patterns as non-binding while still preserving type annotations and validation.
- Fix control-flow, catch handling, and type inference so discard patterns do not create locals, duplicate definitions, or accidental name resolution for `_`.
- Add syntax and compiler tests covering discard lets, typed discards, matches, catches, and unresolved `_` references.

## Testing
- Added HIR tests for discard let bindings not creating duplicate definitions or visible scope bindings.
- Added TIR tests for discard patterns in matches and catch clauses.
- Added LSP syntax test coverage in `discard_bindings.baml`.
- Not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discard patterns to explicitly ignore values in let bindings, for loops, and match expressions
  * Added support for typed discard patterns with explicit type annotations
  * Discard patterns create no variable bindings and cannot be referenced

* **Tests**
  * Added test coverage for discard binding functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->