### PR TITLE
Streaming fixes

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_llm/llm.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_llm/llm.baml
@@ -45,6 +45,15 @@ function build_request(client: Client, function_name: string, args: map<string, 
   primitive_client.build_request(specialized_prompt)
 }
 
+function build_request_stream(client: Client, function_name: string, args: map<string, unknown>) -> root.http.Request {
+  let primitive_client = client.to_primitive_client();
+  let specialized_prompt = render_prompt(client, function_name, args);
+
+  primitive_client.build_request_stream(specialized_prompt)
+}
+
+/// UNSAFE: do not call from user code
+///
 /// Used by LLM function companion functions.
 /// Only parses full responses, not partials.
 function parse<T, S>(function_name: string, json: string) -> T {
@@ -54,6 +63,8 @@ function parse<T, S>(function_name: string, json: string) -> T {
   __sap_parse_final(json, cache)
 }
 
+/// UNSAFE: do not call from user code
+///
 /// Call an LLM function and return its full result.
 function call_llm_function<T>(client: Client, function_name: string, args: map<string, unknown>) -> T {
   let jinja_string = get_jinja_template(function_name);
@@ -68,6 +79,8 @@ function call_llm_function<T>(client: Client, function_name: string, args: map<s
   result
 }
 
+/// UNSAFE: do not call from user code
+///
 /// The streaming counterpart of `call_llm_function`.
 ///
 /// Sends the request and returns a `Stream<T, S>` which can be used to consume the data as it arrives.

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_llm/llm_types.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_llm/llm_types.baml
@@ -175,16 +175,13 @@ class Client {
       ClientType.Primitive => {
         let primitive = self.to_primitive_client();
         let return_type = get_return_type(context.function_name);
-        let stream_return_type = get_stream_return_type(context.function_name);
 
         let prompt = primitive.render_prompt(context.jinja_string, context.args, return_type);
         let specialized = primitive.specialize_prompt(prompt);
 
         let http_request = primitive.build_request_stream(specialized);
         let sse = root.http.fetch_sse(http_request);
-        let acc = primitive.new_stream_accumulator();
-        let cache = StreamCache.new(return_type, stream_return_type);
-        let stream: Stream<T, S> = Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache };
+        let stream: Stream<T, S> = self.__make_stream(sse, context.function_name);
         return stream;
       }
 
@@ -214,6 +211,16 @@ class Client {
         return result3;
       }
     }
+  }
+
+  /// DO NOT CALL FROM USER CODE
+  function __make_stream<T, S>(self, sse: root.http.SseStream, function_name: string) -> Stream<T, S> {
+    let primitive = self.to_primitive_client()
+    let return_type = get_return_type(function_name)
+    let stream_return_type = get_stream_return_type(function_name)
+    let acc = primitive.new_stream_accumulator()
+    let cache: StreamCache<T, S> = StreamCache.new(return_type, stream_return_type)
+    Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache }
   }
 
   function execute_oneshot<T>(

--- a/baml_language/crates/baml_compiler2_ast/src/companions.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/companions.rs
@@ -18,7 +18,12 @@ use crate::{
 
 type CompanionExpander = fn(&FunctionDef) -> Option<FunctionDef>;
 
-const COMPANIONS: &[CompanionExpander] = &[llm_render_prompt, llm_build_request, llm_parse];
+const COMPANIONS: &[CompanionExpander] = &[
+    llm_render_prompt,
+    llm_build_request,
+    llm_build_request_stream,
+    llm_parse,
+];
 
 /// Run all companion expanders on the given function.
 /// Works identically for top-level functions and class methods.
@@ -49,6 +54,17 @@ fn llm_build_request(parent: &FunctionDef) -> Option<FunctionDef> {
     Some(make_llm_companion(
         parent,
         "build_request",
+        &["baml", "http", "Request"],
+    ))
+}
+
+fn llm_build_request_stream(parent: &FunctionDef) -> Option<FunctionDef> {
+    if !matches!(&parent.declarative_meta, Some(DeclarativeMeta::Llm(_))) {
+        return None;
+    }
+    Some(make_llm_companion(
+        parent,
+        "build_request_stream",
         &["baml", "http", "Request"],
     ))
 }

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -18,7 +18,10 @@ pub mod lowering_diagnostic;
 
 pub use ast::*;
 pub use disambiguate::is_field_attr;
-pub use lower_cst::{lower_file, lower_file_with_file_id, synthesize_llm_make_stream_call};
+pub use lower_cst::{
+    lower_file, lower_file_with_file_id, synthesize_llm_builtin_call,
+    synthesize_llm_make_stream_call,
+};
 pub use lowering_diagnostic::LoweringDiagnostic;
 
 /// Decode common escape sequences in a quoted string literal body.

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -545,12 +545,12 @@ pub(crate) fn synthesize_llm_parse_call(
     (body, source_map)
 }
 
-/// Synthesize a `baml.llm.__make_stream(sse, "FunctionName", CLIENT)` call.
+/// Synthesize a `CLIENT.__make_stream(sse, "FunctionName")` method call.
 ///
 /// Used by the PPIR to generate `$parse_stream` companion function bodies.
 pub fn synthesize_llm_make_stream_call(
     function_name: &str,
-    client_name: Option<&str>,
+    client_name: &str,
     span: text_size::TextRange,
 ) -> (crate::ast::ExprBody, crate::ast::AstSourceMap) {
     use la_arena::Arena;
@@ -572,48 +572,45 @@ pub fn synthesize_llm_make_stream_call(
     // 2. Function name literal: "FunctionName"
     let fn_name_expr = alloc(Expr::Literal(Literal::String(function_name.to_string())));
 
-    // 3. Callee: baml.llm.__make_stream
-    let callee = alloc(Expr::Path(vec![
-        Name::new("baml"),
-        Name::new("llm"),
-        Name::new("__make_stream"),
-    ]));
-
-    // 4. Client argument (same logic as synthesize_llm_builtin_call)
-    let client_arg = match client_name {
-        Some(name) if name.contains('/') => {
-            let name_lit = alloc(Expr::Literal(Literal::String(name.to_string())));
-            let ct_path = alloc(Expr::Path(vec![
-                Name::new("baml"),
-                Name::new("llm"),
-                Name::new("ClientType"),
-            ]));
-            let ct_variant = alloc(Expr::MemberAccess {
-                base: ct_path,
-                member: Name::new("Primitive"),
-            });
-            let sub = alloc(Expr::Array { elements: vec![] });
-            let retry = alloc(Expr::Null);
-            let counter = alloc(Expr::Literal(Literal::Int(0)));
-            alloc(Expr::Object {
-                type_name: Some(Name::new("baml.llm.Client")),
-                fields: vec![
-                    (Name::new("name"), name_lit),
-                    (Name::new("client_type"), ct_variant),
-                    (Name::new("sub_clients"), sub),
-                    (Name::new("retry"), retry),
-                    (Name::new("counter"), counter),
-                ],
-                spreads: vec![],
-            })
-        }
-        Some(name) => alloc(Expr::Path(vec![Name::new(name)])),
-        None => alloc(Expr::Null),
+    // 3. Client argument (same logic as synthesize_llm_builtin_call)
+    let client_arg = if client_name.contains('/') {
+        let name_lit = alloc(Expr::Literal(Literal::String(client_name.to_string())));
+        let ct_path = alloc(Expr::Path(vec![
+            Name::new("baml"),
+            Name::new("llm"),
+            Name::new("ClientType"),
+        ]));
+        let ct_variant = alloc(Expr::MemberAccess {
+            base: ct_path,
+            member: Name::new("Primitive"),
+        });
+        let sub = alloc(Expr::Array { elements: vec![] });
+        let retry = alloc(Expr::Null);
+        let counter = alloc(Expr::Literal(Literal::Int(0)));
+        alloc(Expr::Object {
+            type_name: Some(Name::new("baml.llm.Client")),
+            fields: vec![
+                (Name::new("name"), name_lit),
+                (Name::new("client_type"), ct_variant),
+                (Name::new("sub_clients"), sub),
+                (Name::new("retry"), retry),
+                (Name::new("counter"), counter),
+            ],
+            spreads: vec![],
+        })
+    } else {
+        alloc(Expr::Path(vec![Name::new(client_name)]))
     };
+
+    // 4. Callee: CLIENT.__make_stream (method call on the client)
+    let callee = alloc(Expr::MemberAccess {
+        base: client_arg,
+        member: Name::new("__make_stream"),
+    });
 
     let call = alloc(Expr::Call {
         callee,
-        args: vec![sse_expr, fn_name_expr, client_arg],
+        args: vec![sse_expr, fn_name_expr],
     });
 
     let body = ExprBody {

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -373,7 +373,7 @@ fn lower_llm_body(llm_body: &ast::LlmFunctionBody) -> LlmBodyDef {
 /// use `client_name = None` and keep their existing 2-argument signature.
 ///
 /// All synthetic spans point to `span`.
-pub(crate) fn synthesize_llm_builtin_call(
+pub fn synthesize_llm_builtin_call(
     builtin_name: &str,
     function_name: &str,
     param_names: &[Name],

--- a/baml_language/crates/baml_compiler2_hir/src/package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/package.rs
@@ -226,11 +226,13 @@ pub fn package_dependencies<'db>(
     package_id: PackageId<'db>,
 ) -> Vec<PackageId<'db>> {
     match package_id.name(db).as_str() {
-        // The "baml" package provides core builtins; every other package
-        // implicitly depends on it.
-        "baml" => vec![],
-        // The "testing", "assert", and "log" packages depend on "baml" only.
-        "testing" | "assert" | "log" => vec![PackageId::new(db, Name::new("baml"))],
+        // "log" has no deps — it only uses primitives, and "baml" depends on
+        // it so the stdlib can emit log events.
+        "log" => vec![],
+        // "baml" depends on "log" so stdlib code can call log.info/debug/etc.
+        "baml" => vec![PackageId::new(db, Name::new("log"))],
+        // The "testing" and "assert" packages depend on "baml" only.
+        "testing" | "assert" => vec![PackageId::new(db, Name::new("baml"))],
         // User packages depend on "baml", "testing", "assert", and "log".
         _ => vec![
             PackageId::new(db, Name::new("baml")),

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -332,11 +332,11 @@ use baml_compiler2_ast::{
 };
 use baml_compiler2_hir::{
     body::{FunctionBody, LetBody, let_body, let_body_source_map},
-    file_semantic_index,
     loc::{FunctionLoc, LetLoc},
     package::{PackageId, package_dependencies, package_items},
     scope::FileScopeId,
 };
+use baml_compiler2_ppir::file_semantic_index;
 use baml_compiler2_tir::{
     inference::infer_scope_types,
     resolve::{ResolvedName, resolve_name_at_in_scope},

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -370,43 +370,16 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                 stream_return_types.push((qualified_name, stream_type_expr.clone()));
 
                 // Extract client name from parent's LLM metadata.
-                // $parse_stream requires a client (it calls CLIENT.__make_stream),
-                // so skip generation when no client is specified.
                 let client_name = match &func.declarative_meta {
                     Some(ast::DeclarativeMeta::Llm(llm)) => {
-                        match llm.client.as_ref().map(|n| n.as_str().to_string()) {
-                            Some(name) => name,
-                            None => continue,
-                        }
+                        llm.client.as_ref().map(|n| n.as_str().to_string())
                     }
-                    _ => continue,
+                    _ => None,
                 };
-
-                // Build the companion function.
-                let companion_name = SmolStr::new(format!("{}$parse_stream", func.name));
 
                 // Share the parent function's span — same as AST-level companions.
                 let span = func.span;
                 let name_span = func.name_span;
-
-                // Parameter: sse: baml.http.SseStream
-                let sse_param = ast::Param {
-                    name: Name::new("sse"),
-                    type_expr: Some(ast::SpannedTypeExpr {
-                        expr: ast::TypeExpr::Path {
-                            segments: vec![
-                                Name::new("baml"),
-                                Name::new("http"),
-                                Name::new("SseStream"),
-                            ],
-                            generic_args: vec![],
-                            attrs: vec![],
-                        },
-                        span,
-                    }),
-                    span,
-                    name_span,
-                };
 
                 // Return type: baml.llm.Stream<ORIGINAL_RETURN_TYPE, STREAM_EXPANDED_TYPE>
                 let original_return_type_expr = return_type_spanned.expr.clone();
@@ -419,25 +392,73 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                     span,
                 };
 
-                // Body: CLIENT.__make_stream(sse, "FuncName")
-                let (body, source_map) =
-                    ast::synthesize_llm_make_stream_call(func.name.as_str(), &client_name, span);
+                // --- $stream companion ---
+                // Calls baml.llm.stream_llm_function(CLIENT, "FuncName", map { args })
+                {
+                    let param_names: Vec<Name> =
+                        func.params.iter().map(|p| p.name.clone()).collect();
+                    let (body, source_map) = ast::synthesize_llm_builtin_call(
+                        "stream_llm_function",
+                        func.name.as_str(),
+                        &param_names,
+                        client_name.as_deref(),
+                        span,
+                    );
+                    let companion = ast::FunctionDef {
+                        name: SmolStr::new(format!("{}$stream", func.name)),
+                        generic_params: func.generic_params.clone(),
+                        params: func.params.clone(),
+                        return_type: Some(stream_return_type.clone()),
+                        throws: None,
+                        body: Some(ast::FunctionBodyDef::Expr(body, source_map)),
+                        declarative_meta: None,
+                        origin: ast::FunctionOrigin::Companion,
+                        attributes: vec![],
+                        span,
+                        name_span,
+                    };
+                    synthetic_items.push(ast::Item::Function(companion));
+                }
 
-                let companion = ast::FunctionDef {
-                    name: companion_name,
-                    generic_params: func.generic_params.clone(),
-                    params: vec![sse_param],
-                    return_type: Some(stream_return_type),
-                    throws: None,
-                    body: Some(ast::FunctionBodyDef::Expr(body, source_map)),
-                    declarative_meta: None,
-                    origin: ast::FunctionOrigin::Companion,
-                    attributes: vec![],
-                    span,
-                    name_span,
-                };
+                // --- $parse_stream companion ---
+                // Requires a client (calls CLIENT.__make_stream).
+                if let Some(ref client_name) = client_name {
+                    let sse_param = ast::Param {
+                        name: Name::new("sse"),
+                        type_expr: Some(ast::SpannedTypeExpr {
+                            expr: ast::TypeExpr::Path {
+                                segments: vec![
+                                    Name::new("baml"),
+                                    Name::new("http"),
+                                    Name::new("SseStream"),
+                                ],
+                                generic_args: vec![],
+                                attrs: vec![],
+                            },
+                            span,
+                        }),
+                        span,
+                        name_span,
+                    };
 
-                synthetic_items.push(ast::Item::Function(companion));
+                    let (body, source_map) =
+                        ast::synthesize_llm_make_stream_call(func.name.as_str(), client_name, span);
+
+                    let companion = ast::FunctionDef {
+                        name: SmolStr::new(format!("{}$parse_stream", func.name)),
+                        generic_params: func.generic_params.clone(),
+                        params: vec![sse_param],
+                        return_type: Some(stream_return_type),
+                        throws: None,
+                        body: Some(ast::FunctionBodyDef::Expr(body, source_map)),
+                        declarative_meta: None,
+                        origin: ast::FunctionOrigin::Companion,
+                        attributes: vec![],
+                        span,
+                        name_span,
+                    };
+                    synthetic_items.push(ast::Item::Function(companion));
+                }
             }
             _ => {}
         }

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -370,11 +370,16 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                 stream_return_types.push((qualified_name, stream_type_expr.clone()));
 
                 // Extract client name from parent's LLM metadata.
+                // $parse_stream requires a client (it calls CLIENT.__make_stream),
+                // so skip generation when no client is specified.
                 let client_name = match &func.declarative_meta {
                     Some(ast::DeclarativeMeta::Llm(llm)) => {
-                        llm.client.as_ref().map(|n| n.as_str().to_string())
+                        match llm.client.as_ref().map(|n| n.as_str().to_string()) {
+                            Some(name) => name,
+                            None => continue,
+                        }
                     }
-                    _ => None,
+                    _ => continue,
                 };
 
                 // Build the companion function.
@@ -414,12 +419,9 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                     span,
                 };
 
-                // Body: baml.llm.__make_stream(sse, "FuncName", CLIENT)
-                let (body, source_map) = ast::synthesize_llm_make_stream_call(
-                    func.name.as_str(),
-                    client_name.as_deref(),
-                    span,
-                );
+                // Body: CLIENT.__make_stream(sse, "FuncName")
+                let (body, source_map) =
+                    ast::synthesize_llm_make_stream_call(func.name.as_str(), &client_name, span);
 
                 let companion = ast::FunctionDef {
                     name: companion_name,

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -3792,16 +3792,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                         }
                     }
 
-                    // Don't report errors for synthesized PPIR functions like __make_stream.
-                    // These are generated at the PPIR layer for $parse_stream companions.
-                    if unresolved_segment.is_some()
-                        && item_path.len() == 2
-                        && item_path[0].as_str() == "llm"
-                        && item_path[1].as_str() == "__make_stream"
-                    {
-                        unresolved_segment = None;
-                    }
-
                     if let Some(seg) = unresolved_segment {
                         self.context.report_simple(
                             TirTypeError::UnresolvedName { name: seg.clone() },

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -523,7 +523,20 @@ pub fn infer_scope_types<'db>(
                     break;
                 }
             }
-            let _ = found;
+            if !found {
+                // Template strings create ScopeKind::Function scopes but are
+                // stored in item_tree.template_strings, not item_tree.functions.
+                // They have no expression body to type-check, so skip silently.
+                let is_template_string = item_tree
+                    .template_strings
+                    .values()
+                    .any(|ts| scope.name.as_ref() == Some(&ts.name));
+                debug_assert!(
+                    is_template_string,
+                    "TIR: no item_tree function matched scope (name={:?}, range={:?})",
+                    scope.name, scope.range
+                );
+            }
         }
         ScopeKind::Lambda => {
             // Find the enclosing Function (or Let) scope by walking ancestors.

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____03_hir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 484
 ---
 === HIR2 ===
 
@@ -151,6 +150,9 @@ class baml.llm.PlannerState {
 function baml.llm.build_request(client: baml.llm.Client, function_name: string, args: map<string, unknown>) -> root.http.Request  [expr] {
   { let primitive_client = client.to_primitive_client(); let specialized_prompt = render_prompt(client, function_name, args) } primitive_client.build_request(specialized_prompt)
 }
+function baml.llm.build_request_stream(client: baml.llm.Client, function_name: string, args: map<string, unknown>) -> root.http.Request  [expr] {
+  { let primitive_client = client.to_primitive_client(); let specialized_prompt = render_prompt(client, function_name, args) } primitive_client.build_request_stream(specialized_prompt)
+}
 function baml.llm.call_llm_function(client: baml.llm.Client, function_name: string, args: map<string, unknown>) -> baml.llm.T  [expr] {
   { let jinja_string = get_jinja_template(function_name); let context = baml.llm.ExecutionContext { jinja_string: jinja_string, args: args, function_name: function_name }; let result: baml.llm.T = client.execute_oneshot(context, 0) } result
 }
@@ -255,6 +257,9 @@ class baml.llm.VertexAiOptions {
   project_id: string | null
 }
 enum baml.llm.ClientType {Primitive, Fallback, RoundRobin}
+function baml.llm.__make_stream(self: ?, sse: root.http.SseStream, function_name: string) -> baml.llm.Stream  [expr] {
+  { let primitive = self.to_primitive_client(); let return_type = get_return_type(function_name); let stream_return_type = get_stream_return_type(function_name); let acc = primitive.new_stream_accumulator(); let cache: baml.llm.StreamCache = StreamCache.new(return_type, stream_return_type) } baml.llm.Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache }
+}
 function baml.llm.__sap_parse_final(json: string, cache: baml.llm.StreamCache) -> baml.llm.T  [builtin]
 function baml.llm.__sap_parse_partial(json: string, cache: baml.llm.StreamCache) -> baml.llm.S | root.stream.StreamNoYield  [builtin]
 function baml.llm.add_events(self: ?, events: string) -> null  [builtin]
@@ -277,7 +282,7 @@ function baml.llm.execute_once_oneshot(self: ?, context: baml.llm.ExecutionConte
   {  } match (self.client_type) { baml.llm.ClientType.Primitive => { let primitive = self.to_primitive_client(); let return_type = get_return_type(context.function_name); let prompt = primitive.render_prompt(context.jinja_string, context.args, return_type); let specialized = primitive.specialize_prompt(prompt); let http_request = primitive.build_request(specialized); let http_response = root.http.send(http_request) } if (http_response.ok()) { let body = http_response.text(); let result: baml.llm.T = primitive.parse(body, return_type) catch (e) { _ => { if (active_delay_ms Gt 0) {  } root.sys.sleep(active_delay_ms); throw e } } } result else { let error_body = http_response.text() catch (e) { _ => {  } "" }; if (active_delay_ms Gt 0) {  } root.sys.sleep(active_delay_ms); throw DevOther { message: "HTTP request fail..." Add error_body } }, baml.llm.ClientType.Fallback => { for sub in self.sub_clients { let result2: baml.llm.T = sub.execute_oneshot(context, active_delay_ms) catch (e) { _ => { continue } }; return result2 }; throw DevOther { message: "All orchestration..." } }, baml.llm.ClientType.RoundRobin => { if (self.sub_clients.length() Eq 0) { throw DevOther { message: "RoundRobin client..." } }; let idx = self.counter Mod self.sub_clients.length(); self.counter Add= 1; let result3: baml.llm.T = self.sub_clients[idx].execute_oneshot(context, active_delay_ms); return result3 } }
 }
 function baml.llm.execute_once_stream(self: ?, context: baml.llm.ExecutionContext, active_delay_ms: int) -> baml.llm.Stream  [expr] {
-  {  } match (self.client_type) { baml.llm.ClientType.Primitive => { let primitive = self.to_primitive_client(); let return_type = get_return_type(context.function_name); let stream_return_type = get_stream_return_type(context.function_name); let prompt = primitive.render_prompt(context.jinja_string, context.args, return_type); let specialized = primitive.specialize_prompt(prompt); let http_request = primitive.build_request_stream(specialized); let sse = root.http.fetch_sse(http_request); let acc = primitive.new_stream_accumulator(); let cache = StreamCache.new(return_type, stream_return_type); let stream: baml.llm.Stream = baml.llm.Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache }; return stream }, baml.llm.ClientType.Fallback => { for sub in self.sub_clients { let result2: baml.llm.Stream = sub.execute_stream(context, active_delay_ms) catch (e) { _ => { continue } }; return result2 }; throw DevOther { message: "All orchestration..." } }, baml.llm.ClientType.RoundRobin => { if (self.sub_clients.length() Eq 0) { throw DevOther { message: "RoundRobin client..." } }; let idx = self.counter Mod self.sub_clients.length(); self.counter Add= 1; let result3: baml.llm.Stream = self.sub_clients[idx].execute_stream(context, active_delay_ms); return result3 } }
+  {  } match (self.client_type) { baml.llm.ClientType.Primitive => { let primitive = self.to_primitive_client(); let return_type = get_return_type(context.function_name); let prompt = primitive.render_prompt(context.jinja_string, context.args, return_type); let specialized = primitive.specialize_prompt(prompt); let http_request = primitive.build_request_stream(specialized); let sse = root.http.fetch_sse(http_request); let stream: baml.llm.Stream = self.__make_stream(sse, context.function_name); return stream }, baml.llm.ClientType.Fallback => { for sub in self.sub_clients { let result2: baml.llm.Stream = sub.execute_stream(context, active_delay_ms) catch (e) { _ => { continue } }; return result2 }; throw DevOther { message: "All orchestration..." } }, baml.llm.ClientType.RoundRobin => { if (self.sub_clients.length() Eq 0) { throw DevOther { message: "RoundRobin client..." } }; let idx = self.counter Mod self.sub_clients.length(); self.counter Add= 1; let result3: baml.llm.Stream = self.sub_clients[idx].execute_stream(context, active_delay_ms); return result3 } }
 }
 function baml.llm.execute_oneshot(self: ?, context: baml.llm.ExecutionContext, inherited_delay_ms: int) -> baml.llm.T  [expr] {
   {  } match (self.retry) { r: baml.llm.RetryPolicy => { let current_delay = r.initial_delay_ms Add 0.0; { let attempt = 0; while attempt Le r.max_retries { let attempt_delay = inherited_delay_ms; if (attempt Gt 0) { attempt_delay = root.math.trunc(current_delay); let next = current_delay Mul r.multiplier } if (next Gt r.max_delay_ms Add 0.0) { current_delay = r.max_delay_ms Add 0.0 } else { current_delay = next }; if (attempt Eq r.max_retries) { attempt_delay = inherited_delay_ms }; let result2: baml.llm.T = self.execute_once_oneshot(context, attempt_delay) catch (e) { _ => { continue } }; return result2 } }; throw DevOther { message: "All orchestration..." } }, null => { let result: baml.llm.T = self.execute_once_oneshot(context, inherited_delay_ms); return result } }

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_5_mir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 585
 ---
 === MIR2 ===
 
@@ -171,6 +170,39 @@ fn baml.llm.build_request(client: baml.llm.Client, function_name: string, args: 
     bb2: {
         _6 = copy _5;
         _7 = dispatch_future const fn baml.llm.PrimitiveClient.build_request(copy _4, copy _6) -> bb3;
+    }
+
+    bb3: {
+        _0 = await _7 -> [bb4];
+    }
+
+    bb4: {
+        return;
+    }
+}
+
+fn baml.llm.build_request_stream(client: baml.llm.Client, function_name: string, args: map<string, unknown>) -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: baml.llm.Client // client // param
+    let _2: string // function_name // param
+    let _3: map<string, unknown> // args // param
+    let _4: baml.llm.PrimitiveClient // primitive_client
+    let _5: baml.llm.PromptAst // specialized_prompt
+    let _6: baml.llm.PromptAst
+    let _7: future<baml.http.Request>
+
+    bb0: {
+        _4 = call const fn baml.llm.Client.to_primitive_client(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _5 = call const fn baml.llm.render_prompt(copy _1, copy _2, copy _3) -> [bb2];
+    }
+
+    bb2: {
+        _6 = copy _5;
+        _7 = dispatch_future const fn baml.llm.PrimitiveClient.build_request_stream(copy _4, copy _6) -> bb3;
     }
 
     bb3: {
@@ -463,6 +495,78 @@ fn baml.llm.stream_llm_function(client: baml.llm.Client, function_name: string, 
     }
 
     bb4: {
+        return;
+    }
+}
+
+fn baml.llm.Client.__make_stream(self: baml.llm.Client, sse: baml.http.SseStream, function_name: string) -> baml.llm.Stream {
+    // Locals:
+    let _0: baml.llm.Stream // _0 // return
+    let _1: baml.llm.Client // self // param
+    let _2: baml.http.SseStream // sse // param
+    let _3: string // function_name // param
+    let _4: baml.llm.PrimitiveClient // primitive
+    let _5: type // return_type
+    let _6: future<type>
+    let _7: type // stream_return_type
+    let _8: future<type>
+    let _9: baml.llm.StreamAccumulator // acc
+    let _10: future<baml.llm.StreamAccumulator>
+    let _11: baml.llm.StreamCache // cache
+    let _12: type
+    let _13: type
+    let _14: future<baml.llm.StreamCache>
+    let _15: baml.llm.PrimitiveClient
+    let _16: baml.llm.StreamAccumulator
+    let _17: baml.llm.StreamCache
+
+    bb0: {
+        _4 = call const fn baml.llm.Client.to_primitive_client(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _6 = dispatch_future const fn baml.llm.get_return_type(copy _3) -> bb2;
+    }
+
+    bb2: {
+        _5 = await _6 -> [bb3];
+    }
+
+    bb3: {
+        _8 = dispatch_future const fn baml.llm.get_stream_return_type(copy _3) -> bb4;
+    }
+
+    bb4: {
+        _7 = await _8 -> [bb5];
+    }
+
+    bb5: {
+        _10 = dispatch_future const fn baml.llm.PrimitiveClient.new_stream_accumulator(copy _4) -> bb6;
+    }
+
+    bb6: {
+        _9 = await _10 -> [bb7];
+    }
+
+    bb7: {
+        _12 = copy _5;
+        _13 = copy _7;
+        _14 = dispatch_future const fn baml.llm.StreamCache.new(const null, copy _12, copy _13) -> bb8;
+    }
+
+    bb8: {
+        _11 = await _14 -> [bb9];
+    }
+
+    bb9: {
+        _15 = copy _4;
+        _16 = copy _9;
+        _17 = copy _11;
+        _0 = Stream { copy _15, copy _16, copy _2, copy _17 };
+        goto -> bb10;
+    }
+
+    bb10: {
         return;
     }
 }
@@ -1140,55 +1244,44 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
     let _7: type // return_type
     let _8: string
     let _9: future<type>
-    let _10: type // stream_return_type
+    let _10: baml.llm.PromptAst // prompt
     let _11: string
-    let _12: future<type>
-    let _13: baml.llm.PromptAst // prompt
-    let _14: string
-    let _15: map<string, unknown>
-    let _16: type
+    let _12: map<string, unknown>
+    let _13: type
+    let _14: future<baml.llm.PromptAst>
+    let _15: baml.llm.PromptAst // specialized
+    let _16: baml.llm.PromptAst
     let _17: future<baml.llm.PromptAst>
-    let _18: baml.llm.PromptAst // specialized
+    let _18: baml.http.Request // http_request
     let _19: baml.llm.PromptAst
-    let _20: future<baml.llm.PromptAst>
-    let _21: baml.http.Request // http_request
-    let _22: baml.llm.PromptAst
-    let _23: future<baml.http.Request>
-    let _24: baml.http.SseStream // sse
-    let _25: baml.http.Request
-    let _26: future<baml.http.SseStream>
-    let _27: baml.llm.StreamAccumulator // acc
-    let _28: future<baml.llm.StreamAccumulator>
-    let _29: baml.llm.StreamCache // cache
-    let _30: type
-    let _31: type
-    let _32: future<baml.llm.StreamCache>
-    let _33: baml.llm.Stream // stream
-    let _34: baml.llm.PrimitiveClient
-    let _35: baml.llm.StreamAccumulator
-    let _36: baml.http.SseStream
-    let _37: baml.llm.StreamCache
-    let _38: baml.llm.Client[]
-    let _39: int // __for_idx
-    let _40: int
-    let _41: bool
-    let _42: baml.llm.Client
-    let _43: baml.llm.Client // sub
-    let _44: baml.llm.Stream // result2
-    let _45: unknown // e
-    let _46: void
-    let _47: bool
-    let _48: int
-    let _49: (baml.llm.Client[]) -> int throws never
-    let _50: void
-    let _51: int // idx
-    let _52: int
-    let _53: int
-    let _54: (baml.llm.Client[]) -> int throws never
-    let _55: baml.llm.Stream // result3
-    let _56: baml.llm.Client
-    let _57: baml.llm.Client[]
-    let _58: int
+    let _20: future<baml.http.Request>
+    let _21: baml.http.SseStream // sse
+    let _22: baml.http.Request
+    let _23: future<baml.http.SseStream>
+    let _24: baml.llm.Stream // stream
+    let _25: baml.http.SseStream
+    let _26: string
+    let _27: baml.llm.Client[]
+    let _28: int // __for_idx
+    let _29: int
+    let _30: bool
+    let _31: baml.llm.Client
+    let _32: baml.llm.Client // sub
+    let _33: baml.llm.Stream // result2
+    let _34: unknown // e
+    let _35: void
+    let _36: bool
+    let _37: int
+    let _38: (baml.llm.Client[]) -> int throws never
+    let _39: void
+    let _40: int // idx
+    let _41: int
+    let _42: int
+    let _43: (baml.llm.Client[]) -> int throws never
+    let _44: baml.llm.Stream // result3
+    let _45: baml.llm.Client
+    let _46: baml.llm.Client[]
+    let _47: int
 
     bb0: {
         _4 = copy _1.1;
@@ -1201,44 +1294,44 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
     }
 
     bb2: {
-        _49 = copy _1.2;
-        _48 = call const fn baml.Array.length(copy _49) -> [bb3];
+        _38 = copy _1.2;
+        _37 = call const fn baml.Array.length(copy _38) -> [bb3];
     }
 
     bb3: {
-        _47 = copy _48 == const 0_i64;
-        branch copy _47 -> [bb7, bb4];
+        _36 = copy _37 == const 0_i64;
+        branch copy _36 -> [bb7, bb4];
     }
 
     bb4: {
-        _52 = copy _1.4;
-        _54 = copy _1.2;
-        _53 = call const fn baml.Array.length(copy _54) -> [bb5];
+        _41 = copy _1.4;
+        _43 = copy _1.2;
+        _42 = call const fn baml.Array.length(copy _43) -> [bb5];
     }
 
     bb5: {
-        _51 = copy _52 % copy _53;
+        _40 = copy _41 % copy _42;
         _1.4 = copy _1.4 + const 1_i64;
-        _57 = copy _1.2;
-        _58 = copy _51;
-        _56 = copy _57[_58];
-        _55 = call const fn baml.llm.Client.execute_stream(copy _56, copy _2, copy _3) -> [bb6];
+        _46 = copy _1.2;
+        _47 = copy _40;
+        _45 = copy _46[_47];
+        _44 = call const fn baml.llm.Client.execute_stream(copy _45, copy _2, copy _3) -> [bb6];
     }
 
     bb6: {
-        _0 = copy _55;
-        goto -> bb33;
+        _0 = copy _44;
+        goto -> bb28;
     }
 
     bb7: {
-        _50 = DevOther { const "RoundRobin client has no sub-clients" };
-        throw copy _50;
+        _39 = DevOther { const "RoundRobin client has no sub-clients" };
+        throw copy _39;
     }
 
     bb8: {
-        _38 = copy _1.2;
-        _39 = const 0_i64;
-        goto -> bb29;
+        _27 = copy _1.2;
+        _28 = const 0_i64;
+        goto -> bb24;
     }
 
     bb9: {
@@ -1255,28 +1348,28 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
     }
 
     bb12: {
-        _11 = copy _2.2;
-        _12 = dispatch_future const fn baml.llm.get_stream_return_type(copy _11) -> bb13;
+        _11 = copy _2.0;
+        _12 = copy _2.1;
+        _13 = copy _7;
+        _14 = dispatch_future const fn baml.llm.PrimitiveClient.render_prompt(copy _6, copy _11, copy _12, copy _13) -> bb13;
     }
 
     bb13: {
-        _10 = await _12 -> [bb14];
+        _10 = await _14 -> [bb14];
     }
 
     bb14: {
-        _14 = copy _2.0;
-        _15 = copy _2.1;
-        _16 = copy _7;
-        _17 = dispatch_future const fn baml.llm.PrimitiveClient.render_prompt(copy _6, copy _14, copy _15, copy _16) -> bb15;
+        _16 = copy _10;
+        _17 = dispatch_future const fn baml.llm.PrimitiveClient.specialize_prompt(copy _6, copy _16) -> bb15;
     }
 
     bb15: {
-        _13 = await _17 -> [bb16];
+        _15 = await _17 -> [bb16];
     }
 
     bb16: {
-        _19 = copy _13;
-        _20 = dispatch_future const fn baml.llm.PrimitiveClient.specialize_prompt(copy _6, copy _19) -> bb17;
+        _19 = copy _15;
+        _20 = dispatch_future const fn baml.llm.PrimitiveClient.build_request_stream(copy _6, copy _19) -> bb17;
     }
 
     bb17: {
@@ -1285,7 +1378,7 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
 
     bb18: {
         _22 = copy _18;
-        _23 = dispatch_future const fn baml.llm.PrimitiveClient.build_request_stream(copy _6, copy _22) -> bb19;
+        _23 = dispatch_future const fn baml.http.fetch_sse(copy _22) -> bb19;
     }
 
     bb19: {
@@ -1294,74 +1387,48 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
 
     bb20: {
         _25 = copy _21;
-        _26 = dispatch_future const fn baml.http.fetch_sse(copy _25) -> bb21;
+        _26 = copy _2.2;
+        _24 = call const fn baml.llm.Client.__make_stream(copy _1, copy _25, copy _26) -> [bb21];
     }
 
     bb21: {
-        _24 = await _26 -> [bb22];
+        _0 = copy _24;
+        goto -> bb28;
     }
 
     bb22: {
-        _28 = dispatch_future const fn baml.llm.PrimitiveClient.new_stream_accumulator(copy _6) -> bb23;
+        throw_if_panic copy _34 -> bb23;
     }
 
     bb23: {
-        _27 = await _28 -> [bb24];
+        _28 = copy _28 + const 1_i64;
+        goto -> bb24;
     }
 
     bb24: {
-        _30 = copy _7;
-        _31 = copy _10;
-        _32 = dispatch_future const fn baml.llm.StreamCache.new(const null, copy _30, copy _31) -> bb25;
+        _29 = len(_27);
+        _30 = copy _28 < copy _29;
+        branch copy _30 -> [bb26, bb25];
     }
 
     bb25: {
-        _29 = await _32 -> [bb26];
+        _35 = DevOther { const "All orchestration steps failed" };
+        throw copy _35;
     }
 
     bb26: {
-        _34 = copy _6;
-        _35 = copy _27;
-        _36 = copy _24;
-        _37 = copy _29;
-        _33 = Stream { copy _34, copy _35, copy _36, copy _37 };
-        _0 = copy _33;
-        goto -> bb33;
+        _31 = copy _27[_28];
+        fresh_cell(_32);
+        _32 = copy _31;
+        _33 = call const fn baml.llm.Client.execute_stream(copy _32, copy _2, copy _3) -> [bb27, unwind: bb22];
     }
 
     bb27: {
-        throw_if_panic copy _45 -> bb28;
+        _0 = copy _33;
+        goto -> bb28;
     }
 
     bb28: {
-        _39 = copy _39 + const 1_i64;
-        goto -> bb29;
-    }
-
-    bb29: {
-        _40 = len(_38);
-        _41 = copy _39 < copy _40;
-        branch copy _41 -> [bb31, bb30];
-    }
-
-    bb30: {
-        _46 = DevOther { const "All orchestration steps failed" };
-        throw copy _46;
-    }
-
-    bb31: {
-        _42 = copy _38[_39];
-        fresh_cell(_43);
-        _43 = copy _42;
-        _44 = call const fn baml.llm.Client.execute_stream(copy _43, copy _2, copy _3) -> [bb32, unwind: bb27];
-    }
-
-    bb32: {
-        _0 = copy _44;
-        goto -> bb33;
-    }
-
-    bb33: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____04_tir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 522
 ---
 === TIR2 ===
 
@@ -205,6 +204,13 @@ function baml.llm.build_request(client: baml.llm.Client, function_name: string, 
     let primitive_client = client.to_primitive_client() : baml.llm.PrimitiveClient
     let specialized_prompt = render_prompt(client, function_name, args) : baml.llm.PromptAst
     primitive_client.build_request(specialized_prompt) : baml.http.Request
+  }
+}
+function baml.llm.build_request_stream(client: baml.llm.Client, function_name: string, args: map<string, unknown>) -> baml.http.Request throws never {
+  { : baml.http.Request
+    let primitive_client = client.to_primitive_client() : baml.llm.PrimitiveClient
+    let specialized_prompt = render_prompt(client, function_name, args) : baml.llm.PromptAst
+    primitive_client.build_request_stream(specialized_prompt) : baml.http.Request
   }
 }
 function baml.llm.parse<T, S>(function_name: string, json: string) -> T throws never {
@@ -412,14 +418,11 @@ function baml.llm.Client.execute_once_stream<T, S>(self: baml.llm.Client, contex
         { : never
           let primitive = self.to_primitive_client() : baml.llm.PrimitiveClient
           let return_type = get_return_type(context.function_name) : type
-          let stream_return_type = get_stream_return_type(context.function_name) : type
           let prompt = primitive.render_prompt(context.jinja_string, context.args, return_type) : baml.llm.PromptAst
           let specialized = primitive.specialize_prompt(prompt) : baml.llm.PromptAst
           let http_request = primitive.build_request_stream(specialized) : baml.http.Request
           let sse = root.http.fetch_sse(http_request) : baml.http.SseStream
-          let acc = primitive.new_stream_accumulator() : baml.llm.StreamAccumulator
-          let cache = StreamCache.new(return_type, stream_return_type) : baml.llm.StreamCache<T, S>
-          let stream = Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache } : baml.llm.Stream<T, S>
+          let stream = self.__make_stream(sse, context.function_name) : baml.llm.Stream<T, S>
           return stream : baml.llm.Stream<T, S>
         }
       ClientType.Fallback =>
@@ -448,6 +451,16 @@ function baml.llm.Client.execute_once_stream<T, S>(self: baml.llm.Client, contex
           let result3 = self.sub_clients[idx].execute_stream(context, active_delay_ms) : baml.llm.Stream<T, S>
           return result3 : baml.llm.Stream<T, S>
         }
+  }
+}
+function baml.llm.Client.__make_stream<T, S>(self: baml.llm.Client, sse: baml.http.SseStream, function_name: string) -> baml.llm.Stream<T, S> throws never {
+  { : baml.llm.Stream<T, S>
+    let primitive = self.to_primitive_client() : baml.llm.PrimitiveClient
+    let return_type = get_return_type(function_name) : type
+    let stream_return_type = get_stream_return_type(function_name) : type
+    let acc = primitive.new_stream_accumulator() : baml.llm.StreamAccumulator
+    let cache = StreamCache.new(return_type, stream_return_type) : baml.llm.StreamCache<T, S>
+    Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache } : baml.llm.Stream<T, S>
   }
 }
 function baml.llm.Client.execute_oneshot<T>(self: baml.llm.Client, context: baml.llm.ExecutionContext, inherited_delay_ms: int) -> T throws never {

--- a/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/__baml_std__/baml_tests____baml_std____06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 690
 ---
 function baml.Array.at(self: null, index: int) -> void? {
 }
@@ -251,6 +250,40 @@ function baml.http.send(request: void) -> void {
 }
 
 function baml.io.input(prompt: string?) -> string {
+}
+
+function baml.llm.Client.__make_stream(self: null, sse: baml.http.SseStream, function_name: string) -> void {
+    load_var self
+    call baml.llm.Client.to_primitive_client
+    store_var primitive
+    load_var function_name
+    dispatch_future baml.llm.get_return_type
+    await
+    store_var return_type
+    load_var function_name
+    dispatch_future baml.llm.get_stream_return_type
+    await
+    store_var stream_return_type
+    load_var primitive
+    dispatch_future baml.llm.PrimitiveClient.new_stream_accumulator
+    await
+    store_var acc
+    load_const null
+    load_var return_type
+    load_var stream_return_type
+    dispatch_future baml.llm.StreamCache.new
+    await
+    store_var cache
+    alloc_instance Stream
+    load_var primitive
+    init_field ._client
+    load_var acc
+    init_field ._acc
+    load_var sse
+    init_field ._sse
+    load_var cache
+    init_field ._cache
+    return
 }
 
 function baml.llm.Client.build_attempt(self: null) -> void[] {
@@ -747,11 +780,11 @@ function baml.llm.Client.execute_once_stream(self: null, context: void, active_d
   L2:
     load_var self
     load_field .counter
-    store_var _52
+    store_var _41
     load_var self
     load_field .sub_clients
     call baml.Array.length
-    store_var _53
+    store_var _42
     load_var self
     load_var self
     load_field .counter
@@ -760,8 +793,8 @@ function baml.llm.Client.execute_once_stream(self: null, context: void, active_d
     store_field .counter
     load_var self
     load_field .sub_clients
-    load_var _52
-    load_var _53
+    load_var _41
+    load_var _42
     bin_op %
     load_array_element
     load_var context
@@ -778,13 +811,13 @@ function baml.llm.Client.execute_once_stream(self: null, context: void, active_d
   L4:
     load_var self
     load_field .sub_clients
-    store_var _38
+    store_var _27
     load_const 0
     store_var __for_idx
 
   L5:
     load_var __for_idx
-    load_var _38
+    load_var _27
     call baml.Array.length
     cmp_op <
     pop_jump_if_false L6
@@ -797,7 +830,7 @@ function baml.llm.Client.execute_once_stream(self: null, context: void, active_d
     throw
 
   L7:
-    load_var _38
+    load_var _27
     load_var __for_idx
     load_array_element
     load_var context
@@ -824,11 +857,6 @@ function baml.llm.Client.execute_once_stream(self: null, context: void, active_d
     dispatch_future baml.llm.get_return_type
     await
     store_var return_type
-    load_var context
-    load_field .function_name
-    dispatch_future baml.llm.get_stream_return_type
-    await
-    store_var stream_return_type
     load_var primitive
     load_var context
     load_field .jinja_string
@@ -850,25 +878,11 @@ function baml.llm.Client.execute_once_stream(self: null, context: void, active_d
     dispatch_future baml.http.fetch_sse
     await
     store_var sse
-    load_var primitive
-    dispatch_future baml.llm.PrimitiveClient.new_stream_accumulator
-    await
-    store_var acc
-    load_const null
-    load_var return_type
-    load_var stream_return_type
-    dispatch_future baml.llm.StreamCache.new
-    await
-    store_var cache
-    alloc_instance Stream
-    load_var primitive
-    init_field ._client
-    load_var acc
-    init_field ._acc
+    load_var self
     load_var sse
-    init_field ._sse
-    load_var cache
-    init_field ._cache
+    load_var context
+    load_field .function_name
+    call baml.llm.Client.__make_stream
 
   L10:
     return
@@ -1406,6 +1420,22 @@ function baml.llm.build_request(client: void, function_name: string, args: map<s
     load_var primitive_client
     load_var specialized_prompt
     dispatch_future baml.llm.PrimitiveClient.build_request
+    await
+    return
+}
+
+function baml.llm.build_request_stream(client: void, function_name: string, args: map<string, unknown>) -> baml.http.Request {
+    load_var client
+    call baml.llm.Client.to_primitive_client
+    store_var primitive_client
+    load_var client
+    load_var function_name
+    load_var args
+    call baml.llm.render_prompt
+    store_var specialized_prompt
+    load_var primitive_client
+    load_var specialized_prompt
+    dispatch_future baml.llm.PrimitiveClient.build_request_stream
     await
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__03_hir.snap
@@ -20,6 +20,9 @@ function user.GetMixedList() -> int | string[]  [llm] {
 function user.GetMixedList$build_request() -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "GetMixedList", map {  })
 }
+function user.GetMixedList$build_request_stream() -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "GetMixedList", map {  })
+}
 function user.GetMixedList$parse(json: string) -> int | string[]  [expr] {
   baml.llm.parse("GetMixedList", json)
 }
@@ -31,6 +34,9 @@ function user.GetMixedMap() -> map<string, int | string>  [llm] {
 }
 function user.GetMixedMap$build_request() -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "GetMixedMap", map {  })
+}
+function user.GetMixedMap$build_request_stream() -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "GetMixedMap", map {  })
 }
 function user.GetMixedMap$parse(json: string) -> map<string, int | string>  [expr] {
   baml.llm.parse("GetMixedMap", json)
@@ -44,6 +50,9 @@ function user.GetStatus() -> user.Status  [llm] {
 function user.GetStatus$build_request() -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "GetStatus", map {  })
 }
+function user.GetStatus$build_request_stream() -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "GetStatus", map {  })
+}
 function user.GetStatus$parse(json: string) -> user.Status  [expr] {
   baml.llm.parse("GetStatus", json)
 }
@@ -55,6 +64,9 @@ function user.GetUser(id: int) -> user.User  [llm] {
 }
 function user.GetUser$build_request(id: int) -> baml.http.Request  [expr] {
   baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id })
+}
+function user.GetUser$build_request_stream(id: int) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id })
 }
 function user.GetUser$parse(json: string) -> user.User  [expr] {
   baml.llm.parse("GetUser", json)

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__04_tir.snap
@@ -35,6 +35,9 @@ function user.GetUser$render_prompt(id: int) -> baml.llm.PromptAst throws never 
 function user.GetUser$build_request(id: int) -> baml.http.Request throws never {
   baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id }) : baml.http.Request
 }
+function user.GetUser$build_request_stream(id: int) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id }) : baml.http.Request
+}
 function user.GetUser$parse(json: string) -> user.User throws never {
   baml.llm.parse<T>("GetUser", json) : user.User
 }
