### PR TITLE
fix(bex_engine): substitute placeholder for non-convertible trace payload leaves

### DIFF
--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -361,7 +361,17 @@ impl BexEngine {
             Value::Bool(b) => BexExternalValue::Bool(*b),
             Value::Object(ptr) => BexValue::HeapPtr(ptr)
                 .as_owned_for_trace(&self.heap, permit)
-                .unwrap_or(BexExternalValue::Null),
+                .unwrap_or_else(|e| {
+                    // Remaining errors here (InvalidHandle, TypeMismatch,
+                    // FieldNotFound) indicate engine-level invariant
+                    // violations — they shouldn't happen in normal operation.
+                    // Surface via structured tracing rather than stderr so
+                    // they're visible in logs without polluting CLI output,
+                    // and embed the error in the trace payload so it shows
+                    // up wherever traces are consumed.
+                    tracing::error!(error = %e, "trace payload deep-copy failed");
+                    BexExternalValue::String(format!("<trace-error: {e}>"))
+                }),
         }
     }
 

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -360,14 +360,8 @@ impl BexEngine {
             Value::Float(f) => BexExternalValue::Float(*f),
             Value::Bool(b) => BexExternalValue::Bool(*b),
             Value::Object(ptr) => BexValue::HeapPtr(ptr)
-                .as_owned_but_very_slow(&self.heap, permit)
-                .unwrap_or_else(|_| {
-                    #[allow(clippy::print_stderr)]
-                    {
-                        eprintln!("Failed to deep-copy VM value for trace payload");
-                    }
-                    BexExternalValue::Null
-                }),
+                .as_owned_for_trace(&self.heap, permit)
+                .unwrap_or(BexExternalValue::Null),
         }
     }
 

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -472,209 +472,215 @@ impl<'a> BexValue<'a> {
 
     /// Attempts to own as much as possible.
     /// If it can't be owned, it fails.
-    #[allow(clippy::only_used_in_recursion)]
     pub fn as_owned_but_very_slow(
         self,
         heap: &BexHeap,
-        permit: PermitProof<'_>,
+        _permit: PermitProof<'_>,
     ) -> Result<BexExternalValue, AccessError> {
-        match self {
-            BexValue::ExternalValue(bex_external_value) => match bex_external_value {
-                BexExternalValue::Handle(handle) => {
-                    let heap_ptr = heap
-                        .resolve_handle_ptr(handle.slab_key())
-                        .ok_or(AccessError::InvalidHandle { expected: "handle" })?;
-                    BexValue::HeapPtr(&heap_ptr).as_owned_but_very_slow(heap, permit)
-                }
-                BexExternalValue::FunctionRef { .. } => Err(AccessError::CannotConvertToOwned {
-                    reason: "function definition".to_string(),
-                }),
-                BexExternalValue::Null => Ok(BexExternalValue::Null),
-                BexExternalValue::Int(i) => Ok(BexExternalValue::Int(*i)),
-                BexExternalValue::Float(f) => Ok(BexExternalValue::Float(*f)),
-                BexExternalValue::Bool(b) => Ok(BexExternalValue::Bool(*b)),
-                BexExternalValue::String(s) => Ok(BexExternalValue::String(s.clone())),
-                BexExternalValue::Array {
-                    element_type,
-                    items,
-                } => Ok(BexExternalValue::Array {
-                    element_type: element_type.clone(),
-                    items: items
+        // `_permit` is a zero-sized witness that GC exclusion is held; we don't
+        // need to thread it through the recursion since the proof only has to
+        // exist at the API boundary.
+        owned_inner(self, heap, /* lossy */ false)
+    }
+
+    /// Like `as_owned_but_very_slow`, but substitutes non-convertible leaves
+    /// (closures, functions, futures, bound methods, cells, function refs,
+    /// class/enum definitions) with a `<kind>` string placeholder rather than
+    /// failing the entire conversion.
+    ///
+    /// Use this for trace event payloads, where dropping the whole tree because
+    /// a single field happens to hold a closure is worse than emitting partial
+    /// data with a stub.
+    pub fn as_owned_for_trace(
+        self,
+        heap: &BexHeap,
+        _permit: PermitProof<'_>,
+    ) -> Result<BexExternalValue, AccessError> {
+        owned_inner(self, heap, /* lossy */ true)
+    }
+}
+
+fn owned_inner(
+    value: BexValue<'_>,
+    heap: &BexHeap,
+    lossy: bool,
+) -> Result<BexExternalValue, AccessError> {
+    let unconvertible = |reason: &str| -> Result<BexExternalValue, AccessError> {
+        if lossy {
+            Ok(BexExternalValue::String(format!("<{reason}>")))
+        } else {
+            Err(AccessError::CannotConvertToOwned {
+                reason: reason.to_string(),
+            })
+        }
+    };
+
+    match value {
+        BexValue::ExternalValue(bex_external_value) => match bex_external_value {
+            BexExternalValue::Handle(handle) => {
+                let heap_ptr = heap
+                    .resolve_handle_ptr(handle.slab_key())
+                    .ok_or(AccessError::InvalidHandle { expected: "handle" })?;
+                owned_inner(BexValue::HeapPtr(&heap_ptr), heap, lossy)
+            }
+            BexExternalValue::FunctionRef { .. } => unconvertible("function"),
+            BexExternalValue::Null => Ok(BexExternalValue::Null),
+            BexExternalValue::Int(i) => Ok(BexExternalValue::Int(*i)),
+            BexExternalValue::Float(f) => Ok(BexExternalValue::Float(*f)),
+            BexExternalValue::Bool(b) => Ok(BexExternalValue::Bool(*b)),
+            BexExternalValue::String(s) => Ok(BexExternalValue::String(s.clone())),
+            BexExternalValue::Array {
+                element_type,
+                items,
+            } => Ok(BexExternalValue::Array {
+                element_type: element_type.clone(),
+                items: items
+                    .iter()
+                    .map(|item| owned_inner(BexValue::ExternalValue(item), heap, lossy))
+                    .collect::<Result<_, _>>()?,
+            }),
+            BexExternalValue::Map {
+                key_type,
+                value_type,
+                entries,
+            } => Ok(BexExternalValue::Map {
+                key_type: key_type.clone(),
+                value_type: value_type.clone(),
+                entries: entries
+                    .iter()
+                    .map(|(k, v)| {
+                        Ok((
+                            k.clone(),
+                            owned_inner(BexValue::ExternalValue(v), heap, lossy)?,
+                        ))
+                    })
+                    .collect::<Result<_, _>>()?,
+            }),
+            BexExternalValue::Instance { class_name, fields } => Ok(BexExternalValue::Instance {
+                class_name: class_name.clone(),
+                fields: fields
+                    .iter()
+                    .map(|(k, v)| {
+                        Ok((
+                            k.clone(),
+                            owned_inner(BexValue::ExternalValue(v), heap, lossy)?,
+                        ))
+                    })
+                    .collect::<Result<_, _>>()?,
+            }),
+            BexExternalValue::Variant {
+                enum_name,
+                variant_name,
+            } => Ok(BexExternalValue::Variant {
+                enum_name: enum_name.clone(),
+                variant_name: variant_name.clone(),
+            }),
+            BexExternalValue::Union { value, metadata } => Ok(BexExternalValue::Union {
+                value: Box::new(owned_inner(BexValue::ExternalValue(value), heap, lossy)?),
+                metadata: metadata.clone(),
+            }),
+            BexExternalValue::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.clone())),
+            BexExternalValue::RustData(data) => {
+                Ok(BexExternalValue::RustData(std::sync::Arc::clone(data)))
+            }
+            BexExternalValue::Adt(adt) => Ok(BexExternalValue::Adt(adt.clone())),
+        },
+        BexValue::Value(Value::Object(heap_ptr)) | BexValue::HeapPtr(heap_ptr) => {
+            let obj = unsafe { heap_ptr.get() };
+            match obj {
+                Object::Function(..) => unconvertible("function"),
+                Object::Class(..) => unconvertible("class"),
+                Object::Enum(..) => unconvertible("enum"),
+                Object::Future(..) => unconvertible("future"),
+
+                Object::String(s) => Ok(BexExternalValue::String(s.clone())),
+                // Deep-copy path for trace payloads: no declared type is available here,
+                // so placeholder types with default attr are used.
+                Object::Array(array) => Ok(BexExternalValue::Array {
+                    element_type: Ty::BuiltinUnknown {
+                        attr: baml_type::TyAttr::default(),
+                    },
+                    items: array
                         .iter()
-                        .map(|item| {
-                            BexValue::ExternalValue(item).as_owned_but_very_slow(heap, permit)
-                        })
+                        .map(|item| owned_inner(BexValue::Value(item), heap, lossy))
                         .collect::<Result<_, _>>()?,
                 }),
-                BexExternalValue::Map {
-                    key_type,
-                    value_type,
-                    entries,
-                } => Ok(BexExternalValue::Map {
-                    key_type: key_type.clone(),
-                    value_type: value_type.clone(),
-                    entries: entries
+                Object::Map(map) => Ok(BexExternalValue::Map {
+                    key_type: Ty::String {
+                        attr: baml_type::TyAttr::default(),
+                    },
+                    value_type: Ty::BuiltinUnknown {
+                        attr: baml_type::TyAttr::default(),
+                    },
+                    entries: map
                         .iter()
                         .map(|(k, v)| {
-                            Ok((
-                                k.clone(),
-                                BexValue::ExternalValue(v).as_owned_but_very_slow(heap, permit)?,
-                            ))
+                            Ok((k.clone(), owned_inner(BexValue::Value(v), heap, lossy)?))
                         })
                         .collect::<Result<_, _>>()?,
                 }),
-                BexExternalValue::Instance { class_name, fields } => {
+                Object::Instance(instance) => {
+                    let class_obj = unsafe { instance.class.get() };
+                    let Object::Class(class) = class_obj else {
+                        return Err(AccessError::TypeMismatch {
+                            expected: "class",
+                            actual: class_obj.to_string(),
+                        });
+                    };
+                    let fields = class
+                        .fields
+                        .iter()
+                        .zip(instance.fields.iter())
+                        .map(|(field, value)| {
+                            Ok((
+                                field.name.clone(),
+                                owned_inner(BexValue::Value(value), heap, lossy)?,
+                            ))
+                        })
+                        .collect::<Result<_, _>>()?;
                     Ok(BexExternalValue::Instance {
-                        class_name: class_name.clone(),
-                        fields: fields
-                            .iter()
-                            .map(|(k, v)| {
-                                Ok((
-                                    k.clone(),
-                                    BexValue::ExternalValue(v)
-                                        .as_owned_but_very_slow(heap, permit)?,
-                                ))
-                            })
-                            .collect::<Result<_, _>>()?,
+                        class_name: class.name.to_string(),
+                        fields,
                     })
                 }
-                BexExternalValue::Variant {
-                    enum_name,
-                    variant_name,
-                } => Ok(BexExternalValue::Variant {
-                    enum_name: enum_name.clone(),
-                    variant_name: variant_name.clone(),
-                }),
-                BexExternalValue::Union { value, metadata } => Ok(BexExternalValue::Union {
-                    value: Box::new(
-                        BexValue::ExternalValue(value).as_owned_but_very_slow(heap, permit)?,
-                    ),
-                    metadata: metadata.clone(),
-                }),
-                BexExternalValue::Uint8Array(bytes) => {
-                    Ok(BexExternalValue::Uint8Array(bytes.clone()))
+                Object::Variant(variant) => {
+                    let variant_obj = unsafe { variant.enm.get() };
+                    let Object::Enum(enum_) = variant_obj else {
+                        return Err(AccessError::TypeMismatch {
+                            expected: "enum",
+                            actual: variant_obj.to_string(),
+                        });
+                    };
+                    let variant_def = enum_.variants.get(variant.index).ok_or_else(|| {
+                        AccessError::FieldNotFound {
+                            expected: format!("variant index {}", variant.index),
+                        }
+                    })?;
+                    Ok(BexExternalValue::Variant {
+                        enum_name: enum_.name.to_string(),
+                        variant_name: variant_def.name.clone(),
+                    })
                 }
-                BexExternalValue::RustData(data) => {
-                    Ok(BexExternalValue::RustData(std::sync::Arc::clone(data)))
+                Object::Collector(c) => {
+                    Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone())))
                 }
-                BexExternalValue::Adt(adt) => Ok(BexExternalValue::Adt(adt.clone())),
-            },
-            BexValue::Value(Value::Object(heap_ptr)) | BexValue::HeapPtr(heap_ptr) => {
-                let obj = unsafe { heap_ptr.get() };
-                match obj {
-                    Object::Function(..) => Err(AccessError::CannotConvertToOwned {
-                        reason: "function definition".to_string(),
-                    }),
-                    Object::Class(..) => Err(AccessError::CannotConvertToOwned {
-                        reason: "class definition".to_string(),
-                    }),
-                    Object::Enum(..) => Err(AccessError::CannotConvertToOwned {
-                        reason: "enum definition".to_string(),
-                    }),
-                    Object::Future(..) => Err(AccessError::CannotConvertToOwned {
-                        reason: "future".to_string(),
-                    }),
-
-                    Object::String(s) => Ok(BexExternalValue::String(s.clone())),
-                    // Deep-copy path for trace payloads: no declared type is available here,
-                    // so placeholder types with default attr are used.
-                    Object::Array(array) => Ok(BexExternalValue::Array {
-                        element_type: Ty::BuiltinUnknown {
-                            attr: baml_type::TyAttr::default(),
-                        },
-                        items: array
-                            .iter()
-                            .map(|item| BexValue::Value(item).as_owned_but_very_slow(heap, permit))
-                            .collect::<Result<_, _>>()?,
-                    }),
-                    Object::Map(map) => Ok(BexExternalValue::Map {
-                        key_type: Ty::String {
-                            attr: baml_type::TyAttr::default(),
-                        },
-                        value_type: Ty::BuiltinUnknown {
-                            attr: baml_type::TyAttr::default(),
-                        },
-                        entries: map
-                            .iter()
-                            .map(|(k, v)| {
-                                Ok((
-                                    k.clone(),
-                                    BexValue::Value(v).as_owned_but_very_slow(heap, permit)?,
-                                ))
-                            })
-                            .collect::<Result<_, _>>()?,
-                    }),
-                    Object::Instance(instance) => {
-                        let class_obj = unsafe { instance.class.get() };
-                        let Object::Class(class) = class_obj else {
-                            return Err(AccessError::TypeMismatch {
-                                expected: "class",
-                                actual: class_obj.to_string(),
-                            });
-                        };
-                        let fields = class
-                            .fields
-                            .iter()
-                            .zip(instance.fields.iter())
-                            .map(|(field, value)| {
-                                Ok((
-                                    field.name.clone(),
-                                    BexValue::Value(value).as_owned_but_very_slow(heap, permit)?,
-                                ))
-                            })
-                            .collect::<Result<_, _>>()?;
-                        Ok(BexExternalValue::Instance {
-                            class_name: class.name.to_string(),
-                            fields,
-                        })
-                    }
-                    Object::Variant(variant) => {
-                        let variant_obj = unsafe { variant.enm.get() };
-                        let Object::Enum(enum_) = variant_obj else {
-                            return Err(AccessError::TypeMismatch {
-                                expected: "enum",
-                                actual: variant_obj.to_string(),
-                            });
-                        };
-                        let variant_def = enum_.variants.get(variant.index).ok_or_else(|| {
-                            AccessError::FieldNotFound {
-                                expected: format!("variant index {}", variant.index),
-                            }
-                        })?;
-                        Ok(BexExternalValue::Variant {
-                            enum_name: enum_.name.to_string(),
-                            variant_name: variant_def.name.clone(),
-                        })
-                    }
-                    Object::Collector(c) => {
-                        Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone())))
-                    }
-                    Object::Type(ty) => {
-                        Ok(BexExternalValue::Adt(BexExternalAdt::Type((**ty).clone())))
-                    }
-                    Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.clone())),
-                    Object::RustData(data) => Ok(bex_external_types::try_convert_rust_data(data)
-                        .unwrap_or_else(|| BexExternalValue::RustData(data.clone()))),
-                    Object::Closure(_) => Err(AccessError::CannotConvertToOwned {
-                        reason: "closure".to_string(),
-                    }),
-                    Object::BoundMethod(_) => Err(AccessError::CannotConvertToOwned {
-                        reason: "bound_method".to_string(),
-                    }),
-                    Object::Cell(_) => Err(AccessError::CannotConvertToOwned {
-                        reason: "cell".to_string(),
-                    }),
-                    #[cfg(feature = "heap_debug")]
-                    Object::Sentinel(sentinel_kind) => Err(AccessError::CannotConvertToOwned {
-                        reason: format!("sentinel: {:?}", sentinel_kind),
-                    }),
+                Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type((**ty).clone()))),
+                Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.clone())),
+                Object::RustData(data) => Ok(bex_external_types::try_convert_rust_data(data)
+                    .unwrap_or_else(|| BexExternalValue::RustData(data.clone()))),
+                Object::Closure(_) => unconvertible("closure"),
+                Object::BoundMethod(_) => unconvertible("bound_method"),
+                Object::Cell(_) => unconvertible("cell"),
+                #[cfg(feature = "heap_debug")]
+                Object::Sentinel(sentinel_kind) => {
+                    unconvertible(&format!("sentinel: {:?}", sentinel_kind))
                 }
             }
