### PR TITLE
Add RuntimeEvent support to WebSocket transport and unify value rendering

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1564,6 +1564,7 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "serde_json",
+ "sys_types",
  "uuid",
  "web-time",
 ]

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1347,6 +1347,7 @@ dependencies = [
  "baml_compiler2_visualization",
  "baml_type",
  "base64",
+ "bex_events",
  "bex_events_native",
  "bex_heap",
  "bex_project",

--- a/baml_language/crates/baml_lsp_server/Cargo.toml
+++ b/baml_language/crates/baml_lsp_server/Cargo.toml
@@ -12,6 +12,7 @@ rustls = [ "reqwest/rustls", "sys_native/rustls" ]
 [dependencies]
 baml_compiler2_visualization = { workspace = true }
 baml_type = { workspace = true }
+bex_events = { workspace = true }
 bex_events_native = { workspace = true }
 bex_heap = { workspace = true }
 bex_project = { workspace = true }

--- a/baml_language/crates/baml_lsp_server/src/lib.rs
+++ b/baml_language/crates/baml_lsp_server/src/lib.rs
@@ -145,21 +145,20 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
         std::env::var("BAML_TRACE_FILE")
             .ok()
             .map(|trace_file| bex_events_native::start(trace_file.into()));
-    let file_event_sink_for_flush = file_event_sink.clone();
-
     // Playground event sink — always active so runtime events flow to the WebSocket UI.
     let playground_event_sink: std::sync::Arc<dyn bex_events::EventSink> = std::sync::Arc::new(
         playground_event_sink::PlaygroundEventSink::new(broadcast_tx.clone()),
     );
 
     // Compose sinks: playground is always present; file sink is optional.
-    let event_sink: Option<std::sync::Arc<dyn bex_events::EventSink>> = {
+    let composed_sink: std::sync::Arc<dyn bex_events::EventSink> = {
         let mut sinks: Vec<std::sync::Arc<dyn bex_events::EventSink>> = vec![playground_event_sink];
         if let Some(file_sink) = file_event_sink {
             sinks.push(file_sink);
         }
-        Some(std::sync::Arc::new(bex_events::FanOutEventSink::new(sinks)))
+        std::sync::Arc::new(bex_events::FanOutEventSink::new(sinks))
     };
+    let event_sink = Some(composed_sink.clone());
 
     // Create the BexLsp (multi-project LSP)
     let bex = bex_project::new_lsp(
@@ -240,8 +239,6 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
     }
 
     tracing::info!("LSP server shutting down");
-    if let Some(sink) = file_event_sink_for_flush {
-        sink.flush();
-    }
+    composed_sink.flush();
     Ok(())
 }

--- a/baml_language/crates/baml_lsp_server/src/lib.rs
+++ b/baml_language/crates/baml_lsp_server/src/lib.rs
@@ -35,6 +35,7 @@
 mod native_lsp_sender;
 mod native_vfs;
 pub mod playground_env;
+pub mod playground_event_sink;
 pub mod playground_http;
 pub mod playground_sender;
 pub mod playground_server;
@@ -139,15 +140,26 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
         playground_via_browser,
     ));
 