@@ -48,6 +51,10 @@ function user.GetStatus$render_prompt() -> baml.llm.PromptAst throws never {
 }
 function user.GetStatus$build_request() -> baml.http.Request throws never {
   baml.llm.build_request(GPT4, "GetStatus", map {  }) : baml.http.Request
+  !! 95..173: unresolved name: GPT4
+}
+function user.GetStatus$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "GetStatus", map {  }) : baml.http.Request
   !! 95..173: unresolved name: GPT4
 }
 function user.GetStatus$parse(json: string) -> user.Status throws never {
@@ -65,6 +72,10 @@ function user.GetMixedList$build_request() -> baml.http.Request throws never {
   baml.llm.build_request(GPT4, "GetMixedList", map {  }) : baml.http.Request
   !! 173..308: unresolved name: GPT4
 }
+function user.GetMixedList$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "GetMixedList", map {  }) : baml.http.Request
+  !! 173..308: unresolved name: GPT4
+}
 function user.GetMixedList$parse(json: string) -> (int | string)[] throws never {
   baml.llm.parse<T>("GetMixedList", json) : (int | string)[]
 }
@@ -80,22 +91,26 @@ function user.GetMixedMap$build_request() -> baml.http.Request throws never {
   baml.llm.build_request(GPT4, "GetMixedMap", map {  }) : baml.http.Request
   !! 308..410: unresolved name: GPT4
 }