-            BexValue::Value(Value::Null) => Ok(BexExternalValue::Null),
-            BexValue::Value(Value::Int(i)) => Ok(BexExternalValue::Int(*i)),
-            BexValue::Value(Value::Float(f)) => Ok(BexExternalValue::Float(*f)),
-            BexValue::Value(Value::Bool(b)) => Ok(BexExternalValue::Bool(*b)),
         }
+        BexValue::Value(Value::Null) => Ok(BexExternalValue::Null),
+        BexValue::Value(Value::Int(i)) => Ok(BexExternalValue::Int(*i)),
+        BexValue::Value(Value::Float(f)) => Ok(BexExternalValue::Float(*f)),
+        BexValue::Value(Value::Bool(b)) => Ok(BexExternalValue::Bool(*b)),
     }
 }
 


### PR DESCRIPTION
## Summary

`baml-cli test` (and any other run that emits a trace event for a value containing a closure, future, function ref, or class/enum definition) printed `Failed to deep-copy VM value for trace payload` to stderr on every invocation, and silently dropped the entire trace payload to `Null`.

The trigger in practice: `$collect_tests` returns a `TestRegistry` whose fields hold the test bodies as closures. The engine emits a `FunctionEnd` trace event for that call, `vm_value_to_owned` calls `as_owned_but_very_slow`, hits `CannotConvertToOwned { reason: "closure" }` deep in the tree, and the whole result is replaced with `Null` plus an unconditional `eprintln!`.