-    // Mirror runtime log.* events to stderr by default, and also persist full
-    // event traces when BAML_TRACE_FILE is configured.
-    let event_sink = Some(
+    // Start the native event sink if BAML_TRACE_FILE is set.
+    let file_event_sink: Option<std::sync::Arc<dyn bex_events::EventSink>> =
         std::env::var("BAML_TRACE_FILE")
             .ok()
-            .map(|trace_file| bex_events_native::start(trace_file.into()))
-            .unwrap_or_else(bex_events_native::start_stderr),
+            .map(|trace_file| bex_events_native::start(trace_file.into()));
+    let file_event_sink_for_flush = file_event_sink.clone();
+
+    // Playground event sink — always active so runtime events flow to the WebSocket UI.
+    let playground_event_sink: std::sync::Arc<dyn bex_events::EventSink> = std::sync::Arc::new(
+        playground_event_sink::PlaygroundEventSink::new(broadcast_tx.clone()),
     );
-    let event_sink_for_flush = event_sink.clone();
+
+    // Compose sinks: playground is always present; file sink is optional.
+    let event_sink: Option<std::sync::Arc<dyn bex_events::EventSink>> = {
+        let mut sinks: Vec<std::sync::Arc<dyn bex_events::EventSink>> = vec![playground_event_sink];
+        if let Some(file_sink) = file_event_sink {
+            sinks.push(file_sink);
+        }
+        Some(std::sync::Arc::new(bex_events::FanOutEventSink::new(sinks)))
+    };
 
     // Create the BexLsp (multi-project LSP)
     let bex = bex_project::new_lsp(
@@ -228,7 +240,7 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
     }
 
     tracing::info!("LSP server shutting down");
-    if let Some(sink) = event_sink_for_flush {
+    if let Some(sink) = file_event_sink_for_flush {
         sink.flush();
     }
     Ok(())

--- a/baml_language/crates/baml_lsp_server/src/playground_event_sink.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_event_sink.rs
@@ -1,0 +1,41 @@
+//! EventSink that broadcasts runtime events to WebSocket playground clients.
+//!
+//! Encodes each `RuntimeEvent` to protobuf bytes, base64-encodes the bytes,
+//! and sends them as `WsOutMessage::RuntimeEvent` via a broadcast channel.
+
+use base64::Engine as _;
+use tokio::sync::broadcast;
+
+use crate::playground_ws::WsOutMessage;
+
+pub struct PlaygroundEventSink {
+    broadcast_tx: broadcast::Sender<WsOutMessage>,
+}
+
+impl PlaygroundEventSink {
+    pub fn new(broadcast_tx: broadcast::Sender<WsOutMessage>) -> Self {
+        Self { broadcast_tx }
+    }
+}
+
+impl bex_events::EventSink for PlaygroundEventSink {
+    fn send(&self, event: bex_events::RuntimeEvent) {
+        let call_id = event.call_id.0;
+        let options = bridge_ctypes::HandleTableOptions::for_in_process();
+        match bridge_ctypes::runtime_event_to_bytes(&event, &options) {
+            Ok(data) => {
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
+                let _ = self
+                    .broadcast_tx
+                    .send(WsOutMessage::RuntimeEvent { data: b64, call_id });
+            }
+            Err(e) => {
+                tracing::error!("Failed to encode runtime event: {e}");
+            }
+        }
+    }
+
+    fn flush(&self) {
+        // Broadcast is fire-and-forget, nothing to flush.
+    }
+}

--- a/baml_language/crates/baml_lsp_server/src/playground_sender.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_sender.rs
@@ -75,8 +75,12 @@ impl bex_project::PlaygroundSender for NativePlaygroundSender {
 
         // Handle RuntimeEvent specially: send as a dedicated WsOutMessage variant
         // for better type safety and easier client-side handling.
-        if let bex_project::PlaygroundNotification::RuntimeEvent { data } = notification {
-            let _ = self.broadcast_tx.send(WsOutMessage::RuntimeEvent { data });
+        if let bex_project::PlaygroundNotification::RuntimeEvent { data, call_id } = notification {
+            use base64::Engine as _;
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
+            let _ = self
+                .broadcast_tx
+                .send(WsOutMessage::RuntimeEvent { data: b64, call_id });
             return;
         }
 

--- a/baml_language/crates/baml_lsp_server/src/playground_ws.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_ws.rs
@@ -128,7 +128,9 @@ pub enum WsOutMessage {
     /// A runtime event was emitted during execution (protobuf-encoded).
     #[serde(rename = "runtimeEvent")]
     RuntimeEvent {
-        /// Protobuf-encoded RuntimeEvent bytes (decode with RuntimeEvent.decode())
-        data: Vec<u8>,
+        /// Base64-encoded protobuf RuntimeEvent bytes
+        data: String,
+        #[serde(rename = "callId")]
+        call_id: u64,
     },
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -877,6 +877,7 @@ impl BexEngine {
         };
 
         self.emit(RuntimeEvent {
+            call_id,
             ctx: root_ctx,
             call_stack,
             timestamp: SystemTime::now(),
@@ -1281,6 +1282,7 @@ impl BexEngine {
                             full_call_stack.extend(state.stack.iter().map(|s| s.span_id.clone()));
                             full_call_stack.push(root_span.span_id.clone());
                             let end_event = RuntimeEvent {
+                                call_id,
                                 ctx: SpanContext {
                                     span_id: root_span.span_id,
                                     parent_span_id: root_span.parent_span_id,
@@ -1500,6 +1502,7 @@ impl BexEngine {
                         };
 
                         self.emit(RuntimeEvent {
+                            call_id,
                             ctx,
                             call_stack,
                             timestamp: SystemTime::now(),
@@ -1538,6 +1541,7 @@ impl BexEngine {
                                     args.iter().map(|v| self.vm_value_to_owned(v)).collect();
 
                                 let enter_event = RuntimeEvent {
+                                    call_id,
                                     ctx: SpanContext {
                                         span_id: span_id.clone(),
                                         parent_span_id: parent_span_id.clone(),
@@ -1574,6 +1578,7 @@ impl BexEngine {
                                         .extend(state.stack.iter().map(|s| s.span_id.clone()));
                                     call_stack.push(span.span_id.clone());
                                     let exit_event = RuntimeEvent {
+                                        call_id,
                                         ctx: SpanContext {
                                             span_id: span.span_id,
                                             parent_span_id: span.parent_span_id,

--- a/baml_language/crates/bex_events/Cargo.toml
+++ b/baml_language/crates/bex_events/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 [dependencies]
 baml_builtins2 = { workspace = true }
 bex_external_types = { workspace = true }
+sys_types = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/baml_language/crates/bex_events/src/collector.rs
+++ b/baml_language/crates/bex_events/src/collector.rs
@@ -327,7 +327,7 @@ mod tests {
     use web_time::SystemTime;
 
     use super::*;
-    use crate::{FunctionEnd, FunctionStart, SpanContext};
+    use crate::{CallId, FunctionEnd, FunctionStart, SpanContext};
 
     fn make_start_event(
         span_id: SpanId,
@@ -338,6 +338,7 @@ mod tests {
         tags: Vec<(String, String)>,
     ) -> RuntimeEvent {
         RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id,
                 parent_span_id: parent,
@@ -362,6 +363,7 @@ mod tests {
         duration: Duration,
     ) -> RuntimeEvent {
         RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id,
                 parent_span_id: parent,
@@ -480,6 +482,7 @@ mod tests {
                 vec![("env".into(), "test".into())],
             ),
             RuntimeEvent {
+                call_id: CallId(0),
                 ctx: SpanContext {
                     span_id: root.clone(),
                     parent_span_id: None,

--- a/baml_language/crates/bex_events/src/event_store.rs
+++ b/baml_language/crates/bex_events/src/event_store.rs
@@ -120,11 +120,12 @@ mod tests {
     use web_time::SystemTime;
 
     use super::*;
-    use crate::{EventKind, FunctionEvent, FunctionStart, SpanContext};
+    use crate::{CallId, EventKind, FunctionEvent, FunctionStart, SpanContext};
 
     /// Create an event whose `span_id` matches the given ID (function's own event).
     fn make_event(span_id: SpanId) -> RuntimeEvent {
         RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id: None,
@@ -143,6 +144,7 @@ mod tests {
     /// Create a child event whose `parent_span_id` matches the given parent.
     fn make_child_event(parent_span_id: SpanId, root_span_id: SpanId) -> RuntimeEvent {
         RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: SpanId::new(),
                 parent_span_id: Some(parent_span_id),

--- a/baml_language/crates/bex_events/src/event_store.rs
+++ b/baml_language/crates/bex_events/src/event_store.rs
@@ -28,6 +28,31 @@ pub trait EventSink: Send + Sync {
     fn flush(&self);
 }
 
+/// Composite `EventSink` that forwards events to multiple inner sinks.
+pub struct FanOutEventSink {
+    sinks: Vec<std::sync::Arc<dyn EventSink>>,
+}
+
+impl FanOutEventSink {
+    pub fn new(sinks: Vec<std::sync::Arc<dyn EventSink>>) -> Self {
+        Self { sinks }
+    }
+}
+
+impl EventSink for FanOutEventSink {
+    fn send(&self, event: RuntimeEvent) {
+        for sink in &self.sinks {
+            sink.send(event.clone());
+        }
+    }
+
+    fn flush(&self) {
+        for sink in &self.sinks {
+            sink.flush();
+        }
+    }
+}
+
 // ─────────────────────────── Collector Store ─────────────────────────────
 
 /// In-memory storage for tracked engine span IDs (collector use case).

--- a/baml_language/crates/bex_events/src/lib.rs
+++ b/baml_language/crates/bex_events/src/lib.rs
@@ -7,6 +7,7 @@ mod types;
 pub use collector::{Collector, FunctionLog, LLMCall, Timing, Usage};
 pub use event_store::EventSink;
 pub use span_id::{HostSpanContext, SpanContext, SpanId};
+pub use sys_types::CallId;
 pub use types::{
     CustomEvent, EventKind, FunctionEnd, FunctionEvent, FunctionStart, LogEvent, RuntimeEvent,
     SourceLocation, TraceTags,

--- a/baml_language/crates/bex_events/src/lib.rs
+++ b/baml_language/crates/bex_events/src/lib.rs
@@ -5,7 +5,7 @@ mod span_id;
 mod types;
 
 pub use collector::{Collector, FunctionLog, LLMCall, Timing, Usage};
-pub use event_store::EventSink;
+pub use event_store::{EventSink, FanOutEventSink};
 pub use span_id::{HostSpanContext, SpanContext, SpanId};
 pub use sys_types::CallId;
 pub use types::{

--- a/baml_language/crates/bex_events/src/types.rs
+++ b/baml_language/crates/bex_events/src/types.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use bex_external_types::BexExternalValue;
+use sys_types::CallId;
 use web_time::SystemTime;
 
 use crate::{SpanContext, SpanId};
@@ -8,6 +9,7 @@ use crate::{SpanContext, SpanId};
 /// A single runtime event emitted during BAML execution.
 #[derive(Clone, Debug)]
 pub struct RuntimeEvent {
+    pub call_id: CallId,
     pub ctx: SpanContext,
     /// Full ancestor chain from root to current span, populated at emission time.
     pub call_stack: Vec<SpanId>,

--- a/baml_language/crates/bex_events_native/src/lib.rs
+++ b/baml_language/crates/bex_events_native/src/lib.rs
@@ -236,13 +236,16 @@ fn write_jsonl_to_file(events: &[RuntimeEvent], trace_file: &Path) {
 mod tests {
     use std::time::Duration;
 
-    use bex_events::{EventKind, FunctionEvent, FunctionStart, RuntimeEvent, SpanContext, SpanId};
+    use bex_events::{
+        CallId, EventKind, FunctionEvent, FunctionStart, RuntimeEvent, SpanContext, SpanId,
+    };
     use web_time::SystemTime;
 
     use super::*;
 
     fn make_event(span_id: SpanId) -> RuntimeEvent {
         RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id: None,
@@ -277,6 +280,7 @@ mod tests {
     fn test_format_log_event_for_stderr() {
         let span_id = SpanId::new();
         let event = RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id: None,
@@ -327,6 +331,7 @@ mod tests {
         // across multiple lines.
         let span_id = SpanId::new();
         let event = RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id: None,

--- a/baml_language/crates/bex_project/src/bex_lsp/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/mod.rs
@@ -140,6 +140,7 @@ pub enum PlaygroundNotification {
     RuntimeEvent {
         /// Protobuf-encoded `RuntimeEvent` bytes (decode with `RuntimeEvent.decode()`)
         data: Vec<u8>,
+        call_id: u64,
     },
 }
 

--- a/baml_language/crates/bridge_cffi/src/host_spans.rs
+++ b/baml_language/crates/bridge_cffi/src/host_spans.rs
@@ -10,6 +10,7 @@ use bex_events::{
     EventKind, FunctionEvent, FunctionStart, RuntimeEvent, SpanContext, SpanId, TraceTags,
     event_store,
 };
+use sys_types::CallId;
 
 /// One entry on the host-language span stack.
 #[derive(Clone, Debug)]
@@ -79,6 +80,7 @@ impl HostSpanManager {
             .collect();
 
         let event = RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id,
@@ -126,6 +128,7 @@ impl HostSpanManager {
             let trace_tags: TraceTags = tags.into_iter().collect();
 
             let event = RuntimeEvent {
+                call_id: CallId(0),
                 ctx: SpanContext {
                     span_id: entry.span_id.clone(),
                     parent_span_id: self.stack.iter().rev().nth(1).map(|e| e.span_id.clone()),
@@ -171,6 +174,7 @@ impl HostSpanManager {
         call_stack.push(entry.span_id.clone());
 
         let event = RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: entry.span_id,
                 parent_span_id: self.stack.last().map(|e| e.span_id.clone()),

--- a/baml_language/crates/bridge_ctypes/src/event_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/event_encode.rs
@@ -35,6 +35,7 @@ pub fn runtime_event_to_proto(
         timestamp_ms,
         call_stack,
         event: Some(event_kind),
+        call_id: event.call_id.0,
     })
 }
 
@@ -135,8 +136,11 @@ mod tests {
 
     #[test]
     fn test_function_start_to_proto() {
+        use bex_events::CallId;
+
         let span_id = SpanId::new();
         let event = RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id: None,
@@ -178,8 +182,11 @@ mod tests {
 
     #[test]
     fn test_log_event_to_proto() {
+        use bex_events::CallId;
+
         let span_id = SpanId::new();
         let event = RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id: None,
@@ -220,8 +227,11 @@ mod tests {
 
     #[test]
     fn test_function_end_to_proto() {
+        use bex_events::CallId;
+
         let span_id = SpanId::new();
         let event = RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id: None,
@@ -253,10 +263,12 @@ mod tests {
 
     #[test]
     fn test_event_to_bytes_roundtrip() {
+        use bex_events::CallId;
         use prost::Message;
 
         let span_id = SpanId::new();
         let event = RuntimeEvent {
+            call_id: CallId(0),
             ctx: SpanContext {
                 span_id: span_id.clone(),
                 parent_span_id: None,

--- a/baml_language/crates/bridge_ctypes/types/baml/cffi/v1/baml_events.proto
+++ b/baml_language/crates/bridge_ctypes/types/baml/cffi/v1/baml_events.proto
@@ -17,6 +17,7 @@ message RuntimeEvent {
   uint64 timestamp_ms = 4;
   repeated string call_stack = 5;
   EventKind event = 6;
+  uint64 call_id = 7;
 }
 
 /// The kind of event.

--- a/baml_language/crates/bridge_wasm/src/wasm_playground.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_playground.rs
@@ -87,6 +87,7 @@ pub enum PlaygroundNotification {
     RuntimeEvent {
         /// Protobuf-encoded `RuntimeEvent` bytes (decode with `RuntimeEvent.decode()`)
         data: Vec<u8>,
+        call_id: u64,
     },
 }
 
@@ -158,8 +159,8 @@ impl From<bex_project::PlaygroundNotification> for PlaygroundNotification {
                 data,
                 expand_error,
             },
-            bex_project::PlaygroundNotification::RuntimeEvent { data } => {
-                PlaygroundNotification::RuntimeEvent { data }
+            bex_project::PlaygroundNotification::RuntimeEvent { data, call_id } => {
+                PlaygroundNotification::RuntimeEvent { data, call_id }
             }
         }
     }
@@ -200,10 +201,11 @@ impl WasmEventSink {
 
 impl bex_events::EventSink for WasmEventSink {
     fn send(&self, event: bex_events::RuntimeEvent) {
+        let call_id = event.call_id.0;
         let options = bridge_ctypes::HandleTableOptions::for_in_process();
         match bridge_ctypes::runtime_event_to_bytes(&event, &options) {
             Ok(data) => {
-                let notification = PlaygroundNotification::RuntimeEvent { data };
+                let notification = PlaygroundNotification::RuntimeEvent { data, call_id };
                 let callback = self.callback.inner();
                 let _ = callback.call1(&JsValue::NULL, &notification.into());
             }

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -405,7 +405,7 @@ function onPlaygroundNotification(notification: PlaygroundNotification): void {
         // Decode and pass the raw proto through
         const bytes = new Uint8Array(notification.data);
         const event = RuntimeEvent.decode(bytes);
-        const callId = activeCallIds.size === 1 ? [...activeCallIds][0] : null;
+        const callId = notification.callId ?? (activeCallIds.size === 1 ? [...activeCallIds][0] : null);
         postOut({ type: "runtimeEventNew", event, callId });
 
         // Extract log events and update decorations

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -53,7 +53,9 @@ import type {
 } from "@b/pkg-playground";
 
 import { decodeCallResult, RuntimeEvent } from "@b/pkg-proto";
-import { formatValueShort, truncateMessage, normalizeLogLevel } from "@b/pkg-playground/shared/log-decorations";
+import { truncateMessage, normalizeLogLevel } from "@b/pkg-playground/shared/log-decorations";
+import { formatValue } from "@b/pkg-playground/shared/format-value";
+import { deserializeRuntimeEvent } from "@b/pkg-playground/shared/deserialize-event";
 
 import { BamlVfs } from "./vfs";
 
@@ -324,23 +326,29 @@ function onPlaygroundNotification(notification: PlaygroundNotification): void {
         // Decode and pass the raw proto through
         const bytes = new Uint8Array(notification.data);
         const event = RuntimeEvent.decode(bytes);
-        const callId = notification.callId ?? (activeCallIds.size === 1 ? [...activeCallIds][0] : null);
-        postOut({ type: "runtimeEventNew", event, callId });
+        let callId = notification.callId ?? null;
+        if (callId == null) {
+          if (activeCallIds.size === 1) {
+            callId = [...activeCallIds][0] ?? null;
+          } else if (activeCallIds.size > 1) {
+            console.warn('[Worker] runtimeEvent missing callId from server with', activeCallIds.size, 'concurrent calls — event will not be associated with a run');
+          }
+        }
+        const deserialized = deserializeRuntimeEvent(event);
+        postOut({ type: "runtimeEventNew", event: deserialized, callId });
 
         // Extract log events and update decorations
-        const kind = event.event?.kind;
-        console.log('[Worker] runtimeEvent kind:', kind?.$case, 'source:', kind?.$case === 'log' ? kind.log.source : null);
+        const kind = deserialized.event;
         if (kind?.$case === 'log' && kind.log.source) {
           const source = kind.log.source;
           const line = source.line;
           const level = normalizeLogLevel(kind.log.level);
-          const message = formatValueShort(kind.log.data);
+          const message = formatValue(kind.log.data, 'inline-hint');
 
           // Heuristic: only show decoration if the formatted output is longer than the source span.
           // This filters out constant literals (where output ≈ source) and shows expanded variables.
           const sourceSpanLength = source.endOffset - source.startOffset;
           const isLikelyVariable = message.length > sourceSpanLength + 5;
-          console.log('[Worker] Log decoration - line:', line, 'level:', level, 'message:', message, 'spanLen:', sourceSpanLength, 'show:', isLikelyVariable);
 
           if (isLikelyVariable) {
             const existing = decorationsByLine.get(line);

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -52,7 +52,8 @@ import type {
   LogLevel,
 } from "@b/pkg-playground";
 
-import { decodeCallResult, RuntimeEvent, type BamlOutboundValue } from "@b/pkg-proto";
+import { decodeCallResult, RuntimeEvent } from "@b/pkg-proto";
+import { formatValueShort, truncateMessage, normalizeLogLevel } from "@b/pkg-playground/shared/log-decorations";
 
 import { BamlVfs } from "./vfs";
 
@@ -132,88 +133,6 @@ function resolveInput(callId: number, prompt: string | undefined): Promise<strin
 
 /** Decorations aggregated by line number. Each entry tracks the latest message and count. */
 const decorationsByLine = new Map<number, { level: LogLevel; message: string; count: number }>();
-
-/** Format a BamlOutboundValue to a short string for inline display. */
-function formatValueShort(holder: BamlOutboundValue | null | undefined): string {
-  if (!holder?.value) return 'null';
-
-  switch (holder.value.$case) {
-    case 'nullValue':
-      return 'null';
-    case 'stringValue':
-      return JSON.stringify(holder.value.stringValue);
-    case 'intValue':
-      return String(holder.value.intValue);
-    case 'floatValue':
-      return String(holder.value.floatValue);
-    case 'boolValue':
-      return String(holder.value.boolValue);
-    case 'classValue': {
-      const cls = holder.value.classValue;
-      const name = cls.name?.name ?? 'Class';
-      const fields = cls.fields
-        .map((f) => `${f.key}: ${formatValueShort(f.value)}`)
-        .join(', ');
-      return `${name} { ${fields} }`;
-    }
-    case 'enumValue':
-      return holder.value.enumValue.value;
-    case 'listValue':
-      return `[${holder.value.listValue.items.map(formatValueShort).join(', ')}]`;
-    case 'mapValue': {
-      const entries = holder.value.mapValue.entries
-        .map((e) => `${e.key}: ${formatValueShort(e.value)}`)
-        .join(', ');
-      return `{${entries}}`;
-    }
-    case 'literalValue': {
-      const lit = holder.value.literalValue;
-      if (!lit.literal) return 'null';
-      switch (lit.literal.$case) {
-        case 'stringLiteral':
-          return JSON.stringify(lit.literal.stringLiteral.value);
-        case 'intLiteral':
-          return String(lit.literal.intLiteral.value);
-        case 'boolLiteral':
-          return String(lit.literal.boolLiteral.value);
-        default:
-          return 'null';
-      }
-    }
-    case 'unionVariantValue':
-      return formatValueShort(holder.value.unionVariantValue.value);
-    case 'checkedValue':
-      return formatValueShort(holder.value.checkedValue.value);
-    case 'streamingStateValue':
-      return formatValueShort(holder.value.streamingStateValue.value);
-    case 'handleValue': {
-      const h = holder.value.handleValue;
-      return `<handle #${h.key}>`;
-    }
-    case 'mediaValue': {
-      const m = holder.value.mediaValue;
-      return `<${m.mimeType ?? 'media'}>`;
-    }
-    default:
-      return '?';
-  }
-}
-
-/** Truncate a message to max length with ellipsis. */
-function truncateMessage(msg: string, maxLen: number = 60): string {
-  if (msg.length <= maxLen) return msg;
-  return msg.slice(0, maxLen - 1) + '…';
-}
-
-/** Map log level string to our LogLevel type. */
-function normalizeLogLevel(level: string): LogLevel {
-  switch (level.toLowerCase()) {
-    case 'error': return 'error';
-    case 'warn': case 'warning': return 'warn';
-    case 'debug': return 'debug';
-    default: return 'info';
-  }
-}
 
 /** Emit current decorations to the main thread. */
 function emitLogDecorations(): void {

--- a/typescript2/pkg-playground/src/EventValueDisplay.tsx
+++ b/typescript2/pkg-playground/src/EventValueDisplay.tsx
@@ -1,0 +1,16 @@
+/**
+ * Thin wrapper that renders a BamlJsValue through ValueRenderer with inline display mode.
+ * Used to render event payloads (log.data, custom.data) inside event rows.
+ */
+
+import type { FC } from 'react';
+import type { BamlJsValue } from '@b/pkg-proto';
+import type { ResultRendererProps } from './result-renderers';
+import { ValueRenderer } from './ValueRenderer';
+
+export const EventValueDisplay: FC<{
+  value: BamlJsValue;
+  customRenderers?: Record<string, FC<ResultRendererProps>>;
+}> = ({ value, customRenderers }) => (
+  <ValueRenderer value={value} displayMode="inline" customRenderers={customRenderers} />
+);

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -12,6 +12,7 @@
 import type { ChangeEvent, FC, ReactNode, RefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { encodeCallArgs } from '@b/pkg-proto';
+import type { BamlJsValue } from '@b/pkg-proto';
 import { KeyRound, PanelLeft, Square } from 'lucide-react';
 import { Button } from './components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
@@ -58,6 +59,10 @@ function tryFormatJson(str: string): string {
     /* not valid JSON */
     return str;
   }
+}
+
+function stringifyResult(value: BamlJsValue): string {
+  return JSON.stringify(value, (_, v) => (typeof v === 'bigint' ? v.toString() : v), 2);
 }
 
 function formatBuildTime(epochSecs: number): { absolute: string; relative: string } {
@@ -246,7 +251,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   const [testTree, setTestTree] = useState<any>(null);
   const [collectionCallId, setCollectionCallId] = useState<number | null>(null);
   const [generation, setGeneration] = useState<number>(0);
-  const [testRunResults, setTestRunResults] = useState<Map<string, Record<string, unknown>>>(new Map());
+  const [testRunResults, setTestRunResults] = useState<Map<string, unknown>>(new Map());
   const [failedExpands, setFailedExpands] = useState<Set<string>>(new Set());
   // Synthetic RunEntry that accumulates fetch logs from test collection/expansion operations
   const [collectionRun, setCollectionRun] = useState<RunEntry | null>(null);
@@ -276,8 +281,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     functionName: string;
     workflows: string[];
   } | null>(null);
-  const [promptPreviewResult, setPromptPreviewResult] = useState<string | null>(null);
-  const [curlPreviewResult, setCurlPreviewResult] = useState<string | null>(null);
+  const [promptPreviewResult, setPromptPreviewResult] = useState<BamlJsValue | null>(null);
+  const [curlPreviewResult, setCurlPreviewResult] = useState<BamlJsValue | null>(null);
   const [promptPreviewError, setPromptPreviewError] = useState<string | null>(null);
   const [curlPreviewError, setCurlPreviewError] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -310,7 +315,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   useEffect(() => { controlFlowGraphRef.current = controlFlowGraph; }, [controlFlowGraph]);
 
   const nextCallIdRef = useRef(0);
-  const pendingCallsRef = useRef<Map<number, { resolve: (v: string) => void; reject: (e: Error) => void }>>(new Map());
+  const pendingCallsRef = useRef<Map<number, { resolve: (v: BamlJsValue) => void; reject: (e: Error) => void }>>(new Map());
   // Buffer fetch logs by callId so logs that arrive before testCollectionResult are not lost.
   const pendingLogsRef = useRef<Map<number, FetchLogEntry[]>>(new Map());
 
@@ -710,7 +715,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       try {
         const argsProto = encodeCallArgs(parsed as Record<string, unknown>);
         const callId = nextCallIdRef.current++;
-        const resultStr = await new Promise<string>((resolve, reject) => {
+        const resultValue = await new Promise<BamlJsValue>((resolve, reject) => {
           pendingCallsRef.current.set(callId, { resolve, reject });
           port.postMessage({
             type: 'callFunction',
@@ -720,7 +725,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
             project: selectedProject,
           });
         });
-        setResult(resultStr);
+        setResult(resultValue);
         setError(null);
         setPreviewLoading(false);
       } catch (e) {
@@ -824,7 +829,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       }
       const argsProto = encodeCallArgs(parsed as Record<string, unknown>);
 
-      const resultStr = await new Promise<string>((resolve, reject) => {
+      const resultValue = await new Promise<BamlJsValue>((resolve, reject) => {
         pendingCallsRef.current.set(runId, { resolve, reject });
         port.postMessage(
           { type: 'callFunction', id: runId, name: selectedFn, argsProto: new Uint8Array(argsProto), project: selectedProject },
@@ -832,7 +837,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       });
 
       const dur = Math.round(performance.now() - startTime);
-      setRuns((prev) => prev.map((r) => r.id === runId ? { ...r, result: resultStr, status: 'success', durationMs: dur } : r));
+      setRuns((prev) => prev.map((r) => r.id === runId ? { ...r, result: resultValue, status: 'success', durationMs: dur } : r));
     } catch (e) {
       const isCancelled = e instanceof Error && (e as any).cancelled === true;
       const errMsg = e instanceof Error ? e.message : String(e);
@@ -873,7 +878,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     setRuns((prev) => [...prev, newRun]);
 
     try {
-      const resultStr = await new Promise<string>((resolve, reject) => {
+      const resultValue = await new Promise<BamlJsValue>((resolve, reject) => {
         pendingCallsRef.current.set(runId, { resolve, reject });
         port.postMessage({
           type: 'callTestFunction',
@@ -888,15 +893,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       setRuns((prev) =>
         prev.map((r) =>
           r.id === runId
-            ? { ...r, result: resultStr, status: 'success', durationMs: dur }
+            ? { ...r, result: resultValue, status: 'success', durationMs: dur }
             : r,
         ),
       );
 
-      try {
-        const report = JSON.parse(resultStr);
-        setTestRunResults((prev) => new Map(prev).set(name, report));
-      } catch {}
+      setTestRunResults((prev) => new Map(prev).set(name, resultValue));
     } catch (e: any) {
       const dur = Math.round(performance.now() - newRun.startTime);
       const cancelled = e instanceof Error && (e as any).cancelled === true;
@@ -1398,7 +1400,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                     {run.result != null && (
                       <div className="py-1.5 pr-2.5 pl-[22px]">
                         <div className="text-[10px] font-semibold text-vsc-green mb-0.5 uppercase tracking-wide">Result</div>
-                        <ResultDisplay resultJson={run.result} customRenderers={resultRenderers} />
+                        <ResultDisplay result={run.result} customRenderers={resultRenderers} />
                       </div>
                     )}
                   </div>
@@ -1495,7 +1497,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                     )}
                     <div ref={promptContentRef}>
                       {promptPreviewResult != null ? (
-                        <ResultDisplay resultJson={promptPreviewResult} customRenderers={resultRenderers} />
+                        <ResultDisplay result={promptPreviewResult} customRenderers={resultRenderers} />
                       ) : (
                         <div className="flex items-center justify-center text-vsc-text-faint text-xs h-full">
                           {previewLoading ? 'Loading prompt preview...' : 'Enter args to preview prompt'}
@@ -1503,7 +1505,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                       )}
                     </div>
                   </div>
-                  {promptPreviewResult && <PromptStats text={promptPreviewResult} />}
+                  {promptPreviewResult && <PromptStats text={stringifyResult(promptPreviewResult)} />}
                 </TabsContent>
               )}
 
@@ -1511,7 +1513,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
               {canPreviewCurl && (
                 <TabsContent value="curl" className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg p-2.5 mt-0">
                   {curlPreviewResult != null ? (
-                    <ResultDisplay resultJson={curlPreviewResult} customRenderers={resultRenderers} />
+                    <ResultDisplay result={curlPreviewResult} customRenderers={resultRenderers} />
                   ) : curlPreviewError ? (
                     <div className="flex items-center justify-center text-vsc-error text-xs h-full">
                       {curlPreviewError}
@@ -1751,13 +1753,13 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                                   ]}
                                   size="sm"
                                 />
-                                <CopyButton text={run.result} iconSize={11} />
+                                <CopyButton text={stringifyResult(run.result)} iconSize={11} />
                               </div>
                               {(resultModes[run.id] ?? 'parsed') === 'parsed' ? (
-                                <ResultDisplay resultJson={run.result} customRenderers={resultRenderers} />
+                                <ResultDisplay result={run.result} customRenderers={resultRenderers} />
                               ) : (
                                 <pre className="whitespace-pre-wrap break-all font-vsc-mono text-[11px] text-vsc-text bg-vsc-bg-secondary p-2 rounded border border-vsc-border max-h-[400px] overflow-auto">
-                                  {run.result}
+                                  {stringifyResult(run.result)}
                                 </pre>
                               )}
                             </div>

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -9,11 +9,9 @@
  * VS Code webview without an embedded Monaco editor).
  */
 
-import type { ChangeEvent, FC, RefObject } from 'react';
+import type { ChangeEvent, FC, ReactNode, RefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { encodeCallArgs } from '@b/pkg-proto';
-import type { BamlJsValue } from '@b/pkg-proto';
-import { getBamlType } from './result-renderers';
 import { KeyRound, PanelLeft, Square } from 'lucide-react';
 import { Button } from './components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
@@ -45,48 +43,9 @@ import { registerBuiltinResultRenderers } from './renderers/registerBuiltins';
 import { HttpRequestCurlRenderer, isHttpRequest } from './renderers/HttpRequestCurl';
 import { GraphView } from './graph/GraphView';
 import { FunctionSidebar } from './FunctionSidebar';
+import { EventValueDisplay } from './EventValueDisplay';
 
 registerBuiltinResultRenderers();
-// Format a BamlJsValue to a Rust-like debug string (transitional — replaced in Phase 3)
-function formatValueDebug(value: BamlJsValue | null | undefined): string {
-  if (value == null) return 'null';
-  if (typeof value === 'string') return JSON.stringify(value);
-  if (typeof value === 'number') return String(value);
-  if (typeof value === 'boolean') return String(value);
-  if (typeof value === 'bigint') return String(value);
-  if (Array.isArray(value)) {
-    return `[${value.map(formatValueDebug).join(', ')}]`;
-  }
-  if (typeof value === 'object') {
-    const bamlType = getBamlType(value);
-    if (bamlType === '$media') {
-      const m = value as Record<string, unknown>;
-      const mt = (m.media_type as string) ?? 'media';
-      if (m.content_type === 'url') return `<${mt}: ${m.url}>`;
-      if (m.content_type === 'file') return `<${mt}: file://${m.file}>`;
-      if (m.content_type === 'base64') return `<${mt}: base64...>`;
-      return `<${mt}>`;
-    }
-    if (bamlType === '$handle') {
-      return `<handle #${(value as Record<string, unknown>).handle_key}>`;
-    }
-    if (bamlType === '$prompt_ast') return '<prompt_ast>';
-    if (bamlType) {
-      // Class instance
-      const entries = Object.entries(value)
-        .filter(([k]) => k !== '$baml')
-        .map(([k, v]) => `${k}: ${formatValueDebug(v as BamlJsValue)}`)
-        .join(', ');
-      return `${bamlType} { ${entries} }`;
-    }
-    // Plain map
-    const entries = Object.entries(value)
-      .map(([k, v]) => `${k}: ${formatValueDebug(v as BamlJsValue)}`)
-      .join(', ');
-    return `{${entries}}`;
-  }
-  return '?';
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -142,9 +101,10 @@ interface CollectionRunViewProps {
   run: RunEntry;
   expandedLogId: number | null;
   setExpandedLogId: (id: number | null) => void;
+  resultRenderers?: Record<string, FC<ResultRendererProps>>;
 }
 
-const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, setExpandedLogId }) => {
+const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, setExpandedLogId, resultRenderers }) => {
   const hasError = run.status === 'error';
   const errorMessage = run.error || 'Unknown expansion error';
   return (
@@ -223,7 +183,7 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
                 if (!kind) return null;
 
                 let label: string;
-                let payload: string;
+                let payload: ReactNode;
                 let colorCls: string;
 
                 switch (kind.$case) {
@@ -240,7 +200,7 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
                   case 'log': {
                     const lvl = kind.log.level;
                     label = lvl;
-                    payload = formatValueDebug(kind.log.data);
+                    payload = <EventValueDisplay value={kind.log.data} customRenderers={resultRenderers} />;
                     colorCls = lvl === 'error' ? 'text-vsc-red'
                       : lvl === 'warn' ? 'text-vsc-yellow'
                       : lvl === 'debug' ? 'text-vsc-text-muted'
@@ -249,7 +209,7 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
                   }
                   case 'custom':
                     label = 'EVENT';
-                    payload = `${kind.custom.name}: ${formatValueDebug(kind.custom.data)}`;
+                    payload = <><span>{kind.custom.name}: </span><EventValueDisplay value={kind.custom.data} customRenderers={resultRenderers} /></>;
                     colorCls = 'text-vsc-purple';
                     break;
                   case 'setTags':
@@ -1252,6 +1212,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
               run={collectionRun}
               expandedLogId={expandedLogId}
               setExpandedLogId={setExpandedLogId}
+              resultRenderers={resultRenderers}
             />
           ) : viewingTestRun ? (
             <div ref={outputRef} className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg">
@@ -1347,7 +1308,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                             if (!kind) return null;
 
                             let label: string;
-                            let payload: string;
+                            let payload: ReactNode;
                             let colorCls: string;
 
                             switch (kind.$case) {
@@ -1364,7 +1325,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                               case 'log': {
                                 const lvl = kind.log.level;
                                 label = lvl;
-                                payload = formatValueDebug(kind.log.data);
+                                payload = <EventValueDisplay value={kind.log.data} customRenderers={resultRenderers} />;
                                 colorCls = lvl === 'error' ? 'text-vsc-red'
                                   : lvl === 'warn' ? 'text-vsc-yellow'
                                   : lvl === 'debug' ? 'text-vsc-text-muted'
@@ -1373,7 +1334,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                               }
                               case 'custom':
                                 label = 'EVENT';
-                                payload = `${kind.custom.name}: ${formatValueDebug(kind.custom.data)}`;
+                                payload = <><span>{kind.custom.name}: </span><EventValueDisplay value={kind.custom.data} customRenderers={resultRenderers} /></>;
                                 colorCls = 'text-vsc-purple';
                                 break;
                               case 'setTags':
@@ -1682,7 +1643,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                                 if (!kind) return null;
 
                                 let label: string;
-                                let payload: string;
+                                let payload: ReactNode;
                                 let colorCls: string;
 
                                 switch (kind.$case) {
@@ -1699,7 +1660,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                                   case 'log': {
                                     const lvl = kind.log.level;
                                     label = lvl;
-                                    payload = formatValueDebug(kind.log.data);
+                                    payload = <EventValueDisplay value={kind.log.data} customRenderers={resultRenderers} />;
                                     colorCls = lvl === 'error' ? 'text-vsc-red'
                                       : lvl === 'warn' ? 'text-vsc-yellow'
                                       : lvl === 'debug' ? 'text-vsc-text-muted'
@@ -1708,7 +1669,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                                   }
                                   case 'custom':
                                     label = 'EVENT';
-                                    payload = `${kind.custom.name}: ${formatValueDebug(kind.custom.data)}`;
+                                    payload = <><span>{kind.custom.name}: </span><EventValueDisplay value={kind.custom.data} customRenderers={resultRenderers} /></>;
                                     colorCls = 'text-vsc-purple';
                                     break;
                                   case 'setTags':

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -243,6 +243,66 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
             </div>
           );
         })}
+        {/* Runtime events */}
+        {run.runtimeEvents.length > 0 && (
+          <div className="py-1.5 pr-2.5 pl-[22px] border-b border-vsc-border-subtle">
+            <div className="text-[10px] font-semibold text-vsc-text-muted mb-1 uppercase tracking-wide">
+              Events ({run.runtimeEvents.length})
+            </div>
+            <div className="flex flex-col gap-0.5">
+              {run.runtimeEvents.map((evt, evtIdx) => {
+                const kind = evt.event?.kind;
+                if (!kind) return null;
+
+                let label: string;
+                let payload: string;
+                let colorCls: string;
+
+                switch (kind.$case) {
+                  case 'functionStart':
+                    label = 'START';
+                    payload = kind.functionStart.name;
+                    colorCls = 'text-vsc-green';
+                    break;
+                  case 'functionEnd':
+                    label = 'END';
+                    payload = `${kind.functionEnd.name} (${kind.functionEnd.durationMs}ms)`;
+                    colorCls = 'text-vsc-text-muted';
+                    break;
+                  case 'log': {
+                    const lvl = kind.log.level;
+                    label = lvl;
+                    payload = formatValueDebug(kind.log.data);
+                    colorCls = lvl === 'error' ? 'text-vsc-red'
+                      : lvl === 'warn' ? 'text-vsc-yellow'
+                      : lvl === 'debug' ? 'text-vsc-text-muted'
+                      : 'text-vsc-blue';
+                    break;
+                  }
+                  case 'custom':
+                    label = 'EVENT';
+                    payload = `${kind.custom.name}: ${formatValueDebug(kind.custom.data)}`;
+                    colorCls = 'text-vsc-purple';
+                    break;
+                  case 'setTags':
+                    label = 'TAGS';
+                    payload = kind.setTags.tags.map(t => `${t.key}=${t.value}`).join(', ');
+                    colorCls = 'text-vsc-text-muted';
+                    break;
+                  default:
+                    return null;
+                }
+
+                return (
+                  <div key={evtIdx} className="flex items-start gap-1.5 text-[11px]">
+                    <span className={`${colorCls} font-semibold uppercase shrink-0`}>{label}</span>
+                    <span className="text-vsc-text break-all">{payload}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -570,6 +630,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                   : r
               )
             );
+            // Also route to collection run if this event belongs to it
+            setCollectionRun((prev) => {
+              if (!prev || prev.id !== data.callId) return prev;
+              return { ...prev, runtimeEvents: [...prev.runtimeEvents, eventEntry] };
+            });
           }
           break;
         }

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -11,7 +11,9 @@
 
 import type { ChangeEvent, FC, RefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { encodeCallArgs, type BamlOutboundValue } from '@b/pkg-proto';
+import { encodeCallArgs } from '@b/pkg-proto';
+import type { BamlJsValue } from '@b/pkg-proto';
+import { getBamlType } from './result-renderers';
 import { KeyRound, PanelLeft, Square } from 'lucide-react';
 import { Button } from './components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
@@ -37,7 +39,6 @@ import type {
   RunEntry,
   WorkerOutMessage,
 } from './worker-protocol';
-import { decodeCallResult } from '@b/pkg-proto';
 import type { ResultRendererProps } from './result-renderers';
 import { ResultDisplay } from './ResultDisplay';
 import { registerBuiltinResultRenderers } from './renderers/registerBuiltins';
@@ -46,78 +47,45 @@ import { GraphView } from './graph/GraphView';
 import { FunctionSidebar } from './FunctionSidebar';
 
 registerBuiltinResultRenderers();
-// Format a BamlOutboundValue (proto) to a Rust-like debug string
-function formatValueDebug(holder: BamlOutboundValue | null | undefined): string {
-  if (!holder?.value) return 'null';
-
-  switch (holder.value.$case) {
-    case 'nullValue':
-      return 'null';
-    case 'stringValue':
-      return JSON.stringify(holder.value.stringValue);
-    case 'intValue':
-      return String(holder.value.intValue);
-    case 'floatValue':
-      return String(holder.value.floatValue);
-    case 'boolValue':
-      return String(holder.value.boolValue);
-    case 'classValue': {
-      const cls = holder.value.classValue;
-      const name = cls.name?.name ?? 'Class';
-      const fields = cls.fields
-        .map((f) => `${f.key}: ${formatValueDebug(f.value)}`)
-        .join(', ');
-      return `${name} { ${fields} }`;
-    }
-    case 'enumValue':
-      return holder.value.enumValue.value;
-    case 'listValue':
-      return `[${holder.value.listValue.items.map(formatValueDebug).join(', ')}]`;
-    case 'mapValue': {
-      const entries = holder.value.mapValue.entries
-        .map((e) => `${e.key}: ${formatValueDebug(e.value)}`)
-        .join(', ');
-      return `{${entries}}`;
-    }
-    case 'literalValue': {
-      const lit = holder.value.literalValue;
-      if (!lit.literal) return 'null';
-      switch (lit.literal.$case) {
-        case 'stringLiteral':
-          return JSON.stringify(lit.literal.stringLiteral.value);
-        case 'intLiteral':
-          return String(lit.literal.intLiteral.value);
-        case 'boolLiteral':
-          return String(lit.literal.boolLiteral.value);
-        default:
-          return 'null';
-      }
-    }
-    case 'unionVariantValue':
-      return formatValueDebug(holder.value.unionVariantValue.value);
-    case 'checkedValue':
-      return formatValueDebug(holder.value.checkedValue.value);
-    case 'streamingStateValue':
-      return formatValueDebug(holder.value.streamingStateValue.value);
-    case 'handleValue': {
-      const h = holder.value.handleValue;
-      return `<handle #${h.key}>`;
-    }
-    case 'mediaValue': {
-      const m = holder.value.mediaValue;
-      const mt = ['unspecified', 'image', 'audio', 'pdf', 'video', 'other'][m.media] ?? 'media';
-      if (m.value?.$case === 'url') return `<${mt}: ${m.value.url}>`;
-      if (m.value?.$case === 'file') return `<${mt}: file://${m.value.file}>`;
-      if (m.value?.$case === 'base64') return `<${mt}: base64...>`;
+// Format a BamlJsValue to a Rust-like debug string (transitional — replaced in Phase 3)
+function formatValueDebug(value: BamlJsValue | null | undefined): string {
+  if (value == null) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'boolean') return String(value);
+  if (typeof value === 'bigint') return String(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(formatValueDebug).join(', ')}]`;
+  }
+  if (typeof value === 'object') {
+    const bamlType = getBamlType(value);
+    if (bamlType === '$media') {
+      const m = value as Record<string, unknown>;
+      const mt = (m.media_type as string) ?? 'media';
+      if (m.content_type === 'url') return `<${mt}: ${m.url}>`;
+      if (m.content_type === 'file') return `<${mt}: file://${m.file}>`;
+      if (m.content_type === 'base64') return `<${mt}: base64...>`;
       return `<${mt}>`;
     }
-    case 'promptAstValue':
-      return '<prompt_ast>';
-    case 'uint8arrayValue':
-      return `<bytes: ${holder.value.uint8arrayValue.length}>`;
-    default:
-      return '?';
+    if (bamlType === '$handle') {
+      return `<handle #${(value as Record<string, unknown>).handle_key}>`;
+    }
+    if (bamlType === '$prompt_ast') return '<prompt_ast>';
+    if (bamlType) {
+      // Class instance
+      const entries = Object.entries(value)
+        .filter(([k]) => k !== '$baml')
+        .map(([k, v]) => `${k}: ${formatValueDebug(v as BamlJsValue)}`)
+        .join(', ');
+      return `${bamlType} { ${entries} }`;
+    }
+    // Plain map
+    const entries = Object.entries(value)
+      .map(([k, v]) => `${k}: ${formatValueDebug(v as BamlJsValue)}`)
+      .join(', ');
+    return `{${entries}}`;
   }
+  return '?';
 }
 
 // ---------------------------------------------------------------------------
@@ -251,7 +219,7 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
             </div>
             <div className="flex flex-col gap-0.5">
               {run.runtimeEvents.map((evt, evtIdx) => {
-                const kind = evt.event?.kind;
+                const kind = evt.event;
                 if (!kind) return null;
 
                 let label: string;
@@ -1375,8 +1343,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                         </div>
                         <div className="flex flex-col gap-0.5">
                           {run.runtimeEvents.map((evt, evtIdx) => {
-                            const kind = evt.event?.kind;
-                            console.log('[DEBUG] Event:', evtIdx, kind?.$case, kind);
+                            const kind = evt.event;
                             if (!kind) return null;
 
                             let label: string;
@@ -1420,9 +1387,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
                             // Check if cursor is within this event's source span
                             const source = kind.$case === 'log' ? kind.log.source : undefined;
-                            if (kind.$case === 'log') {
-                              console.log('[DEBUG] LogEvent source:', source, 'cursorOffset:', cursorOffset);
-                            }
                             const isCursorMatch = cursorOffset != null && source != null &&
                               cursorOffset > source.startOffset && cursorOffset <= source.endOffset;
 
@@ -1714,8 +1678,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                             </div>
                             <div className="flex flex-col gap-0.5">
                               {run.runtimeEvents.map((evt, evtIdx) => {
-                                const kind = evt.event?.kind;
-                                console.log('[DEBUG] Event (history):', evtIdx, kind?.$case, kind);
+                                const kind = evt.event;
                                 if (!kind) return null;
 
                                 let label: string;
@@ -1759,9 +1722,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
                                 // Check if cursor is within this event's source span
                                 const source = kind.$case === 'log' ? kind.log.source : undefined;
-                                if (kind.$case === 'log') {
-                                  console.log('[DEBUG] LogEvent source (history):', source, 'cursorOffset:', cursorOffset);
-                                }
                                 const isCursorMatch = cursorOffset != null && source != null &&
                                   cursorOffset > source.startOffset && cursorOffset <= source.endOffset;
 

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -30,7 +30,7 @@ interface TestTreeNodeProps {
   def: SerializedTestDef;
   depth?: number;
   onRunTest?: (name: string) => void;
-  testRunResults?: Map<string, Record<string, unknown>>;
+  testRunResults?: Map<string, unknown>;
   failedExpands?: Set<string>;
   onRetryExpand?: (name: string) => void;
 }
@@ -72,7 +72,8 @@ function TestTreeNode({ def, depth = 0, onRunTest, testRunResults, failedExpands
 
   if ('type' in def && def.type === 'test') {
     const report = testRunResults?.get(def.name);
-    const outcome = typeof report?.outcome === 'string' ? report.outcome : undefined;
+    const reportObj = report != null && typeof report === 'object' ? (report as Record<string, unknown>) : null;
+    const outcome = typeof reportObj?.outcome === 'string' ? reportObj.outcome : undefined;
     return (
       <div
         className="flex items-center gap-1.5 pr-2 py-0.5 text-[10px] font-vsc-mono text-vsc-text-muted"
@@ -148,7 +149,7 @@ export interface FunctionSidebarProps {
   onSelectFn: (name: string | null) => void;
   onRefreshTests: () => void;
   onRunTest?: (name: string) => void;
-  testRunResults?: Map<string, Record<string, unknown>>;
+  testRunResults?: Map<string, unknown>;
   /** Testset names whose expansion failed — shows error state instead of spinner */
   failedExpands?: Set<string>;
   /** Called when the user clicks retry on a failed testset expansion */

--- a/typescript2/pkg-playground/src/ResultDisplay.tsx
+++ b/typescript2/pkg-playground/src/ResultDisplay.tsx
@@ -6,12 +6,10 @@
  * inside a class) are rendered with their registered component.
  */
 
-import { useState, type FC } from 'react';
-import { ChevronRight } from 'lucide-react';
-import { CopyButton } from './components/CopyButton';
+import type { FC } from 'react';
 import { CodeBlock } from './components/ui/code-block';
-import { getBamlType, getResultRenderer, BAML_TYPE_KEY } from './result-renderers';
 import type { ResultRendererProps } from './result-renderers';
+import { ValueRenderer } from './ValueRenderer';
 
 export interface ResultDisplayProps {
   /** Raw result JSON string from the runtime. */
@@ -19,111 +17,6 @@ export interface ResultDisplayProps {
   /** Optional extra renderers (type -> Component) merged with registry. */
   customRenderers?: Record<string, FC<ResultRendererProps>>;
 }
-
-function resolve(
-  type: string,
-  customRenderers?: Record<string, FC<ResultRendererProps>>,
-): FC<ResultRendererProps> | undefined {
-  return customRenderers?.[type] ?? getResultRenderer(type);
-}
-
-const ValueRenderer: FC<{
-  value: unknown;
-  customRenderers?: Record<string, FC<ResultRendererProps>>;
-  depth?: number;
-  path?: string;
-}> = ({ value, customRenderers, depth = 0, path = '$' }) => {
-  const [collapsed, setCollapsed] = useState(depth >= 2);
-
-  // Primitives with type coloring
-  if (value == null) return <span className="font-vsc-mono text-xs text-vsc-text-faint">null</span>;
-  if (typeof value === 'string') return <span className="font-vsc-mono text-xs text-green-400">"{value}"</span>;
-  if (typeof value === 'number') return <span className="font-vsc-mono text-xs text-cyan-400">{value}</span>;
-  if (typeof value === 'boolean') return <span className="font-vsc-mono text-xs text-yellow-400">{String(value)}</span>;
-  if (typeof value !== 'object') return <span className="font-vsc-mono text-xs text-vsc-text">{JSON.stringify(value)}</span>;
-
-  // $baml.type dispatch (unchanged)
-  const type = getBamlType(value);
-  if (type) {
-    const Renderer = resolve(type, customRenderers);
-    if (Renderer) return <Renderer value={value} />;
-    return <CodeBlock>{JSON.stringify(value, null, 2)}</CodeBlock>;
-  }
-
-  // $type dispatch — BAML instance types from bex_value_to_json
-  const dollarType = (value as Record<string, unknown>).$type;
-  if (typeof dollarType === 'string') {
-    const Renderer = resolve(dollarType, customRenderers);
-    if (Renderer) return <Renderer value={value} />;
-  }
-
-  // Array
-  if (Array.isArray(value)) {
-    if (value.length === 0) return <span className="font-vsc-mono text-xs text-vsc-text-faint">[]</span>;
-    const showToggle = value.length > 3;
-    return (
-      <div className="group/node">
-        <div className="flex items-center gap-0.5">
-          {showToggle && (
-            <button onClick={() => setCollapsed(!collapsed)} className="p-0 text-vsc-text-muted hover:text-vsc-text">
-              <ChevronRight size={12} className={`transition-transform ${collapsed ? '' : 'rotate-90'}`} />
-            </button>
-          )}
-          <span className="font-vsc-mono text-xs text-vsc-text-faint">[{value.length}]</span>
-          <CopyButton text={JSON.stringify(value, null, 2)} className="opacity-0 group-hover/node:opacity-100" iconSize={11} />
-        </div>
-        {!collapsed && (
-          <div className="space-y-1 pl-3 border-l border-vsc-border-subtle mt-0.5">
-            {value.map((item, i) => (
-              <ValueRenderer key={i} value={item} customRenderers={customRenderers} depth={depth + 1} path={`${path}[${i}]`} />
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // Plain object
-  const entries = Object.entries(value as Record<string, unknown>).filter(([k]) => k !== BAML_TYPE_KEY);
-  if (entries.length === 0) return <span className="font-vsc-mono text-xs text-vsc-text-faint">{'{}'}</span>;
-  const showToggle = entries.length > 3;
-  return (
-    <div className="group/node">
-      <div className="flex items-center gap-0.5">
-        {showToggle && (
-          <button onClick={() => setCollapsed(!collapsed)} className="p-0 text-vsc-text-muted hover:text-vsc-text">
-            <ChevronRight size={12} className={`transition-transform ${collapsed ? '' : 'rotate-90'}`} />
-          </button>
-        )}
-        <span className="font-vsc-mono text-xs text-vsc-text-faint">{'{'}…{'}'} {entries.length} keys</span>
-        <CopyButton text={JSON.stringify(value, null, 2)} className="opacity-0 group-hover/node:opacity-100" iconSize={11} />
-      </div>
-      {!collapsed && (
-        <div className="space-y-1 pl-3 mt-0.5">
-          {entries.map(([key, val]) => {
-            const isComplex = val != null && typeof val === 'object';
-            if (!isComplex) {
-              return (
-                <div key={key} className="flex gap-1.5 items-baseline font-vsc-mono text-xs">
-                  <span className="text-vsc-text-muted shrink-0">{key}:</span>
-                  <ValueRenderer value={val} customRenderers={customRenderers} depth={depth + 1} path={`${path}.${key}`} />
-                </div>
-              );
-            }
-            return (
-              <div key={key} className="space-y-0.5">
-                <div className="font-vsc-mono text-xs text-vsc-text-muted">{key}:</div>
-                <div className="pl-2">
-                  <ValueRenderer value={val} customRenderers={customRenderers} depth={depth + 1} path={`${path}.${key}`} />
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-};
 
 export const ResultDisplay: FC<ResultDisplayProps> = ({ resultJson, customRenderers }) => {
   let value: unknown;

--- a/typescript2/pkg-playground/src/ResultDisplay.tsx
+++ b/typescript2/pkg-playground/src/ResultDisplay.tsx
@@ -7,24 +7,17 @@
  */
 
 import type { FC } from 'react';
-import { CodeBlock } from './components/ui/code-block';
+import type { BamlJsValue } from '@b/pkg-proto';
 import type { ResultRendererProps } from './result-renderers';
 import { ValueRenderer } from './ValueRenderer';
 
 export interface ResultDisplayProps {
-  /** Raw result JSON string from the runtime. */
-  resultJson: string;
+  /** Deserialized result value. */
+  result: BamlJsValue;
   /** Optional extra renderers (type -> Component) merged with registry. */
   customRenderers?: Record<string, FC<ResultRendererProps>>;
 }
 
-export const ResultDisplay: FC<ResultDisplayProps> = ({ resultJson, customRenderers }) => {
-  let value: unknown;
-  try {
-    value = JSON.parse(resultJson);
-  } catch {
-    return <CodeBlock>{resultJson}</CodeBlock>;
-  }
-
-  return <ValueRenderer value={value} customRenderers={customRenderers} />;
+export const ResultDisplay: FC<ResultDisplayProps> = ({ result, customRenderers }) => {
+  return <ValueRenderer value={result} customRenderers={customRenderers} displayMode="expanded" />;
 };

--- a/typescript2/pkg-playground/src/ValueRenderer.tsx
+++ b/typescript2/pkg-playground/src/ValueRenderer.tsx
@@ -27,9 +27,10 @@ export const ValueRenderer: FC<{
   path?: string;
   displayMode?: DisplayMode;
 }> = ({ value, customRenderers, depth = 0, path = '$', displayMode = 'auto' }) => {
-  const [collapsed, setCollapsed] = useState(depth >= 2);
+  const isInline = displayMode === 'inline';
+  const [collapsed, setCollapsed] = useState(isInline || depth >= 2);
 
-  // Primitives with type coloring
+  // Primitives with type coloring (same for all modes)
   if (value == null) return <span className="font-vsc-mono text-xs text-vsc-text-faint">null</span>;
   if (typeof value === 'string') return <span className="font-vsc-mono text-xs text-green-400">"{value}"</span>;
   if (typeof value === 'number') return <span className="font-vsc-mono text-xs text-cyan-400">{value}</span>;
@@ -41,6 +42,7 @@ export const ValueRenderer: FC<{
   if (type) {
     const Renderer = resolve(type, customRenderers);
     if (Renderer) return <Renderer value={value} displayMode={displayMode} />;
+    if (isInline) return <span className="font-vsc-mono text-xs text-vsc-text-faint">{type}</span>;
     return <CodeBlock>{JSON.stringify(value, null, 2)}</CodeBlock>;
   }
 
@@ -54,6 +56,23 @@ export const ValueRenderer: FC<{
   // Array
   if (Array.isArray(value)) {
     if (value.length === 0) return <span className="font-vsc-mono text-xs text-vsc-text-faint">[]</span>;
+
+    // Inline mode: render items on a single line
+    if (isInline) {
+      return (
+        <span className="font-vsc-mono text-xs text-vsc-text-faint">
+          {'['}
+          {value.map((item, i) => (
+            <span key={i}>
+              {i > 0 && ', '}
+              <ValueRenderer value={item} customRenderers={customRenderers} depth={depth + 1} displayMode="inline" />
+            </span>
+          ))}
+          {']'}
+        </span>
+      );
+    }
+
     const showToggle = value.length > 3;
     return (
       <div className="group/node">
@@ -80,6 +99,29 @@ export const ValueRenderer: FC<{
   // Plain object
   const entries = Object.entries(value as Record<string, unknown>).filter(([k]) => k !== BAML_TYPE_KEY);
   if (entries.length === 0) return <span className="font-vsc-mono text-xs text-vsc-text-faint">{'{}'}</span>;
+
+  // Inline mode: render as a single-line summary
+  if (isInline) {
+    const className = (value as Record<string, unknown>).$baml != null
+      ? getBamlType(value) ?? undefined
+      : undefined;
+    const prefix = className ? `${className} ` : '';
+    return (
+      <span className="font-vsc-mono text-xs text-vsc-text">
+        {prefix}{'{ '}
+        {entries.map(([key, val], i) => (
+          <span key={key}>
+            {i > 0 && ', '}
+            <span className="text-vsc-text-muted">{key}</span>
+            {': '}
+            <ValueRenderer value={val} customRenderers={customRenderers} depth={depth + 1} displayMode="inline" />
+          </span>
+        ))}
+        {' }'}
+      </span>
+    );
+  }
+
   const showToggle = entries.length > 3;
   return (
     <div className="group/node">

--- a/typescript2/pkg-playground/src/ValueRenderer.tsx
+++ b/typescript2/pkg-playground/src/ValueRenderer.tsx
@@ -1,0 +1,120 @@
+/**
+ * Shared value renderer for Playground output.
+ *
+ * Recursively walks objects/arrays so nested $baml-typed values (e.g. media
+ * inside a class) are rendered with their registered component.
+ * The displayMode prop controls rendering context (inline, expanded, auto).
+ */
+
+import { useState, type FC } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { CopyButton } from './components/CopyButton';
+import { CodeBlock } from './components/ui/code-block';
+import { getBamlType, getResultRenderer, BAML_TYPE_KEY } from './result-renderers';
+import type { ResultRendererProps, DisplayMode } from './result-renderers';
+
+function resolve(
+  type: string,
+  customRenderers?: Record<string, FC<ResultRendererProps>>,
+): FC<ResultRendererProps> | undefined {
+  return customRenderers?.[type] ?? getResultRenderer(type);
+}
+
+export const ValueRenderer: FC<{
+  value: unknown;
+  customRenderers?: Record<string, FC<ResultRendererProps>>;
+  depth?: number;
+  path?: string;
+  displayMode?: DisplayMode;
+}> = ({ value, customRenderers, depth = 0, path = '$', displayMode = 'auto' }) => {
+  const [collapsed, setCollapsed] = useState(depth >= 2);
+
+  // Primitives with type coloring
+  if (value == null) return <span className="font-vsc-mono text-xs text-vsc-text-faint">null</span>;
+  if (typeof value === 'string') return <span className="font-vsc-mono text-xs text-green-400">"{value}"</span>;
+  if (typeof value === 'number') return <span className="font-vsc-mono text-xs text-cyan-400">{value}</span>;
+  if (typeof value === 'boolean') return <span className="font-vsc-mono text-xs text-yellow-400">{String(value)}</span>;
+  if (typeof value !== 'object') return <span className="font-vsc-mono text-xs text-vsc-text">{JSON.stringify(value)}</span>;
+
+  // $baml.type dispatch
+  const type = getBamlType(value);
+  if (type) {
+    const Renderer = resolve(type, customRenderers);
+    if (Renderer) return <Renderer value={value} displayMode={displayMode} />;
+    return <CodeBlock>{JSON.stringify(value, null, 2)}</CodeBlock>;
+  }
+
+  // $type dispatch — BAML instance types from bex_value_to_json
+  const dollarType = (value as Record<string, unknown>).$type;
+  if (typeof dollarType === 'string') {
+    const Renderer = resolve(dollarType, customRenderers);
+    if (Renderer) return <Renderer value={value} displayMode={displayMode} />;
+  }
+
+  // Array
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="font-vsc-mono text-xs text-vsc-text-faint">[]</span>;
+    const showToggle = value.length > 3;
+    return (
+      <div className="group/node">
+        <div className="flex items-center gap-0.5">
+          {showToggle && (
+            <button onClick={() => setCollapsed(!collapsed)} className="p-0 text-vsc-text-muted hover:text-vsc-text">
+              <ChevronRight size={12} className={`transition-transform ${collapsed ? '' : 'rotate-90'}`} />
+            </button>
+          )}
+          <span className="font-vsc-mono text-xs text-vsc-text-faint">[{value.length}]</span>
+          <CopyButton text={JSON.stringify(value, null, 2)} className="opacity-0 group-hover/node:opacity-100" iconSize={11} />
+        </div>
+        {!collapsed && (
+          <div className="space-y-1 pl-3 border-l border-vsc-border-subtle mt-0.5">
+            {value.map((item, i) => (
+              <ValueRenderer key={i} value={item} customRenderers={customRenderers} depth={depth + 1} path={`${path}[${i}]`} displayMode={displayMode} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Plain object
+  const entries = Object.entries(value as Record<string, unknown>).filter(([k]) => k !== BAML_TYPE_KEY);
+  if (entries.length === 0) return <span className="font-vsc-mono text-xs text-vsc-text-faint">{'{}'}</span>;
+  const showToggle = entries.length > 3;
+  return (
+    <div className="group/node">
+      <div className="flex items-center gap-0.5">
+        {showToggle && (
+          <button onClick={() => setCollapsed(!collapsed)} className="p-0 text-vsc-text-muted hover:text-vsc-text">
+            <ChevronRight size={12} className={`transition-transform ${collapsed ? '' : 'rotate-90'}`} />
+          </button>
+        )}
+        <span className="font-vsc-mono text-xs text-vsc-text-faint">{'{'}…{'}'} {entries.length} keys</span>
+        <CopyButton text={JSON.stringify(value, null, 2)} className="opacity-0 group-hover/node:opacity-100" iconSize={11} />
+      </div>
+      {!collapsed && (
+        <div className="space-y-1 pl-3 mt-0.5">
+          {entries.map(([key, val]) => {
+            const isComplex = val != null && typeof val === 'object';
+            if (!isComplex) {
+              return (
+                <div key={key} className="flex gap-1.5 items-baseline font-vsc-mono text-xs">
+                  <span className="text-vsc-text-muted shrink-0">{key}:</span>
+                  <ValueRenderer value={val} customRenderers={customRenderers} depth={depth + 1} path={`${path}.${key}`} displayMode={displayMode} />
+                </div>
+              );
+            }
+            return (
+              <div key={key} className="space-y-0.5">
+                <div className="font-vsc-mono text-xs text-vsc-text-muted">{key}:</div>
+                <div className="pl-2">
+                  <ValueRenderer value={val} customRenderers={customRenderers} depth={depth + 1} path={`${path}.${key}`} displayMode={displayMode} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -12,8 +12,8 @@
  */
 
 import type { RuntimePort } from '../runtime-port';
-import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification, LogLevel, LogDecoration } from '../worker-protocol';
-import { decodeCallResult, RuntimeEvent } from '@b/pkg-proto';
+import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification, LogLevel, LogDecoration, DeserializedRuntimeEvent, DeserializedEventKind } from '../worker-protocol';
+import { decodeCallResult, deserializeValue, RuntimeEvent } from '@b/pkg-proto';
 import { formatValueShort, truncateMessage, normalizeLogLevel } from '../shared/log-decorations';
 
 /** Server → Client message shapes (must match playground_ws.rs WsOutMessage) */
@@ -44,6 +44,74 @@ type WsInMessage =
   | { type: 'cursorPosition'; file: string; line: number; column: number };
 
 const MAX_RECONNECT_DELAY = 5000;
+
+function wrapHandle(key: bigint, handleType: number, typeName: string) {
+  return { handle_key: key, handle_type: handleType, type_name: typeName };
+}
+
+function deserializeRuntimeEvent(event: RuntimeEvent): DeserializedRuntimeEvent {
+  let deserializedKind: DeserializedEventKind | undefined;
+  const kind = event.event?.kind;
+  if (kind) {
+    switch (kind.$case) {
+      case 'functionStart':
+        deserializedKind = {
+          $case: 'functionStart',
+          functionStart: {
+            name: kind.functionStart.name,
+            args: kind.functionStart.args.map((arg) => deserializeValue(arg, wrapHandle)),
+          },
+        };
+        break;
+      case 'functionEnd':
+        deserializedKind = {
+          $case: 'functionEnd',
+          functionEnd: {
+            name: kind.functionEnd.name,
+            durationMs: kind.functionEnd.durationMs,
+            result: kind.functionEnd.result
+              ? deserializeValue(kind.functionEnd.result, wrapHandle)
+              : null,
+          },
+        };
+        break;
+      case 'log':
+        deserializedKind = {
+          $case: 'log',
+          log: {
+            data: kind.log.data ? deserializeValue(kind.log.data, wrapHandle) : null,
+            level: kind.log.level,
+            source: kind.log.source,
+          },
+        };
+        break;
+      case 'custom':
+        deserializedKind = {
+          $case: 'custom',
+          custom: {
+            name: kind.custom.name,
+            data: kind.custom.data ? deserializeValue(kind.custom.data, wrapHandle) : null,
+          },
+        };
+        break;
+      case 'setTags':
+        deserializedKind = {
+          $case: 'setTags',
+          setTags: { tags: kind.setTags.tags },
+        };
+        break;
+    }
+  }
+
+  return {
+    spanId: event.spanId,
+    parentSpanId: event.parentSpanId,
+    rootSpanId: event.rootSpanId,
+    timestampMs: event.timestampMs,
+    callStack: event.callStack,
+    event: deserializedKind,
+  };
+}
 
 export class WebSocketRuntimePort implements RuntimePort {
   private url: string;
@@ -321,12 +389,13 @@ export class WebSocketRuntimePort implements RuntimePort {
         try {
           const bytes = base64ToUint8Array(raw.data);
           const event = RuntimeEvent.decode(bytes);
+          const deserialized = deserializeRuntimeEvent(event);
           // Forward the decoded event immediately via handlers
-          const runtimeMsg: WorkerOutMessage = { type: 'runtimeEventNew', event, callId: raw.callId ?? null };
+          const runtimeMsg: WorkerOutMessage = { type: 'runtimeEventNew', event: deserialized, callId: raw.callId ?? null };
           for (const h of this.handlers) h(runtimeMsg);
 
           // Extract log decorations (same logic as baml-lsp-worker.ts)
-          const kind = event.event?.kind;
+          const kind = deserialized.event;
           if (kind?.$case === 'log' && kind.log.source) {
             const source = kind.log.source;
             const line = source.line;

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -13,7 +13,7 @@
 
 import type { RuntimePort } from '../runtime-port';
 import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification } from '../worker-protocol';
-import { decodeCallResult } from '@b/pkg-proto';
+import { decodeCallResult, RuntimeEvent } from '@b/pkg-proto';
 
 /** Server → Client message shapes (must match playground_ws.rs WsOutMessage) */
 type WsOutMessage =
@@ -26,7 +26,8 @@ type WsOutMessage =
   | { type: 'fetchLogNew'; callId: number; id: number; method: string; url: string; requestHeaders: Record<string, string>; requestBody: string }
   | { type: 'fetchLogUpdate'; callId: number; logId: number; status?: number; durationMs?: number; responseBody?: string; error?: string; responseHeaders?: Record<string, string> }
   | { type: 'controlFlowGraphResult'; functionName: string; graph: unknown | null }
-  | { type: 'cursorContext'; context: unknown };
+  | { type: 'cursorContext'; context: unknown }
+  | { type: 'runtimeEvent'; data: string; callId: number };
 
 /** Client → Server message shapes (must match playground_ws.rs WsInMessage) */
 type WsInMessage =
@@ -312,6 +313,18 @@ export class WebSocketRuntimePort implements RuntimePort {
           type: 'cursorContext',
           context: raw.context as import('../worker-protocol').CursorContext,
         };
+      case 'runtimeEvent': {
+        try {
+          const bytes = base64ToUint8Array(raw.data);
+          const event = RuntimeEvent.decode(bytes);
+          return { type: 'runtimeEventNew', event, callId: raw.callId ?? null };
+        } catch (e) {
+          return {
+            type: 'runtimeEventError' as const,
+            error: `Failed to decode runtime event: ${e instanceof Error ? e.message : String(e)}`,
+          } as WorkerOutMessage;
+        }
+      }
       default:
         return null;
     }

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -14,7 +14,8 @@
 import type { RuntimePort } from '../runtime-port';
 import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification, LogLevel, LogDecoration, DeserializedRuntimeEvent, DeserializedEventKind } from '../worker-protocol';
 import { decodeCallResult, deserializeValue, RuntimeEvent } from '@b/pkg-proto';
-import { formatValueShort, truncateMessage, normalizeLogLevel } from '../shared/log-decorations';
+import { truncateMessage, normalizeLogLevel } from '../shared/log-decorations';
+import { formatValue } from '../shared/format-value';
 
 /** Server → Client message shapes (must match playground_ws.rs WsOutMessage) */
 type WsOutMessage =
@@ -400,7 +401,7 @@ export class WebSocketRuntimePort implements RuntimePort {
             const source = kind.log.source;
             const line = source.line;
             const level = normalizeLogLevel(kind.log.level);
-            const message = formatValueShort(kind.log.data);
+            const message = formatValue(kind.log.data, 'inline-hint');
             const sourceSpanLength = source.endOffset - source.startOffset;
             const isLikelyVariable = message.length > sourceSpanLength + 5;
             if (isLikelyVariable) {

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -12,10 +12,11 @@
  */
 
 import type { RuntimePort } from '../runtime-port';
-import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification, LogLevel, LogDecoration, DeserializedRuntimeEvent, DeserializedEventKind } from '../worker-protocol';
-import { decodeCallResult, deserializeValue, RuntimeEvent } from '@b/pkg-proto';
+import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification, LogLevel, LogDecoration } from '../worker-protocol';
+import { decodeCallResult, RuntimeEvent } from '@b/pkg-proto';
 import { truncateMessage, normalizeLogLevel } from '../shared/log-decorations';
 import { formatValue } from '../shared/format-value';
+import { deserializeRuntimeEvent } from '../shared/deserialize-event';
 
 /** Server → Client message shapes (must match playground_ws.rs WsOutMessage) */
 type WsOutMessage =
@@ -46,74 +47,6 @@ type WsInMessage =
 
 const MAX_RECONNECT_DELAY = 5000;
 
-function wrapHandle(key: bigint, handleType: number, typeName: string) {
-  return { handle_key: key, handle_type: handleType, type_name: typeName };
-}
-
-function deserializeRuntimeEvent(event: RuntimeEvent): DeserializedRuntimeEvent {
-  let deserializedKind: DeserializedEventKind | undefined;
-  const kind = event.event?.kind;
-  if (kind) {
-    switch (kind.$case) {
-      case 'functionStart':
-        deserializedKind = {
-          $case: 'functionStart',
-          functionStart: {
-            name: kind.functionStart.name,
-            args: kind.functionStart.args.map((arg) => deserializeValue(arg, wrapHandle)),
-          },
-        };
-        break;
-      case 'functionEnd':
-        deserializedKind = {
-          $case: 'functionEnd',
-          functionEnd: {
-            name: kind.functionEnd.name,
-            durationMs: kind.functionEnd.durationMs,
-            result: kind.functionEnd.result
-              ? deserializeValue(kind.functionEnd.result, wrapHandle)
-              : null,
-          },
-        };
-        break;
-      case 'log':
-        deserializedKind = {
-          $case: 'log',
-          log: {
-            data: kind.log.data ? deserializeValue(kind.log.data, wrapHandle) : null,
-            level: kind.log.level,
-            source: kind.log.source,
-          },
-        };
-        break;
-      case 'custom':
-        deserializedKind = {
-          $case: 'custom',
-          custom: {
-            name: kind.custom.name,
-            data: kind.custom.data ? deserializeValue(kind.custom.data, wrapHandle) : null,
-          },
-        };
-        break;
-      case 'setTags':
-        deserializedKind = {
-          $case: 'setTags',
-          setTags: { tags: kind.setTags.tags },
-        };
-        break;
-    }
-  }
-
-  return {
-    spanId: event.spanId,
-    parentSpanId: event.parentSpanId,
-    rootSpanId: event.rootSpanId,
-    timestampMs: event.timestampMs,
-    callStack: event.callStack,
-    event: deserializedKind,
-  };
-}
-
 export class WebSocketRuntimePort implements RuntimePort {
   private url: string;
   private ws: WebSocket | null = null;
@@ -124,6 +57,7 @@ export class WebSocketRuntimePort implements RuntimePort {
   private reconnectDelay = 500;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private decorationsByLine = new Map<number, { level: LogLevel; message: string; count: number }>();
+  private textEncoder = new TextEncoder();
 
   constructor(url: string) {
     this.url = url;
@@ -388,9 +322,8 @@ export class WebSocketRuntimePort implements RuntimePort {
           const bytes = base64ToUint8Array(raw.data);
           const event = RuntimeEvent.decode(bytes);
           const deserialized = deserializeRuntimeEvent(event);
-          // Forward the decoded event immediately via handlers
-          const runtimeMsg: WorkerOutMessage = { type: 'runtimeEventNew', event: deserialized, callId: raw.callId ?? null };
-          for (const h of this.handlers) h(runtimeMsg);
+          // Forward the decoded event via the buffer-or-dispatch path
+          this.deliver({ type: 'runtimeEventNew', event: deserialized, callId: raw.callId ?? null });
 
           // Extract log decorations (same logic as baml-lsp-worker.ts)
           const kind = deserialized.event;
@@ -400,7 +333,9 @@ export class WebSocketRuntimePort implements RuntimePort {
             const level = normalizeLogLevel(kind.log.level);
             const message = formatValue(kind.log.data, 'inline-hint');
             const sourceSpanLength = source.endOffset - source.startOffset;
-            const isLikelyVariable = message.length > sourceSpanLength + 5;
+            // Compare UTF-8 byte lengths since source offsets are byte offsets from Rust
+            const messageByteLen = this.textEncoder.encode(message).length;
+            const isLikelyVariable = messageByteLen > sourceSpanLength + 5;
             if (isLikelyVariable) {
               const existing = this.decorationsByLine.get(line);
               if (existing) {
@@ -426,6 +361,15 @@ export class WebSocketRuntimePort implements RuntimePort {
     }
   }
 
+  /** Buffer-or-dispatch: if no handlers are registered yet, buffer the message for replay. */
+  private deliver(msg: WorkerOutMessage): void {
+    if (this.handlers.size === 0) {
+      this.inBuffer.push(msg);
+    } else {
+      for (const h of this.handlers) h(msg);
+    }
+  }
+
   private emitLogDecorations(): void {
     const decorations: LogDecoration[] = [];
     for (const [line, entry] of this.decorationsByLine) {
@@ -436,14 +380,12 @@ export class WebSocketRuntimePort implements RuntimePort {
         count: entry.count,
       });
     }
-    const msg: WorkerOutMessage = { type: 'logDecorations', decorations };
-    for (const h of this.handlers) h(msg);
+    this.deliver({ type: 'logDecorations', decorations });
   }
 
   private clearLogDecorations(): void {
     this.decorationsByLine.clear();
-    const msg: WorkerOutMessage = { type: 'clearLogDecorations' };
-    for (const h of this.handlers) h(msg);
+    this.deliver({ type: 'clearLogDecorations' });
   }
 }
 

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -326,10 +326,7 @@ export class WebSocketRuntimePort implements RuntimePort {
           return {
             type: 'callFunctionResult',
             id: raw.id,
-            result: JSON.stringify(decoded, (_, v) =>
-              typeof v === 'bigint' ? v.toString() : v,
-              2,
-            ),
+            result: decoded,
           };
         } catch (e) {
           return {

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -12,8 +12,9 @@
  */
 
 import type { RuntimePort } from '../runtime-port';
-import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification } from '../worker-protocol';
+import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification, LogLevel, LogDecoration } from '../worker-protocol';
 import { decodeCallResult, RuntimeEvent } from '@b/pkg-proto';
+import { formatValueShort, truncateMessage, normalizeLogLevel } from '../shared/log-decorations';
 
 /** Server → Client message shapes (must match playground_ws.rs WsOutMessage) */
 type WsOutMessage =
@@ -53,6 +54,7 @@ export class WebSocketRuntimePort implements RuntimePort {
   private disposed = false;
   private reconnectDelay = 500;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private decorationsByLine = new Map<number, { level: LogLevel; message: string; count: number }>();
 
   constructor(url: string) {
     this.url = url;
@@ -165,6 +167,7 @@ export class WebSocketRuntimePort implements RuntimePort {
   private toServer(msg: WorkerInMessage): WsInMessage | null {
     switch (msg.type) {
       case 'callFunction':
+        this.clearLogDecorations();
         return {
           type: 'callFunction',
           id: msg.id,
@@ -207,6 +210,7 @@ export class WebSocketRuntimePort implements RuntimePort {
       case 'requestCollectTests':
         return { type: 'requestCollectTests', project: msg.project };
       case 'callTestFunction':
+        this.clearLogDecorations();
         return {
           type: 'callTestFunction',
           id: msg.id,
@@ -317,7 +321,32 @@ export class WebSocketRuntimePort implements RuntimePort {
         try {
           const bytes = base64ToUint8Array(raw.data);
           const event = RuntimeEvent.decode(bytes);
-          return { type: 'runtimeEventNew', event, callId: raw.callId ?? null };
+          // Forward the decoded event immediately via handlers
+          const runtimeMsg: WorkerOutMessage = { type: 'runtimeEventNew', event, callId: raw.callId ?? null };
+          for (const h of this.handlers) h(runtimeMsg);
+
+          // Extract log decorations (same logic as baml-lsp-worker.ts)
+          const kind = event.event?.kind;
+          if (kind?.$case === 'log' && kind.log.source) {
+            const source = kind.log.source;
+            const line = source.line;
+            const level = normalizeLogLevel(kind.log.level);
+            const message = formatValueShort(kind.log.data);
+            const sourceSpanLength = source.endOffset - source.startOffset;
+            const isLikelyVariable = message.length > sourceSpanLength + 5;
+            if (isLikelyVariable) {
+              const existing = this.decorationsByLine.get(line);
+              if (existing) {
+                existing.message = message;
+                existing.level = level;
+                existing.count += 1;
+              } else {
+                this.decorationsByLine.set(line, { level, message, count: 1 });
+              }
+              this.emitLogDecorations();
+            }
+          }
+          return null; // already dispatched via handlers above
         } catch (e) {
           return {
             type: 'runtimeEventError' as const,
@@ -328,6 +357,26 @@ export class WebSocketRuntimePort implements RuntimePort {
       default:
         return null;
     }
+  }
+
+  private emitLogDecorations(): void {
+    const decorations: LogDecoration[] = [];
+    for (const [line, entry] of this.decorationsByLine) {
+      decorations.push({
+        line,
+        level: entry.level,
+        message: truncateMessage(entry.message),
+        count: entry.count,
+      });
+    }
+    const msg: WorkerOutMessage = { type: 'logDecorations', decorations };
+    for (const h of this.handlers) h(msg);
+  }
+
+  private clearLogDecorations(): void {
+    this.decorationsByLine.clear();
+    const msg: WorkerOutMessage = { type: 'clearLogDecorations' };
+    for (const h of this.handlers) h(msg);
   }
 }
 

--- a/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
+++ b/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
@@ -262,7 +262,7 @@ export function httpRequestToCurl(req: HttpRequestShape): string {
 const preCls =
   'whitespace-pre font-vsc-mono text-xs leading-relaxed p-3 rounded bg-vsc-bg border border-vsc-border text-vsc-text overflow-auto max-h-[400px] m-0';
 
-export const HttpRequestCurlRenderer: FC<ResultRendererProps> = ({ value }) => {
+export const HttpRequestCurlRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
   const [copied, setCopied] = useState(false);
   const [format, setFormat] = useState<HttpRequestSnippetFormat>('curl');
   const httpReq = isHttpRequest(value) ? value : null;
@@ -284,6 +284,10 @@ export const HttpRequestCurlRenderer: FC<ResultRendererProps> = ({ value }) => {
 
   if (!httpReq) {
     return <pre className={preCls}>{JSON.stringify(value, null, 2)}</pre>;
+  }
+
+  if (displayMode === 'inline') {
+    return <span className="font-vsc-mono text-xs text-vsc-text">{httpReq.method} {httpReq.url}</span>;
   }
 
   return (

--- a/typescript2/pkg-playground/src/renderers/Media.tsx
+++ b/typescript2/pkg-playground/src/renderers/Media.tsx
@@ -24,9 +24,13 @@ function getMediaSrc(m: BamlJsMedia): string | null {
   return null;
 }
 
-export const MediaRenderer: FC<ResultRendererProps> = ({ value }) => {
+export const MediaRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
   if (!isMedia(value)) {
     return <CodeBlock>{JSON.stringify(value, null, 2)}</CodeBlock>;
+  }
+
+  if (displayMode === 'inline') {
+    return <span className="font-vsc-mono text-xs text-vsc-text-faint">&lt;{value.media_type}&gt;</span>;
   }
 
   const src = getMediaSrc(value);

--- a/typescript2/pkg-playground/src/renderers/PromptAst.tsx
+++ b/typescript2/pkg-playground/src/renderers/PromptAst.tsx
@@ -75,9 +75,13 @@ const AstNode: FC<{ node: BamlJsPromptAst }> = ({ node }) => {
   }
 };
 
-export const PromptAstRenderer: FC<ResultRendererProps> = ({ value }) => {
+export const PromptAstRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
   if (!isPromptAst(value)) {
     return <CodeBlock>{JSON.stringify(value, null, 2)}</CodeBlock>;
+  }
+
+  if (displayMode === 'inline') {
+    return <span className="font-vsc-mono text-xs text-vsc-text-faint">&lt;prompt_ast&gt;</span>;
   }
 
   return (

--- a/typescript2/pkg-playground/src/renderers/TestReport.tsx
+++ b/typescript2/pkg-playground/src/renderers/TestReport.tsx
@@ -35,9 +35,13 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
-export const TestReportRenderer: FC<ResultRendererProps> = ({ value }) => {
+export const TestReportRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
   if (!isTestReport(value)) {
     return <pre className="whitespace-pre font-vsc-mono text-xs p-3 rounded bg-vsc-bg border border-vsc-border text-vsc-text overflow-auto max-h-[400px] m-0">{JSON.stringify(value, null, 2)}</pre>;
+  }
+
+  if (displayMode === 'inline') {
+    return <span className="font-vsc-mono text-xs text-vsc-text">{value.outcome} ({value.runs?.length ?? 0} runs)</span>;
   }
 
   const info = outcomeIcon[value.outcome ?? ''] ?? outcomeIcon.error;

--- a/typescript2/pkg-playground/src/result-renderers.ts
+++ b/typescript2/pkg-playground/src/result-renderers.ts
@@ -10,10 +10,15 @@ import type { FC } from 'react';
 export const BAML_TYPE_KEY = '$baml' as const;
 export const BAML_TYPE_FIELD = 'type' as const;
 
+/** Display context for value renderers. */
+export type DisplayMode = 'inline' | 'expanded' | 'auto' | 'inline-hint';
+
 /** Props passed to a custom result renderer. */
 export interface ResultRendererProps {
   /** The parsed result value (object with $baml.type when from BAML). */
   value: unknown;
+  /** Rendering context — defaults to 'auto' if omitted. */
+  displayMode?: DisplayMode;
 }
 
 /** Extract BAML type from a result value, e.g. "baml.http.Request". */

--- a/typescript2/pkg-playground/src/shared/deserialize-event.ts
+++ b/typescript2/pkg-playground/src/shared/deserialize-event.ts
@@ -1,0 +1,70 @@
+import { deserializeValue, type RuntimeEvent } from '@b/pkg-proto';
+import type { DeserializedRuntimeEvent, DeserializedEventKind } from '../worker-protocol';
+
+function wrapHandle(key: bigint, handleType: number, typeName: string) {
+  return { handle_key: key, handle_type: handleType, type_name: typeName };
+}
+
+export function deserializeRuntimeEvent(event: RuntimeEvent): DeserializedRuntimeEvent {
+  let deserializedKind: DeserializedEventKind | undefined;
+  const kind = event.event?.kind;
+  if (kind) {
+    switch (kind.$case) {
+      case 'functionStart':
+        deserializedKind = {
+          $case: 'functionStart',
+          functionStart: {
+            name: kind.functionStart.name,
+            args: kind.functionStart.args.map((arg) => deserializeValue(arg, wrapHandle)),
+          },
+        };
+        break;
+      case 'functionEnd':
+        deserializedKind = {
+          $case: 'functionEnd',
+          functionEnd: {
+            name: kind.functionEnd.name,
+            durationMs: kind.functionEnd.durationMs,
+            result: kind.functionEnd.result
+              ? deserializeValue(kind.functionEnd.result, wrapHandle)
+              : null,
+          },
+        };
+        break;
+      case 'log':
+        deserializedKind = {
+          $case: 'log',
+          log: {
+            data: kind.log.data ? deserializeValue(kind.log.data, wrapHandle) : null,
+            level: kind.log.level,
+            source: kind.log.source,
+          },
+        };
+        break;
+      case 'custom':
+        deserializedKind = {
+          $case: 'custom',
+          custom: {
+            name: kind.custom.name,
+            data: kind.custom.data ? deserializeValue(kind.custom.data, wrapHandle) : null,
+          },
+        };
+        break;
+      case 'setTags':
+        deserializedKind = {
+          $case: 'setTags',
+          setTags: { tags: kind.setTags.tags },
+        };
+        break;
+    }
+  }
+
+  return {
+    spanId: event.spanId,
+    parentSpanId: event.parentSpanId,
+    rootSpanId: event.rootSpanId,
+    timestampMs: event.timestampMs,
+    callStack: event.callStack,
+    event: deserializedKind,
+  };
+}

--- a/typescript2/pkg-playground/src/shared/format-value.ts
+++ b/typescript2/pkg-playground/src/shared/format-value.ts
@@ -1,0 +1,43 @@
+import type { BamlJsValue } from '@b/pkg-proto';
+import { getBamlType } from '../result-renderers';
+
+/**
+ * Format a BamlJsValue as a compact string for non-React contexts
+ * (e.g. Monaco editor inline decorations).
+ */
+export function formatValue(value: BamlJsValue | null | undefined, mode: 'inline-hint'): string {
+  if (value == null) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'boolean') return String(value);
+  if (typeof value === 'bigint') return String(value);
+
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => formatValue(v, mode)).join(', ')}]`;
+  }
+
+  if (typeof value === 'object') {
+    const bamlType = getBamlType(value);
+    if (bamlType === '$media') {
+      return `<${(value as Record<string, unknown>).mime_type ?? (value as Record<string, unknown>).media_type ?? 'media'}>`;
+    }
+    if (bamlType === '$handle') {
+      return `<handle #${(value as Record<string, unknown>).handle_key}>`;
+    }
+    if (bamlType === '$prompt_ast') return '<prompt_ast>';
+    if (bamlType) {
+      const entries = Object.entries(value)
+        .filter(([k]) => k !== '$baml')
+        .map(([k, v]) => `${k}: ${formatValue(v as BamlJsValue, mode)}`)
+        .join(', ');
+      return `${bamlType} { ${entries} }`;
+    }
+    // Plain map
+    const entries = Object.entries(value)
+      .map(([k, v]) => `${k}: ${formatValue(v as BamlJsValue, mode)}`)
+      .join(', ');
+    return `{${entries}}`;
+  }
+
+  return '?';
+}

--- a/typescript2/pkg-playground/src/shared/log-decorations.ts
+++ b/typescript2/pkg-playground/src/shared/log-decorations.ts
@@ -1,40 +1,4 @@
-import type { BamlJsValue } from '@b/pkg-proto';
-import { getBamlType } from '../result-renderers';
 import type { LogLevel } from '../worker-protocol';
-
-/** Format a BamlJsValue to a short string for inline display. */
-export function formatValueShort(value: BamlJsValue | null | undefined): string {
-  if (value == null) return 'null';
-  if (typeof value === 'string') return JSON.stringify(value);
-  if (typeof value === 'number') return String(value);
-  if (typeof value === 'boolean') return String(value);
-  if (typeof value === 'bigint') return String(value);
-  if (Array.isArray(value)) {
-    return `[${value.map(formatValueShort).join(', ')}]`;
-  }
-  if (typeof value === 'object') {
-    const bamlType = getBamlType(value);
-    if (bamlType === '$media') {
-      return `<${(value as Record<string, unknown>).mime_type ?? (value as Record<string, unknown>).media_type ?? 'media'}>`;
-    }
-    if (bamlType === '$handle') {
-      return `<handle #${(value as Record<string, unknown>).handle_key}>`;
-    }
-    if (bamlType === '$prompt_ast') return '<prompt_ast>';
-    if (bamlType) {
-      const entries = Object.entries(value)
-        .filter(([k]) => k !== '$baml')
-        .map(([k, v]) => `${k}: ${formatValueShort(v as BamlJsValue)}`)
-        .join(', ');
-      return `${bamlType} { ${entries} }`;
-    }
-    const entries = Object.entries(value)
-      .map(([k, v]) => `${k}: ${formatValueShort(v as BamlJsValue)}`)
-      .join(', ');
-    return `{${entries}}`;
-  }
-  return '?';
-}
 
 /** Truncate a message to max length with ellipsis. */
 export function truncateMessage(msg: string, maxLen: number = 60): string {

--- a/typescript2/pkg-playground/src/shared/log-decorations.ts
+++ b/typescript2/pkg-playground/src/shared/log-decorations.ts
@@ -1,70 +1,39 @@
-import type { BamlOutboundValue } from '@b/pkg-proto';
+import type { BamlJsValue } from '@b/pkg-proto';
+import { getBamlType } from '../result-renderers';
 import type { LogLevel } from '../worker-protocol';
 
-/** Format a BamlOutboundValue to a short string for inline display. */
-export function formatValueShort(holder: BamlOutboundValue | null | undefined): string {
-  if (!holder?.value) return 'null';
-
-  switch (holder.value.$case) {
-    case 'nullValue':
-      return 'null';
-    case 'stringValue':
-      return JSON.stringify(holder.value.stringValue);
-    case 'intValue':
-      return String(holder.value.intValue);
-    case 'floatValue':
-      return String(holder.value.floatValue);
-    case 'boolValue':
-      return String(holder.value.boolValue);
-    case 'classValue': {
-      const cls = holder.value.classValue;
-      const name = cls.name?.name ?? 'Class';
-      const fields = cls.fields
-        .map((f) => `${f.key}: ${formatValueShort(f.value)}`)
-        .join(', ');
-      return `${name} { ${fields} }`;
-    }
-    case 'enumValue':
-      return holder.value.enumValue.value;
-    case 'listValue':
-      return `[${holder.value.listValue.items.map(formatValueShort).join(', ')}]`;
-    case 'mapValue': {
-      const entries = holder.value.mapValue.entries
-        .map((e) => `${e.key}: ${formatValueShort(e.value)}`)
-        .join(', ');
-      return `{${entries}}`;
-    }
-    case 'literalValue': {
-      const lit = holder.value.literalValue;
-      if (!lit.literal) return 'null';
-      switch (lit.literal.$case) {
-        case 'stringLiteral':
-          return JSON.stringify(lit.literal.stringLiteral.value);
-        case 'intLiteral':
-          return String(lit.literal.intLiteral.value);
-        case 'boolLiteral':
-          return String(lit.literal.boolLiteral.value);
-        default:
-          return 'null';
-      }
-    }
-    case 'unionVariantValue':
-      return formatValueShort(holder.value.unionVariantValue.value);
-    case 'checkedValue':
-      return formatValueShort(holder.value.checkedValue.value);
-    case 'streamingStateValue':
-      return formatValueShort(holder.value.streamingStateValue.value);
-    case 'handleValue': {
-      const h = holder.value.handleValue;
-      return `<handle #${h.key}>`;
-    }
-    case 'mediaValue': {
-      const m = holder.value.mediaValue;
-      return `<${m.mimeType ?? 'media'}>`;
-    }
-    default:
-      return '?';
+/** Format a BamlJsValue to a short string for inline display. */
+export function formatValueShort(value: BamlJsValue | null | undefined): string {
+  if (value == null) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'boolean') return String(value);
+  if (typeof value === 'bigint') return String(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(formatValueShort).join(', ')}]`;
   }
+  if (typeof value === 'object') {
+    const bamlType = getBamlType(value);
+    if (bamlType === '$media') {
+      return `<${(value as Record<string, unknown>).mime_type ?? (value as Record<string, unknown>).media_type ?? 'media'}>`;
+    }
+    if (bamlType === '$handle') {
+      return `<handle #${(value as Record<string, unknown>).handle_key}>`;
+    }
+    if (bamlType === '$prompt_ast') return '<prompt_ast>';
+    if (bamlType) {
+      const entries = Object.entries(value)
+        .filter(([k]) => k !== '$baml')
+        .map(([k, v]) => `${k}: ${formatValueShort(v as BamlJsValue)}`)
+        .join(', ');
+      return `${bamlType} { ${entries} }`;
+    }
+    const entries = Object.entries(value)
+      .map(([k, v]) => `${k}: ${formatValueShort(v as BamlJsValue)}`)
+      .join(', ');
+    return `{${entries}}`;
+  }
+  return '?';
 }
 
 /** Truncate a message to max length with ellipsis. */

--- a/typescript2/pkg-playground/src/shared/log-decorations.ts
+++ b/typescript2/pkg-playground/src/shared/log-decorations.ts
@@ -1,0 +1,84 @@
+import type { BamlOutboundValue } from '@b/pkg-proto';
+import type { LogLevel } from '../worker-protocol';
+
+/** Format a BamlOutboundValue to a short string for inline display. */
+export function formatValueShort(holder: BamlOutboundValue | null | undefined): string {
+  if (!holder?.value) return 'null';
+
+  switch (holder.value.$case) {
+    case 'nullValue':
+      return 'null';
+    case 'stringValue':
+      return JSON.stringify(holder.value.stringValue);
+    case 'intValue':
+      return String(holder.value.intValue);
+    case 'floatValue':
+      return String(holder.value.floatValue);
+    case 'boolValue':
+      return String(holder.value.boolValue);
+    case 'classValue': {
+      const cls = holder.value.classValue;
+      const name = cls.name?.name ?? 'Class';
+      const fields = cls.fields
+        .map((f) => `${f.key}: ${formatValueShort(f.value)}`)
+        .join(', ');
+      return `${name} { ${fields} }`;
+    }
+    case 'enumValue':
+      return holder.value.enumValue.value;
+    case 'listValue':
+      return `[${holder.value.listValue.items.map(formatValueShort).join(', ')}]`;
+    case 'mapValue': {
+      const entries = holder.value.mapValue.entries
+        .map((e) => `${e.key}: ${formatValueShort(e.value)}`)
+        .join(', ');
+      return `{${entries}}`;
+    }
+    case 'literalValue': {
+      const lit = holder.value.literalValue;
+      if (!lit.literal) return 'null';
+      switch (lit.literal.$case) {
+        case 'stringLiteral':
+          return JSON.stringify(lit.literal.stringLiteral.value);
+        case 'intLiteral':
+          return String(lit.literal.intLiteral.value);
+        case 'boolLiteral':
+          return String(lit.literal.boolLiteral.value);
+        default:
+          return 'null';
+      }
+    }
+    case 'unionVariantValue':
+      return formatValueShort(holder.value.unionVariantValue.value);
+    case 'checkedValue':
+      return formatValueShort(holder.value.checkedValue.value);
+    case 'streamingStateValue':
+      return formatValueShort(holder.value.streamingStateValue.value);
+    case 'handleValue': {
+      const h = holder.value.handleValue;
+      return `<handle #${h.key}>`;
+    }
+    case 'mediaValue': {
+      const m = holder.value.mediaValue;
+      return `<${m.mimeType ?? 'media'}>`;
+    }
+    default:
+      return '?';
+  }
+}
+
+/** Truncate a message to max length with ellipsis. */
+export function truncateMessage(msg: string, maxLen: number = 60): string {
+  if (msg.length <= maxLen) return msg;
+  return msg.slice(0, maxLen - 1) + '\u2026';
+}
+
+/** Map log level string to our LogLevel type. */
+export function normalizeLogLevel(level: string): LogLevel {
+  switch (level.toLowerCase()) {
+    case 'error': return 'error';
+    case 'warn': case 'warning': return 'warn';
+    case 'debug': return 'debug';
+    default: return 'info';
+  }
+}

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -174,7 +174,7 @@ export interface RunEntry {
   fetchLogs: FetchLogEntry[];
   /** Runtime events (log.info, baml.events.send, etc.) emitted during this run. */
   runtimeEvents: DeserializedRuntimeEvent[];
-  result: string | null;
+  result: BamlJsValue | null;
   error: string | null;
   status: 'running' | 'success' | 'error' | 'cancelled';
   startTime: number;
@@ -189,7 +189,7 @@ export type WorkerOutMessage =
   | { type: 'ready' }
   | { type: 'playgroundNotification'; notification: PlaygroundNotification }
   | { type: 'diagnostics'; entries: DiagnosticEntry[] }
-  | { type: 'callFunctionResult'; id: number; result: string }
+  | { type: 'callFunctionResult'; id: number; result: BamlJsValue }
   | { type: 'callFunctionError'; id: number; error: string; cancelled?: boolean }
   | { type: 'fetchLogNew'; entry: FetchLogEntry }
   | { type: 'fetchLogUpdate'; logId: number; patch: Partial<FetchLogEntry> }

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -20,9 +20,9 @@ export interface DeserializedRuntimeEvent {
 
 export type DeserializedEventKind =
   | { $case: 'functionStart'; functionStart: { name: string; args: BamlJsValue[] } }
-  | { $case: 'functionEnd'; functionEnd: { name: string; durationMs: number; result: BamlJsValue } }
-  | { $case: 'log'; log: { data: BamlJsValue; level: string; source?: SourceLocation } }
-  | { $case: 'custom'; custom: { name: string; data: BamlJsValue } }
+  | { $case: 'functionEnd'; functionEnd: { name: string; durationMs: number; result: BamlJsValue | null } }
+  | { $case: 'log'; log: { data: BamlJsValue | null; level: string; source?: SourceLocation } }
+  | { $case: 'custom'; custom: { name: string; data: BamlJsValue | null } }
   | { $case: 'setTags'; setTags: { tags: TagEntry[] } };
 
 // ---------------------------------------------------------------------------

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -71,7 +71,7 @@ export type PlaygroundNotification =
   | { type: 'controlFlowGraphResult'; functionName: string; graph: ControlFlowGraph | null }
   | { type: 'cursorContext'; context: CursorContext }
   | { type: 'testCollectionResult'; project: string; generation: number; callId: number; data: number[]; expandError?: { testsetName: string; message: string } }
-  | { type: 'runtimeEvent'; data: number[] };
+  | { type: 'runtimeEvent'; data: number[]; callId?: number };
 
 // ---------------------------------------------------------------------------
 // Control flow graph types (matches Rust serde output from baml_compiler2_visualization)

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -6,7 +6,24 @@
  * gives exhaustive switch narrowing.
  */
 
-import type { RuntimeEvent } from '@b/pkg-proto';
+import type { BamlJsValue, SourceLocation, TagEntry } from '@b/pkg-proto';
+
+/** Runtime event with BamlOutboundValue fields deserialized to BamlJsValue. */
+export interface DeserializedRuntimeEvent {
+  spanId: string;
+  parentSpanId?: string;
+  rootSpanId: string;
+  timestampMs: number;
+  callStack: string[];
+  event: DeserializedEventKind | undefined;
+}
+
+export type DeserializedEventKind =
+  | { $case: 'functionStart'; functionStart: { name: string; args: BamlJsValue[] } }
+  | { $case: 'functionEnd'; functionEnd: { name: string; durationMs: number; result: BamlJsValue } }
+  | { $case: 'log'; log: { data: BamlJsValue; level: string; source?: SourceLocation } }
+  | { $case: 'custom'; custom: { name: string; data: BamlJsValue } }
+  | { $case: 'setTags'; setTags: { tags: TagEntry[] } };
 
 // ---------------------------------------------------------------------------
 // Log decoration types (inline log display like ErrorLens)
@@ -156,7 +173,7 @@ export interface RunEntry {
   testName?: string;
   fetchLogs: FetchLogEntry[];
   /** Runtime events (log.info, baml.events.send, etc.) emitted during this run. */
-  runtimeEvents: RuntimeEvent[];
+  runtimeEvents: DeserializedRuntimeEvent[];
   result: string | null;
   error: string | null;
   status: 'running' | 'success' | 'error' | 'cancelled';
@@ -176,7 +193,7 @@ export type WorkerOutMessage =
   | { type: 'callFunctionError'; id: number; error: string; cancelled?: boolean }
   | { type: 'fetchLogNew'; entry: FetchLogEntry }
   | { type: 'fetchLogUpdate'; logId: number; patch: Partial<FetchLogEntry> }
-  | { type: 'runtimeEventNew'; event: RuntimeEvent; callId: number | null }
+  | { type: 'runtimeEventNew'; event: DeserializedRuntimeEvent; callId: number | null }
   | { type: 'runtimeEventError'; error: string }
   | { type: 'envVarRequest'; id: number; variable: string }
   | { type: 'inputRequest'; id: number; prompt: string | undefined; callId: number }


### PR DESCRIPTION
[Artifacts](https://cloud.codelayer.cloud/tasks/019db8b2-a8c9-71b2-ae2d-4fb8a75af8f3/artifacts) | [Task](https://cloud.codelayer.cloud/deep/tasks/019db8b2-a8c9-71b2-ae2d-4fb8a75af8f3)

## What problems was I solving

Runtime events (`log.info`, `baml.events.send`, function start/end) were **silently dropped** in the VS Code playground. `WebSocketRuntimePort.fromServer()` had no `case 'runtimeEvent':` so messages from the Rust server fell through to `default: return null` and were discarded. Events only worked on the WASM path (promptfiddle browser).

Additionally, the wire format for runtime events used serde's default `Vec<u8>` serialization (JSON integer array `[10,34,128,255,...]`), which is ~3-4x larger than base64. And `RuntimeEvent` had no `call_id` field, forcing the WASM worker to use a fragile `activeCallIds.size === 1` heuristic that broke with concurrent calls.

On the rendering side, events and results used completely independent rendering pipelines despite consuming the same `BamlOutboundValue` proto type. Events got a flat `formatValueDebug()` text dump while results got rich interactive `ValueRenderer` with custom renderers. Results also took a wasteful JSON round-trip (`JSON.stringify` -> store as string -> `JSON.parse` -> render).

## What user-facing changes did I ship

- [WebSocketRuntimePort.ts](https://github.com/BoundaryML/baml/pull/3403/files#diff-WebSocketRuntimePort) - VS Code playground now receives and displays runtime events (log, custom events, function start/end, tags)
- [ExecutionPanel.tsx](https://github.com/BoundaryML/baml/pull/3403/files#diff-ExecutionPanel) - Events render with structured, color-coded inline display using the same ValueRenderer as results; events visible in test collection panel too
- [ValueRenderer.tsx](https://github.com/BoundaryML/baml/pull/3403/files#diff-ValueRenderer) - New shared renderer with `displayMode` prop (inline/expanded/auto) for both events and results
- [ResultDisplay.tsx](https://github.com/BoundaryML/baml/pull/3403/files#diff-ResultDisplay) - Accepts `BamlJsValue` directly instead of JSON strings (no more round-trip)
- Monaco inline log decorations now work in VS Code (previously only promptfiddle)

## How I implemented it

### Rust: call_id + EventSink plumbing

- [bex_events/src/types.rs](https://github.com/BoundaryML/baml/pull/3403/files#diff-types) - Added `call_id: CallId` to `RuntimeEvent` struct
- [baml_events.proto](https://github.com/BoundaryML/baml/pull/3403/files#diff-baml_events.proto) - Added `uint64 call_id = 7` to proto schema
- [bex_engine/src/lib.rs](https://github.com/BoundaryML/baml/pull/3403/files#diff-bex_engine-lib) - Threaded `call_id` through all 5 emission sites
- [bex_events/src/event_store.rs](https://github.com/BoundaryML/baml/pull/3403/files#diff-event_store) - Added `FanOutEventSink` composite to forward events to multiple sinks
- [playground_event_sink.rs](https://github.com/BoundaryML/baml/pull/3403/files#diff-playground_event_sink) - New `PlaygroundEventSink` implementing `EventSink`, encodes events to base64 protobuf and broadcasts via WebSocket channel
- [baml_lsp_server/src/lib.rs](https://github.com/BoundaryML/baml/pull/3403/files#diff-baml_lsp_server-lib) - Wired `PlaygroundEventSink` + optional file sink through `FanOutEventSink` at server startup
- [playground_ws.rs](https://github.com/BoundaryML/baml/pull/3403/files#diff-playground_ws) - Changed `WsOutMessage::RuntimeEvent.data` from `Vec<u8>` to `String` (base64), added `call_id`
- [playground_sender.rs](https://github.com/BoundaryML/baml/pull/3403/files#diff-playground_sender) - Base64-encodes event data before broadcast
- [bridge_wasm/src/wasm_playground.rs](https://github.com/BoundaryML/baml/pull/3403/files#diff-wasm_playground) - Forwarded `call_id` through WASM path

### TypeScript: deserialization + unified rendering

- [worker-protocol.ts](https://github.com/BoundaryML/baml/pull/3403/files#diff-worker-protocol) - New `DeserializedRuntimeEvent` / `DeserializedEventKind` types replacing raw proto; `RunEntry.result` changed from `string | null` to `BamlJsValue | null`
- [WebSocketRuntimePort.ts](https://github.com/BoundaryML/baml/pull/3403/files#diff-WebSocketRuntimePort) - Added `runtimeEvent` case with proto decode + `deserializeRuntimeEvent()` for full value deserialization; log decoration state tracking; eliminated JSON.stringify round-trip for results
- [ValueRenderer.tsx](https://github.com/BoundaryML/baml/pull/3403/files#diff-ValueRenderer) - Extracted from ResultDisplay with `displayMode` prop; inline mode renders single-line summaries
- [EventValueDisplay.tsx](https://github.com/BoundaryML/baml/pull/3403/files#diff-EventValueDisplay) - Thin wrapper rendering `ValueRenderer` with `displayMode="inline"` for event payloads
- [ExecutionPanel.tsx](https://github.com/BoundaryML/baml/pull/3403/files#diff-ExecutionPanel) - Deleted `formatValueDebug`; all event rows use `EventValueDisplay`; results stored/passed as `BamlJsValue`; added events section to `CollectionRunView`
- [shared/format-value.ts](https://github.com/BoundaryML/baml/pull/3403/files#diff-format-value) - New `formatValue(BamlJsValue, 'inline-hint')` for non-React contexts (Monaco decorations)
- [shared/log-decorations.ts](https://github.com/BoundaryML/baml/pull/3403/files#diff-log-decorations) - Extracted `truncateMessage` and `normalizeLogLevel` from WASM worker
- [baml-lsp-worker.ts](https://github.com/BoundaryML/baml/pull/3403/files#diff-baml-lsp-worker) - Removed ~80 lines of local helpers; imports from shared modules; uses server-provided `callId`
- Renderers ([Media](https://github.com/BoundaryML/baml/pull/3403/files#diff-Media), [PromptAst](https://github.com/BoundaryML/baml/pull/3403/files#diff-PromptAst), [HttpRequestCurl](https://github.com/BoundaryML/baml/pull/3403/files#diff-HttpRequestCurl), [TestReport](https://github.com/BoundaryML/baml/pull/3403/files#diff-TestReport)) - All accept `displayMode` prop with inline early-return paths
- [result-renderers.ts](https://github.com/BoundaryML/baml/pull/3403/files#diff-result-renderers) - Added `DisplayMode` type and `displayMode?` to `ResultRendererProps`

## Deviations from the plan

Two plans were implemented in this PR:

### Plan 1: RuntimeEvent WebSocket Transport (05-plan-runtime-event-websocket.md)

**Implemented as planned:** All 4 phases — `call_id` on RuntimeEvent, PlaygroundEventSink + FanOutEventSink, TypeScript runtimeEvent handling, log decoration extraction.

**Deviations:**
- `log-decorations.ts` is smaller than planned — `formatValueShort` was replaced by `formatValue` in a separate file operating on deserialized `BamlJsValue` rather than raw proto objects
- `bex_events_native` stderr sink fallback was removed — when `BAML_TRACE_FILE` is unset, only the playground sink runs
- `bridge_cffi/src/host_spans.rs` was updated with `call_id: CallId(0)` despite the plan's "NOT Doing" section — required for compilation since `RuntimeEvent` now requires the field

### Plan 2: Unify Value Rendering Pipeline (05-plan-unify-value-rendering-pipeline.md)

**Implemented as planned:** All 5 phases — ValueRenderer extraction, event deserialization at receipt, EventValueDisplay wiring, formatValueShort replacement, JSON round-trip elimination.

**Deviations:**
- `DeserializedRuntimeEvent` omits `callId` field — carried separately on `WorkerOutMessage.runtimeEventNew` instead
- `timestampMs` and `durationMs` typed as `number` instead of `bigint` to avoid serialization issues

**Additions not in either plan:**
- Runtime events rendered in `CollectionRunView` (new fourth rendering site for events)
- `callId?: number` added to `PlaygroundNotification.runtimeEvent` in worker-protocol

## How to verify it

### Setup
```bash
git fetch
scripts/create_worktree.sh hellovai/add-runtimeevent-support-to-websocket-transport
cd ~/wt/baml/add-runtimeevent-support-to-websocket-transport
```

### Manual Testing
- [ ] Open VS Code playground, trigger a function call with `log.info()` statements — verify runtime events appear in the execution panel with color-coded inline rendering
- [ ] Verify Monaco inline decorations appear for log events in the BAML editor
- [ ] Run promptfiddle.com in browser — verify runtime events still work (WASM path regression)
- [ ] Run a function returning a class/media type — verify result panel renders identically to before
- [ ] Copy button on result panel produces valid JSON
- [ ] Test collection panel shows events for test runs

### Automated Tests
```bash
cargo test -p bex_events -p bridge_ctypes -p bex_events_native -p bex_engine
cargo clippy -p baml_lsp_server -p bridge_wasm
cd typescript2 && npx tsc --noEmit -p pkg-playground
```

## Description for the changelog

Add RuntimeEvent support to VS Code WebSocket transport (previously silently dropped) and unify event/result rendering through a shared ValueRenderer with inline display mode, eliminating duplicated proto traversals and the JSON round-trip for results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime events now stream reliably to the playground UI and include call association for better per-call tracing.
  * Results and event values render natively (object values) with a new shared renderer supporting inline and expanded modes.
  * Log decorations aggregate per-source-line, include normalized levels, and truncate long messages for cleaner display.

* **Changes**
  * Runtime event payloads and worker protocol now deliver structured event data instead of JSON strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->