+function user.GetMixedMap$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "GetMixedMap", map {  }) : baml.http.Request
+  !! 308..410: unresolved name: GPT4
+}
 function user.GetMixedMap$parse(json: string) -> map<string, int | string> throws never {
   baml.llm.parse<T>("GetMixedMap", json) : map<string, int | string>
 }
 function user.GetUser$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.User, null | user.User$stream> throws never {
-  baml.llm.__make_stream(sse, "GetUser", baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }) : unknown
+  baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "GetUser") : unknown
 }
 function user.GetStatus$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Status, null | user.Status> throws never {
-  baml.llm.__make_stream(sse, "GetStatus", GPT4) : unknown
+  GPT4.__make_stream(sse, "GetStatus") : unknown
   !! 95..173: unresolved name: GPT4
 }
 function user.GetMixedList$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<(int | string)[], (int | string)[]> throws never {
-  baml.llm.__make_stream(sse, "GetMixedList", GPT4) : unknown
+  GPT4.__make_stream(sse, "GetMixedList") : unknown
   !! 173..308: unresolved name: GPT4
 }
 function user.GetMixedMap$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<map<string, int | string>, map<string, int | string>> throws never {
-  baml.llm.__make_stream(sse, "GetMixedMap", GPT4) : unknown
+  GPT4.__make_stream(sse, "GetMixedMap") : unknown
   !! 308..410: unresolved name: GPT4
 }
 class user.User {

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__04_tir.snap
@@ -98,16 +98,31 @@ function user.GetMixedMap$build_request_stream() -> baml.http.Request throws nev
 function user.GetMixedMap$parse(json: string) -> map<string, int | string> throws never {
   baml.llm.parse<T>("GetMixedMap", json) : map<string, int | string>
 }
+function user.GetUser$stream(id: int) -> baml.llm.Stream<user.User, null | user.User$stream> throws never {
+  baml.llm.stream_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id }) : baml.llm.Stream<user.User, null | user.User$stream>
+}
 function user.GetUser$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.User, null | user.User$stream> throws never {
   baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "GetUser") : unknown
+}
+function user.GetStatus$stream() -> baml.llm.Stream<user.Status, null | user.Status> throws never {
+  baml.llm.stream_llm_function(GPT4, "GetStatus", map {  }) : baml.llm.Stream<user.Status, null | user.Status>
+  !! 95..173: unresolved name: GPT4
 }
 function user.GetStatus$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Status, null | user.Status> throws never {
   GPT4.__make_stream(sse, "GetStatus") : unknown
   !! 95..173: unresolved name: GPT4
 }
+function user.GetMixedList$stream() -> baml.llm.Stream<(int | string)[], (int | string)[]> throws never {
+  baml.llm.stream_llm_function(GPT4, "GetMixedList", map {  }) : baml.llm.Stream<(int | string)[], (int | string)[]>
+  !! 173..308: unresolved name: GPT4
+}
 function user.GetMixedList$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<(int | string)[], (int | string)[]> throws never {
   GPT4.__make_stream(sse, "GetMixedList") : unknown
   !! 173..308: unresolved name: GPT4
+}
+function user.GetMixedMap$stream() -> baml.llm.Stream<map<string, int | string>, map<string, int | string>> throws never {
+  baml.llm.stream_llm_function(GPT4, "GetMixedMap", map {  }) : baml.llm.Stream<map<string, int | string>, map<string, int | string>>
+  !! 308..410: unresolved name: GPT4
 }
 function user.GetMixedMap$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<map<string, int | string>, map<string, int | string>> throws never {
   GPT4.__make_stream(sse, "GetMixedMap") : unknown

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -50,6 +50,14 @@ function user.GetMixedList$render_prompt() -> baml.llm.PromptAst {
     return
 }
 
+function user.GetMixedList$stream() -> baml.llm.Stream {
+    load_const null
+    load_const "GetMixedList"
+    alloc_map 0
+    call baml.llm.parse
+    return
+}
+
 function user.GetMixedMap() -> map<string, int | string> {
     load_const null
     load_const "GetMixedMap"
@@ -99,6 +107,14 @@ function user.GetMixedMap$render_prompt() -> baml.llm.PromptAst {
     return
 }
 
+function user.GetMixedMap$stream() -> baml.llm.Stream {
+    load_const null
+    load_const "GetMixedMap"
+    alloc_map 0
+    call baml.llm.parse
+    return
+}
+
 function user.GetStatus() -> Status {
     load_const null
     load_const "GetStatus"
@@ -145,6 +161,14 @@ function user.GetStatus$render_prompt() -> baml.llm.PromptAst {
     load_const "GetStatus"
     alloc_map 0
     call baml.llm.render_prompt
+    return
+}
+
+function user.GetStatus$stream() -> baml.llm.Stream {
+    load_const null
+    load_const "GetStatus"
+    alloc_map 0
+    call baml.llm.parse
     return
 }
 
@@ -219,7 +243,7 @@ function user.GetUser$parse(json: string) -> User {
 }
 
 function user.GetUser$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
-    load_const "internal compiler error: MIR failed to resolve field access .Primitive against class definition 'User' (module_path: ["user"]). This class should be in class_fields but isn't."
+    load_const "internal compiler error: MIR failed to resolve field access .Primitive against class definition 'User' (module_path: [\"user\"]). This class should be in class_fields but isn't."
     call baml.sys.panic
     pop 1
     jump L0
@@ -246,5 +270,26 @@ function user.GetUser$render_prompt(id: int) -> baml.llm.PromptAst {
     load_const "id"
     alloc_map 1
     call baml.llm.render_prompt
+    return
+}
+
+function user.GetUser$stream(id: int) -> baml.llm.Stream {
+    alloc_instance baml.llm.Client
+    load_const "openai/gpt-4o"
+    init_field .name
+    load_const null
+    init_field .client_type
+    alloc_array 0
+    init_field .sub_clients
+    load_const null
+    init_field .retry
+    load_const 0
+    init_field .counter
+    load_const "GetUser"
+    load_var id
+    load_const "id"
+    alloc_map 1
+    load_const null
+    call_indirect
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -36,8 +36,6 @@ function user.GetMixedList$parse_stream(sse: baml.http.SseStream) -> baml.llm.St
     load_var sse
     load_const "GetMixedList"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -54,7 +52,7 @@ function user.GetMixedList$stream() -> baml.llm.Stream {
     load_const null
     load_const "GetMixedList"
     alloc_map 0
-    call baml.llm.parse
+    call baml.llm.stream_llm_function
     return
 }
 
@@ -93,8 +91,6 @@ function user.GetMixedMap$parse_stream(sse: baml.http.SseStream) -> baml.llm.Str
     load_var sse
     load_const "GetMixedMap"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -111,7 +107,7 @@ function user.GetMixedMap$stream() -> baml.llm.Stream {
     load_const null
     load_const "GetMixedMap"
     alloc_map 0
-    call baml.llm.parse
+    call baml.llm.stream_llm_function
     return
 }
 
@@ -150,8 +146,6 @@ function user.GetStatus$parse_stream(sse: baml.http.SseStream) -> baml.llm.Strea
     load_var sse
     load_const "GetStatus"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -168,7 +162,7 @@ function user.GetStatus$stream() -> baml.llm.Stream {
     load_const null
     load_const "GetStatus"
     alloc_map 0
-    call baml.llm.parse
+    call baml.llm.stream_llm_function
     return
 }
 
@@ -243,13 +237,11 @@ function user.GetUser$parse(json: string) -> User {
 }
 
 function user.GetUser$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
-    load_const "internal compiler error: MIR failed to resolve field access .Primitive against class definition 'User' (module_path: [\"user\"]). This class should be in class_fields but isn't."
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_var sse
+    load_const "GetUser"
+    load_const null
+    call_indirect
+    return
 }
 
 function user.GetUser$render_prompt(id: int) -> baml.llm.PromptAst {
@@ -277,7 +269,8 @@ function user.GetUser$stream(id: int) -> baml.llm.Stream {
     alloc_instance baml.llm.Client
     load_const "openai/gpt-4o"
     init_field .name
-    load_const null
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
     init_field .client_type
     alloc_array 0
     init_field .sub_clients
@@ -289,7 +282,6 @@ function user.GetUser$stream(id: int) -> baml.llm.Stream {
     load_var id
     load_const "id"
     alloc_map 1
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -17,6 +17,14 @@ function user.GetMixedList$build_request() -> baml.http.Request {
     return
 }
 
+function user.GetMixedList$build_request_stream() -> baml.http.Request {
+    load_const null
+    load_const "GetMixedList"
+    alloc_map 0
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.GetMixedList$parse(json: string) -> (int | string)[] {
     load_const "GetMixedList"
     load_var json
@@ -28,7 +36,9 @@ function user.GetMixedList$parse_stream(sse: baml.http.SseStream) -> baml.llm.St
     load_var sse
     load_const "GetMixedList"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -56,6 +66,14 @@ function user.GetMixedMap$build_request() -> baml.http.Request {
     return
 }
 
+function user.GetMixedMap$build_request_stream() -> baml.http.Request {
+    load_const null
+    load_const "GetMixedMap"
+    alloc_map 0
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.GetMixedMap$parse(json: string) -> map<string, int | string> {
     load_const "GetMixedMap"
     load_var json
@@ -67,7 +85,9 @@ function user.GetMixedMap$parse_stream(sse: baml.http.SseStream) -> baml.llm.Str
     load_var sse
     load_const "GetMixedMap"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -95,6 +115,14 @@ function user.GetStatus$build_request() -> baml.http.Request {
     return
 }
 
+function user.GetStatus$build_request_stream() -> baml.http.Request {
+    load_const null
+    load_const "GetStatus"
+    alloc_map 0
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.GetStatus$parse(json: string) -> Status {
     load_const "GetStatus"
     load_var json
@@ -106,7 +134,9 @@ function user.GetStatus$parse_stream(sse: baml.http.SseStream) -> baml.llm.Strea
     load_var sse
     load_const "GetStatus"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -160,6 +190,27 @@ function user.GetUser$build_request(id: int) -> baml.http.Request {
     return
 }
 
+function user.GetUser$build_request_stream(id: int) -> baml.http.Request {
+    alloc_instance baml.llm.Client
+    load_const "openai/gpt-4o"
+    init_field .name
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
+    init_field .client_type
+    alloc_array 0
+    init_field .sub_clients
+    load_const null
+    init_field .retry
+    load_const 0
+    init_field .counter
+    load_const "GetUser"
+    load_var id
+    load_const "id"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.GetUser$parse(json: string) -> User {
     load_const "GetUser"
     load_var json
@@ -168,23 +219,13 @@ function user.GetUser$parse(json: string) -> User {
 }
 
 function user.GetUser$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
-    load_var sse
-    load_const "GetUser"
-    alloc_instance baml.llm.Client
-    load_const "openai/gpt-4o"
-    init_field .name
-    load_const null
-    load_const "Primitive"
-    load_map_element
-    init_field .client_type
-    alloc_array 0
-    init_field .sub_clients
-    load_const null
-    init_field .retry
-    load_const 0
-    init_field .counter
-    call baml.llm.parse
-    return
+    load_const "internal compiler error: MIR failed to resolve field access .Primitive against class definition 'User' (module_path: ["user"]). This class should be in class_fields but isn't."
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
 }
 
 function user.GetUser$render_prompt(id: int) -> baml.llm.PromptAst {

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__03_hir.snap
@@ -8,6 +8,9 @@ function user.CommentAfterArrow() -> string  [llm] {
 function user.CommentAfterArrow$build_request() -> baml.http.Request  [expr] {
   baml.llm.build_request(TestClient, "CommentAfterArrow", map {  })
 }
+function user.CommentAfterArrow$build_request_stream() -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(TestClient, "CommentAfterArrow", map {  })
+}
 function user.CommentAfterArrow$parse(json: string) -> string  [expr] {
   baml.llm.parse("CommentAfterArrow", json)
 }
@@ -19,6 +22,9 @@ function user.FunctionWithComments(a: string, b: int) -> string  [llm] {
 }
 function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http.Request  [expr] {
   baml.llm.build_request(TestClient, "FunctionWithComments", map { "a": a, "b": b })
+}
+function user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(TestClient, "FunctionWithComments", map { "a": a, "b": b })
 }
 function user.FunctionWithComments$parse(json: string) -> string  [expr] {
   baml.llm.parse("FunctionWithComments", json)

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__04_5_mir.snap
@@ -32,6 +32,21 @@ fn user.CommentAfterArrow$build_request() -> baml.http.Request {
     }
 }
 
+fn user.CommentAfterArrow$build_request_stream() -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: map<string, unknown>
+
+    bb0: {
+        _1 = {  };
+        _0 = call const fn baml.llm.build_request_stream(const fn user.TestClient, const "CommentAfterArrow", copy _1) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
 fn user.CommentAfterArrow$parse(json: string) -> string {
     // Locals:
     let _0: string // _0 // return
@@ -88,6 +103,23 @@ fn user.FunctionWithComments$build_request(a: string, b: int) -> baml.http.Reque
     bb0: {
         _3 = { const "a": copy _1, const "b": copy _2 };
         _0 = call const fn baml.llm.build_request(const fn user.TestClient, const "FunctionWithComments", copy _3) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: string // a // param
+    let _2: int // b // param
+    let _3: map<string, unknown>
+
+    bb0: {
+        _3 = { const "a": copy _1, const "b": copy _2 };
+        _0 = call const fn baml.llm.build_request_stream(const fn user.TestClient, const "FunctionWithComments", copy _3) -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__04_tir.snap
@@ -35,8 +35,14 @@ function user.CommentAfterArrow$build_request_stream() -> baml.http.Request thro
 function user.CommentAfterArrow$parse(json: string) -> string throws never {
   baml.llm.parse<T>("CommentAfterArrow", json) : string
 }
+function user.FunctionWithComments$stream(a: string, b: int) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(TestClient, "FunctionWithComments", map { "a": a, "b": b }) : baml.llm.Stream<string, null | string>
+}
 function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   TestClient.__make_stream(sse, "FunctionWithComments") : unknown
+}
+function user.CommentAfterArrow$stream() -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(TestClient, "CommentAfterArrow", map {  }) : baml.llm.Stream<string, null | string>
 }
 function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   TestClient.__make_stream(sse, "CommentAfterArrow") : unknown

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__04_tir.snap
@@ -14,6 +14,9 @@ function user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.
 function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http.Request throws never {
   baml.llm.build_request(TestClient, "FunctionWithComments", map { "a": a, "b": b }) : baml.http.Request
 }
+function user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(TestClient, "FunctionWithComments", map { "a": a, "b": b }) : baml.http.Request
+}
 function user.FunctionWithComments$parse(json: string) -> string throws never {
   baml.llm.parse<T>("FunctionWithComments", json) : string
 }
@@ -26,12 +29,15 @@ function user.CommentAfterArrow$render_prompt() -> baml.llm.PromptAst throws nev
 function user.CommentAfterArrow$build_request() -> baml.http.Request throws never {
   baml.llm.build_request(TestClient, "CommentAfterArrow", map {  }) : baml.http.Request
 }
+function user.CommentAfterArrow$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(TestClient, "CommentAfterArrow", map {  }) : baml.http.Request
+}
 function user.CommentAfterArrow$parse(json: string) -> string throws never {
   baml.llm.parse<T>("CommentAfterArrow", json) : string
 }
 function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "FunctionWithComments", TestClient) : unknown
+  TestClient.__make_stream(sse, "FunctionWithComments") : unknown
 }
 function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "CommentAfterArrow", TestClient) : unknown
+  TestClient.__make_stream(sse, "CommentAfterArrow") : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -57,6 +57,14 @@ function user.CommentAfterArrow$render_prompt() -> baml.llm.PromptAst {
     return
 }
 
+function user.CommentAfterArrow$stream() -> baml.llm.Stream {
+    load_global user.TestClient
+    load_const "CommentAfterArrow"
+    alloc_map 0
+    call baml.llm.parse
+    return
+}
+
 function user.FunctionWithComments(a: string, b: int) -> string {
     load_global user.TestClient
     load_const "FunctionWithComments"
@@ -119,6 +127,19 @@ function user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.
     load_const "b"
     alloc_map 2
     call baml.llm.render_prompt
+    return
+}
+
+function user.FunctionWithComments$stream(a: string, b: int) -> baml.llm.Stream {
+    load_global user.TestClient
+    load_const "FunctionWithComments"
+    load_var a
+    load_var b
+    load_const "a"
+    load_const "b"
+    alloc_map 2
+    load_const null
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -24,6 +24,14 @@ function user.CommentAfterArrow$build_request() -> baml.http.Request {
     return
 }
 
+function user.CommentAfterArrow$build_request_stream() -> baml.http.Request {
+    load_global user.TestClient
+    load_const "CommentAfterArrow"
+    alloc_map 0
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.CommentAfterArrow$parse(json: string) -> string {
     load_const "CommentAfterArrow"
     load_var json
@@ -35,7 +43,9 @@ function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream) -> baml.l
     load_var sse
     load_const "CommentAfterArrow"
     load_global user.TestClient
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -71,6 +81,18 @@ function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http
     return
 }
 
+function user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request {
+    load_global user.TestClient
+    load_const "FunctionWithComments"
+    load_var a
+    load_var b
+    load_const "a"
+    load_const "b"
+    alloc_map 2
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.FunctionWithComments$parse(json: string) -> string {
     load_const "FunctionWithComments"
     load_var json
@@ -82,7 +104,9 @@ function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream) -> bam
     load_var sse
     load_const "FunctionWithComments"
     load_global user.TestClient
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -42,9 +42,7 @@ function user.CommentAfterArrow$parse(json: string) -> string {
 function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "CommentAfterArrow"
-    load_global user.TestClient
-    load_const "__make_stream"
-    load_map_element
+    load_const null
     call_indirect
     return
 }
@@ -61,7 +59,7 @@ function user.CommentAfterArrow$stream() -> baml.llm.Stream {
     load_global user.TestClient
     load_const "CommentAfterArrow"
     alloc_map 0
-    call baml.llm.parse
+    call baml.llm.stream_llm_function
     return
 }
 
@@ -111,9 +109,7 @@ function user.FunctionWithComments$parse(json: string) -> string {
 function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "FunctionWithComments"
-    load_global user.TestClient
-    load_const "__make_stream"
-    load_map_element
+    load_const null
     call_indirect
     return
 }
@@ -138,8 +134,7 @@ function user.FunctionWithComments$stream(a: string, b: int) -> baml.llm.Stream 
     load_const "a"
     load_const "b"
     alloc_map 2
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__03_hir.snap
@@ -17,6 +17,9 @@ function user.LlmFunction(input: string) -> string  [llm] {
 function user.LlmFunction$build_request(input: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(TestClient, "LlmFunction", map { "input": input })
 }
+function user.LlmFunction$build_request_stream(input: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(TestClient, "LlmFunction", map { "input": input })
+}
 function user.LlmFunction$parse(json: string) -> string  [expr] {
   baml.llm.parse("LlmFunction", json)
 }

--- a/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__04_tir.snap
@@ -130,9 +130,12 @@ function user.LlmFunction$render_prompt(input: string) -> baml.llm.PromptAst thr
 function user.LlmFunction$build_request(input: string) -> baml.http.Request throws never {
   baml.llm.build_request(TestClient, "LlmFunction", map { "input": input }) : baml.http.Request
 }
+function user.LlmFunction$build_request_stream(input: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(TestClient, "LlmFunction", map { "input": input }) : baml.http.Request
+}
 function user.LlmFunction$parse(json: string) -> string throws never {
   baml.llm.parse<T>("LlmFunction", json) : string
 }
 function user.LlmFunction$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "LlmFunction", TestClient) : unknown
+  TestClient.__make_stream(sse, "LlmFunction") : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__04_tir.snap
@@ -136,6 +136,9 @@ function user.LlmFunction$build_request_stream(input: string) -> baml.http.Reque
 function user.LlmFunction$parse(json: string) -> string throws never {
   baml.llm.parse<T>("LlmFunction", json) : string
 }
+function user.LlmFunction$stream(input: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(TestClient, "LlmFunction", map { "input": input }) : baml.llm.Stream<string, null | string>
+}
 function user.LlmFunction$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   TestClient.__make_stream(sse, "LlmFunction") : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__06_codegen.snap
@@ -137,6 +137,17 @@ function user.LlmFunction$render_prompt(input: string) -> baml.llm.PromptAst {
     return
 }
 
+function user.LlmFunction$stream(input: string) -> baml.llm.Stream {
+    load_global user.TestClient
+    load_const "LlmFunction"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    load_const null
+    call_indirect
+    return
+}
+
 function user.MatchExpression(x: int) -> string {
     load_var x
     load_const 1

--- a/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__06_codegen.snap
@@ -100,6 +100,16 @@ function user.LlmFunction$build_request(input: string) -> baml.http.Request {
     return
 }
 
+function user.LlmFunction$build_request_stream(input: string) -> baml.http.Request {
+    load_global user.TestClient
+    load_const "LlmFunction"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.LlmFunction$parse(json: string) -> string {
     load_const "LlmFunction"
     load_var json
@@ -111,7 +121,9 @@ function user.LlmFunction$parse_stream(sse: baml.http.SseStream) -> baml.llm.Str
     load_var sse
     load_const "LlmFunction"
     load_global user.TestClient
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/control_flow/baml_tests__control_flow__06_codegen.snap
@@ -120,9 +120,7 @@ function user.LlmFunction$parse(json: string) -> string {
 function user.LlmFunction$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "LlmFunction"
-    load_global user.TestClient
-    load_const "__make_stream"
-    load_map_element
+    load_const null
     call_indirect
     return
 }
@@ -143,8 +141,7 @@ function user.LlmFunction$stream(input: string) -> baml.llm.Stream {
     load_var input
     load_const "input"
     alloc_map 1
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__03_hir.snap
@@ -289,6 +289,9 @@ function user.TestTarget() -> string  [llm] {
 function user.TestTarget$build_request() -> baml.http.Request  [expr] {
   baml.llm.build_request(BasicClient, "TestTarget", map {  })
 }
+function user.TestTarget$build_request_stream() -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(BasicClient, "TestTarget", map {  })
+}
 function user.TestTarget$parse(json: string) -> string  [expr] {
   baml.llm.parse("TestTarget", json)
 }
@@ -377,6 +380,9 @@ function user.LlmBasic(name: string) -> string  [llm] {
 function user.LlmBasic$build_request(name: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "LlmBasic", map { "name": name })
 }
+function user.LlmBasic$build_request_stream(name: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "LlmBasic", map { "name": name })
+}
 function user.LlmBasic$parse(json: string) -> string  [expr] {
   baml.llm.parse("LlmBasic", json)
 }
@@ -388,6 +394,9 @@ function user.LlmMultiLine(text: string) -> string  [llm] {
 }
 function user.LlmMultiLine$build_request(text: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "LlmMultiLine", map { "text": text })
+}
+function user.LlmMultiLine$build_request_stream(text: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "LlmMultiLine", map { "text": text })
 }
 function user.LlmMultiLine$parse(json: string) -> string  [expr] {
   baml.llm.parse("LlmMultiLine", json)
@@ -401,6 +410,9 @@ function user.LlmReversedOrder(text: string) -> string  [llm] {
 function user.LlmReversedOrder$build_request(text: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "LlmReversedOrder", map { "text": text })
 }
+function user.LlmReversedOrder$build_request_stream(text: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "LlmReversedOrder", map { "text": text })
+}
 function user.LlmReversedOrder$parse(json: string) -> string  [expr] {
   baml.llm.parse("LlmReversedOrder", json)
 }
@@ -413,6 +425,9 @@ function user.LlmStringClient(text: string) -> string  [llm] {
 function user.LlmStringClient$build_request(text: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text })
 }
+function user.LlmStringClient$build_request_stream(text: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text })
+}
 function user.LlmStringClient$parse(json: string) -> string  [expr] {
   baml.llm.parse("LlmStringClient", json)
 }
@@ -424,6 +439,9 @@ function user.LlmWithLongSignature(first_context: string, second_context: string
 }
 function user.LlmWithLongSignature$build_request(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
+}
+function user.LlmWithLongSignature$build_request_stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
 }
 function user.LlmWithLongSignature$parse(json: string) -> string  [expr] {
   baml.llm.parse("LlmWithLongSignature", json)

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_tir.snap
@@ -672,6 +672,9 @@ function user.CommaClient$new() -> ? throws never {
 function user.SameLineClient$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "SameLineClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : unknown
 }
+function user.TestTarget$stream() -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(BasicClient, "TestTarget", map {  }) : baml.llm.Stream<string, null | string>
+}
 function user.TestTarget$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   BasicClient.__make_stream(sse, "TestTarget") : unknown
 }
@@ -1083,20 +1086,39 @@ function user.NoColonComplexTypes(items: int[], mapping: map<string, int>) -> st
     "done" : "done"
   }
 }
+function user.LlmBasic$stream(name: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "LlmBasic", map { "name": name }) : baml.llm.Stream<string, null | string>
+  !! 11234..11368: unresolved name: GPT4
+}
 function user.LlmBasic$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "LlmBasic") : unknown
   !! 11234..11368: unresolved name: GPT4
+}
+function user.LlmMultiLine$stream(text: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "LlmMultiLine", map { "text": text }) : baml.llm.Stream<string, null | string>
+  !! 11368..11593: unresolved name: GPT4
 }
 function user.LlmMultiLine$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "LlmMultiLine") : unknown
   !! 11368..11593: unresolved name: GPT4
 }