## Fix

- Add `BexValue::as_owned_for_trace`, which delegates to a free `owned_inner` helper. In trace mode, non-convertible leaves (`closure`, `future`, `function`, `class`, `enum`, `bound_method`, `cell`, `function-ref`) become `<kind>` string placeholders instead of failing the whole conversion.
- The strict `as_owned_but_very_slow` keeps its public signature and behavior — strict callers (builtins, `bex_project`, IO codegen) are unchanged. Both methods share `owned_inner` to avoid duplication.
- `vm_value_to_owned` (the engine's trace-payload path) calls `as_owned_for_trace` and drops the `eprintln!` since the conversion can no longer fail on the closure-leaf case.

The `_permit: PermitProof<'_>` argument on the public methods is kept (to preserve the GC-exclusion proof at the API boundary) but isn't threaded through `owned_inner` — it's a zero-sized type-level witness, never destructured or method-called.

## Test plan

- [x] `cargo clippy -p bex_heap -- -D warnings` clean
- [x] `cargo test -p bex_heap --lib` (89 passed)
- [x] `cargo test -p bex_engine --lib` passes
- [x] `baml-cli test` on `hackathon/coding-agent`: 9 passed, no `Failed to deep-copy VM value for trace payload` on stderr
- [x] `baml-cli run -e '...'`: clean stderr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Trace output now includes readable error text for previously unrepresentable values, improving diagnostics.
  * Conversions no longer emit noise to stderr; related errors are logged cleanly.
  * Deep-copy/conversion performance improved, reducing failures and speeding trace generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->