### PR TITLE
[codex] Fix async future handling across GC

### DIFF
--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -82,6 +82,7 @@ use ::core::sync::atomic::AtomicBool;
 use async_trait::async_trait;
 use bex_events::{EventKind, FunctionEnd, FunctionEvent, FunctionStart, SpanContext};
 pub use bex_events::{HostSpanContext, RuntimeEvent, SpanId};
+use bex_external_types::Handle;
 pub use bex_external_types::{BexExternalValue, EpochGuard, Ty, TypeName, UnionMetadata};
 use bex_heap::BexHeap;
 // Re-export GcStats for users of the engine
@@ -116,8 +117,12 @@ pub struct UserFunctionInfo {
 }
 
 /// Result of an external future.
+///
+/// We carry a GC-stable handle rather than a raw `HeapPtr` because the VM can
+/// hit a GC safepoint while awaiting the result. The handle resolves to the
+/// future's current location when the async task completes.
 struct FutureResult {
-    id: HeapPtr,
+    id: Handle,
     result: Result<BexExternalValue, EngineError>,
 }
 
@@ -194,6 +199,9 @@ pub enum EngineError {
 
     #[error("Future channel closed unexpectedly")]
     FutureChannelClosed,
+
+    #[error("Future handle {slab_key} became invalid during execution")]
+    FutureHandleInvalid { slab_key: usize },
 
     #[error("VM internal error: {0}")]
     VmInternalError(bex_vm::errors::VmInternalError),
@@ -1185,6 +1193,17 @@ impl BexEngine {
         Ok(())
     }
 
+    fn resolve_future_handle(
+        vm: &ActiveHeapPermit<BexVm>,
+        future: &Handle,
+    ) -> Result<HeapPtr, EngineError> {
+        future
+            .object_ptr(&vm.epoch_guard())
+            .ok_or(EngineError::FutureHandleInvalid {
+                slab_key: future.slab_key(),
+            })
+    }
+
     /// Drive the VM to completion, dispatching sys-ops, awaits, span
     /// notifications, and early-yield events.
     ///
@@ -1362,6 +1381,7 @@ impl BexEngine {
                             Self::cancellation_safepoint(cancel, &abort_handles)?;
 
                             // Async operation — wrap in Abortable and spawn.
+                            let future_handle = self.heap.create_handle(id);
                             let pending_futures = pending_futures.clone();
                             let (abort_handle, abort_reg) =
                                 futures::future::AbortHandle::new_pair();
@@ -1369,7 +1389,7 @@ impl BexEngine {
                                 async move {
                                     let result = fut.await;
                                     let _ = pending_futures.send(FutureResult {
-                                        id,
+                                        id: future_handle,
                                         result: result.map_err(EngineError::from),
                                     });
                                 },
@@ -1389,17 +1409,21 @@ impl BexEngine {
                 }
 
                 VmExecState::Await(future_id) => {
+                    let awaited_future = self.heap.create_handle(future_id);
                     Self::cancellation_safepoint(cancel, &abort_handles)?;
                     vm = self.gc_safepoint(vm).await;
 
                     // First, drain any already-completed futures.
                     while let Ok(future) = processed_futures.try_recv() {
+                        let future_ptr = Self::resolve_future_handle(&vm, &future.id)?;
+                        let awaited_future_ptr =
+                            Self::resolve_future_handle(&vm, &awaited_future)?;
                         let external = future.result?;
                         let value = self.convert_external_to_vm_value(&mut vm, external);
-                        vm.fulfil_future(future.id, value)
+                        vm.fulfil_future(future_ptr, value)
                             .map_err(EngineError::VmInternalError)?;
 
-                        if future.id == future_id {
+                        if future_ptr == awaited_future_ptr {
                             continue 'vm_exec;
                         }
                     }
@@ -1419,15 +1443,18 @@ impl BexEngine {
                             future = processed_futures.recv() => {
                                 let future = future
                                     .ok_or(EngineError::FutureChannelClosed)?;
+                                let future_ptr = Self::resolve_future_handle(&vm, &future.id)?;
+                                let awaited_future_ptr =
+                                    Self::resolve_future_handle(&vm, &awaited_future)?;
                                 let external = future.result?;
                                 let value = self.convert_external_to_vm_value(
                                     &mut vm,
                                     external,
                                 );
-                                vm.fulfil_future(future.id, value)
+                                vm.fulfil_future(future_ptr, value)
                                     .map_err(EngineError::VmInternalError)?;
 
-                                if future.id == future_id {
+                                if future_ptr == awaited_future_ptr {
                                     break;
                                 }
                             }

--- a/baml_language/crates/bex_engine/tests/early_yield.rs
+++ b/baml_language/crates/bex_engine/tests/early_yield.rs
@@ -266,3 +266,34 @@ async fn objects_allocated_after_mid_call_gc_survive() {
         "post-GC allocations must not corrupt pre-GC ones, and vice versa"
     );
 }
+
+/// Regression test for async future completion across a GC triggered at the
+/// `Await` safepoint. The loop creates enough allocation pressure to force a
+/// minor collection right before the engine blocks on `sleep()`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sleep_future_survives_gc_safepoint() {
+    let source = r#"
+        function alloc_then_sleep(n: int) -> int {
+            let i = 0;
+            while (i < n) {
+                let _ = [i, i + 1, i + 2];
+                i += 1;
+            }
+            baml.sys.sleep(1);
+            42
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let value = engine
+        .call_function(
+            "alloc_then_sleep",
+            vec![BexExternalValue::Int(12_000)],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("sleep future must survive the GC safepoint");
+
+    assert_eq!(value, BexExternalValue::Int(42));
+}


### PR DESCRIPTION
## Summary
- keep in-flight async futures GC-stable in `bex_engine` by storing handles instead of raw `HeapPtr`s
- resolve the current future pointer from the handle before calling `set_future_ready` / `fulfil_future`
- add an `early_yield` regression test that forces allocation pressure before `baml.sys.sleep(1)` completes

## Root cause
The engine was carrying raw `HeapPtr`s for async futures outside the VM while the VM could hit a GC safepoint during `Await`. If GC moved the future object before the async sys-op completed, the engine later called `fulfil_future` with a stale pointer. That stale pointer could then drop the wrong `PendingFuture`, which matches the nondeterministic libmalloc abort seen in the VM double-free repro.

## Impact
This removes a GC-sensitive use-after-move in the async future fulfillment path. The practical effect is that long-running async/sys-op flows should stop aborting when a future completes after GC has run.

## Validation
- `cargo test -p bex_engine --manifest-path baml_language/Cargo.toml --test early_yield -- --nocapture`
- `cargo test -p bex_engine --manifest-path baml_language/Cargo.toml --test early_yield sleep_future_survives_gc_safepoint -- --nocapture`
- `cargo build -p baml_cli --manifest-path baml_language/Cargo.toml`
- manually reran a minimal `baml-cli run` repro that allocates, awaits `baml.sys.sleep(1)`, and completed successfully across repeated runs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the engine’s async/await fulfillment path and GC coordination by changing how future identities are tracked, which could impact correctness under load or cancellation. Changes are localized and include a regression test covering the previously failing GC-at-`Await` scenario.
> 
> **Overview**
> Fixes async sys-op future completion across GC safepoints by storing a GC-stable `Handle` (not a raw `HeapPtr`) for in-flight futures and resolving the current pointer right before `set_future_ready`/`fulfil_future`.
> 
> Adds a new engine error (`FutureHandleInvalid`) for cases where a future handle can no longer be resolved, and introduces an `early_yield` regression test (`sleep_future_survives_gc_safepoint`) that forces allocation pressure before awaiting `baml.sys.sleep(1)` to ensure futures survive a GC at `Await`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933b2afe6543ae891adec9ba24a188e7d156b0ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->