+function user.LlmStringClient$stream(text: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text }) : baml.llm.Stream<string, null | string>
+}
 function user.LlmStringClient$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "LlmStringClient") : unknown
+}
+function user.LlmReversedOrder$stream(text: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "LlmReversedOrder", map { "text": text }) : baml.llm.Stream<string, null | string>
+  !! 11758..11928: unresolved name: GPT4
 }
 function user.LlmReversedOrder$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "LlmReversedOrder") : unknown
   !! 11758..11928: unresolved name: GPT4
+}
+function user.LlmWithLongSignature$stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.llm.Stream<string, null | string>
+  !! 11928..12264: unresolved name: GPT4
 }
 function user.LlmWithLongSignature$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "LlmWithLongSignature") : unknown

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__04_tir.snap
@@ -654,6 +654,9 @@ function user.TestTarget$render_prompt() -> baml.llm.PromptAst throws never {
 function user.TestTarget$build_request() -> baml.http.Request throws never {
   baml.llm.build_request(BasicClient, "TestTarget", map {  }) : baml.http.Request
 }
+function user.TestTarget$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(BasicClient, "TestTarget", map {  }) : baml.http.Request
+}
 function user.TestTarget$parse(json: string) -> string throws never {
   baml.llm.parse<T>("TestTarget", json) : string
 }
@@ -670,7 +673,7 @@ function user.SameLineClient$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "SameLineClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : unknown
 }
 function user.TestTarget$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "TestTarget", BasicClient) : unknown
+  BasicClient.__make_stream(sse, "TestTarget") : unknown
 }
 enum user.Minimal
 enum user.TwoVariants
@@ -971,6 +974,10 @@ function user.LlmBasic$build_request(name: string) -> baml.http.Request throws n
   baml.llm.build_request(GPT4, "LlmBasic", map { "name": name }) : baml.http.Request
   !! 11234..11368: unresolved name: GPT4
 }
+function user.LlmBasic$build_request_stream(name: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "LlmBasic", map { "name": name }) : baml.http.Request
+  !! 11234..11368: unresolved name: GPT4
+}
 function user.LlmBasic$parse(json: string) -> string throws never {
   baml.llm.parse<T>("LlmBasic", json) : string
 }
@@ -986,6 +993,10 @@ function user.LlmMultiLine$build_request(text: string) -> baml.http.Request thro
   baml.llm.build_request(GPT4, "LlmMultiLine", map { "text": text }) : baml.http.Request
   !! 11368..11593: unresolved name: GPT4
 }
+function user.LlmMultiLine$build_request_stream(text: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "LlmMultiLine", map { "text": text }) : baml.http.Request
+  !! 11368..11593: unresolved name: GPT4
+}
 function user.LlmMultiLine$parse(json: string) -> string throws never {
   baml.llm.parse<T>("LlmMultiLine", json) : string
 }
@@ -997,6 +1008,9 @@ function user.LlmStringClient$render_prompt(text: string) -> baml.llm.PromptAst 
 }
 function user.LlmStringClient$build_request(text: string) -> baml.http.Request throws never {
   baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text }) : baml.http.Request
+}
+function user.LlmStringClient$build_request_stream(text: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text }) : baml.http.Request
 }
 function user.LlmStringClient$parse(json: string) -> string throws never {
   baml.llm.parse<T>("LlmStringClient", json) : string
@@ -1013,6 +1027,10 @@ function user.LlmReversedOrder$build_request(text: string) -> baml.http.Request 
   baml.llm.build_request(GPT4, "LlmReversedOrder", map { "text": text }) : baml.http.Request
   !! 11758..11928: unresolved name: GPT4
 }
+function user.LlmReversedOrder$build_request_stream(text: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "LlmReversedOrder", map { "text": text }) : baml.http.Request
+  !! 11758..11928: unresolved name: GPT4
+}
 function user.LlmReversedOrder$parse(json: string) -> string throws never {
   baml.llm.parse<T>("LlmReversedOrder", json) : string
 }
@@ -1026,6 +1044,10 @@ function user.LlmWithLongSignature$render_prompt(first_context: string, second_c
 }
 function user.LlmWithLongSignature$build_request(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request throws never {
   baml.llm.build_request(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.http.Request
+  !! 11928..12264: unresolved name: GPT4
+}
+function user.LlmWithLongSignature$build_request_stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.http.Request
   !! 11928..12264: unresolved name: GPT4
 }
 function user.LlmWithLongSignature$parse(json: string) -> string throws never {
@@ -1062,22 +1084,22 @@ function user.NoColonComplexTypes(items: int[], mapping: map<string, int>) -> st
   }
 }
 function user.LlmBasic$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "LlmBasic", GPT4) : unknown
+  GPT4.__make_stream(sse, "LlmBasic") : unknown
   !! 11234..11368: unresolved name: GPT4
 }
 function user.LlmMultiLine$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "LlmMultiLine", GPT4) : unknown
+  GPT4.__make_stream(sse, "LlmMultiLine") : unknown
   !! 11368..11593: unresolved name: GPT4
 }
 function user.LlmStringClient$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "LlmStringClient", baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }) : unknown
+  baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "LlmStringClient") : unknown
 }
 function user.LlmReversedOrder$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "LlmReversedOrder", GPT4) : unknown
+  GPT4.__make_stream(sse, "LlmReversedOrder") : unknown
   !! 11758..11928: unresolved name: GPT4
 }
 function user.LlmWithLongSignature$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "LlmWithLongSignature", GPT4) : unknown
+  GPT4.__make_stream(sse, "LlmWithLongSignature") : unknown
   !! 11928..12264: unresolved name: GPT4
 }
 function user.MyFunction(a: int, b: int) -> int throws never {

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__06_codegen.snap
@@ -1343,6 +1343,16 @@ function user.LlmBasic$render_prompt(name: string) -> baml.llm.PromptAst {
     return
 }
 
+function user.LlmBasic$stream(name: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
+}
+
 function user.LlmMultiLine(text: string) -> string {
     load_const null
     load_const "LlmMultiLine"
@@ -1400,6 +1410,16 @@ function user.LlmMultiLine$render_prompt(text: string) -> baml.llm.PromptAst {
     return
 }
 
+function user.LlmMultiLine$stream(text: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
+}
+
 function user.LlmReversedOrder(text: string) -> string {
     load_const null
     load_const "LlmReversedOrder"
@@ -1455,6 +1475,16 @@ function user.LlmReversedOrder$render_prompt(text: string) -> baml.llm.PromptAst
     alloc_map 1
     call baml.llm.render_prompt
     return
+}
+
+function user.LlmReversedOrder$stream(text: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
 }
 
 function user.LlmStringClient(text: string) -> string {
@@ -1570,6 +1600,27 @@ function user.LlmStringClient$render_prompt(text: string) -> baml.llm.PromptAst 
     return
 }
 
+function user.LlmStringClient$stream(text: string) -> baml.llm.Stream {
+    alloc_instance baml.llm.Client
+    load_const "openai/gpt-4o"
+    init_field .name
+    load_const null
+    init_field .client_type
+    alloc_array 0
+    init_field .sub_clients
+    load_const null
+    init_field .retry
+    load_const 0
+    init_field .counter
+    load_const "LlmStringClient"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    load_const null
+    call_indirect
+    return
+}
+
 function user.LlmWithLongSignature(first_context: string, second_context: string, third_context: string, user_query: string) -> string {
     load_const null
     load_const "LlmWithLongSignature"
@@ -1649,6 +1700,16 @@ function user.LlmWithLongSignature$render_prompt(first_context: string, second_c
     alloc_map 4
     call baml.llm.render_prompt
     return
+}
+
+function user.LlmWithLongSignature$stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
 }
 
 function user.LongArrayClient$new() -> null {
@@ -4592,6 +4653,14 @@ function user.TestTarget$render_prompt() -> baml.llm.PromptAst {
     load_const "TestTarget"
     alloc_map 0
     call baml.llm.render_prompt
+    return
+}
+
+function user.TestTarget$stream() -> baml.llm.Stream {
+    load_global user.BasicClient
+    load_const "TestTarget"
+    alloc_map 0
+    call baml.llm.parse
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__06_codegen.snap
@@ -1327,8 +1327,6 @@ function user.LlmBasic$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream
     load_var sse
     load_const "LlmBasic"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -1344,13 +1342,13 @@ function user.LlmBasic$render_prompt(name: string) -> baml.llm.PromptAst {
 }
 
 function user.LlmBasic$stream(name: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "LlmBasic"
+    load_var name
+    load_const "name"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.LlmMultiLine(text: string) -> string {
@@ -1394,8 +1392,6 @@ function user.LlmMultiLine$parse_stream(sse: baml.http.SseStream) -> baml.llm.St
     load_var sse
     load_const "LlmMultiLine"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -1411,13 +1407,13 @@ function user.LlmMultiLine$render_prompt(text: string) -> baml.llm.PromptAst {
 }
 
 function user.LlmMultiLine$stream(text: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "LlmMultiLine"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.LlmReversedOrder(text: string) -> string {
@@ -1461,8 +1457,6 @@ function user.LlmReversedOrder$parse_stream(sse: baml.http.SseStream) -> baml.ll
     load_var sse
     load_const "LlmReversedOrder"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -1478,13 +1472,13 @@ function user.LlmReversedOrder$render_prompt(text: string) -> baml.llm.PromptAst
 }
 
 function user.LlmReversedOrder$stream(text: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "LlmReversedOrder"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.LlmStringClient(text: string) -> string {
@@ -1560,21 +1554,7 @@ function user.LlmStringClient$parse(json: string) -> string {
 function user.LlmStringClient$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "LlmStringClient"
-    alloc_instance baml.llm.Client
-    load_const "openai/gpt-4o"
-    init_field .name
     load_const null
-    load_const "Primitive"
-    load_map_element
-    init_field .client_type
-    alloc_array 0
-    init_field .sub_clients
-    load_const null
-    init_field .retry
-    load_const 0
-    init_field .counter
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -1604,7 +1584,8 @@ function user.LlmStringClient$stream(text: string) -> baml.llm.Stream {
     alloc_instance baml.llm.Client
     load_const "openai/gpt-4o"
     init_field .name
-    load_const null
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
     init_field .client_type
     alloc_array 0
     init_field .sub_clients
@@ -1616,8 +1597,7 @@ function user.LlmStringClient$stream(text: string) -> baml.llm.Stream {
     load_var text
     load_const "text"
     alloc_map 1
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }
 
@@ -1680,8 +1660,6 @@ function user.LlmWithLongSignature$parse_stream(sse: baml.http.SseStream) -> bam
     load_var sse
     load_const "LlmWithLongSignature"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -1703,13 +1681,19 @@ function user.LlmWithLongSignature$render_prompt(first_context: string, second_c
 }
 
 function user.LlmWithLongSignature$stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "LlmWithLongSignature"
+    load_var first_context
+    load_var second_context
+    load_var third_context
+    load_var user_query
+    load_const "first_context"
+    load_const "second_context"
+    load_const "third_context"
+    load_const "user_query"
+    alloc_map 4
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.LongArrayClient$new() -> null {
@@ -4641,9 +4625,7 @@ function user.TestTarget$parse(json: string) -> string {
 function user.TestTarget$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "TestTarget"
-    load_global user.BasicClient
-    load_const "__make_stream"
-    load_map_element
+    load_const null
     call_indirect
     return
 }
@@ -4660,7 +4642,7 @@ function user.TestTarget$stream() -> baml.llm.Stream {
     load_global user.BasicClient
     load_const "TestTarget"
     alloc_map 0
-    call baml.llm.parse
+    call baml.llm.stream_llm_function
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/format_checks/baml_tests__format_checks__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 12006
 ---
 function $init() -> null {
     call $init_let_0
@@ -1307,6 +1306,16 @@ function user.LlmBasic$build_request(name: string) -> baml.http.Request {
     return
 }
 
+function user.LlmBasic$build_request_stream(name: string) -> baml.http.Request {
+    load_const null
+    load_const "LlmBasic"
+    load_var name
+    load_const "name"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.LlmBasic$parse(json: string) -> string {
     load_const "LlmBasic"
     load_var json
@@ -1318,7 +1327,9 @@ function user.LlmBasic$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream
     load_var sse
     load_const "LlmBasic"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -1352,6 +1363,16 @@ function user.LlmMultiLine$build_request(text: string) -> baml.http.Request {
     return
 }
 
+function user.LlmMultiLine$build_request_stream(text: string) -> baml.http.Request {
+    load_const null
+    load_const "LlmMultiLine"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.LlmMultiLine$parse(json: string) -> string {
     load_const "LlmMultiLine"
     load_var json
@@ -1363,7 +1384,9 @@ function user.LlmMultiLine$parse_stream(sse: baml.http.SseStream) -> baml.llm.St
     load_var sse
     load_const "LlmMultiLine"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -1397,6 +1420,16 @@ function user.LlmReversedOrder$build_request(text: string) -> baml.http.Request 
     return
 }
 
+function user.LlmReversedOrder$build_request_stream(text: string) -> baml.http.Request {
+    load_const null
+    load_const "LlmReversedOrder"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.LlmReversedOrder$parse(json: string) -> string {
     load_const "LlmReversedOrder"
     load_var json
@@ -1408,7 +1441,9 @@ function user.LlmReversedOrder$parse_stream(sse: baml.http.SseStream) -> baml.ll
     load_var sse
     load_const "LlmReversedOrder"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -1464,6 +1499,27 @@ function user.LlmStringClient$build_request(text: string) -> baml.http.Request {
     return
 }
 
+function user.LlmStringClient$build_request_stream(text: string) -> baml.http.Request {
+    alloc_instance baml.llm.Client
+    load_const "openai/gpt-4o"
+    init_field .name
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
+    init_field .client_type
+    alloc_array 0
+    init_field .sub_clients
+    load_const null
+    init_field .retry
+    load_const 0
+    init_field .counter
+    load_const "LlmStringClient"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.LlmStringClient$parse(json: string) -> string {
     load_const "LlmStringClient"
     load_var json
@@ -1487,7 +1543,9 @@ function user.LlmStringClient$parse_stream(sse: baml.http.SseStream) -> baml.llm
     init_field .retry
     load_const 0
     init_field .counter
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -1544,6 +1602,22 @@ function user.LlmWithLongSignature$build_request(first_context: string, second_c
     return
 }
 
+function user.LlmWithLongSignature$build_request_stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request {
+    load_const null
+    load_const "LlmWithLongSignature"
+    load_var first_context
+    load_var second_context
+    load_var third_context
+    load_var user_query
+    load_const "first_context"
+    load_const "second_context"
+    load_const "third_context"
+    load_const "user_query"
+    alloc_map 4
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.LlmWithLongSignature$parse(json: string) -> string {
     load_const "LlmWithLongSignature"
     load_var json
@@ -1555,7 +1629,9 @@ function user.LlmWithLongSignature$parse_stream(sse: baml.http.SseStream) -> bam
     load_var sse
     load_const "LlmWithLongSignature"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -4486,6 +4562,14 @@ function user.TestTarget$build_request() -> baml.http.Request {
     return
 }
 
+function user.TestTarget$build_request_stream() -> baml.http.Request {
+    load_global user.BasicClient
+    load_const "TestTarget"
+    alloc_map 0
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.TestTarget$parse(json: string) -> string {
     load_const "TestTarget"
     load_var json
@@ -4497,7 +4581,9 @@ function user.TestTarget$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stre
     load_var sse
     load_const "TestTarget"
     load_global user.BasicClient
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__03_hir.snap
@@ -12,6 +12,9 @@ function user.GetUser() -> user.MyClass  [llm] {
 function user.GetUser$build_request() -> baml.http.Request  [expr] {
   baml.llm.build_request(null, "GetUser", map {  })
 }
+function user.GetUser$build_request_stream() -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(null, "GetUser", map {  })
+}
 function user.GetUser$parse(json: string) -> user.MyClass  [expr] {
   baml.llm.parse("GetUser", json)
 }

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__04_tir.snap
@@ -18,13 +18,14 @@ function user.GetUser$build_request() -> baml.http.Request throws never {
   baml.llm.build_request(null, "GetUser", map {  }) : baml.http.Request
   !! 316..397: type mismatch: expected baml.llm.Client, got null
 }
+function user.GetUser$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(null, "GetUser", map {  }) : baml.http.Request
+  !! 316..397: type mismatch: expected baml.llm.Client, got null
+}
 function user.GetUser$parse(json: string) -> user.MyClass throws never {
   baml.llm.parse<T>("GetUser", json) : user.MyClass
 }
 class user.MyClass$stream {
   name: null | string
   age: null | int
-}
-function user.GetUser$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.MyClass, null | user.MyClass$stream> throws never {
-  baml.llm.__make_stream(sse, "GetUser", null) : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__04_tir.snap
@@ -29,3 +29,7 @@ class user.MyClass$stream {
   name: null | string
   age: null | int
 }
+function user.GetUser$stream() -> baml.llm.Stream<user.MyClass, null | user.MyClass$stream> throws never {
+  baml.llm.stream_llm_function(null, "GetUser", map {  }) : baml.llm.Stream<user.MyClass, null | user.MyClass$stream>
+  !! 316..397: type mismatch: expected baml.llm.Client, got null
+}

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -39,3 +39,11 @@ function user.GetUser$render_prompt() -> baml.llm.PromptAst {
     call baml.llm.render_prompt
     return
 }
+
+function user.GetUser$stream() -> baml.llm.Stream {
+    load_const null
+    load_const "GetUser"
+    alloc_map 0
+    call baml.llm.parse
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -17,17 +17,17 @@ function user.GetUser$build_request() -> baml.http.Request {
     return
 }
 
-function user.GetUser$parse(json: string) -> MyClass {
+function user.GetUser$build_request_stream() -> baml.http.Request {
+    load_const null
     load_const "GetUser"
-    load_var json
-    call baml.llm.parse
+    alloc_map 0
+    call baml.llm.build_request_stream
     return
 }
 
-function user.GetUser$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
-    load_var sse
+function user.GetUser$parse(json: string) -> MyClass {
     load_const "GetUser"
-    load_const null
+    load_var json
     call baml.llm.parse
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -44,6 +44,6 @@ function user.GetUser$stream() -> baml.llm.Stream {
     load_const null
     load_const "GetUser"
     alloc_map 0
-    call baml.llm.parse
+    call baml.llm.stream_llm_function
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__03_hir.snap
@@ -11,6 +11,9 @@ function user.FetchDatax(user_id: string) -> user.Hi  [llm] {
 function user.FetchDatax$build_request(user_id: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(VertexGCP, "FetchDatax", map { "user_id": user_id })
 }
+function user.FetchDatax$build_request_stream(user_id: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(VertexGCP, "FetchDatax", map { "user_id": user_id })
+}
 function user.FetchDatax$parse(json: string) -> user.Hi  [expr] {
   baml.llm.parse("FetchDatax", json)
 }

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__04_tir.snap
@@ -26,6 +26,9 @@ function user.FetchDatax$parse(json: string) -> user.Hi throws never {
 class user.Hi$stream {
   name: null | string
 }
+function user.FetchDatax$stream(user_id: string) -> baml.llm.Stream<user.Hi, null | user.Hi$stream> throws never {
+  baml.llm.stream_llm_function(VertexGCP, "FetchDatax", map { "user_id": user_id }) : baml.llm.Stream<user.Hi, null | user.Hi$stream>
+}
 function user.FetchDatax$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Hi, null | user.Hi$stream> throws never {
   VertexGCP.__make_stream(sse, "FetchDatax") : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__04_tir.snap
@@ -17,6 +17,9 @@ function user.FetchDatax$render_prompt(user_id: string) -> baml.llm.PromptAst th
 function user.FetchDatax$build_request(user_id: string) -> baml.http.Request throws never {
   baml.llm.build_request(VertexGCP, "FetchDatax", map { "user_id": user_id }) : baml.http.Request
 }
+function user.FetchDatax$build_request_stream(user_id: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(VertexGCP, "FetchDatax", map { "user_id": user_id }) : baml.http.Request
+}
 function user.FetchDatax$parse(json: string) -> user.Hi throws never {
   baml.llm.parse<T>("FetchDatax", json) : user.Hi
 }
@@ -24,5 +27,5 @@ class user.Hi$stream {
   name: null | string
 }
 function user.FetchDatax$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Hi, null | user.Hi$stream> throws never {
-  baml.llm.__make_stream(sse, "FetchDatax", VertexGCP) : unknown
+  VertexGCP.__make_stream(sse, "FetchDatax") : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -65,6 +65,17 @@ function user.FetchDatax$render_prompt(user_id: string) -> baml.llm.PromptAst {
     return
 }
 
+function user.FetchDatax$stream(user_id: string) -> baml.llm.Stream {
+    load_global user.VertexGCP
+    load_const "FetchDatax"
+    load_var user_id
+    load_const "user_id"
+    alloc_map 1
+    load_const null
+    call_indirect
+    return
+}
+
 function user.VertexGCP$new() -> null {
     alloc_instance baml.llm.PrimitiveClient
     load_const "VertexGCP"

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -48,9 +48,7 @@ function user.FetchDatax$parse(json: string) -> Hi {
 function user.FetchDatax$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "FetchDatax"
-    load_global user.VertexGCP
-    load_const "__make_stream"
-    load_map_element
+    load_const null
     call_indirect
     return
 }
@@ -71,8 +69,7 @@ function user.FetchDatax$stream(user_id: string) -> baml.llm.Stream {
     load_var user_id
     load_const "user_id"
     alloc_map 1
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -28,6 +28,16 @@ function user.FetchDatax$build_request(user_id: string) -> baml.http.Request {
     return
 }
 
+function user.FetchDatax$build_request_stream(user_id: string) -> baml.http.Request {
+    load_global user.VertexGCP
+    load_const "FetchDatax"
+    load_var user_id
+    load_const "user_id"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.FetchDatax$parse(json: string) -> Hi {
     load_const "FetchDatax"
     load_var json
@@ -39,7 +49,9 @@ function user.FetchDatax$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stre
     load_var sse
     load_const "FetchDatax"
     load_global user.VertexGCP
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__03_hir.snap
@@ -8,6 +8,9 @@ function user.Ambiguous(input: string) -> string  [llm] {
 function user.Ambiguous$build_request(input: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "Ambiguous", map { "input": input })
 }
+function user.Ambiguous$build_request_stream(input: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "Ambiguous", map { "input": input })
+}
 function user.Ambiguous$parse(json: string) -> string  [expr] {
   baml.llm.parse("Ambiguous", json)
 }
@@ -19,6 +22,9 @@ function user.AnotherLLM(input: string) -> string  [llm] {
 }
 function user.AnotherLLM$build_request(input: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(null, "AnotherLLM", map { "input": input })
+}
+function user.AnotherLLM$build_request_stream(input: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(null, "AnotherLLM", map { "input": input })
 }
 function user.AnotherLLM$parse(json: string) -> string  [expr] {
   baml.llm.parse("AnotherLLM", json)
@@ -39,6 +45,9 @@ function user.ExtractData(text: string) -> user.JsonData  [llm] {
 function user.ExtractData$build_request(text: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "ExtractData", map { "text": text })
 }
+function user.ExtractData$build_request_stream(text: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "ExtractData", map { "text": text })
+}
 function user.ExtractData$parse(json: string) -> user.JsonData  [expr] {
   baml.llm.parse("ExtractData", json)
 }
@@ -56,6 +65,9 @@ function user.ChainedProcess(input: string) -> string  [llm] {
 function user.ChainedProcess$build_request(input: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "ChainedProcess", map { "input": input })
 }
+function user.ChainedProcess$build_request_stream(input: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "ChainedProcess", map { "input": input })
+}
 function user.ChainedProcess$parse(json: string) -> string  [expr] {
   baml.llm.parse("ChainedProcess", json)
 }
@@ -67,6 +79,9 @@ function user.LLMAnalyze(text: string) -> user.Analysis  [llm] {
 }
 function user.LLMAnalyze$build_request(text: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "LLMAnalyze", map { "text": text })
+}
+function user.LLMAnalyze$build_request_stream(text: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "LLMAnalyze", map { "text": text })
 }
 function user.LLMAnalyze$parse(json: string) -> user.Analysis  [expr] {
   baml.llm.parse("LLMAnalyze", json)

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__04_tir.snap
@@ -40,9 +40,17 @@ function user.AnotherLLM$build_request_stream(input: string) -> baml.http.Reques
 function user.AnotherLLM$parse(json: string) -> string throws never {
   baml.llm.parse<T>("AnotherLLM", json) : string
 }
+function user.Ambiguous$stream(input: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "Ambiguous", map { "input": input }) : baml.llm.Stream<string, null | string>
+  !! 0..220: unresolved name: GPT4
+}
 function user.Ambiguous$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "Ambiguous") : unknown
   !! 0..220: unresolved name: GPT4
+}
+function user.AnotherLLM$stream(input: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(null, "AnotherLLM", map { "input": input }) : baml.llm.Stream<string, null | string>
+  !! 220..421: type mismatch: expected baml.llm.Client, got null
 }
 class user.JsonData {
   field1: int
@@ -80,6 +88,10 @@ function user.ExtractData$build_request_stream(text: string) -> baml.http.Reques
 }
 function user.ExtractData$parse(json: string) -> user.JsonData throws never {
   baml.llm.parse<T>("ExtractData", json) : user.JsonData
+}
+function user.ExtractData$stream(text: string) -> baml.llm.Stream<user.JsonData, null | user.JsonData$stream> throws never {
+  baml.llm.stream_llm_function(GPT4, "ExtractData", map { "text": text }) : baml.llm.Stream<user.JsonData, null | user.JsonData$stream>
+  !! 0..146: unresolved name: GPT4
 }
 function user.ExtractData$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.JsonData, null | user.JsonData$stream> throws never {
   GPT4.__make_stream(sse, "ExtractData") : unknown
@@ -156,6 +168,10 @@ function user.SimpleCalc(a: int, b: int) -> int throws never {
     return a + b * 2 : int
   }
 }
+function user.LLMAnalyze$stream(text: string) -> baml.llm.Stream<user.Analysis, null | user.Analysis$stream> throws never {
+  baml.llm.stream_llm_function(GPT4, "LLMAnalyze", map { "text": text }) : baml.llm.Stream<user.Analysis, null | user.Analysis$stream>
+  !! 0..242: unresolved name: GPT4
+}
 function user.LLMAnalyze$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Analysis, null | user.Analysis$stream> throws never {
   GPT4.__make_stream(sse, "LLMAnalyze") : unknown
   !! 0..242: unresolved name: GPT4
@@ -164,6 +180,10 @@ class user.Analysis$stream {
   sentiment: null | string
   keywords: string[]
   score: null | float
+}
+function user.ChainedProcess$stream(input: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "ChainedProcess", map { "input": input }) : baml.llm.Stream<string, null | string>
+  !! 674..860: unresolved name: GPT4
 }
 function user.ChainedProcess$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "ChainedProcess") : unknown

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__04_tir.snap
@@ -14,6 +14,10 @@ function user.Ambiguous$build_request(input: string) -> baml.http.Request throws
   baml.llm.build_request(GPT4, "Ambiguous", map { "input": input }) : baml.http.Request
   !! 0..220: unresolved name: GPT4
 }
+function user.Ambiguous$build_request_stream(input: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "Ambiguous", map { "input": input }) : baml.http.Request
+  !! 0..220: unresolved name: GPT4
+}
 function user.Ambiguous$parse(json: string) -> string throws never {
   baml.llm.parse<T>("Ambiguous", json) : string
 }
@@ -29,15 +33,16 @@ function user.AnotherLLM$build_request(input: string) -> baml.http.Request throw
   baml.llm.build_request(null, "AnotherLLM", map { "input": input }) : baml.http.Request
   !! 220..421: type mismatch: expected baml.llm.Client, got null
 }
+function user.AnotherLLM$build_request_stream(input: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(null, "AnotherLLM", map { "input": input }) : baml.http.Request
+  !! 220..421: type mismatch: expected baml.llm.Client, got null
+}
 function user.AnotherLLM$parse(json: string) -> string throws never {
   baml.llm.parse<T>("AnotherLLM", json) : string
 }
 function user.Ambiguous$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "Ambiguous", GPT4) : unknown
+  GPT4.__make_stream(sse, "Ambiguous") : unknown
   !! 0..220: unresolved name: GPT4
-}
-function user.AnotherLLM$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "AnotherLLM", null) : unknown
 }
 class user.JsonData {
   field1: int
@@ -69,11 +74,15 @@ function user.ExtractData$build_request(text: string) -> baml.http.Request throw
   baml.llm.build_request(GPT4, "ExtractData", map { "text": text }) : baml.http.Request
   !! 0..146: unresolved name: GPT4
 }
+function user.ExtractData$build_request_stream(text: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "ExtractData", map { "text": text }) : baml.http.Request
+  !! 0..146: unresolved name: GPT4
+}
 function user.ExtractData$parse(json: string) -> user.JsonData throws never {
   baml.llm.parse<T>("ExtractData", json) : user.JsonData
 }
 function user.ExtractData$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.JsonData, null | user.JsonData$stream> throws never {
-  baml.llm.__make_stream(sse, "ExtractData", GPT4) : unknown
+  GPT4.__make_stream(sse, "ExtractData") : unknown
   !! 0..146: unresolved name: GPT4
 }
 function user.LLMAnalyze(text: string) -> user.Analysis throws never {
@@ -86,6 +95,10 @@ function user.LLMAnalyze$render_prompt(text: string) -> baml.llm.PromptAst throw
 }
 function user.LLMAnalyze$build_request(text: string) -> baml.http.Request throws never {
   baml.llm.build_request(GPT4, "LLMAnalyze", map { "text": text }) : baml.http.Request
+  !! 0..242: unresolved name: GPT4
+}
+function user.LLMAnalyze$build_request_stream(text: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "LLMAnalyze", map { "text": text }) : baml.http.Request
   !! 0..242: unresolved name: GPT4
 }
 function user.LLMAnalyze$parse(json: string) -> user.Analysis throws never {
@@ -131,6 +144,10 @@ function user.ChainedProcess$build_request(input: string) -> baml.http.Request t
   baml.llm.build_request(GPT4, "ChainedProcess", map { "input": input }) : baml.http.Request
   !! 674..860: unresolved name: GPT4
 }
+function user.ChainedProcess$build_request_stream(input: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "ChainedProcess", map { "input": input }) : baml.http.Request
+  !! 674..860: unresolved name: GPT4
+}
 function user.ChainedProcess$parse(json: string) -> string throws never {
   baml.llm.parse<T>("ChainedProcess", json) : string
 }
@@ -140,7 +157,7 @@ function user.SimpleCalc(a: int, b: int) -> int throws never {
   }
 }
 function user.LLMAnalyze$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Analysis, null | user.Analysis$stream> throws never {
-  baml.llm.__make_stream(sse, "LLMAnalyze", GPT4) : unknown
+  GPT4.__make_stream(sse, "LLMAnalyze") : unknown
   !! 0..242: unresolved name: GPT4
 }
 class user.Analysis$stream {
@@ -149,6 +166,6 @@ class user.Analysis$stream {
   score: null | float
 }
 function user.ChainedProcess$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "ChainedProcess", GPT4) : unknown
+  GPT4.__make_stream(sse, "ChainedProcess") : unknown
   !! 674..860: unresolved name: GPT4
 }

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -58,6 +58,16 @@ function user.Ambiguous$render_prompt(input: string) -> baml.llm.PromptAst {
     return
 }
 
+function user.Ambiguous$stream(input: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
+}
+
 function user.AnotherLLM(input: string) -> string {
     load_const null
     load_const "AnotherLLM"
@@ -102,6 +112,17 @@ function user.AnotherLLM$render_prompt(input: string) -> baml.llm.PromptAst {
     load_const "input"
     alloc_map 1
     call baml.llm.render_prompt
+    return
+}
+
+function user.AnotherLLM$stream(input: string) -> baml.llm.Stream {
+    load_const null
+    load_const "AnotherLLM"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    load_const null
+    call_indirect
     return
 }
 
@@ -162,6 +183,16 @@ function user.ChainedProcess$render_prompt(input: string) -> baml.llm.PromptAst 
     return
 }
 
+function user.ChainedProcess$stream(input: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
+}
+
 function user.ExtractData(text: string) -> JsonData {
     load_const null
     load_const "ExtractData"
@@ -219,6 +250,16 @@ function user.ExtractData$render_prompt(text: string) -> baml.llm.PromptAst {
     return
 }
 
+function user.ExtractData$stream(text: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
+}
+
 function user.LLMAnalyze(text: string) -> Analysis {
     load_const null
     load_const "LLMAnalyze"
@@ -274,6 +315,16 @@ function user.LLMAnalyze$render_prompt(text: string) -> baml.llm.PromptAst {
     alloc_map 1
     call baml.llm.render_prompt
     return
+}
+
+function user.LLMAnalyze$stream(text: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
 }
 
 function user.ProcessAnalysis(analysis: Analysis) -> string {

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -21,6 +21,16 @@ function user.Ambiguous$build_request(input: string) -> baml.http.Request {
     return
 }
 
+function user.Ambiguous$build_request_stream(input: string) -> baml.http.Request {
+    load_const null
+    load_const "Ambiguous"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.Ambiguous$parse(json: string) -> string {
     load_const "Ambiguous"
     load_var json
@@ -32,7 +42,9 @@ function user.Ambiguous$parse_stream(sse: baml.http.SseStream) -> baml.llm.Strea
     load_var sse
     load_const "Ambiguous"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -66,17 +78,19 @@ function user.AnotherLLM$build_request(input: string) -> baml.http.Request {
     return
 }
 
-function user.AnotherLLM$parse(json: string) -> string {
+function user.AnotherLLM$build_request_stream(input: string) -> baml.http.Request {
+    load_const null
     load_const "AnotherLLM"
-    load_var json
-    call baml.llm.parse
+    load_var input
+    load_const "input"
+    alloc_map 1
+    call baml.llm.build_request_stream
     return
 }
 
-function user.AnotherLLM$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
-    load_var sse
+function user.AnotherLLM$parse(json: string) -> string {
     load_const "AnotherLLM"
-    load_const null
+    load_var json
     call baml.llm.parse
     return
 }
@@ -111,6 +125,16 @@ function user.ChainedProcess$build_request(input: string) -> baml.http.Request {
     return
 }
 
+function user.ChainedProcess$build_request_stream(input: string) -> baml.http.Request {
+    load_const null
+    load_const "ChainedProcess"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.ChainedProcess$parse(json: string) -> string {
     load_const "ChainedProcess"
     load_var json
@@ -122,7 +146,9 @@ function user.ChainedProcess$parse_stream(sse: baml.http.SseStream) -> baml.llm.
     load_var sse
     load_const "ChainedProcess"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -156,6 +182,16 @@ function user.ExtractData$build_request(text: string) -> baml.http.Request {
     return
 }
 
+function user.ExtractData$build_request_stream(text: string) -> baml.http.Request {
+    load_const null
+    load_const "ExtractData"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.ExtractData$parse(json: string) -> JsonData {
     load_const "ExtractData"
     load_var json
@@ -167,7 +203,9 @@ function user.ExtractData$parse_stream(sse: baml.http.SseStream) -> baml.llm.Str
     load_var sse
     load_const "ExtractData"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -201,6 +239,16 @@ function user.LLMAnalyze$build_request(text: string) -> baml.http.Request {
     return
 }
 
+function user.LLMAnalyze$build_request_stream(text: string) -> baml.http.Request {
+    load_const null
+    load_const "LLMAnalyze"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.LLMAnalyze$parse(json: string) -> Analysis {
     load_const "LLMAnalyze"
     load_var json
@@ -212,7 +260,9 @@ function user.LLMAnalyze$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stre
     load_var sse
     load_const "LLMAnalyze"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -42,8 +42,6 @@ function user.Ambiguous$parse_stream(sse: baml.http.SseStream) -> baml.llm.Strea
     load_var sse
     load_const "Ambiguous"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -59,13 +57,13 @@ function user.Ambiguous$render_prompt(input: string) -> baml.llm.PromptAst {
 }
 
 function user.Ambiguous$stream(input: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "Ambiguous"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.AnotherLLM(input: string) -> string {
@@ -121,8 +119,7 @@ function user.AnotherLLM$stream(input: string) -> baml.llm.Stream {
     load_var input
     load_const "input"
     alloc_map 1
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }
 
@@ -167,8 +164,6 @@ function user.ChainedProcess$parse_stream(sse: baml.http.SseStream) -> baml.llm.
     load_var sse
     load_const "ChainedProcess"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -184,13 +179,13 @@ function user.ChainedProcess$render_prompt(input: string) -> baml.llm.PromptAst 
 }
 
 function user.ChainedProcess$stream(input: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "ChainedProcess"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.ExtractData(text: string) -> JsonData {
@@ -234,8 +229,6 @@ function user.ExtractData$parse_stream(sse: baml.http.SseStream) -> baml.llm.Str
     load_var sse
     load_const "ExtractData"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -251,13 +244,13 @@ function user.ExtractData$render_prompt(text: string) -> baml.llm.PromptAst {
 }
 
 function user.ExtractData$stream(text: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "ExtractData"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.LLMAnalyze(text: string) -> Analysis {
@@ -301,8 +294,6 @@ function user.LLMAnalyze$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stre
     load_var sse
     load_const "LLMAnalyze"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -318,13 +309,13 @@ function user.LLMAnalyze$render_prompt(text: string) -> baml.llm.PromptAst {
 }
 
 function user.LLMAnalyze$stream(text: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "LLMAnalyze"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.ProcessAnalysis(analysis: Analysis) -> string {

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__03_hir.snap
@@ -20,6 +20,9 @@ function user.FormatMessage(name: string) -> string  [llm] {
 function user.FormatMessage$build_request(name: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "FormatMessage", map { "name": name })
 }
+function user.FormatMessage$build_request_stream(name: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "FormatMessage", map { "name": name })
+}
 function user.FormatMessage$parse(json: string) -> string  [expr] {
   baml.llm.parse("FormatMessage", json)
 }
@@ -37,6 +40,9 @@ function user.ProcessText(input: string) -> string  [llm] {
 }
 function user.ProcessText$build_request(input: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "ProcessText", map { "input": input })
+}
+function user.ProcessText$build_request_stream(input: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "ProcessText", map { "input": input })
 }
 function user.ProcessText$parse(json: string) -> string  [expr] {
   baml.llm.parse("ProcessText", json)

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__04_tir.snap
@@ -26,6 +26,10 @@ function user.FormatMessage$build_request(name: string) -> baml.http.Request thr
   baml.llm.build_request(GPT4, "FormatMessage", map { "name": name }) : baml.http.Request
   !! 345..553: unresolved name: GPT4
 }
+function user.FormatMessage$build_request_stream(name: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "FormatMessage", map { "name": name }) : baml.http.Request
+  !! 345..553: unresolved name: GPT4
+}
 function user.FormatMessage$parse(json: string) -> string throws never {
   baml.llm.parse<T>("FormatMessage", json) : string
 }
@@ -41,7 +45,7 @@ class user.NestedQuotes$stream {
   json_like: null | string @alias("{\"key\": \"value\"}")
 }
 function user.FormatMessage$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "FormatMessage", GPT4) : unknown
+  GPT4.__make_stream(sse, "FormatMessage") : unknown
   !! 345..553: unresolved name: GPT4
 }
 class user.RawStrings {
@@ -66,6 +70,10 @@ function user.ProcessText$build_request(input: string) -> baml.http.Request thro
   baml.llm.build_request(GPT4, "ProcessText", map { "input": input }) : baml.http.Request
   !! 364..532: unresolved name: GPT4
 }
+function user.ProcessText$build_request_stream(input: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "ProcessText", map { "input": input }) : baml.http.Request
+  !! 364..532: unresolved name: GPT4
+}
 function user.ProcessText$parse(json: string) -> string throws never {
   baml.llm.parse<T>("ProcessText", json) : string
 }
@@ -80,7 +88,7 @@ class user.RawStrings$stream {
   "###)
 }
 function user.ProcessText$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "ProcessText", GPT4) : unknown
+  GPT4.__make_stream(sse, "ProcessText") : unknown
   !! 364..532: unresolved name: GPT4
 }
 class user.Messages {

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__04_tir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 29695
 ---
 === TIR2 ===
 class user.NestedQuotes {
@@ -44,6 +43,10 @@ class user.NestedQuotes$stream {
   complex_nesting: null | string @description("It's \"really\" 'complex'")
   json_like: null | string @alias("{\"key\": \"value\"}")
 }
+function user.FormatMessage$stream(name: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "FormatMessage", map { "name": name }) : baml.llm.Stream<string, null | string>
+  !! 345..553: unresolved name: GPT4
+}
 function user.FormatMessage$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "FormatMessage") : unknown
   !! 345..553: unresolved name: GPT4
@@ -86,6 +89,10 @@ class user.RawStrings$stream {
     raw string with "quotes"
     and #hashes#
   "###)
+}
+function user.ProcessText$stream(input: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "ProcessText", map { "input": input }) : baml.llm.Stream<string, null | string>
+  !! 364..532: unresolved name: GPT4
 }
 function user.ProcessText$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "ProcessText") : unknown

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -21,6 +21,16 @@ function user.FormatMessage$build_request(name: string) -> baml.http.Request {
     return
 }
 
+function user.FormatMessage$build_request_stream(name: string) -> baml.http.Request {
+    load_const null
+    load_const "FormatMessage"
+    load_var name
+    load_const "name"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.FormatMessage$parse(json: string) -> string {
     load_const "FormatMessage"
     load_var json
@@ -32,7 +42,9 @@ function user.FormatMessage$parse_stream(sse: baml.http.SseStream) -> baml.llm.S
     load_var sse
     load_const "FormatMessage"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -71,6 +83,16 @@ function user.ProcessText$build_request(input: string) -> baml.http.Request {
     return
 }
 
+function user.ProcessText$build_request_stream(input: string) -> baml.http.Request {
+    load_const null
+    load_const "ProcessText"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.ProcessText$parse(json: string) -> string {
     load_const "ProcessText"
     load_var json
@@ -82,7 +104,9 @@ function user.ProcessText$parse_stream(sse: baml.http.SseStream) -> baml.llm.Str
     load_var sse
     load_const "ProcessText"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -58,6 +58,16 @@ function user.FormatMessage$render_prompt(name: string) -> baml.llm.PromptAst {
     return
 }
 
+function user.FormatMessage$stream(name: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
+}
+
 function user.GetRole() -> "admin" | "user" | "guest" {
     load_const "user"
     return
@@ -118,4 +128,14 @@ function user.ProcessText$render_prompt(input: string) -> baml.llm.PromptAst {
     alloc_map 1
     call baml.llm.render_prompt
     return
+}
+
+function user.ProcessText$stream(input: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
 }

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -42,8 +42,6 @@ function user.FormatMessage$parse_stream(sse: baml.http.SseStream) -> baml.llm.S
     load_var sse
     load_const "FormatMessage"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -59,13 +57,13 @@ function user.FormatMessage$render_prompt(name: string) -> baml.llm.PromptAst {
 }
 
 function user.FormatMessage$stream(name: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "FormatMessage"
+    load_var name
+    load_const "name"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.GetRole() -> "admin" | "user" | "guest" {
@@ -114,8 +112,6 @@ function user.ProcessText$parse_stream(sse: baml.http.SseStream) -> baml.llm.Str
     load_var sse
     load_const "ProcessText"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -131,11 +127,11 @@ function user.ProcessText$render_prompt(input: string) -> baml.llm.PromptAst {
 }
 
 function user.ProcessText$stream(input: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "ProcessText"
+    load_var input
+    load_const "input"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__03_hir.snap
@@ -18,6 +18,9 @@ function user.BadParam(x: map<string, int>) -> string  [llm] {
 function user.BadParam$build_request(x: map<string, int>) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "BadParam", map { "x": x })
 }
+function user.BadParam$build_request_stream(x: map<string, int>) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "BadParam", map { "x": x })
+}
 function user.BadParam$parse(json: string) -> string  [expr] {
   baml.llm.parse("BadParam", json)
 }
@@ -29,6 +32,9 @@ function user.BadReturnType() -> map<string, int>  [llm] {
 }
 function user.BadReturnType$build_request() -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "BadReturnType", map {  })
+}
+function user.BadReturnType$build_request_stream() -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "BadReturnType", map {  })
 }
 function user.BadReturnType$parse(json: string) -> map<string, int>  [expr] {
   baml.llm.parse("BadReturnType", json)

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__04_tir.snap
@@ -23,6 +23,10 @@ function user.BadParam$build_request(x: map<string, int>) -> baml.http.Request t
   baml.llm.build_request(GPT4, "BadParam", map { "x": x }) : baml.http.Request
   !! 655..777: unresolved name: GPT4
 }
+function user.BadParam$build_request_stream(x: map<string, int>) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "BadParam", map { "x": x }) : baml.http.Request
+  !! 655..777: unresolved name: GPT4
+}
 function user.BadParam$parse(json: string) -> string throws never {
   baml.llm.parse<T>("BadParam", json) : string
 }
@@ -36,6 +40,10 @@ function user.BadReturnType$render_prompt() -> baml.llm.PromptAst throws never {
 }
 function user.BadReturnType$build_request() -> baml.http.Request throws never {
   baml.llm.build_request(GPT4, "BadReturnType", map {  }) : baml.http.Request
+  !! 777..897: unresolved name: GPT4
+}
+function user.BadReturnType$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "BadReturnType", map {  }) : baml.http.Request
   !! 777..897: unresolved name: GPT4
 }
 function user.BadReturnType$parse(json: string) -> map<string, int> throws never {
@@ -52,11 +60,11 @@ class user.NestedGenerics$stream {
   simple: map<string, int>
 }
 function user.BadParam$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "BadParam", GPT4) : unknown
+  GPT4.__make_stream(sse, "BadParam") : unknown
   !! 655..777: unresolved name: GPT4
 }
 function user.BadReturnType$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<map<string, int>, map<string, int>> throws never {
-  baml.llm.__make_stream(sse, "BadReturnType", GPT4) : unknown
+  GPT4.__make_stream(sse, "BadReturnType") : unknown
   !! 777..897: unresolved name: GPT4
 }
 type user.BadAlias$stream = map<string, int>

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__04_tir.snap
@@ -59,9 +59,17 @@ class user.NestedGenerics$stream {
   nested: map<string, map<string, int>>
   simple: map<string, int>
 }
+function user.BadParam$stream(x: map<string, int>) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "BadParam", map { "x": x }) : baml.llm.Stream<string, null | string>
+  !! 655..777: unresolved name: GPT4
+}
 function user.BadParam$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "BadParam") : unknown
   !! 655..777: unresolved name: GPT4
+}
+function user.BadReturnType$stream() -> baml.llm.Stream<map<string, int>, map<string, int>> throws never {
+  baml.llm.stream_llm_function(GPT4, "BadReturnType", map {  }) : baml.llm.Stream<map<string, int>, map<string, int>>
+  !! 777..897: unresolved name: GPT4
 }
 function user.BadReturnType$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<map<string, int>, map<string, int>> throws never {
   GPT4.__make_stream(sse, "BadReturnType") : unknown

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -58,6 +58,16 @@ function user.BadParam$render_prompt(x: map<string, int>) -> baml.llm.PromptAst 
     return
 }
 
+function user.BadParam$stream(x: map<string, int>) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
+}
+
 function user.BadReturnType() -> map<string, int> {
     load_const null
     load_const "BadReturnType"
@@ -104,5 +114,13 @@ function user.BadReturnType$render_prompt() -> baml.llm.PromptAst {
     load_const "BadReturnType"
     alloc_map 0
     call baml.llm.render_prompt
+    return
+}
+
+function user.BadReturnType$stream() -> baml.llm.Stream {
+    load_const null
+    load_const "BadReturnType"
+    alloc_map 0
+    call baml.llm.parse
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -42,8 +42,6 @@ function user.BadParam$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream
     load_var sse
     load_const "BadParam"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -59,13 +57,13 @@ function user.BadParam$render_prompt(x: map<string, int>) -> baml.llm.PromptAst 
 }
 
 function user.BadParam$stream(x: map<string, int>) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "BadParam"
+    load_var x
+    load_const "x"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }
 
 function user.BadReturnType() -> map<string, int> {
@@ -103,8 +101,6 @@ function user.BadReturnType$parse_stream(sse: baml.http.SseStream) -> baml.llm.S
     load_var sse
     load_const "BadReturnType"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -121,6 +117,6 @@ function user.BadReturnType$stream() -> baml.llm.Stream {
     load_const null
     load_const "BadReturnType"
     alloc_map 0
-    call baml.llm.parse
+    call baml.llm.stream_llm_function
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -21,6 +21,16 @@ function user.BadParam$build_request(x: map<string, int>) -> baml.http.Request {
     return
 }
 
+function user.BadParam$build_request_stream(x: map<string, int>) -> baml.http.Request {
+    load_const null
+    load_const "BadParam"
+    load_var x
+    load_const "x"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.BadParam$parse(json: string) -> string {
     load_const "BadParam"
     load_var json
@@ -32,7 +42,9 @@ function user.BadParam$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream
     load_var sse
     load_const "BadParam"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -62,6 +74,14 @@ function user.BadReturnType$build_request() -> baml.http.Request {
     return
 }
 
+function user.BadReturnType$build_request_stream() -> baml.http.Request {
+    load_const null
+    load_const "BadReturnType"
+    alloc_map 0
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.BadReturnType$parse(json: string) -> map<string, int> {
     load_const "BadReturnType"
     load_var json
@@ -73,7 +93,9 @@ function user.BadReturnType$parse_stream(sse: baml.http.SseStream) -> baml.llm.S
     load_var sse
     load_const "BadReturnType"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__03_hir.snap
@@ -12,6 +12,9 @@ function user.HelloWorld(name: string) -> string  [llm] {
 function user.HelloWorld$build_request(name: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4, "HelloWorld", map { "name": name })
 }
+function user.HelloWorld$build_request_stream(name: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4, "HelloWorld", map { "name": name })
+}
 function user.HelloWorld$parse(json: string) -> string  [expr] {
   baml.llm.parse("HelloWorld", json)
 }

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__04_tir.snap
@@ -14,6 +14,10 @@ function user.HelloWorld$build_request(name: string) -> baml.http.Request throws
   baml.llm.build_request(GPT4, "HelloWorld", map { "name": name }) : baml.http.Request
   !! 0..104: unresolved name: GPT4
 }
+function user.HelloWorld$build_request_stream(name: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4, "HelloWorld", map { "name": name }) : baml.http.Request
+  !! 0..104: unresolved name: GPT4
+}
 function user.HelloWorld$parse(json: string) -> string throws never {
   baml.llm.parse<T>("HelloWorld", json) : string
 }
@@ -22,7 +26,7 @@ class user.User {
   age: int
 }
 function user.HelloWorld$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "HelloWorld", GPT4) : unknown
+  GPT4.__make_stream(sse, "HelloWorld") : unknown
   !! 0..104: unresolved name: GPT4
 }
 class user.User$stream {

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__04_tir.snap
@@ -25,6 +25,10 @@ class user.User {
   name: string
   age: int
 }
+function user.HelloWorld$stream(name: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4, "HelloWorld", map { "name": name }) : baml.llm.Stream<string, null | string>
+  !! 0..104: unresolved name: GPT4
+}
 function user.HelloWorld$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4.__make_stream(sse, "HelloWorld") : unknown
   !! 0..104: unresolved name: GPT4

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -21,6 +21,16 @@ function user.HelloWorld$build_request(name: string) -> baml.http.Request {
     return
 }
 
+function user.HelloWorld$build_request_stream(name: string) -> baml.http.Request {
+    load_const null
+    load_const "HelloWorld"
+    load_var name
+    load_const "name"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.HelloWorld$parse(json: string) -> string {
     load_const "HelloWorld"
     load_var json
@@ -32,7 +42,9 @@ function user.HelloWorld$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stre
     load_var sse
     load_const "HelloWorld"
     load_const null
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -57,3 +57,13 @@ function user.HelloWorld$render_prompt(name: string) -> baml.llm.PromptAst {
     call baml.llm.render_prompt
     return
 }
+
+function user.HelloWorld$stream(name: string) -> baml.llm.Stream {
+    load_const "unresolved name: GPT4"
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
+}

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -42,8 +42,6 @@ function user.HelloWorld$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stre
     load_var sse
     load_const "HelloWorld"
     load_const null
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -59,11 +57,11 @@ function user.HelloWorld$render_prompt(name: string) -> baml.llm.PromptAst {
 }
 
 function user.HelloWorld$stream(name: string) -> baml.llm.Stream {
-    load_const "unresolved name: GPT4"
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_const null
+    load_const "HelloWorld"
+    load_var name
+    load_const "name"
+    alloc_map 1
+    call baml.llm.stream_llm_function
+    return
 }

--- a/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__03_hir.snap
@@ -16,6 +16,9 @@ function user.ClassifySentiment(text: string) -> user.Sentiment  [llm] {
 function user.ClassifySentiment$build_request(text: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4o, "ClassifySentiment", map { "text": text })
 }
+function user.ClassifySentiment$build_request_stream(text: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4o, "ClassifySentiment", map { "text": text })
+}
 function user.ClassifySentiment$parse(json: string) -> user.Sentiment  [expr] {
   baml.llm.parse("ClassifySentiment", json)
 }
@@ -27,6 +30,9 @@ function user.ClassifySentiment2(text: string) -> string  [llm] {
 }
 function user.ClassifySentiment2$build_request(text: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4o, "ClassifySentiment2", map { "text": text })
+}
+function user.ClassifySentiment2$build_request_stream(text: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4o, "ClassifySentiment2", map { "text": text })
 }
 function user.ClassifySentiment2$parse(json: string) -> string  [expr] {
   baml.llm.parse("ClassifySentiment2", json)
@@ -45,6 +51,9 @@ function user.GenerateTests(count: int, topic: string) -> string[]  [llm] {
 }
 function user.GenerateTests$build_request(count: int, topic: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(GPT4o, "GenerateTests", map { "count": count, "topic": topic })
+}
+function user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(GPT4o, "GenerateTests", map { "count": count, "topic": topic })
 }
 function user.GenerateTests$parse(json: string) -> string[]  [expr] {
   baml.llm.parse("GenerateTests", json)

--- a/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__04_5_mir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 38512
 ---
 === MIR2 ===
 fn user.$init_test_24(registry: testing.TestCollector) -> null {
@@ -364,6 +363,22 @@ fn user.ClassifySentiment$build_request(text: string) -> baml.http.Request {
     }
 }
 
+fn user.ClassifySentiment$build_request_stream(text: string) -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: string // text // param
+    let _2: map<string, unknown>
+
+    bb0: {
+        _2 = { const "text": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(const fn user.GPT4o, const "ClassifySentiment", copy _2) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
 fn user.ClassifySentiment$parse(json: string) -> Sentiment {
     // Locals:
     let _0: Sentiment // _0 // return
@@ -419,6 +434,22 @@ fn user.ClassifySentiment2$build_request(text: string) -> baml.http.Request {
     bb0: {
         _2 = { const "text": copy _1 };
         _0 = call const fn baml.llm.build_request(const fn user.GPT4o, const "ClassifySentiment2", copy _2) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.ClassifySentiment2$build_request_stream(text: string) -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: string // text // param
+    let _2: map<string, unknown>
+
+    bb0: {
+        _2 = { const "text": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(const fn user.GPT4o, const "ClassifySentiment2", copy _2) -> [bb1];
     }
 
     bb1: {
@@ -556,6 +587,23 @@ fn user.GenerateTests$build_request(count: int, topic: string) -> baml.http.Requ
     bb0: {
         _3 = { const "count": copy _1, const "topic": copy _2 };
         _0 = call const fn baml.llm.build_request(const fn user.GPT4o, const "GenerateTests", copy _3) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: int // count // param
+    let _2: string // topic // param
+    let _3: map<string, unknown>
+
+    bb0: {
+        _3 = { const "count": copy _1, const "topic": copy _2 };
+        _0 = call const fn baml.llm.build_request_stream(const fn user.GPT4o, const "GenerateTests", copy _3) -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__04_tir.snap
@@ -102,11 +102,20 @@ class user.Sentiment$stream {
   confidence: null | float
   reasoning: null | string
 }
+function user.ClassifySentiment$stream(text: string) -> baml.llm.Stream<user.Sentiment, null | user.Sentiment$stream> throws never {
+  baml.llm.stream_llm_function(GPT4o, "ClassifySentiment", map { "text": text }) : baml.llm.Stream<user.Sentiment, null | user.Sentiment$stream>
+}
 function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Sentiment, null | user.Sentiment$stream> throws never {
   GPT4o.__make_stream(sse, "ClassifySentiment") : unknown
 }
+function user.GenerateTests$stream(count: int, topic: string) -> baml.llm.Stream<string[], string[]> throws never {
+  baml.llm.stream_llm_function(GPT4o, "GenerateTests", map { "count": count, "topic": topic }) : baml.llm.Stream<string[], string[]>
+}
 function user.GenerateTests$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string[], string[]> throws never {
   GPT4o.__make_stream(sse, "GenerateTests") : unknown
+}
+function user.ClassifySentiment2$stream(text: string) -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(GPT4o, "ClassifySentiment2", map { "text": text }) : baml.llm.Stream<string, null | string>
 }
 function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   GPT4o.__make_stream(sse, "ClassifySentiment2") : unknown

--- a/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__04_tir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 38471
 ---
 === TIR2 ===
 function user.GPT4o$new() -> ? throws never {
@@ -20,6 +19,9 @@ function user.ClassifySentiment$render_prompt(text: string) -> baml.llm.PromptAs
 function user.ClassifySentiment$build_request(text: string) -> baml.http.Request throws never {
   baml.llm.build_request(GPT4o, "ClassifySentiment", map { "text": text }) : baml.http.Request
 }
+function user.ClassifySentiment$build_request_stream(text: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4o, "ClassifySentiment", map { "text": text }) : baml.http.Request
+}
 function user.ClassifySentiment$parse(json: string) -> user.Sentiment throws never {
   baml.llm.parse<T>("ClassifySentiment", json) : user.Sentiment
 }
@@ -31,6 +33,9 @@ function user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm
 }
 function user.GenerateTests$build_request(count: int, topic: string) -> baml.http.Request throws never {
   baml.llm.build_request(GPT4o, "GenerateTests", map { "count": count, "topic": topic }) : baml.http.Request
+}
+function user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4o, "GenerateTests", map { "count": count, "topic": topic }) : baml.http.Request
 }
 function user.GenerateTests$parse(json: string) -> string[] throws never {
   baml.llm.parse<T>("GenerateTests", json) : string[]
@@ -57,6 +62,9 @@ function user.ClassifySentiment2$render_prompt(text: string) -> baml.llm.PromptA
 }
 function user.ClassifySentiment2$build_request(text: string) -> baml.http.Request throws never {
   baml.llm.build_request(GPT4o, "ClassifySentiment2", map { "text": text }) : baml.http.Request
+}
+function user.ClassifySentiment2$build_request_stream(text: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(GPT4o, "ClassifySentiment2", map { "text": text }) : baml.http.Request
 }
 function user.ClassifySentiment2$parse(json: string) -> string throws never {
   baml.llm.parse<T>("ClassifySentiment2", json) : string
@@ -95,11 +103,11 @@ class user.Sentiment$stream {
   reasoning: null | string
 }
 function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Sentiment, null | user.Sentiment$stream> throws never {
-  baml.llm.__make_stream(sse, "ClassifySentiment", GPT4o) : unknown
+  GPT4o.__make_stream(sse, "ClassifySentiment") : unknown
 }
 function user.GenerateTests$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string[], string[]> throws never {
-  baml.llm.__make_stream(sse, "GenerateTests", GPT4o) : unknown
+  GPT4o.__make_stream(sse, "GenerateTests") : unknown
 }
 function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "ClassifySentiment2", GPT4o) : unknown
+  GPT4o.__make_stream(sse, "ClassifySentiment2") : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__06_codegen.snap
@@ -47,6 +47,16 @@ function user.ClassifySentiment$build_request(text: string) -> baml.http.Request
     return
 }
 
+function user.ClassifySentiment$build_request_stream(text: string) -> baml.http.Request {
+    load_global user.GPT4o
+    load_const "ClassifySentiment"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.ClassifySentiment$parse(json: string) -> Sentiment {
     load_const "ClassifySentiment"
     load_var json
@@ -58,7 +68,9 @@ function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream) -> baml.l
     load_var sse
     load_const "ClassifySentiment"
     load_global user.GPT4o
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -92,6 +104,16 @@ function user.ClassifySentiment2$build_request(text: string) -> baml.http.Reques
     return
 }
 
+function user.ClassifySentiment2$build_request_stream(text: string) -> baml.http.Request {
+    load_global user.GPT4o
+    load_const "ClassifySentiment2"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.ClassifySentiment2$parse(json: string) -> string {
     load_const "ClassifySentiment2"
     load_var json
@@ -103,7 +125,9 @@ function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream) -> baml.
     load_var sse
     load_const "ClassifySentiment2"
     load_global user.GPT4o
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 
@@ -214,6 +238,18 @@ function user.GenerateTests$build_request(count: int, topic: string) -> baml.htt
     return
 }
 
+function user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request {
+    load_global user.GPT4o
+    load_const "GenerateTests"
+    load_var count
+    load_var topic
+    load_const "count"
+    load_const "topic"
+    alloc_map 2
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.GenerateTests$parse(json: string) -> string[] {
     load_const "GenerateTests"
     load_var json
@@ -225,7 +261,9 @@ function user.GenerateTests$parse_stream(sse: baml.http.SseStream) -> baml.llm.S
     load_var sse
     load_const "GenerateTests"
     load_global user.GPT4o
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__06_codegen.snap
@@ -67,9 +67,7 @@ function user.ClassifySentiment$parse(json: string) -> Sentiment {
 function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "ClassifySentiment"
-    load_global user.GPT4o
-    load_const "__make_stream"
-    load_map_element
+    load_const null
     call_indirect
     return
 }
@@ -90,8 +88,7 @@ function user.ClassifySentiment$stream(text: string) -> baml.llm.Stream {
     load_var text
     load_const "text"
     alloc_map 1
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }
 
@@ -135,9 +132,7 @@ function user.ClassifySentiment2$parse(json: string) -> string {
 function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "ClassifySentiment2"
-    load_global user.GPT4o
-    load_const "__make_stream"
-    load_map_element
+    load_const null
     call_indirect
     return
 }
@@ -158,8 +153,7 @@ function user.ClassifySentiment2$stream(text: string) -> baml.llm.Stream {
     load_var text
     load_const "text"
     alloc_map 1
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }
 
@@ -282,9 +276,7 @@ function user.GenerateTests$parse(json: string) -> string[] {
 function user.GenerateTests$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "GenerateTests"
-    load_global user.GPT4o
-    load_const "__make_stream"
-    load_map_element
+    load_const null
     call_indirect
     return
 }
@@ -309,7 +301,6 @@ function user.GenerateTests$stream(count: int, topic: string) -> baml.llm.Stream
     load_const "count"
     load_const "topic"
     alloc_map 2
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/testset_vibes_nested/baml_tests__testset_vibes_nested__06_codegen.snap
@@ -84,6 +84,17 @@ function user.ClassifySentiment$render_prompt(text: string) -> baml.llm.PromptAs
     return
 }
 
+function user.ClassifySentiment$stream(text: string) -> baml.llm.Stream {
+    load_global user.GPT4o
+    load_const "ClassifySentiment"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    load_const null
+    call_indirect
+    return
+}
+
 function user.ClassifySentiment2(text: string) -> string {
     load_global user.GPT4o
     load_const "ClassifySentiment2"
@@ -138,6 +149,17 @@ function user.ClassifySentiment2$render_prompt(text: string) -> baml.llm.PromptA
     load_const "text"
     alloc_map 1
     call baml.llm.render_prompt
+    return
+}
+
+function user.ClassifySentiment2$stream(text: string) -> baml.llm.Stream {
+    load_global user.GPT4o
+    load_const "ClassifySentiment2"
+    load_var text
+    load_const "text"
+    alloc_map 1
+    load_const null
+    call_indirect
     return
 }
 
@@ -276,5 +298,18 @@ function user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm
     load_const "topic"
     alloc_map 2
     call baml.llm.render_prompt
+    return
+}
+
+function user.GenerateTests$stream(count: int, topic: string) -> baml.llm.Stream {
+    load_global user.GPT4o
+    load_const "GenerateTests"
+    load_var count
+    load_var topic
+    load_const "count"
+    load_const "topic"
+    alloc_map 2
+    load_const null
+    call_indirect
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__03_hir.snap
@@ -11,6 +11,9 @@ function user.TypeBuilderFn(from_text: string) -> user.Resume  [llm] {
 function user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Request  [expr] {
   baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text })
 }
+function user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text })
+}
 function user.TypeBuilderFn$parse(json: string) -> user.Resume  [expr] {
   baml.llm.parse("TypeBuilderFn", json)
 }

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__04_5_mir.snap
@@ -42,6 +42,26 @@ fn user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Request {
     }
 }
 
+fn user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: string // from_text // param
+    let _2: baml.llm.Client
+    let _3: baml.llm.Client[]
+    let _4: map<string, unknown>
+
+    bb0: {
+        _3 = [];
+        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
+        _4 = { const "from_text": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(copy _2, const "TypeBuilderFn", copy _4) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
 fn user.TypeBuilderFn$parse(json: string) -> Resume {
     // Locals:
     let _0: Resume // _0 // return

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__04_tir.snap
@@ -11,6 +11,9 @@ function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptA
 function user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Request throws never {
   baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text }) : baml.http.Request
 }
+function user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text }) : baml.http.Request
+}
 function user.TypeBuilderFn$parse(json: string) -> user.Resume throws never {
   baml.llm.parse<T>("TypeBuilderFn", json) : user.Resume
 }
@@ -18,7 +21,7 @@ class user.Resume {
   name: string
 }
 function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Resume, null | user.Resume$stream> throws never {
-  baml.llm.__make_stream(sse, "TypeBuilderFn", baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }) : unknown
+  baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "TypeBuilderFn") : unknown
 }
 class user.Resume$stream {
   name: null | string

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__04_tir.snap
@@ -20,6 +20,9 @@ function user.TypeBuilderFn$parse(json: string) -> user.Resume throws never {
 class user.Resume {
   name: string
 }
+function user.TypeBuilderFn$stream(from_text: string) -> baml.llm.Stream<user.Resume, null | user.Resume$stream> throws never {
+  baml.llm.stream_llm_function(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text }) : baml.llm.Stream<user.Resume, null | user.Resume$stream>
+}
 function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Resume, null | user.Resume$stream> throws never {
   baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "TypeBuilderFn") : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -72,7 +72,7 @@ function user.TypeBuilderFn$parse(json: string) -> Resume {
 }
 
 function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
-    load_const "internal compiler error: MIR failed to resolve field access .Primitive against class definition 'Resume' (module_path: ["user"]). This class should be in class_fields but isn't."
+    load_const "internal compiler error: MIR failed to resolve field access .Primitive against class definition 'Resume' (module_path: [\"user\"]). This class should be in class_fields but isn't."
     call baml.sys.panic
     pop 1
     jump L0
@@ -99,5 +99,26 @@ function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptA
     load_const "from_text"
     alloc_map 1
     call baml.llm.render_prompt
+    return
+}
+
+function user.TypeBuilderFn$stream(from_text: string) -> baml.llm.Stream {
+    alloc_instance baml.llm.Client
+    load_const "openai/gpt-4o-mini"
+    init_field .name
+    load_const null
+    init_field .client_type
+    alloc_array 0
+    init_field .sub_clients
+    load_const null
+    init_field .retry
+    load_const 0
+    init_field .counter
+    load_const "TypeBuilderFn"
+    load_var from_text
+    load_const "from_text"
+    alloc_map 1
+    load_const null
+    call_indirect
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -43,6 +43,27 @@ function user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Reques
     return
 }
 
+function user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http.Request {
+    alloc_instance baml.llm.Client
+    load_const "openai/gpt-4o-mini"
+    init_field .name
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
+    init_field .client_type
+    alloc_array 0
+    init_field .sub_clients
+    load_const null
+    init_field .retry
+    load_const 0
+    init_field .counter
+    load_const "TypeBuilderFn"
+    load_var from_text
+    load_const "from_text"
+    alloc_map 1
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.TypeBuilderFn$parse(json: string) -> Resume {
     load_const "TypeBuilderFn"
     load_var json
@@ -51,23 +72,13 @@ function user.TypeBuilderFn$parse(json: string) -> Resume {
 }
 
 function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
-    load_var sse
-    load_const "TypeBuilderFn"
-    alloc_instance baml.llm.Client
-    load_const "openai/gpt-4o-mini"
-    init_field .name
-    load_const null
-    load_const "Primitive"
-    load_map_element
-    init_field .client_type
-    alloc_array 0
-    init_field .sub_clients
-    load_const null
-    init_field .retry
-    load_const 0
-    init_field .counter
-    call baml.llm.parse
-    return
+    load_const "internal compiler error: MIR failed to resolve field access .Primitive against class definition 'Resume' (module_path: ["user"]). This class should be in class_fields but isn't."
+    call baml.sys.panic
+    pop 1
+    jump L0
+
+  L0:
+    unreachable
 }
 
 function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptAst {

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -72,13 +72,11 @@ function user.TypeBuilderFn$parse(json: string) -> Resume {
 }
 
 function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
-    load_const "internal compiler error: MIR failed to resolve field access .Primitive against class definition 'Resume' (module_path: [\"user\"]). This class should be in class_fields but isn't."
-    call baml.sys.panic
-    pop 1
-    jump L0
-
-  L0:
-    unreachable
+    load_var sse
+    load_const "TypeBuilderFn"
+    load_const null
+    call_indirect
+    return
 }
 
 function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptAst {
@@ -106,7 +104,8 @@ function user.TypeBuilderFn$stream(from_text: string) -> baml.llm.Stream {
     alloc_instance baml.llm.Client
     load_const "openai/gpt-4o-mini"
     init_field .name
-    load_const null
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
     init_field .client_type
     alloc_array 0
     init_field .sub_clients
@@ -118,7 +117,6 @@ function user.TypeBuilderFn$stream(from_text: string) -> baml.llm.Stream {
     load_var from_text
     load_const "from_text"
     alloc_map 1
-    load_const null
-    call_indirect
+    call baml.llm.stream_llm_function
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__03_hir.snap
@@ -12,6 +12,9 @@ function user.Fn() -> string  [llm] {
 function user.Fn$build_request() -> baml.http.Request  [expr] {
   baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  })
 }
+function user.Fn$build_request_stream() -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  })
+}
 function user.Fn$parse(json: string) -> string  [expr] {
   baml.llm.parse("Fn", json)
 }

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__04_5_mir.snap
@@ -40,6 +40,25 @@ fn user.Fn$build_request() -> baml.http.Request {
     }
 }
 
+fn user.Fn$build_request_stream() -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: baml.llm.Client
+    let _2: baml.llm.Client[]
+    let _3: map<string, unknown>
+
+    bb0: {
+        _2 = [];
+        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _2, const null, const 0_i64 };
+        _3 = {  };
+        _0 = call const fn baml.llm.build_request_stream(copy _1, const "Fn", copy _3) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
 fn user.Fn$parse(json: string) -> string {
     // Locals:
     let _0: string // _0 // return

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__04_tir.snap
@@ -11,6 +11,9 @@ function user.Fn$render_prompt() -> baml.llm.PromptAst throws never {
 function user.Fn$build_request() -> baml.http.Request throws never {
   baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  }) : baml.http.Request
 }
+function user.Fn$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  }) : baml.http.Request
+}
 function user.Fn$parse(json: string) -> string throws never {
   baml.llm.parse<T>("Fn", json) : string
 }
@@ -19,7 +22,7 @@ class user.TopLevelClass {
 }
 enum user.TopLevelEnum
 function user.Fn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
-  baml.llm.__make_stream(sse, "Fn", baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }) : unknown
+  baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "Fn") : unknown
 }
 class user.TopLevelClass$stream {
   a: null | string

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__04_tir.snap
@@ -21,6 +21,9 @@ class user.TopLevelClass {
   a: string
 }
 enum user.TopLevelEnum
+function user.Fn$stream() -> baml.llm.Stream<string, null | string> throws never {
+  baml.llm.stream_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  }) : baml.llm.Stream<string, null | string>
+}
 function user.Fn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string, null | string> throws never {
   baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "Fn") : unknown
 }

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -39,6 +39,25 @@ function user.Fn$build_request() -> baml.http.Request {
     return
 }
 
+function user.Fn$build_request_stream() -> baml.http.Request {
+    alloc_instance baml.llm.Client
+    load_const "openai/gpt-4o"
+    init_field .name
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
+    init_field .client_type
+    alloc_array 0
+    init_field .sub_clients
+    load_const null
+    init_field .retry
+    load_const 0
+    init_field .counter
+    load_const "Fn"
+    alloc_map 0
+    call baml.llm.build_request_stream
+    return
+}
+
 function user.Fn$parse(json: string) -> string {
     load_const "Fn"
     load_var json
@@ -62,7 +81,9 @@ function user.Fn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     init_field .retry
     load_const 0
     init_field .counter
-    call baml.llm.parse
+    load_const "__make_stream"
+    load_map_element
+    call_indirect
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -105,3 +105,21 @@ function user.Fn$render_prompt() -> baml.llm.PromptAst {
     call baml.llm.render_prompt
     return
 }
+
+function user.Fn$stream() -> baml.llm.Stream {
+    alloc_instance baml.llm.Client
+    load_const "openai/gpt-4o"
+    init_field .name
+    load_const null
+    init_field .client_type
+    alloc_array 0
+    init_field .sub_clients
+    load_const null
+    init_field .retry
+    load_const 0
+    init_field .counter
+    load_const "Fn"
+    alloc_map 0
+    call baml.llm.parse
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -68,21 +68,7 @@ function user.Fn$parse(json: string) -> string {
 function user.Fn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream {
     load_var sse
     load_const "Fn"
-    alloc_instance baml.llm.Client
-    load_const "openai/gpt-4o"
-    init_field .name
     load_const null
-    load_const "Primitive"
-    load_map_element
-    init_field .client_type
-    alloc_array 0
-    init_field .sub_clients
-    load_const null
-    init_field .retry
-    load_const 0
-    init_field .counter
-    load_const "__make_stream"
-    load_map_element
     call_indirect
     return
 }
@@ -110,7 +96,8 @@ function user.Fn$stream() -> baml.llm.Stream {
     alloc_instance baml.llm.Client
     load_const "openai/gpt-4o"
     init_field .name
-    load_const null
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
     init_field .client_type
     alloc_array 0
     init_field .sub_clients
@@ -120,6 +107,6 @@ function user.Fn$stream() -> baml.llm.Stream {
     init_field .counter
     load_const "Fn"
     alloc_map 0
-    call baml.llm.parse
+    call baml.llm.stream_llm_function
     return
 }

--- a/baml_language/crates/baml_tests/src/compiler2_hir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_hir.rs
@@ -462,7 +462,8 @@ mod tests {
 
         // Five conflicts: greet, greet$render_prompt, greet$build_request,
         // greet$build_request_stream, greet$parse
-        // Each LLM function expands to companions, all duplicated across 3 files.
+        // Each LLM function expands to AST-level companions, all duplicated across 3 files.
+        // ($stream and $parse_stream are PPIR-level and don't appear here.)
         assert_eq!(ns.conflicts().len(), 5);
         for conflict in ns.conflicts() {
             assert_eq!(conflict.entries.len(), 3);

--- a/baml_language/crates/baml_tests/src/compiler2_hir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_hir.rs
@@ -460,9 +460,10 @@ mod tests {
         // First wins
         assert!(ns.values.contains_key(&Name::new("greet")));
 
-        // Four conflicts: greet, greet$render_prompt, greet$build_request, greet$parse
+        // Five conflicts: greet, greet$render_prompt, greet$build_request,
+        // greet$build_request_stream, greet$parse
         // Each LLM function expands to companions, all duplicated across 3 files.
-        assert_eq!(ns.conflicts().len(), 4);
+        assert_eq!(ns.conflicts().len(), 5);
         for conflict in ns.conflicts() {
             assert_eq!(conflict.entries.len(), 3);
         }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/compiler2_tir/phase5.rs
-assertion_line: 389
 expression: output
 ---
 namespace baml:
@@ -50,7 +49,7 @@ namespace baml.llm:
   class AnthropicOptions { methods: [] }
   class AzureOpenAiOptions { methods: [] }
   class BedrockOptions { methods: [] }
-  class Client { methods: [to_primitive_client, get_constructor, build_attempt, build_attempt_with_state, build_plan, build_plan_with_state, execute_stream, execute_once_stream, execute_oneshot, execute_once_oneshot] }
+  class Client { methods: [to_primitive_client, get_constructor, build_attempt, build_attempt_with_state, build_plan, build_plan_with_state, execute_stream, execute_once_stream, __make_stream, execute_oneshot, execute_once_oneshot] }
   enum ClientType
   class ExecutionContext { methods: [] }
   class MediaUrlHandler { methods: [] }
@@ -67,6 +66,7 @@ namespace baml.llm:
   function __sap_parse_final<T, S>
   function __sap_parse_partial<T, S>
   function build_request
+  function build_request_stream
   function call_llm_function<T>
   function from_shorthand
   function get_jinja_template

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
-assertion_line: 42
 ---
 function assert.contains(haystack: string, needle: string) -> null {
   28   0    load_var 1             (haystack)
@@ -393,7 +392,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 
   164   49    load_var 12            (sub)
         50    load_var 2             (name)
-        51    call 155               (testing.TestRegistry.expand_set)
+        51    call 157               (testing.TestRegistry.expand_set)
         52    jump +49               (to 101)
 
   144   53    load_var 3             (_3)
@@ -455,7 +454,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         98    pop 1                  
 
   157   99    load_var 1             (self)
-        100   call 163               (testing.TestRegistry.serialize)
+        100   call 165               (testing.TestRegistry.serialize)
         101   return                 
 }
 
@@ -533,7 +532,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
 
   135   49   load_var 9             (sub)
         50   load_var 2             (name)
-        51   call 165               (testing.TestRegistry.run_test)
+        51   call 167               (testing.TestRegistry.run_test)
         52   jump +21               (to 73)
 
   124   53   load_var 3             (_3)
@@ -558,7 +557,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         69   load_field 1           (body)
         70   load_var 5             (t)
         71   load_field 2           (runner)
-        72   call 164               (testing.run_test)
+        72   call 166               (testing.run_test)
         73   return                 
 }
 
@@ -635,7 +634,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         60   store_var 10            (_25)
 
   110   61   load_var 9              (sub)
-        62   call 163                (testing.TestRegistry.serialize)
+        62   call 165                (testing.TestRegistry.serialize)
         63   store_var 11            (_26)
 
   108   64   load_var 2              (items)
@@ -682,7 +681,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   173   3    load_var 1             (body)
-        4    make_closure 331 1     
+        4    make_closure 333 1     
         5    store_var 3            (base_run)
 
   188   6    load_var 2             (runner)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
-assertion_line: 43
 ---
 function assert.contains(haystack: string, needle: string) -> null {
   28   0    load_var 1             (haystack)
@@ -401,7 +400,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 
   164   49    load_var 13            (sub)
         50    load_var 2             (name)
-        51    call 155               (testing.TestRegistry.expand_set)
+        51    call 157               (testing.TestRegistry.expand_set)
         52    jump +51               (to 103)
 
   144   53    load_var 3             (_3)
@@ -465,7 +464,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         100   pop 1                  
 
   157   101   load_var 1             (self)
-        102   call 163               (testing.TestRegistry.serialize)
+        102   call 165               (testing.TestRegistry.serialize)
         103   return                 
 }
 
@@ -545,7 +544,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
 
   135   49   load_var 9             (sub)
         50   load_var 2             (name)
-        51   call 165               (testing.TestRegistry.run_test)
+        51   call 167               (testing.TestRegistry.run_test)
         52   jump +21               (to 73)
 
   124   53   load_var 3             (_3)
@@ -570,7 +569,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         69   load_field 1           (body)
         70   load_var 5             (t)
         71   load_field 2           (runner)
-        72   call 164               (testing.run_test)
+        72   call 166               (testing.run_test)
         73   return                 
 }
 
@@ -649,7 +648,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         62   store_var 12            (_25)
 
   110   63   load_var 11             (sub)
-        64   call 163                (testing.TestRegistry.serialize)
+        64   call 165                (testing.TestRegistry.serialize)
         65   store_var 13            (_26)
 
   108   66   load_var 3              (items)
@@ -699,7 +698,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1             
 
   173   3    load_var 1              (body)
-        4    make_closure 331 1      
+        4    make_closure 333 1      
         5    store_var 3             (base_run)
 
   188   6    load_var 2              (runner)

--- a/baml_language/crates/bridge_wasm/src/registry.rs
+++ b/baml_language/crates/bridge_wasm/src/registry.rs
@@ -21,7 +21,6 @@ use std::{
 
 use futures::stream::Stream;
 use js_sys::Promise;
-use sys_types::sse::SseParser;
 
 use crate::send_wrapper::SendWrapper;
 
@@ -112,22 +111,21 @@ impl Drop for WasmResponseBody {
 /// On WASM, this wraps a browser `ReadableStream` via reqwest's WASM backend.
 pub(crate) type ByteStream = Pin<Box<dyn Stream<Item = Result<bytes::Bytes, reqwest::Error>>>>;
 
-/// Mutable state for an active SSE stream.
-struct SseStreamInner {
-    stream: Option<ByteStream>,
-    parser: SseParser,
-    done: bool,
-}
+/// Channel receiver type for SSE events.
+pub(crate) type SseEventReceiver =
+    futures::channel::mpsc::UnboundedReceiver<Result<sys_types::sse::SseEvent, String>>;
 
 /// Opaque handle stored in `owned::http::SseStream._handle`.
 ///
-/// Contains the reqwest byte stream and SSE parser. The entire struct is
-/// wrapped in `SendWrapper` so it satisfies `Send + Sync` on the
-/// single-threaded WASM target.
+/// A background task (spawned via `wasm_bindgen_futures::spawn_local`) reads
+/// from the byte stream, parses SSE events, and sends them through an mpsc
+/// channel. `next()` drains available events from the receiver.
+///
+/// Dropping the receiver (via `close()` / `mark_done()`) signals the
+/// background task to exit on its next send attempt.
 pub(crate) struct WasmSseStreamHandle {
-    /// Interior-mutable state. `SendWrapper` provides the required
-    /// `Send + Sync` impls for WASM's single-threaded runtime.
-    inner: SendWrapper<RefCell<SseStreamInner>>,
+    /// Channel receiver for parsed SSE events. `None` after `close()`.
+    receiver: SendWrapper<RefCell<Option<SseEventReceiver>>>,
 }
 
 // SAFETY: wasm32-unknown-unknown is single-threaded.
@@ -135,55 +133,27 @@ unsafe impl Send for WasmSseStreamHandle {}
 unsafe impl Sync for WasmSseStreamHandle {}
 
 impl WasmSseStreamHandle {
-    pub(crate) fn new(stream: ByteStream) -> Self {
+    pub(crate) fn new(receiver: SseEventReceiver) -> Self {
         Self {
-            inner: SendWrapper::new(RefCell::new(SseStreamInner {
-                stream: Some(stream),
-                parser: SseParser::new(),
-                done: false,
-            })),
+            receiver: SendWrapper::new(RefCell::new(Some(receiver))),
         }
     }
 
-    /// Take the byte stream and parser out for async use by `next()`.
-    ///
-    /// Returns `None` if already done or if the stream was already taken.
-    pub(crate) fn take_stream(&self) -> Option<(ByteStream, SseParser)> {
-        let mut inner = self.inner.borrow_mut();
-        if inner.done {
-            return None;
-        }
-        let stream = inner.stream.take()?;
-        let parser = std::mem::replace(&mut inner.parser, SseParser::new());
-        Some((stream, parser))
-    }
-
-    /// Return the byte stream and parser after `next()` is done.
-    ///
-    /// If the stream was marked done while checked out (e.g., by concurrent
-    /// `close()` / `mark_done()`), drop the resources instead of reviving them —
-    /// once done, the stream stays done.
-    pub(crate) fn return_stream(&self, stream: ByteStream, parser: SseParser) {
-        let mut inner = self.inner.borrow_mut();
-        if inner.done {
-            drop(stream);
-            drop(parser);
-            return;
-        }
-        inner.stream = Some(stream);
-        inner.parser = parser;
-    }
-
-    /// Mark the stream as done (no more events will be produced).
-    pub(crate) fn mark_done(&self) {
-        let mut inner = self.inner.borrow_mut();
-        inner.done = true;
-        // Drop the stream to abort any in-flight fetch.
-        inner.stream.take();
-    }
-
-    /// Returns true if the stream has been marked done.
+    /// Returns true if the stream has been closed (receiver dropped).
     pub(crate) fn is_done(&self) -> bool {
-        self.inner.borrow().done
+        self.receiver.borrow().is_none()
+    }
+
+    /// Close the stream by dropping the receiver.
+    ///
+    /// The background task will detect the closed channel on its next send
+    /// and exit.
+    pub(crate) fn mark_done(&self) {
+        self.receiver.borrow_mut().take();
+    }
+
+    /// Borrow the inner `RefCell` for synchronous drain and poll operations.
+    pub(crate) fn receiver_ref(&self) -> &RefCell<Option<SseEventReceiver>> {
+        self.receiver.inner()
     }
 }

--- a/baml_language/crates/bridge_wasm/src/wasm_http.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_http.rs
@@ -242,75 +242,60 @@ impl io::IoClassHttpSseStream for WasmHttp {
             return SysOpOutput::ok(None);
         }
 
-        let Some((stream, parser)) = handle.take_stream() else {
-            return SysOpOutput::ok(None);
-        };
+        // Try to drain available events synchronously first (no async needed).
+        match drain_receiver(&handle) {
+            DrainResult::Events(events) => {
+                return match serialize_sse_events(events) {
+                    Ok(json) => SysOpOutput::ok(Some(json)),
+                    Err(e) => SysOpOutput::err(e),
+                };
+            }
+            DrainResult::Error(e) => {
+                return SysOpOutput::err(OpErrorKind::Other(format!("SSE stream error: {e}")));
+            }
+            DrainResult::Done => {
+                return SysOpOutput::ok(None);
+            }
+            DrainResult::Empty => {
+                // No events available — need to await.
+            }
+        }
 
+        // No events ready — await the next one. We use poll_fn to borrow
+        // the receiver only during poll (not across await points), so there
+        // is no take/return pattern that could break on re-entrant calls.
         SysOpOutput::Async(Box::pin(SendFuture(async move {
-            use futures::StreamExt;
+            use futures::stream::StreamExt;
 
-            let mut stream = stream;
-            let mut parser = parser;
+            let event = futures::future::poll_fn(|cx| {
+                let mut guard = handle.receiver_ref().borrow_mut();
+                let Some(receiver) = guard.as_mut() else {
+                    return std::task::Poll::Ready(None);
+                };
+                receiver.poll_next_unpin(cx)
+            })
+            .await;
 
-            loop {
-                let polled = stream.next().await;
-                // close() / mark_done() may have fired while we were awaiting.
-                // Discard whatever this poll produced and report end-of-stream —
-                // returning buffered events after done==true would violate the
-                // "close means no more events" invariant.
-                if handle.is_done() {
-                    return Ok(None);
+            match event {
+                Some(Ok(first)) => {
+                    let mut events = vec![first];
+                    // Drain any additional events that arrived while we were awaiting.
+                    match drain_receiver(&handle) {
+                        DrainResult::Events(more) => events.extend(more),
+                        DrainResult::Error(e) => {
+                            return Err(OpErrorKind::Other(format!("SSE stream error: {e}")));
+                        }
+                        DrainResult::Done | DrainResult::Empty => {}
+                    }
+                    Ok(Some(serialize_sse_events(events)?))
                 }
-                match polled {
-                    Some(Ok(bytes)) => {
-                        let events = parser.feed(&bytes);
-                        if !events.is_empty() {
-                            let json_events: Vec<serde_json::Value> = events
-                                .into_iter()
-                                .map(|e| {
-                                    serde_json::json!({
-                                        "event": e.event,
-                                        "data": e.data,
-                                        "id": e.id,
-                                    })
-                                })
-                                .collect();
-                            let json = serde_json::to_string(&json_events).map_err(|e| {
-                                OpErrorKind::Other(format!("Failed to serialize SSE events: {e}"))
-                            })?;
-                            // Return the stream + parser for future next() calls.
-                            handle.return_stream(stream, parser);
-                            return Ok(Some(json));
-                        }
-                        // No complete events yet — continue reading.
-                    }
-                    Some(Err(e)) => {
-                        handle.mark_done();
-                        return Err(OpErrorKind::Other(format!("SSE stream error: {e}")));
-                    }
-                    None => {
-                        // Stream ended. Flush any event buffered without a
-                        // trailing blank line.
-                        let final_events = parser.finish();
-                        handle.mark_done();
-                        if final_events.is_empty() {
-                            return Ok(None);
-                        }
-                        let json_events: Vec<serde_json::Value> = final_events
-                            .into_iter()
-                            .map(|e| {
-                                serde_json::json!({
-                                    "event": e.event,
-                                    "data": e.data,
-                                    "id": e.id,
-                                })
-                            })
-                            .collect();
-                        let json = serde_json::to_string(&json_events).map_err(|e| {
-                            OpErrorKind::Other(format!("Failed to serialize SSE events: {e}"))
-                        })?;
-                        return Ok(Some(json));
-                    }
+                Some(Err(e)) => {
+                    handle.mark_done();
+                    Err(OpErrorKind::Other(format!("SSE stream error: {e}")))
+                }
+                None => {
+                    handle.mark_done();
+                    Ok(None)
                 }
             }
         })))
@@ -323,12 +308,113 @@ impl io::IoClassHttpSseStream for WasmHttp {
         sse_stream: io::owned::http::SseStream,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        // Mark done and drop the stream, which aborts the underlying fetch.
+        // Drop the receiver, which signals the background task to exit.
         if let Some(handle) = sse_stream._handle.downcast_ref::<WasmSseStreamHandle>() {
             handle.mark_done();
         }
-        // sse_stream drops here, which drops the Arc<WasmSseStreamHandle>.
         SysOpOutput::ok(())
+    }
+}
+
+/// Result of a synchronous drain attempt on the receiver.
+enum DrainResult {
+    /// Got one or more events.
+    Events(Vec<sys_types::sse::SseEvent>),
+    /// Background task sent an error.
+    Error(String),
+    /// Channel closed — stream is done.
+    Done,
+    /// No events available yet (channel still open).
+    Empty,
+}
+
+/// Drain all currently available events from the handle's receiver without blocking.
+fn drain_receiver(handle: &WasmSseStreamHandle) -> DrainResult {
+    let mut guard = handle.receiver_ref().borrow_mut();
+    let Some(receiver) = guard.as_mut() else {
+        return DrainResult::Done;
+    };
+
+    let mut events = Vec::new();
+    loop {
+        match receiver.try_recv() {
+            Ok(Ok(event)) => events.push(event),
+            Ok(Err(e)) => {
+                // Drop receiver to signal background task.
+                guard.take();
+                return DrainResult::Error(e);
+            }
+            Err(futures::channel::mpsc::TryRecvError::Closed) => {
+                guard.take();
+                if events.is_empty() {
+                    return DrainResult::Done;
+                }
+                return DrainResult::Events(events);
+            }
+            Err(futures::channel::mpsc::TryRecvError::Empty) => {
+                if events.is_empty() {
+                    return DrainResult::Empty;
+                }
+                return DrainResult::Events(events);
+            }
+        }
+    }
+}
+
+/// Serialize a batch of SSE events to JSON.
+fn serialize_sse_events(events: Vec<sys_types::sse::SseEvent>) -> Result<String, OpErrorKind> {
+    let json_events: Vec<serde_json::Value> = events
+        .into_iter()
+        .map(|e| {
+            serde_json::json!({
+                "event": e.event,
+                "data": e.data,
+                "id": e.id,
+            })
+        })
+        .collect();
+    serde_json::to_string(&json_events)
+        .map_err(|e| OpErrorKind::Other(format!("Failed to serialize SSE events: {e}")))
+}
+
+/// Background task that reads from a byte stream, parses SSE events, and sends
+/// them through the channel. Exits when the stream ends, errors, or the
+/// receiver is dropped (channel closed).
+async fn sse_background_task(
+    byte_stream: crate::registry::ByteStream,
+    sender: futures::channel::mpsc::UnboundedSender<Result<sys_types::sse::SseEvent, String>>,
+) {
+    use futures::StreamExt;
+
+    let mut stream = byte_stream;
+    let mut parser = sys_types::sse::SseParser::new();
+
+    loop {
+        match stream.next().await {
+            Some(Ok(bytes)) => {
+                let events = parser.feed(&bytes);
+                for event in events {
+                    if sender.unbounded_send(Ok(event)).is_err() {
+                        // Receiver dropped — stream was closed.
+                        return;
+                    }
+                }
+            }
+            Some(Err(e)) => {
+                let _ = sender.unbounded_send(Err(format!("{e}")));
+                return;
+            }
+            None => {
+                // Stream ended. Flush any buffered event without a trailing blank line.
+                let final_events = parser.finish();
+                for event in final_events {
+                    if sender.unbounded_send(Ok(event)).is_err() {
+                        return;
+                    }
+                }
+                return;
+            }
+        }
     }
 }
 
@@ -400,8 +486,13 @@ impl IoNamespaceHttp for WasmHttp {
 
             let url = response.url().to_string();
             let byte_stream = Box::pin(response.bytes_stream());
+
+            // Create channel and spawn background task to parse SSE events.
+            let (sender, receiver) = futures::channel::mpsc::unbounded();
+            wasm_bindgen_futures::spawn_local(sse_background_task(byte_stream, sender));
+
             let handle: Arc<dyn std::any::Any + Send + Sync> =
-                Arc::new(WasmSseStreamHandle::new(byte_stream));
+                Arc::new(WasmSseStreamHandle::new(receiver));
 
             Ok(io::owned::http::SseStream {
                 url,


### PR DESCRIPTION
- `*$build_request_stream` companion functions which build a request for SSE (streaming version of `*$build_request`)
- `*$stream` companion functions which return a `baml.llm.Stream` and stream the parsed result (streaming version of normal function call)
- Run SSE stream parser in a separate WASM task (on event loop). This deals with some synchronization issues, allowing the receiver to just grab all the ready events if there are some.
- Fix calling bug where incorrect expression indices would be used due to HIR being used (instead of PPIR)
- `log` package is a dependency of `baml` instead of the other way around. This allows `baml` standard library to do logging (for debugging or other things)
- Currently streaming does not fully work due to a `match` bug, but that is an external issue. The individual streaming parts seem to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming request building with new helper functionality.

* **Bug Fixes & Improvements**
  * Enhanced streaming architecture with improved event handling and synchronization.
  * Refactored streaming infrastructure to support more efficient event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->