### PR TITLE
Global futures

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_panics/panics.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_panics/panics.baml
@@ -23,6 +23,11 @@ class Unreachable {
   message string
 }
 
+/// A cancellation was requested.
+class Cancelled {
+  message string
+}
+
 /// A user-caused panic from `baml.sys.panic`.
 class UserPanic {
   message string
@@ -35,4 +40,4 @@ class AllocFailure {
   message string
 }
 
-type Panic = DivisionByZero | IndexOutOfBounds | MapKeyNotFound | StackOverflow | AssertionFailed | Unreachable | UserPanic | AllocFailure
+type Panic = DivisionByZero | IndexOutOfBounds | MapKeyNotFound | StackOverflow | AssertionFailed | Unreachable | Cancelled | UserPanic | AllocFailure

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
@@ -2067,6 +2067,9 @@ pub fn generate_io_adapter(
     let resolve_fn = emit_resolve_helper();
 
     let tokens = quote! {
+        // Bring `HeapPermit::proof()` into scope for the adapter impl below.
+        use ::bex_heap::HeapPermit as _;
+
         #resolve_fn
         #adapter_struct
         #adapter_impl

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -104,9 +104,10 @@ class            panics.MapKeyNotFound            <builtin>/baml/ns_panics/panic
 class            panics.StackOverflow             <builtin>/baml/ns_panics/panics.baml:14
 class            panics.AssertionFailed           <builtin>/baml/ns_panics/panics.baml:18
 class            panics.Unreachable               <builtin>/baml/ns_panics/panics.baml:22
-class            panics.UserPanic                 <builtin>/baml/ns_panics/panics.baml:27
-class            panics.AllocFailure              <builtin>/baml/ns_panics/panics.baml:34
-type             panics.Panic                     <builtin>/baml/ns_panics/panics.baml:38
+class            panics.Cancelled                 <builtin>/baml/ns_panics/panics.baml:27
+class            panics.UserPanic                 <builtin>/baml/ns_panics/panics.baml:32
+class            panics.AllocFailure              <builtin>/baml/ns_panics/panics.baml:39
+type             panics.Panic                     <builtin>/baml/ns_panics/panics.baml:43
 class            stream.StreamFinished            <builtin>/baml/ns_stream/stream.baml:4
 class            stream.StreamNoYield             <builtin>/baml/ns_stream/stream.baml:9
 class            sys.ProcessOptions               <builtin>/baml/ns_sys/sys.baml:1

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -23,6 +23,7 @@ use axum::{
     routing::get,
 };
 use base64::Engine as _;
+use bex_project::{is_cancelled_engine_error, is_cancelled_runtime_error};
 use futures::{SinkExt, stream::StreamExt};
 use prost::Message;
 use tokio::{net::TcpListener, sync::broadcast};
@@ -31,24 +32,6 @@ use crate::{
     playground_env::PlaygroundEnvState,
     playground_ws::{WsInMessage, WsOutMessage},
 };
-
-/// True if `err` is an unhandled `baml.panics.Cancelled` panic.
-fn is_cancelled_engine_error(err: &bex_project::EngineError) -> bool {
-    matches!(
-        err,
-        bex_project::EngineError::UnhandledThrow { value, .. }
-            if matches!(
-                value.as_ref(),
-                bex_project::BexExternalValue::Instance { class_name, .. }
-                    if class_name == bex_project::CANCELLED_PANIC_CLASS
-            )
-    )
-}
-
-/// True if `err` is a runtime error wrapping a cancellation panic.
-fn is_cancelled_runtime_error(err: &bex_project::RuntimeError) -> bool {
-    matches!(err, bex_project::RuntimeError::Engine(e) if is_cancelled_engine_error(e))
-}
 
 fn to_ws_text(msg: &WsOutMessage) -> Option<AxumWsMsg> {
     match serde_json::to_string(msg) {

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -32,6 +32,24 @@ use crate::{
     playground_ws::{WsInMessage, WsOutMessage},
 };
 
+/// True if `err` is an unhandled `baml.panics.Cancelled` panic.
+fn is_cancelled_engine_error(err: &bex_project::EngineError) -> bool {
+    matches!(
+        err,
+        bex_project::EngineError::UnhandledThrow { value, .. }
+            if matches!(
+                value.as_ref(),
+                bex_project::BexExternalValue::Instance { class_name, .. }
+                    if class_name == bex_project::CANCELLED_PANIC_CLASS
+            )
+    )
+}
+
+/// True if `err` is a runtime error wrapping a cancellation panic.
+fn is_cancelled_runtime_error(err: &bex_project::RuntimeError) -> bool {
+    matches!(err, bex_project::RuntimeError::Engine(e) if is_cancelled_engine_error(e))
+}
+
 fn to_ws_text(msg: &WsOutMessage) -> Option<AxumWsMsg> {
     match serde_json::to_string(msg) {
         Ok(json) => Some(AxumWsMsg::Text(json.into())),
@@ -295,10 +313,7 @@ async fn handle_ws_in_message(
                         }
                     }
                     Err(e) => {
-                        let is_cancelled = matches!(
-                            &e,
-                            bex_project::RuntimeError::Engine(bex_project::EngineError::Cancelled)
-                        );
+                        let is_cancelled = is_cancelled_runtime_error(&e);
                         WsOutMessage::CallFunctionError {
                             id,
                             error: format!("{e}"),
@@ -356,7 +371,7 @@ async fn handle_ws_in_message(
                         }
                     }
                     Err(e) => {
-                        let is_cancelled = matches!(&e, bex_project::EngineError::Cancelled);
+                        let is_cancelled = is_cancelled_engine_error(&e);
                         WsOutMessage::CallFunctionError {
                             id,
                             error: format!("{e}"),

--- a/baml_language/crates/baml_tests/Cargo.toml
+++ b/baml_language/crates/baml_tests/Cargo.toml
@@ -26,7 +26,7 @@ baml_workspace = { workspace = true }
 bex_engine = { workspace = true }
 bex_vm = { workspace = true }
 bex_vm_types = { workspace = true }
-sys_native = { workspace = true, features = [ "bundle-http" ] }
+sys_native = { workspace = true, features = [ "bundle-http", "aws-crypto" ] }
 sys_ops = { workspace = true }
 sys_types = { workspace = true }
 anyhow = { workspace = true }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -714,6 +714,9 @@ class baml.panics.AllocFailure {
 class baml.panics.AssertionFailed {
   message: string
 }
+class baml.panics.Cancelled {
+  message: string
+}
 class baml.panics.DivisionByZero {
   dividend: int
 }
@@ -733,15 +736,15 @@ class baml.panics.Unreachable {
 class baml.panics.UserPanic {
   message: string
 }
-type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.UserPanic | baml.panics.AllocFailure
+type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.Cancelled | baml.panics.UserPanic | baml.panics.AllocFailure
 function baml.panics.from_json(j: baml.json.json) -> baml.panics.DivisionByZero  [expr] {
   baml.panics.DivisionByZero { dividend: baml.json.from_json(baml.json.field(j, "dividend")) }
 }
 function baml.panics.from_json(j: baml.json.json) -> baml.panics.StackOverflow  [expr] {
   baml.panics.StackOverflow { message: baml.json.from_json(baml.json.field(j, "message")) }
 }
-function baml.panics.from_json(j: baml.json.json) -> baml.panics.UserPanic  [expr] {
-  baml.panics.UserPanic { message: baml.json.from_json(baml.json.field(j, "message")) }
+function baml.panics.from_json(j: baml.json.json) -> baml.panics.Cancelled  [expr] {
+  baml.panics.Cancelled { message: baml.json.from_json(baml.json.field(j, "message")) }
 }
 function baml.panics.from_json(j: baml.json.json) -> baml.panics.IndexOutOfBounds  [expr] {
   baml.panics.IndexOutOfBounds { index: baml.json.from_json(baml.json.field(j, "index")), length: baml.json.from_json(baml.json.field(j, "length")) }
@@ -749,14 +752,20 @@ function baml.panics.from_json(j: baml.json.json) -> baml.panics.IndexOutOfBound
 function baml.panics.from_json(j: baml.json.json) -> baml.panics.AssertionFailed  [expr] {
   baml.panics.AssertionFailed { message: baml.json.from_json(baml.json.field(j, "message")) }
 }
-function baml.panics.from_json(j: baml.json.json) -> baml.panics.AllocFailure  [expr] {
-  baml.panics.AllocFailure { message: baml.json.from_json(baml.json.field(j, "message")) }
+function baml.panics.from_json(j: baml.json.json) -> baml.panics.UserPanic  [expr] {
+  baml.panics.UserPanic { message: baml.json.from_json(baml.json.field(j, "message")) }
 }
 function baml.panics.from_json(j: baml.json.json) -> baml.panics.MapKeyNotFound  [expr] {
   baml.panics.MapKeyNotFound { key: baml.json.from_json(baml.json.field(j, "key")) }
 }
 function baml.panics.from_json(j: baml.json.json) -> baml.panics.Unreachable  [expr] {
   baml.panics.Unreachable { message: baml.json.from_json(baml.json.field(j, "message")) }
+}
+function baml.panics.from_json(j: baml.json.json) -> baml.panics.AllocFailure  [expr] {
+  baml.panics.AllocFailure { message: baml.json.from_json(baml.json.field(j, "message")) }
+}
+function baml.panics.to_json(self: ?) -> baml.json.json  [expr] {
+  map { "message": self.message.to_json() }
 }
 function baml.panics.to_json(self: ?) -> baml.json.json  [expr] {
   map { "dividend": self.dividend.to_json() }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -5936,9 +5936,9 @@ fn baml.panics.StackOverflow.from_json(j: baml.json.json) -> baml.panics.StackOv
     }
 }
 
-fn baml.panics.UserPanic.from_json(j: baml.json.json) -> baml.panics.UserPanic {
+fn baml.panics.Cancelled.from_json(j: baml.json.json) -> baml.panics.Cancelled {
     // Locals:
-    let _0: baml.panics.UserPanic // _0 // return
+    let _0: baml.panics.Cancelled // _0 // return
     let _1: baml.json.json // j // param
     let _2: string
     let _3: baml.json.json
@@ -5954,7 +5954,7 @@ fn baml.panics.UserPanic.from_json(j: baml.json.json) -> baml.panics.UserPanic {
     }
 
     bb2: {
-        _0 = baml.panics.UserPanic { copy _2 };
+        _0 = baml.panics.Cancelled { copy _2 };
         goto -> bb3;
     }
 
@@ -6029,9 +6029,9 @@ fn baml.panics.AssertionFailed.from_json(j: baml.json.json) -> baml.panics.Asser
     }
 }
 
-fn baml.panics.AllocFailure.from_json(j: baml.json.json) -> baml.panics.AllocFailure {
+fn baml.panics.UserPanic.from_json(j: baml.json.json) -> baml.panics.UserPanic {
     // Locals:
-    let _0: baml.panics.AllocFailure // _0 // return
+    let _0: baml.panics.UserPanic // _0 // return
     let _1: baml.json.json // j // param
     let _2: string
     let _3: baml.json.json
@@ -6047,7 +6047,7 @@ fn baml.panics.AllocFailure.from_json(j: baml.json.json) -> baml.panics.AllocFai
     }
 
     bb2: {
-        _0 = baml.panics.AllocFailure { copy _2 };
+        _0 = baml.panics.UserPanic { copy _2 };
         goto -> bb3;
     }
 
@@ -6110,6 +6110,57 @@ fn baml.panics.Unreachable.from_json(j: baml.json.json) -> baml.panics.Unreachab
     }
 }
 
+fn baml.panics.AllocFailure.from_json(j: baml.json.json) -> baml.panics.AllocFailure {
+    // Locals:
+    let _0: baml.panics.AllocFailure // _0 // return
+    let _1: baml.json.json // j // param
+    let _2: string
+    let _3: baml.json.json
+    let _4: type
+
+    bb0: {
+        _3 = call const fn baml.json.field(copy _1, const "message") -> [bb1];
+    }
+
+    bb1: {
+        _4 = load_type(string);
+        _2 = call const fn baml.json.from_json<copy _4>(copy _3) -> [bb2];
+    }
+
+    bb2: {
+        _0 = baml.panics.AllocFailure { copy _2 };
+        goto -> bb3;
+    }
+
+    bb3: {
+        return;
+    }
+}
+
+fn baml.panics.AllocFailure.to_json(self: baml.panics.AllocFailure) -> baml.json.json {
+    // Locals:
+    let _0: baml.json.json // _0 // return
+    let _1: baml.panics.AllocFailure // self // param
+    let _2: baml.json.json
+    let _3: string
+    let _4: baml.panics.AllocFailure
+
+    bb0: {
+        _4 = copy _1;
+        _3 = copy _4.0;
+        _2 = call const fn baml.String.to_json(copy _3) -> [bb1];
+    }
+
+    bb1: {
+        _0 = { const "message": copy _2 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        return;
+    }
+}
+
 fn baml.panics.DivisionByZero.to_json(self: baml.panics.DivisionByZero) -> baml.json.json {
     // Locals:
     let _0: baml.json.json // _0 // return
@@ -6158,13 +6209,13 @@ fn baml.panics.StackOverflow.to_json(self: baml.panics.StackOverflow) -> baml.js
     }
 }
 
-fn baml.panics.UserPanic.to_json(self: baml.panics.UserPanic) -> baml.json.json {
+fn baml.panics.Cancelled.to_json(self: baml.panics.Cancelled) -> baml.json.json {
     // Locals:
     let _0: baml.json.json // _0 // return
-    let _1: baml.panics.UserPanic // self // param
+    let _1: baml.panics.Cancelled // self // param
     let _2: baml.json.json
     let _3: string
-    let _4: baml.panics.UserPanic
+    let _4: baml.panics.Cancelled
 
     bb0: {
         _4 = copy _1;
@@ -6239,13 +6290,13 @@ fn baml.panics.AssertionFailed.to_json(self: baml.panics.AssertionFailed) -> bam
     }
 }
 
-fn baml.panics.AllocFailure.to_json(self: baml.panics.AllocFailure) -> baml.json.json {
+fn baml.panics.UserPanic.to_json(self: baml.panics.UserPanic) -> baml.json.json {
     // Locals:
     let _0: baml.json.json // _0 // return
-    let _1: baml.panics.AllocFailure // self // param
+    let _1: baml.panics.UserPanic // self // param
     let _2: baml.json.json
     let _3: string
-    let _4: baml.panics.AllocFailure
+    let _4: baml.panics.UserPanic
 
     bb0: {
         _4 = copy _1;

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -1242,6 +1242,15 @@ function baml.panics.Unreachable.to_json(self: baml.panics.Unreachable) -> baml.
 function baml.panics.Unreachable.from_json(j: baml.json.json) -> baml.panics.Unreachable throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   Unreachable { message: baml.json.from_json<string>(baml.json.field(j, "message")) } : baml.panics.Unreachable
 }
+class baml.panics.Cancelled {
+  message: string
+}
+function baml.panics.Cancelled.to_json(self: baml.panics.Cancelled) -> baml.json.json throws baml.json.JsonSerializationError | baml.json.JsonParseError {
+  map { "message": self.message.to_json() } : map<string, baml.json.json>
+}
+function baml.panics.Cancelled.from_json(j: baml.json.json) -> baml.panics.Cancelled throws baml.json.JsonParseError | baml.json.JsonDecodeError {
+  Cancelled { message: baml.json.from_json<string>(baml.json.field(j, "message")) } : baml.panics.Cancelled
+}
 class baml.panics.UserPanic {
   message: string
 }
@@ -1260,7 +1269,7 @@ function baml.panics.AllocFailure.to_json(self: baml.panics.AllocFailure) -> bam
 function baml.panics.AllocFailure.from_json(j: baml.json.json) -> baml.panics.AllocFailure throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   AllocFailure { message: baml.json.from_json<string>(baml.json.field(j, "message")) } : baml.panics.AllocFailure
 }
-type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.UserPanic | baml.panics.AllocFailure
+type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.Cancelled | baml.panics.UserPanic | baml.panics.AllocFailure
 class baml.panics.DivisionByZero$stream {
   dividend: null | int
 }
@@ -1280,13 +1289,16 @@ class baml.panics.AssertionFailed$stream {
 class baml.panics.Unreachable$stream {
   message: null | string
 }
+class baml.panics.Cancelled$stream {
+  message: null | string
+}
 class baml.panics.UserPanic$stream {
   message: null | string
 }
 class baml.panics.AllocFailure$stream {
   message: null | string
 }
-type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.IndexOutOfBounds$stream | baml.panics.MapKeyNotFound$stream | baml.panics.StackOverflow$stream | baml.panics.AssertionFailed$stream | baml.panics.Unreachable$stream | baml.panics.UserPanic$stream | baml.panics.AllocFailure$stream
+type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.IndexOutOfBounds$stream | baml.panics.MapKeyNotFound$stream | baml.panics.StackOverflow$stream | baml.panics.AssertionFailed$stream | baml.panics.Unreachable$stream | baml.panics.Cancelled$stream | baml.panics.UserPanic$stream | baml.panics.AllocFailure$stream
 
 --- <builtin>/baml/ns_stream/stream.baml ---
 class baml.stream.StreamFinished {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -4043,6 +4043,30 @@ function baml.panics.AssertionFailed.to_json(self: null) -> baml.json.json {
     return
 }
 
+function baml.panics.Cancelled.from_json(j: baml.json.json) -> baml.panics.Cancelled {
+    load_var j
+    load_const "message"
+    call baml.json.field
+    store_var _3
+    load_type string
+    load_var _3
+    call baml.json.from_json
+    store_var _2
+    alloc_instance baml.panics.Cancelled
+    load_var _2
+    init_field .message
+    return
+}
+
+function baml.panics.Cancelled.to_json(self: null) -> baml.json.json {
+    load_var self
+    load_field .message
+    call baml.String.to_json
+    load_const "message"
+    alloc_map 1
+    return
+}
+
 function baml.panics.DivisionByZero.from_json(j: baml.json.json) -> baml.panics.DivisionByZero {
     load_var j
     load_const "dividend"

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -114,6 +114,7 @@ namespace baml.net:
 namespace baml.panics:
   class AllocFailure { methods: [to_json, from_json] }
   class AssertionFailed { methods: [to_json, from_json] }
+  class Cancelled { methods: [to_json, from_json] }
   class DivisionByZero { methods: [to_json, from_json] }
   class IndexOutOfBounds { methods: [to_json, from_json] }
   class MapKeyNotFound { methods: [to_json, from_json] }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -14,7 +14,7 @@ function assert.contains(haystack: string, needle: string) -> null {
   28   7    jump +3                (to 10)
 
   29   8    load_const 1           ("assertion failed: string does not contain expected substring")
-       9    call 141 ntypeargs=0   (baml.sys.panic)
+       9    call 143 ntypeargs=0   (baml.sys.panic)
        10   return                 
 }
 
@@ -30,7 +30,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   20   6   jump +3                (to 9)
 
   21   7   load_const 1           ("assertion failed: expected equal values")
-       8   call 141 ntypeargs=0   (baml.sys.panic)
+       8   call 143 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -45,7 +45,7 @@ function assert.is_true(condition: bool) -> null {
   4   5   jump +3                (to 8)
 
   5   6   load_const 1           ("assertion failed: expected true")
-      7   call 141 ntypeargs=0   (baml.sys.panic)
+      7   call 143 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
@@ -61,7 +61,7 @@ function assert.not_null(value: unknown?) -> null {
   12   6   jump +3                (to 9)
 
   13   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 141 ntypeargs=0   (baml.sys.panic)
+       8   call 143 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -75,21 +75,21 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
   5   0    load_var 1                       (j)
       1    load_const 0                     ("outcome")
-      2    call 228 ntypeargs=0             (baml.json.field)
+      2    call 230 ntypeargs=0             (baml.json.field)
       3    store_var 3                      (_3)
       4    load_type 1                      
       5    load_var 3                       (_3)
-      6    call 227 ntypeargs=1             (baml.json.from_json)
+      6    call 229 ntypeargs=1             (baml.json.from_json)
       7    store_var 2                      (_2)
       8    load_var 1                       (j)
       9    load_const 2                     ("duration_ms")
-      10   call 228 ntypeargs=0             (baml.json.field)
+      10   call 230 ntypeargs=0             (baml.json.field)
       11   store_var 5                      (_6)
       12   load_type 3                      
       13   load_var 5                       (_6)
-      14   call 227 ntypeargs=1             (baml.json.from_json)
+      14   call 229 ntypeargs=1             (baml.json.from_json)
       15   store_var 4                      (_5)
-      16   alloc_instance 153 ntypeargs=0   (testing.RunReport)
+      16   alloc_instance 155 ntypeargs=0   (testing.RunReport)
       17   load_var 2                       (_2)
       18   init_field 0                     (outcome)
       19   load_var 4                       (_5)
@@ -119,21 +119,21 @@ function testing.RunReport.to_json(self: null) -> baml.json.json {
 function testing.SerializedTest.from_json(j: baml.json.json) -> testing.SerializedTest {
   78   0    load_var 1                       (j)
        1    load_const 0                     ("type")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 3                      (_3)
        4    load_type 1                      
        5    load_var 3                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 2                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("name")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 5                      (_6)
        12   load_type 1                      
        13   load_var 5                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 4                      (_5)
-       16   alloc_instance 138 ntypeargs=0   (testing.SerializedTest)
+       16   alloc_instance 140 ntypeargs=0   (testing.SerializedTest)
        17   load_var 2                       (_2)
        18   init_field 0                     (type)
        19   load_var 4                       (_5)
@@ -161,29 +161,29 @@ function testing.SerializedTest.to_json(self: null) -> baml.json.json {
 function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.SerializedTestSet {
   83   0    load_var 1                       (j)
        1    load_const 0                     ("name")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 3                      (_3)
        4    load_type 1                      
        5    load_var 3                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 2                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("items")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 5                      (_6)
        12   load_type 3                      
        13   load_var 5                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 4                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("loadingTimeMs")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 7                      (_9)
        20   load_type 5                      
        21   load_var 7                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 6                      (_8)
-       24   alloc_instance 136 ntypeargs=0   (testing.SerializedTestSet)
+       24   alloc_instance 138 ntypeargs=0   (testing.SerializedTestSet)
        25   load_var 2                       (_2)
        26   init_field 0                     (name)
        27   load_var 4                       (_5)
@@ -259,29 +259,29 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
   29   0    load_var 1                       (j)
        1    load_const 0                     ("prefix")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 3                      (_3)
        4    load_type 1                      
        5    load_var 3                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 2                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("tests")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 5                      (_6)
        12   load_type 3                      
        13   load_var 5                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 4                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("testsets")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 7                      (_9)
        20   load_type 5                      
        21   load_var 7                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 6                      (_8)
-       24   alloc_instance 145 ntypeargs=0   (testing.TestCollector)
+       24   alloc_instance 147 ntypeargs=0   (testing.TestCollector)
        25   load_var 2                       (_2)
        26   init_field 0                     (prefix)
        27   load_var 4                       (_5)
@@ -292,7 +292,7 @@ function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestColle
 }
 
 function testing.TestCollector.new(prefix: string) -> testing.TestCollector {
-  35   0   alloc_instance 145 ntypeargs=0   (testing.TestCollector)
+  35   0   alloc_instance 147 ntypeargs=0   (testing.TestCollector)
        1   load_var 1                       (prefix)
        2   init_field 0                     (prefix)
        3   alloc_array 0                    
@@ -355,7 +355,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
        45   load_var 6                       (count)
        46   load_const 5                     (1)
        47   bin_op +                         
-       48   call 232 ntypeargs=0             (baml.unstable.string)
+       48   call 234 ntypeargs=0             (baml.unstable.string)
        49   store_var 13                     (_30)
        50   load_var 12                      (_28)
        51   load_var 13                      (_30)
@@ -364,7 +364,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
 
   46   54   load_var 1                       (self)
        55   load_field 1                     (tests)
-       56   alloc_instance 137 ntypeargs=0   (testing.TestRegistration)
+       56   alloc_instance 139 ntypeargs=0   (testing.TestRegistration)
        57   load_var 11                      (final_name)
        58   init_field 0                     (name)
        59   load_var 3                       (body)
@@ -459,7 +459,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
        45   load_var 6                       (count)
        46   load_const 5                     (1)
        47   bin_op +                         
-       48   call 232 ntypeargs=0             (baml.unstable.string)
+       48   call 234 ntypeargs=0             (baml.unstable.string)
        49   store_var 13                     (_30)
        50   load_var 12                      (_28)
        51   load_var 13                      (_30)
@@ -468,7 +468,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
 
   57   54   load_var 1                       (self)
        55   load_field 2                     (testsets)
-       56   alloc_instance 139 ntypeargs=0   (testing.TestSetRegistration)
+       56   alloc_instance 141 ntypeargs=0   (testing.TestSetRegistration)
        57   load_var 11                      (final_name)
        58   init_field 0                     (name)
        59   load_var 3                       (collector)
@@ -536,29 +536,29 @@ function testing.TestCollector.to_json(self: null) -> baml.json.json {
 function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRegistration {
   5   0    load_var 1                       (j)
       1    load_const 0                     ("name")
-      2    call 228 ntypeargs=0             (baml.json.field)
+      2    call 230 ntypeargs=0             (baml.json.field)
       3    store_var 3                      (_3)
       4    load_type 1                      
       5    load_var 3                       (_3)
-      6    call 227 ntypeargs=1             (baml.json.from_json)
+      6    call 229 ntypeargs=1             (baml.json.from_json)
       7    store_var 2                      (_2)
       8    load_var 1                       (j)
       9    load_const 2                     ("body")
-      10   call 228 ntypeargs=0             (baml.json.field)
+      10   call 230 ntypeargs=0             (baml.json.field)
       11   store_var 5                      (_6)
       12   load_type 3                      
       13   load_var 5                       (_6)
-      14   call 227 ntypeargs=1             (baml.json.from_json)
+      14   call 229 ntypeargs=1             (baml.json.from_json)
       15   store_var 4                      (_5)
       16   load_var 1                       (j)
       17   load_const 4                     ("runner")
-      18   call 228 ntypeargs=0             (baml.json.field)
+      18   call 230 ntypeargs=0             (baml.json.field)
       19   store_var 7                      (_9)
       20   load_type 5                      
       21   load_var 7                       (_9)
-      22   call 227 ntypeargs=1             (baml.json.from_json)
+      22   call 229 ntypeargs=1             (baml.json.from_json)
       23   store_var 6                      (_8)
-      24   alloc_instance 137 ntypeargs=0   (testing.TestRegistration)
+      24   alloc_instance 139 ntypeargs=0   (testing.TestRegistration)
       25   load_var 2                       (_2)
       26   init_field 0                     (name)
       27   load_var 4                       (_5)
@@ -571,8 +571,8 @@ function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRe
 function testing.TestRegistration.to_json(self: null) -> baml.json.json {
   13   0   load_type 0            
        1   load_var 1             (self)
-       2   call 224 ntypeargs=1   (baml.json.to_string)
-       3   call 229 ntypeargs=0   (baml.json.parse)
+       2   call 226 ntypeargs=1   (baml.json.to_string)
+       3   call 231 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
@@ -637,7 +637,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 
   176   49    load_var 12                      (sub)
         50    load_var 2                       (name)
-        51    call 325 ntypeargs=0             (testing.TestRegistry.expand_set)
+        51    call 327 ntypeargs=0             (testing.TestRegistry.expand_set)
         52    jump +49                         (to 101)
 
   156   53    load_var 3                       (_3)
@@ -658,10 +658,10 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         66    store_var 4                      (__for_idx)
         67    jump -61                         (to 6)
 
-  159   68    call 146 ntypeargs=0             (baml.sys.now_ms)
+  159   68    call 148 ntypeargs=0             (baml.sys.now_ms)
         69    store_var 6                      (start)
 
-  160   70    alloc_instance 145 ntypeargs=0   (testing.TestCollector)
+  160   70    alloc_instance 147 ntypeargs=0   (testing.TestCollector)
         71    load_var 2                       (name)
         72    init_field 0                     (prefix)
         73    alloc_array 0                    
@@ -676,14 +676,14 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         81    call_indirect                    
         82    pop 1                            
 
-  162   83    call 146 ntypeargs=0             (baml.sys.now_ms)
+  162   83    call 148 ntypeargs=0             (baml.sys.now_ms)
         84    store_var 8                      (_19)
 
   168   85    load_var 1                       (self)
         86    load_field 1                     (expansions)
         87    load_var 2                       (name)
 
-  163   88    alloc_instance 144 ntypeargs=0   (testing.TestRegistry)
+  163   88    alloc_instance 146 ntypeargs=0   (testing.TestRegistry)
 
   164   89    load_var 7                       (sub_collector)
         90    init_field 0                     (collector)
@@ -699,36 +699,36 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         98    pop 1                            
 
   169   99    load_var 1                       (self)
-        100   call 320 ntypeargs=0             (testing.TestRegistry.serialize)
+        100   call 322 ntypeargs=0             (testing.TestRegistry.serialize)
         101   return                           
 }
 
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
   93   0    load_var 1                       (j)
        1    load_const 0                     ("collector")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 3                      (_3)
        4    load_type 1                      
        5    load_var 3                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 2                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("expansions")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 5                      (_6)
        12   load_type 3                      
        13   load_var 5                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 4                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("loading_time_ms")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 7                      (_9)
        20   load_type 5                      
        21   load_var 7                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 6                      (_8)
-       24   alloc_instance 144 ntypeargs=0   (testing.TestRegistry)
+       24   alloc_instance 146 ntypeargs=0   (testing.TestRegistry)
        25   load_var 2                       (_2)
        26   init_field 0                     (collector)
        27   load_var 4                       (_5)
@@ -739,7 +739,7 @@ function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegist
 }
 
 function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.TestRegistry {
-  99    0   alloc_instance 144 ntypeargs=0   (testing.TestRegistry)
+  99    0   alloc_instance 146 ntypeargs=0   (testing.TestRegistry)
         1   load_var 1                       (collector)
         2   init_field 0                     (collector)
 
@@ -812,7 +812,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
 
   147   49   load_var 9             (sub)
         50   load_var 2             (name)
-        51   call 324 ntypeargs=0   (testing.TestRegistry.run_test)
+        51   call 326 ntypeargs=0   (testing.TestRegistry.run_test)
         52   jump +21               (to 73)
 
   136   53   load_var 3             (_3)
@@ -837,7 +837,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         69   load_field 1           (body)
         70   load_var 5             (t)
         71   load_field 2           (runner)
-        72   call 331 ntypeargs=0   (testing.run_test)
+        72   call 333 ntypeargs=0   (testing.run_test)
         73   return                 
 }
 
@@ -896,7 +896,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         45   pop_jump_if_false +30            (to 75)
 
   127   46   load_var 2                       (items)
-        47   alloc_instance 138 ntypeargs=0   (testing.SerializedTest)
+        47   alloc_instance 140 ntypeargs=0   (testing.SerializedTest)
         48   load_const 3                     ("lazyTestSet")
         49   init_field 0                     (type)
         50   load_var 7                       (ts)
@@ -914,11 +914,11 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         60   store_var 10                     (_25)
 
   122   61   load_var 9                       (sub)
-        62   call 320 ntypeargs=0             (testing.TestRegistry.serialize)
+        62   call 322 ntypeargs=0             (testing.TestRegistry.serialize)
         63   store_var 11                     (_26)
 
   120   64   load_var 2                       (items)
-        65   alloc_instance 136 ntypeargs=0   (testing.SerializedTestSet)
+        65   alloc_instance 138 ntypeargs=0   (testing.SerializedTestSet)
         66   load_var 10                      (_25)
         67   init_field 0                     (name)
         68   load_var 11                      (_26)
@@ -937,7 +937,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         79   jump -59                         (to 20)
 
   114   80   load_var 2                       (items)
-        81   alloc_instance 138 ntypeargs=0   (testing.SerializedTest)
+        81   alloc_instance 140 ntypeargs=0   (testing.SerializedTest)
         82   load_const 5                     ("test")
         83   init_field 0                     (type)
 
@@ -958,7 +958,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
 function testing.TestRegistry.to_json(self: null) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 332 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 334 ntypeargs=0   (testing.TestCollector.to_json)
        3    store_var 2            (_2)
        4    load_var 1             (self)
        5    load_field 1           (expansions)
@@ -981,21 +981,21 @@ function testing.TestRegistry.to_json(self: null) -> baml.json.json {
 function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
   15   0    load_var 1                       (j)
        1    load_const 0                     ("outcome")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 3                      (_3)
        4    load_type 1                      
        5    load_var 3                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 2                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("runs")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 5                      (_6)
        12   load_type 3                      
        13   load_var 5                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 4                      (_5)
-       16   alloc_instance 148 ntypeargs=0   (testing.TestReport)
+       16   alloc_instance 150 ntypeargs=0   (testing.TestReport)
        17   load_var 2                       (_2)
        18   init_field 0                     (outcome)
        19   load_var 4                       (_5)
@@ -1025,29 +1025,29 @@ function testing.TestReport.to_json(self: null) -> baml.json.json {
 function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.TestSetRegistration {
   17   0    load_var 1                       (j)
        1    load_const 0                     ("name")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 3                      (_3)
        4    load_type 1                      
        5    load_var 3                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 2                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("collector")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 5                      (_6)
        12   load_type 3                      
        13   load_var 5                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 4                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("runner")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 7                      (_9)
        20   load_type 5                      
        21   load_var 7                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 6                      (_8)
-       24   alloc_instance 139 ntypeargs=0   (testing.TestSetRegistration)
+       24   alloc_instance 141 ntypeargs=0   (testing.TestSetRegistration)
        25   load_var 2                       (_2)
        26   init_field 0                     (name)
        27   load_var 4                       (_5)
@@ -1060,53 +1060,53 @@ function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.Tes
 function testing.TestSetRegistration.to_json(self: null) -> baml.json.json {
   25   0   load_type 0            
        1   load_var 1             (self)
-       2   call 224 ntypeargs=1   (baml.json.to_string)
-       3   call 229 ntypeargs=0   (baml.json.parse)
+       2   call 226 ntypeargs=1   (baml.json.to_string)
+       3   call 231 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
 function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetReport {
   21   0    load_var 1                       (j)
        1    load_const 0                     ("outcome")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 3                      (_3)
        4    load_type 1                      
        5    load_var 3                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 2                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("passed")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 5                      (_6)
        12   load_type 3                      
        13   load_var 5                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 4                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("failed")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 7                      (_9)
        20   load_type 3                      
        21   load_var 7                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 6                      (_8)
        24   load_var 1                       (j)
        25   load_const 5                     ("total")
-       26   call 228 ntypeargs=0             (baml.json.field)
+       26   call 230 ntypeargs=0             (baml.json.field)
        27   store_var 9                      (_12)
        28   load_type 3                      
        29   load_var 9                       (_12)
-       30   call 227 ntypeargs=1             (baml.json.from_json)
+       30   call 229 ntypeargs=1             (baml.json.from_json)
        31   store_var 8                      (_11)
        32   load_var 1                       (j)
        33   load_const 6                     ("results")
-       34   call 228 ntypeargs=0             (baml.json.field)
+       34   call 230 ntypeargs=0             (baml.json.field)
        35   store_var 11                     (_15)
        36   load_type 7                      
        37   load_var 11                      (_15)
-       38   call 227 ntypeargs=1             (baml.json.from_json)
+       38   call 229 ntypeargs=1             (baml.json.from_json)
        39   store_var 10                     (_14)
-       40   alloc_instance 152 ntypeargs=0   (testing.TestSetReport)
+       40   alloc_instance 154 ntypeargs=0   (testing.TestSetReport)
        41   load_var 2                       (_2)
        42   init_field 0                     (outcome)
        43   load_var 4                       (_5)
@@ -1163,7 +1163,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 758 1     
+        4    make_closure 764 1     
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)
@@ -1212,19 +1212,19 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
   26   0    load_var 1                     (j)
        1    load_const 0                   ("code")
-       2    call 228 ntypeargs=0           (baml.json.field)
+       2    call 230 ntypeargs=0           (baml.json.field)
        3    store_var 3                    (_3)
        4    load_type 1                    
        5    load_var 3                     (_3)
-       6    call 227 ntypeargs=1           (baml.json.from_json)
+       6    call 229 ntypeargs=1           (baml.json.from_json)
        7    store_var 2                    (_2)
        8    load_var 1                     (j)
        9    load_const 2                   ("message")
-       10   call 228 ntypeargs=0           (baml.json.field)
+       10   call 230 ntypeargs=0           (baml.json.field)
        11   store_var 5                    (_6)
        12   load_type 3                    
        13   load_var 5                     (_6)
-       14   call 227 ntypeargs=1           (baml.json.from_json)
+       14   call 229 ntypeargs=1           (baml.json.from_json)
        15   store_var 4                    (_5)
        16   alloc_instance 1 ntypeargs=0   (user.ErrorInfo)
        17   load_var 2                     (_2)
@@ -1254,27 +1254,27 @@ function user.ErrorInfo.to_json(self: null) -> baml.json.json {
 function user.Report.from_json(j: baml.json.json) -> Report {
   20   0    load_var 1                     (j)
        1    load_const 0                   ("score")
-       2    call 228 ntypeargs=0           (baml.json.field)
+       2    call 230 ntypeargs=0           (baml.json.field)
        3    store_var 3                    (_3)
        4    load_type 1                    
        5    load_var 3                     (_3)
-       6    call 227 ntypeargs=1           (baml.json.from_json)
+       6    call 229 ntypeargs=1           (baml.json.from_json)
        7    store_var 2                    (_2)
        8    load_var 1                     (j)
        9    load_const 2                   ("label")
-       10   call 228 ntypeargs=0           (baml.json.field)
+       10   call 230 ntypeargs=0           (baml.json.field)
        11   store_var 5                    (_6)
        12   load_type 3                    
        13   load_var 5                     (_6)
-       14   call 227 ntypeargs=1           (baml.json.from_json)
+       14   call 229 ntypeargs=1           (baml.json.from_json)
        15   store_var 4                    (_5)
        16   load_var 1                     (j)
        17   load_const 4                   ("breakdown")
-       18   call 228 ntypeargs=0           (baml.json.field)
+       18   call 230 ntypeargs=0           (baml.json.field)
        19   store_var 7                    (_9)
        20   load_type 5                    
        21   load_var 7                     (_9)
-       22   call 227 ntypeargs=1           (baml.json.from_json)
+       22   call 229 ntypeargs=1           (baml.json.from_json)
        23   store_var 6                    (_8)
        24   alloc_instance 5 ntypeargs=0   (user.Report)
        25   load_var 2                     (_2)
@@ -1312,27 +1312,27 @@ function user.Report.to_json(self: null) -> baml.json.json {
 function user.User.from_json(j: baml.json.json) -> User {
   3   0    load_var 1                     (j)
       1    load_const 0                   ("name")
-      2    call 228 ntypeargs=0           (baml.json.field)
+      2    call 230 ntypeargs=0           (baml.json.field)
       3    store_var 3                    (_3)
       4    load_type 1                    
       5    load_var 3                     (_3)
-      6    call 227 ntypeargs=1           (baml.json.from_json)
+      6    call 229 ntypeargs=1           (baml.json.from_json)
       7    store_var 2                    (_2)
       8    load_var 1                     (j)
       9    load_const 2                   ("age")
-      10   call 228 ntypeargs=0           (baml.json.field)
+      10   call 230 ntypeargs=0           (baml.json.field)
       11   store_var 5                    (_6)
       12   load_type 3                    
       13   load_var 5                     (_6)
-      14   call 227 ntypeargs=1           (baml.json.from_json)
+      14   call 229 ntypeargs=1           (baml.json.from_json)
       15   store_var 4                    (_5)
       16   load_var 1                     (j)
       17   load_const 4                   ("role")
-      18   call 228 ntypeargs=0           (baml.json.field)
+      18   call 230 ntypeargs=0           (baml.json.field)
       19   store_var 7                    (_9)
       20   load_type 5                    
       21   load_var 7                     (_9)
-      22   call 227 ntypeargs=1           (baml.json.from_json)
+      22   call 229 ntypeargs=1           (baml.json.from_json)
       23   store_var 6                    (_8)
       24   alloc_instance 4 ntypeargs=0   (user.User)
       25   load_var 2                     (_2)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -14,7 +14,7 @@ function assert.contains(haystack: string, needle: string) -> null {
   28   7    jump +3                (to 10)
 
   29   8    load_const 1           ("assertion failed: string does not contain expected substring")
-       9    call 141 ntypeargs=0   (baml.sys.panic)
+       9    call 143 ntypeargs=0   (baml.sys.panic)
        10   return                 
 }
 
@@ -30,7 +30,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   20   6   jump +3                (to 9)
 
   21   7   load_const 1           ("assertion failed: expected equal values")
-       8   call 141 ntypeargs=0   (baml.sys.panic)
+       8   call 143 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -45,7 +45,7 @@ function assert.is_true(condition: bool) -> null {
   4   5   jump +3                (to 8)
 
   5   6   load_const 1           ("assertion failed: expected true")
-      7   call 141 ntypeargs=0   (baml.sys.panic)
+      7   call 143 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
@@ -61,7 +61,7 @@ function assert.not_null(value: unknown?) -> null {
   12   6   jump +3                (to 9)
 
   13   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 141 ntypeargs=0   (baml.sys.panic)
+       8   call 143 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -75,21 +75,21 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
   5   0    load_var 1                       (j)
       1    load_const 0                     ("outcome")
-      2    call 228 ntypeargs=0             (baml.json.field)
+      2    call 230 ntypeargs=0             (baml.json.field)
       3    store_var 4                      (_3)
       4    load_type 1                      
       5    load_var 4                       (_3)
-      6    call 227 ntypeargs=1             (baml.json.from_json)
+      6    call 229 ntypeargs=1             (baml.json.from_json)
       7    store_var 3                      (_2)
       8    load_var 1                       (j)
       9    load_const 2                     ("duration_ms")
-      10   call 228 ntypeargs=0             (baml.json.field)
+      10   call 230 ntypeargs=0             (baml.json.field)
       11   store_var 6                      (_6)
       12   load_type 3                      
       13   load_var 6                       (_6)
-      14   call 227 ntypeargs=1             (baml.json.from_json)
+      14   call 229 ntypeargs=1             (baml.json.from_json)
       15   store_var 5                      (_5)
-      16   alloc_instance 153 ntypeargs=0   (testing.RunReport)
+      16   alloc_instance 155 ntypeargs=0   (testing.RunReport)
       17   load_var 3                       (_2)
       18   init_field 0                     (outcome)
       19   load_var 5                       (_5)
@@ -123,21 +123,21 @@ function testing.RunReport.to_json(self: null) -> baml.json.json {
 function testing.SerializedTest.from_json(j: baml.json.json) -> testing.SerializedTest {
   78   0    load_var 1                       (j)
        1    load_const 0                     ("type")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 4                      (_3)
        4    load_type 1                      
        5    load_var 4                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 3                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("name")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 6                      (_6)
        12   load_type 1                      
        13   load_var 6                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 5                      (_5)
-       16   alloc_instance 138 ntypeargs=0   (testing.SerializedTest)
+       16   alloc_instance 140 ntypeargs=0   (testing.SerializedTest)
        17   load_var 3                       (_2)
        18   init_field 0                     (type)
        19   load_var 5                       (_5)
@@ -169,29 +169,29 @@ function testing.SerializedTest.to_json(self: null) -> baml.json.json {
 function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.SerializedTestSet {
   83   0    load_var 1                       (j)
        1    load_const 0                     ("name")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 4                      (_3)
        4    load_type 1                      
        5    load_var 4                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 3                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("items")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 6                      (_6)
        12   load_type 3                      
        13   load_var 6                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 5                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("loadingTimeMs")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 8                      (_9)
        20   load_type 5                      
        21   load_var 8                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 7                      (_8)
-       24   alloc_instance 136 ntypeargs=0   (testing.SerializedTestSet)
+       24   alloc_instance 138 ntypeargs=0   (testing.SerializedTestSet)
        25   load_var 3                       (_2)
        26   init_field 0                     (name)
        27   load_var 5                       (_5)
@@ -273,29 +273,29 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
   29   0    load_var 1                       (j)
        1    load_const 0                     ("prefix")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 4                      (_3)
        4    load_type 1                      
        5    load_var 4                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 3                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("tests")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 6                      (_6)
        12   load_type 3                      
        13   load_var 6                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 5                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("testsets")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 8                      (_9)
        20   load_type 5                      
        21   load_var 8                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 7                      (_8)
-       24   alloc_instance 145 ntypeargs=0   (testing.TestCollector)
+       24   alloc_instance 147 ntypeargs=0   (testing.TestCollector)
        25   load_var 3                       (_2)
        26   init_field 0                     (prefix)
        27   load_var 5                       (_5)
@@ -308,7 +308,7 @@ function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestColle
 }
 
 function testing.TestCollector.new(prefix: string) -> testing.TestCollector {
-  35   0   alloc_instance 145 ntypeargs=0   (testing.TestCollector)
+  35   0   alloc_instance 147 ntypeargs=0   (testing.TestCollector)
        1   load_var 1                       (prefix)
        2   init_field 0                     (prefix)
        3   alloc_array 0                    
@@ -373,7 +373,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
        45   load_var 7                       (count)
        46   load_const 5                     (1)
        47   bin_op +                         
-       48   call 232 ntypeargs=0             (baml.unstable.string)
+       48   call 234 ntypeargs=0             (baml.unstable.string)
        49   store_var 14                     (_30)
        50   load_var 13                      (_28)
        51   load_var 14                      (_30)
@@ -382,7 +382,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
 
   46   54   load_var 1                       (self)
        55   load_field 1                     (tests)
-       56   alloc_instance 137 ntypeargs=0   (testing.TestRegistration)
+       56   alloc_instance 139 ntypeargs=0   (testing.TestRegistration)
        57   load_var 12                      (final_name)
        58   init_field 0                     (name)
        59   load_var 3                       (body)
@@ -479,7 +479,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
        45   load_var 7                       (count)
        46   load_const 5                     (1)
        47   bin_op +                         
-       48   call 232 ntypeargs=0             (baml.unstable.string)
+       48   call 234 ntypeargs=0             (baml.unstable.string)
        49   store_var 14                     (_30)
        50   load_var 13                      (_28)
        51   load_var 14                      (_30)
@@ -488,7 +488,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
 
   57   54   load_var 1                       (self)
        55   load_field 2                     (testsets)
-       56   alloc_instance 139 ntypeargs=0   (testing.TestSetRegistration)
+       56   alloc_instance 141 ntypeargs=0   (testing.TestSetRegistration)
        57   load_var 12                      (final_name)
        58   init_field 0                     (name)
        59   load_var 3                       (collector)
@@ -560,29 +560,29 @@ function testing.TestCollector.to_json(self: null) -> baml.json.json {
 function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRegistration {
   5   0    load_var 1                       (j)
       1    load_const 0                     ("name")
-      2    call 228 ntypeargs=0             (baml.json.field)
+      2    call 230 ntypeargs=0             (baml.json.field)
       3    store_var 4                      (_3)
       4    load_type 1                      
       5    load_var 4                       (_3)
-      6    call 227 ntypeargs=1             (baml.json.from_json)
+      6    call 229 ntypeargs=1             (baml.json.from_json)
       7    store_var 3                      (_2)
       8    load_var 1                       (j)
       9    load_const 2                     ("body")
-      10   call 228 ntypeargs=0             (baml.json.field)
+      10   call 230 ntypeargs=0             (baml.json.field)
       11   store_var 6                      (_6)
       12   load_type 3                      
       13   load_var 6                       (_6)
-      14   call 227 ntypeargs=1             (baml.json.from_json)
+      14   call 229 ntypeargs=1             (baml.json.from_json)
       15   store_var 5                      (_5)
       16   load_var 1                       (j)
       17   load_const 4                     ("runner")
-      18   call 228 ntypeargs=0             (baml.json.field)
+      18   call 230 ntypeargs=0             (baml.json.field)
       19   store_var 8                      (_9)
       20   load_type 5                      
       21   load_var 8                       (_9)
-      22   call 227 ntypeargs=1             (baml.json.from_json)
+      22   call 229 ntypeargs=1             (baml.json.from_json)
       23   store_var 7                      (_8)
-      24   alloc_instance 137 ntypeargs=0   (testing.TestRegistration)
+      24   alloc_instance 139 ntypeargs=0   (testing.TestRegistration)
       25   load_var 3                       (_2)
       26   init_field 0                     (name)
       27   load_var 5                       (_5)
@@ -597,8 +597,8 @@ function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRe
 function testing.TestRegistration.to_json(self: null) -> baml.json.json {
   13   0   load_type 0            
        1   load_var 1             (self)
-       2   call 224 ntypeargs=1   (baml.json.to_string)
-       3   call 229 ntypeargs=0   (baml.json.parse)
+       2   call 226 ntypeargs=1   (baml.json.to_string)
+       3   call 231 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
@@ -663,7 +663,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 
   176   49    load_var 13                      (sub)
         50    load_var 2                       (name)
-        51    call 325 ntypeargs=0             (testing.TestRegistry.expand_set)
+        51    call 327 ntypeargs=0             (testing.TestRegistry.expand_set)
         52    jump +51                         (to 103)
 
   156   53    load_var 3                       (_3)
@@ -684,10 +684,10 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         66    store_var 4                      (__for_idx)
         67    jump -61                         (to 6)
 
-  159   68    call 146 ntypeargs=0             (baml.sys.now_ms)
+  159   68    call 148 ntypeargs=0             (baml.sys.now_ms)
         69    store_var 6                      (start)
 
-  160   70    alloc_instance 145 ntypeargs=0   (testing.TestCollector)
+  160   70    alloc_instance 147 ntypeargs=0   (testing.TestCollector)
         71    load_var 2                       (name)
         72    init_field 0                     (prefix)
         73    alloc_array 0                    
@@ -702,12 +702,12 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         81    call_indirect                    
         82    pop 1                            
 
-  162   83    call 146 ntypeargs=0             (baml.sys.now_ms)
+  162   83    call 148 ntypeargs=0             (baml.sys.now_ms)
         84    load_var 6                       (start)
         85    sub_int                          
         86    store_var 8                      (elapsed)
 
-  163   87    alloc_instance 144 ntypeargs=0   (testing.TestRegistry)
+  163   87    alloc_instance 146 ntypeargs=0   (testing.TestRegistry)
 
   164   88    load_var 7                       (sub_collector)
         89    init_field 0                     (collector)
@@ -727,36 +727,36 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         100   pop 1                            
 
   169   101   load_var 1                       (self)
-        102   call 320 ntypeargs=0             (testing.TestRegistry.serialize)
+        102   call 322 ntypeargs=0             (testing.TestRegistry.serialize)
         103   return                           
 }
 
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
   93   0    load_var 1                       (j)
        1    load_const 0                     ("collector")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 4                      (_3)
        4    load_type 1                      
        5    load_var 4                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 3                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("expansions")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 6                      (_6)
        12   load_type 3                      
        13   load_var 6                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 5                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("loading_time_ms")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 8                      (_9)
        20   load_type 5                      
        21   load_var 8                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 7                      (_8)
-       24   alloc_instance 144 ntypeargs=0   (testing.TestRegistry)
+       24   alloc_instance 146 ntypeargs=0   (testing.TestRegistry)
        25   load_var 3                       (_2)
        26   init_field 0                     (collector)
        27   load_var 5                       (_5)
@@ -769,7 +769,7 @@ function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegist
 }
 
 function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.TestRegistry {
-  99    0   alloc_instance 144 ntypeargs=0   (testing.TestRegistry)
+  99    0   alloc_instance 146 ntypeargs=0   (testing.TestRegistry)
         1   load_var 1                       (collector)
         2   init_field 0                     (collector)
 
@@ -844,7 +844,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
 
   147   49   load_var 9             (sub)
         50   load_var 2             (name)
-        51   call 324 ntypeargs=0   (testing.TestRegistry.run_test)
+        51   call 326 ntypeargs=0   (testing.TestRegistry.run_test)
         52   jump +21               (to 73)
 
   136   53   load_var 3             (_3)
@@ -869,7 +869,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         69   load_field 1           (body)
         70   load_var 5             (t)
         71   load_field 2           (runner)
-        72   call 331 ntypeargs=0   (testing.run_test)
+        72   call 333 ntypeargs=0   (testing.run_test)
         73   return                 
 }
 
@@ -930,7 +930,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         47   pop_jump_if_false +30            (to 77)
 
   127   48   load_var 3                       (items)
-        49   alloc_instance 138 ntypeargs=0   (testing.SerializedTest)
+        49   alloc_instance 140 ntypeargs=0   (testing.SerializedTest)
         50   load_const 3                     ("lazyTestSet")
         51   init_field 0                     (type)
         52   load_var 9                       (ts)
@@ -948,11 +948,11 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         62   store_var 12                     (_25)
 
   122   63   load_var 11                      (sub)
-        64   call 320 ntypeargs=0             (testing.TestRegistry.serialize)
+        64   call 322 ntypeargs=0             (testing.TestRegistry.serialize)
         65   store_var 13                     (_26)
 
   120   66   load_var 3                       (items)
-        67   alloc_instance 136 ntypeargs=0   (testing.SerializedTestSet)
+        67   alloc_instance 138 ntypeargs=0   (testing.SerializedTestSet)
         68   load_var 12                      (_25)
         69   init_field 0                     (name)
         70   load_var 13                      (_26)
@@ -976,7 +976,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         85   store_var 6                      (t)
 
   114   86   load_var 3                       (items)
-        87   alloc_instance 138 ntypeargs=0   (testing.SerializedTest)
+        87   alloc_instance 140 ntypeargs=0   (testing.SerializedTest)
         88   load_const 5                     ("test")
         89   init_field 0                     (type)
         90   load_var 6                       (t)
@@ -995,7 +995,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
 function testing.TestRegistry.to_json(self: null) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 332 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 334 ntypeargs=0   (testing.TestCollector.to_json)
        3    store_var 3            (_2)
        4    load_var 1             (self)
        5    load_field 1           (expansions)
@@ -1020,21 +1020,21 @@ function testing.TestRegistry.to_json(self: null) -> baml.json.json {
 function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
   15   0    load_var 1                       (j)
        1    load_const 0                     ("outcome")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 4                      (_3)
        4    load_type 1                      
        5    load_var 4                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 3                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("runs")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 6                      (_6)
        12   load_type 3                      
        13   load_var 6                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 5                      (_5)
-       16   alloc_instance 148 ntypeargs=0   (testing.TestReport)
+       16   alloc_instance 150 ntypeargs=0   (testing.TestReport)
        17   load_var 3                       (_2)
        18   init_field 0                     (outcome)
        19   load_var 5                       (_5)
@@ -1068,29 +1068,29 @@ function testing.TestReport.to_json(self: null) -> baml.json.json {
 function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.TestSetRegistration {
   17   0    load_var 1                       (j)
        1    load_const 0                     ("name")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 4                      (_3)
        4    load_type 1                      
        5    load_var 4                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 3                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("collector")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 6                      (_6)
        12   load_type 3                      
        13   load_var 6                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 5                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("runner")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 8                      (_9)
        20   load_type 5                      
        21   load_var 8                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 7                      (_8)
-       24   alloc_instance 139 ntypeargs=0   (testing.TestSetRegistration)
+       24   alloc_instance 141 ntypeargs=0   (testing.TestSetRegistration)
        25   load_var 3                       (_2)
        26   init_field 0                     (name)
        27   load_var 5                       (_5)
@@ -1105,53 +1105,53 @@ function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.Tes
 function testing.TestSetRegistration.to_json(self: null) -> baml.json.json {
   25   0   load_type 0            
        1   load_var 1             (self)
-       2   call 224 ntypeargs=1   (baml.json.to_string)
-       3   call 229 ntypeargs=0   (baml.json.parse)
+       2   call 226 ntypeargs=1   (baml.json.to_string)
+       3   call 231 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
 function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetReport {
   21   0    load_var 1                       (j)
        1    load_const 0                     ("outcome")
-       2    call 228 ntypeargs=0             (baml.json.field)
+       2    call 230 ntypeargs=0             (baml.json.field)
        3    store_var 4                      (_3)
        4    load_type 1                      
        5    load_var 4                       (_3)
-       6    call 227 ntypeargs=1             (baml.json.from_json)
+       6    call 229 ntypeargs=1             (baml.json.from_json)
        7    store_var 3                      (_2)
        8    load_var 1                       (j)
        9    load_const 2                     ("passed")
-       10   call 228 ntypeargs=0             (baml.json.field)
+       10   call 230 ntypeargs=0             (baml.json.field)
        11   store_var 6                      (_6)
        12   load_type 3                      
        13   load_var 6                       (_6)
-       14   call 227 ntypeargs=1             (baml.json.from_json)
+       14   call 229 ntypeargs=1             (baml.json.from_json)
        15   store_var 5                      (_5)
        16   load_var 1                       (j)
        17   load_const 4                     ("failed")
-       18   call 228 ntypeargs=0             (baml.json.field)
+       18   call 230 ntypeargs=0             (baml.json.field)
        19   store_var 8                      (_9)
        20   load_type 3                      
        21   load_var 8                       (_9)
-       22   call 227 ntypeargs=1             (baml.json.from_json)
+       22   call 229 ntypeargs=1             (baml.json.from_json)
        23   store_var 7                      (_8)
        24   load_var 1                       (j)
        25   load_const 5                     ("total")
-       26   call 228 ntypeargs=0             (baml.json.field)
+       26   call 230 ntypeargs=0             (baml.json.field)
        27   store_var 10                     (_12)
        28   load_type 3                      
        29   load_var 10                      (_12)
-       30   call 227 ntypeargs=1             (baml.json.from_json)
+       30   call 229 ntypeargs=1             (baml.json.from_json)
        31   store_var 9                      (_11)
        32   load_var 1                       (j)
        33   load_const 6                     ("results")
-       34   call 228 ntypeargs=0             (baml.json.field)
+       34   call 230 ntypeargs=0             (baml.json.field)
        35   store_var 12                     (_15)
        36   load_type 7                      
        37   load_var 12                      (_15)
-       38   call 227 ntypeargs=1             (baml.json.from_json)
+       38   call 229 ntypeargs=1             (baml.json.from_json)
        39   store_var 11                     (_14)
-       40   alloc_instance 152 ntypeargs=0   (testing.TestSetReport)
+       40   alloc_instance 154 ntypeargs=0   (testing.TestSetReport)
        41   load_var 3                       (_2)
        42   init_field 0                     (outcome)
        43   load_var 5                       (_5)
@@ -1212,7 +1212,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1             
 
   185   3    load_var 1              (body)
-        4    make_closure 758 1      
+        4    make_closure 764 1      
         5    store_var 3             (base_run)
 
   200   6    load_var 2              (runner)
@@ -1265,19 +1265,19 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
   26   0    load_var 1                     (j)
        1    load_const 0                   ("code")
-       2    call 228 ntypeargs=0           (baml.json.field)
+       2    call 230 ntypeargs=0           (baml.json.field)
        3    store_var 4                    (_3)
        4    load_type 1                    
        5    load_var 4                     (_3)
-       6    call 227 ntypeargs=1           (baml.json.from_json)
+       6    call 229 ntypeargs=1           (baml.json.from_json)
        7    store_var 3                    (_2)
        8    load_var 1                     (j)
        9    load_const 2                   ("message")
-       10   call 228 ntypeargs=0           (baml.json.field)
+       10   call 230 ntypeargs=0           (baml.json.field)
        11   store_var 6                    (_6)
        12   load_type 3                    
        13   load_var 6                     (_6)
-       14   call 227 ntypeargs=1           (baml.json.from_json)
+       14   call 229 ntypeargs=1           (baml.json.from_json)
        15   store_var 5                    (_5)
        16   alloc_instance 1 ntypeargs=0   (user.ErrorInfo)
        17   load_var 3                     (_2)
@@ -1311,27 +1311,27 @@ function user.ErrorInfo.to_json(self: null) -> baml.json.json {
 function user.Report.from_json(j: baml.json.json) -> Report {
   20   0    load_var 1                     (j)
        1    load_const 0                   ("score")
-       2    call 228 ntypeargs=0           (baml.json.field)
+       2    call 230 ntypeargs=0           (baml.json.field)
        3    store_var 4                    (_3)
        4    load_type 1                    
        5    load_var 4                     (_3)
-       6    call 227 ntypeargs=1           (baml.json.from_json)
+       6    call 229 ntypeargs=1           (baml.json.from_json)
        7    store_var 3                    (_2)
        8    load_var 1                     (j)
        9    load_const 2                   ("label")
-       10   call 228 ntypeargs=0           (baml.json.field)
+       10   call 230 ntypeargs=0           (baml.json.field)
        11   store_var 6                    (_6)
        12   load_type 3                    
        13   load_var 6                     (_6)
-       14   call 227 ntypeargs=1           (baml.json.from_json)
+       14   call 229 ntypeargs=1           (baml.json.from_json)
        15   store_var 5                    (_5)
        16   load_var 1                     (j)
        17   load_const 4                   ("breakdown")
-       18   call 228 ntypeargs=0           (baml.json.field)
+       18   call 230 ntypeargs=0           (baml.json.field)
        19   store_var 8                    (_9)
        20   load_type 5                    
        21   load_var 8                     (_9)
-       22   call 227 ntypeargs=1           (baml.json.from_json)
+       22   call 229 ntypeargs=1           (baml.json.from_json)
        23   store_var 7                    (_8)
        24   alloc_instance 5 ntypeargs=0   (user.Report)
        25   load_var 3                     (_2)
@@ -1373,27 +1373,27 @@ function user.Report.to_json(self: null) -> baml.json.json {
 function user.User.from_json(j: baml.json.json) -> User {
   3   0    load_var 1                     (j)
       1    load_const 0                   ("name")
-      2    call 228 ntypeargs=0           (baml.json.field)
+      2    call 230 ntypeargs=0           (baml.json.field)
       3    store_var 4                    (_3)
       4    load_type 1                    
       5    load_var 4                     (_3)
-      6    call 227 ntypeargs=1           (baml.json.from_json)
+      6    call 229 ntypeargs=1           (baml.json.from_json)
       7    store_var 3                    (_2)
       8    load_var 1                     (j)
       9    load_const 2                   ("age")
-      10   call 228 ntypeargs=0           (baml.json.field)
+      10   call 230 ntypeargs=0           (baml.json.field)
       11   store_var 6                    (_6)
       12   load_type 3                    
       13   load_var 6                     (_6)
-      14   call 227 ntypeargs=1           (baml.json.from_json)
+      14   call 229 ntypeargs=1           (baml.json.from_json)
       15   store_var 5                    (_5)
       16   load_var 1                     (j)
       17   load_const 4                   ("role")
-      18   call 228 ntypeargs=0           (baml.json.field)
+      18   call 230 ntypeargs=0           (baml.json.field)
       19   store_var 8                    (_9)
       20   load_type 5                    
       21   load_var 8                     (_9)
-      22   call 227 ntypeargs=1           (baml.json.from_json)
+      22   call 229 ntypeargs=1           (baml.json.from_json)
       23   store_var 7                    (_8)
       24   alloc_instance 4 ntypeargs=0   (user.User)
       25   load_var 3                     (_2)

--- a/baml_language/crates/baml_tests/tests/exceptions.rs
+++ b/baml_language/crates/baml_tests/tests/exceptions.rs
@@ -3013,7 +3013,7 @@ async fn panic_alias_catches_any_panic() {
         }
     "#
     );
-    insta::assert_snapshot!(output.bytecode, @r"
+    insta::assert_snapshot!(output.bytecode, @"
     function divides() -> int {
         load_const 1
         load_const 0
@@ -3026,7 +3026,7 @@ async fn panic_alias_catches_any_panic() {
         jump L2
         load_var e
         type_tag
-        jump_table [L1, L1, L1, _, _, L1, _, _, _, L1, L1, _, L1, L1], default L0
+        jump_table [L1, L1, L1, L1, _, _, L1, _, _, _, L1, L1, _, L1, L1], default L0
 
       L0:
         load_var e
@@ -3067,7 +3067,7 @@ async fn panic_alias_plus_wildcard_dispatch() {
         jump L2
         load_var e
         type_tag
-        jump_table [L1, L1, L1, _, _, L1, _, _, _, L1, L1, _, L1, L1], default L0
+        jump_table [L1, L1, L1, L1, _, _, L1, _, _, _, L1, L1, _, L1, L1], default L0
 
       L0:
         load_var e

--- a/baml_language/crates/bex_engine/Cargo.toml
+++ b/baml_language/crates/bex_engine/Cargo.toml
@@ -38,7 +38,7 @@ wasm-bindgen-futures = { workspace = true }
 baml_builtins2 = { workspace = true }
 baml_project = { workspace = true, features = [ "testing" ] }
 sys_llm = { workspace = true }
-sys_native = { workspace = true, features = [ "bundle-http" ] }
+sys_native = { workspace = true, features = [ "bundle-http", "aws-crypto" ] }
 anyhow = { workspace = true }
 indexmap = { workspace = true }
 insta = { workspace = true }
@@ -52,8 +52,11 @@ workspace = true
 
 [features]
 default = [ "aws-crypto" ]
-aws-crypto = [ "sys_ops/aws-crypto", "sys_native/aws-crypto" ]
-ring-crypto = [ "sys_ops/ring-crypto", "sys_native/ring-crypto" ]
+# `sys_native` is a dev-dependency only, so feature propagation here would
+# be a no-op for downstream consumers; its crypto feature is set directly
+# on the `[dev-dependencies]` entry above.
+aws-crypto = [ "sys_ops/aws-crypto" ]
+ring-crypto = [ "sys_ops/ring-crypto" ]
 heap_debug = [
   "bex_vm/heap_debug",
   "bex_heap/heap_debug",

--- a/baml_language/crates/bex_engine/Cargo.toml
+++ b/baml_language/crates/bex_engine/Cargo.toml
@@ -52,8 +52,8 @@ workspace = true
 
 [features]
 default = [ "aws-crypto" ]
-aws-crypto = [ "sys_ops/aws-crypto" ]
-ring-crypto = [ "sys_ops/ring-crypto" ]
+aws-crypto = [ "sys_ops/aws-crypto", "sys_native/aws-crypto" ]
+ring-crypto = [ "sys_ops/ring-crypto", "sys_native/ring-crypto" ]
 heap_debug = [
   "bex_vm/heap_debug",
   "bex_heap/heap_debug",

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -337,14 +337,14 @@ impl BexEngine {
                 Value::Object(holder.holder_mut().tlab_mut().alloc_rust_data(arc))
             }
             BexExternalValue::FunctionRef { global_index } => {
-                let idx = bex_vm_types::GlobalIndex::from_raw(global_index);
+                let _idx = bex_vm_types::GlobalIndex::from_raw(global_index);
                 assert!(
                     (global_index < self.globals.len()),
                     "FunctionRef global_index {} out of bounds (globals len {})",
                     global_index,
                     self.globals.len()
                 );
-                self.globals[idx]
+                self.globals[global_index]
             }
         }
     }

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -4,12 +4,11 @@
 //! between the VM representation (`Value`, `Object`) and the external
 //! representation (`BexValue`, `BexExternalValue`).
 
-use ::bex_vm_types::ObjectType;
+use ::bex_heap::{BexValue, HeapPermit, PermitProof, TlabHolder};
+use ::bex_vm_types::{HeapPtr, Object, ObjectType, RootHaver, Value};
 use baml_type::Literal;
 use bex_external_types::{BexExternalAdt, BexExternalValue, Ty, UnionMetadata};
-use bex_heap::{ActiveHeapPermit, BexValue, PermitProof};
 use bex_vm::BexVm;
-use bex_vm_types::{HeapPtr, Object, Value};
 
 use crate::{BexEngine, EngineError};
 
@@ -194,6 +193,9 @@ impl BexEngine {
             Object::Future(_) => Err(EngineError::CannotConvert {
                 type_name: "future".to_string(),
             }),
+            Object::UnscheduledFuture(_) => Err(EngineError::CannotConvert {
+                type_name: "unscheduled_future".to_string(),
+            }),
             Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
             Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type((**ty).clone()))),
             Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.clone())),
@@ -222,37 +224,43 @@ impl BexEngine {
 
 impl BexEngine {
     /// Convert a `BexExternalValue` result from sys ops back to a VM Value.
-    pub(crate) fn convert_external_to_vm_value(
+    pub(crate) fn convert_external_to_vm_value<T: RootHaver + TlabHolder>(
         &self,
-        vm: &mut ActiveHeapPermit<BexVm>,
+        holder: &mut impl HeapPermit<T>,
         external: BexExternalValue,
     ) -> Value {
         match external {
             BexExternalValue::Handle(handle) => Value::Object(
-                self.resolve_handle(vm.proof(), &handle)
+                self.resolve_handle(holder.proof(), &handle)
                     .expect("Handle should be valid - object was returned to external code"),
             ),
             BexExternalValue::Null => Value::Null,
             BexExternalValue::Int(i) => Value::Int(i),
             BexExternalValue::Float(f) => Value::Float(f),
             BexExternalValue::Bool(b) => Value::Bool(b),
-            BexExternalValue::String(s) => vm.alloc_string(s),
+            BexExternalValue::String(s) => {
+                Value::Object(holder.holder_mut().tlab_mut().alloc_string(s))
+            }
             BexExternalValue::Array { items, .. } => {
                 let values: Vec<Value> = items
                     .into_iter()
-                    .map(|v| self.convert_external_to_vm_value(vm, v))
+                    .map(|v| self.convert_external_to_vm_value(holder, v))
                     .collect();
-                vm.alloc_array(values)
+                Value::Object(holder.holder_mut().tlab_mut().alloc_array(values))
             }
             BexExternalValue::Map { entries, .. } => {
                 let values: indexmap::IndexMap<String, Value> = entries
                     .into_iter()
-                    .map(|(k, v)| (k, self.convert_external_to_vm_value(vm, v)))
+                    .map(|(k, v)| (k, self.convert_external_to_vm_value(holder, v)))
                     .collect();
-                vm.alloc_map(values)
+                Value::Object(holder.holder_mut().tlab_mut().alloc_map(values))
             }
-            BexExternalValue::Uint8Array(bytes) => vm.alloc_uint8array(bytes),
-            BexExternalValue::RustData(data) => vm.alloc_rust_data(data),
+            BexExternalValue::Uint8Array(bytes) => {
+                Value::Object(holder.holder_mut().tlab_mut().alloc_uint8array(bytes))
+            }
+            BexExternalValue::RustData(data) => {
+                Value::Object(holder.holder_mut().tlab_mut().alloc_rust_data(data))
+            }
             // Allocate instance by looking up class and converting fields
             BexExternalValue::Instance { class_name, fields } => {
                 let class_ptr = self
@@ -275,9 +283,14 @@ impl BexEngine {
                     let ext = fields.get(&class_field.name).unwrap_or_else(|| {
                         panic!("missing field '{}' in Instance", class_field.name)
                     });
-                    values.push(self.convert_external_to_vm_value(vm, ext.clone()));
+                    values.push(self.convert_external_to_vm_value(holder, ext.clone()));
                 }
-                vm.alloc_instance(*class_ptr, values)
+                Value::Object(
+                    holder
+                        .holder_mut()
+                        .tlab_mut()
+                        .alloc_instance(*class_ptr, values),
+                )
             }
             BexExternalValue::Variant {
                 enum_name,
@@ -301,24 +314,37 @@ impl BexEngine {
                     .unwrap_or_else(|| {
                         panic!("Variant '{variant_name}' not found in enum '{enum_name}'")
                     });
-                vm.alloc_variant(*enum_ptr, index)
+                Value::Object(
+                    holder
+                        .holder_mut()
+                        .tlab_mut()
+                        .alloc_variant(*enum_ptr, index),
+                )
             }
-            BexExternalValue::Union { value, .. } => self.convert_external_to_vm_value(vm, *value),
-            BexExternalValue::Adt(BexExternalAdt::Collector(c)) => vm.alloc_collector(c),
-            BexExternalValue::Adt(BexExternalAdt::Type(ty)) => vm.alloc_type(ty),
+            BexExternalValue::Union { value, .. } => {
+                self.convert_external_to_vm_value(holder, *value)
+            }
+            BexExternalValue::Adt(BexExternalAdt::Collector(c)) => {
+                Value::Object(holder.holder_mut().tlab_mut().alloc_collector(c))
+            }
+            BexExternalValue::Adt(BexExternalAdt::Type(ty)) => {
+                Value::Object(holder.holder_mut().tlab_mut().alloc_type(ty))
+            }
             BexExternalValue::Adt(BexExternalAdt::PromptAst(_)) => {
                 panic!("PromptAst values cannot be converted to VM values yet")
             }
-            BexExternalValue::Adt(BexExternalAdt::Media(arc)) => vm.alloc_rust_data(arc),
+            BexExternalValue::Adt(BexExternalAdt::Media(arc)) => {
+                Value::Object(holder.holder_mut().tlab_mut().alloc_rust_data(arc))
+            }
             BexExternalValue::FunctionRef { global_index } => {
                 let idx = bex_vm_types::GlobalIndex::from_raw(global_index);
                 assert!(
-                    (global_index < vm.globals.len()),
+                    (global_index < self.globals.len()),
                     "FunctionRef global_index {} out of bounds (globals len {})",
                     global_index,
-                    vm.globals.len()
+                    self.globals.len()
                 );
-                vm.globals[idx]
+                self.globals[idx]
             }
         }
     }
@@ -612,6 +638,7 @@ fn find_matching_union_member<'a>(value: &Value, members: &'a [Ty]) -> Option<&'
                 | Object::Class(_)
                 | Object::Enum(_)
                 | Object::Future(_)
+                | Object::UnscheduledFuture(_)
                 | Object::RustData(_)
                 | Object::Collector(_)
                 | Object::Type(_) => None,
@@ -709,6 +736,7 @@ pub(crate) fn vm_arg_to_external(vm: &BexVm, value: &Value) -> BexExternalValue 
                 | Object::Class(_)
                 | Object::Enum(_)
                 | Object::Future(_)
+                | Object::UnscheduledFuture(_)
                 | Object::RustData(_)
                 | Object::Collector(_)
                 | Object::Type(_) => {

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -337,7 +337,6 @@ impl BexEngine {
                 Value::Object(holder.holder_mut().tlab_mut().alloc_rust_data(arc))
             }
             BexExternalValue::FunctionRef { global_index } => {
-                let _idx = bex_vm_types::GlobalIndex::from_raw(global_index);
                 assert!(
                     (global_index < self.globals.len()),
                     "FunctionRef global_index {} out of bounds (globals len {})",

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -1,3 +1,40 @@
+//! Future tracking for the Bex engine.
+//!
+//! # Lifecycle
+//!
+//! An entry exists in [`FutureManagerInner::active_futures`] **iff** the
+//! corresponding [`bex_vm_types::Future`] heap object is in the `Pending`
+//! state. As soon as any terminal transition succeeds (`fulfill_future`,
+//! `err_future`, `cancel_future`, `internal_error_future`) the entry is
+//! removed in the same critical section that updates the heap object and
+//! signals the cross-task ready notification.
+//!
+//! Why this is safe:
+//!
+//! - The heap object alone is sufficient to drive the VM's `Await`
+//!   instruction after it resumes; the engine's "ready" future does not
+//!   carry the value, it is purely a "you may proceed" signal.
+//! - All operations on a [`FutureManagerGuard`] hold an exclusive
+//!   [`SharedHeapPermitGuard`], so terminal-transition-then-remove is
+//!   atomic with respect to any other [`FutureManagerGuard`] operation
+//!   (notably [`FutureManagerGuard::future_ready`]).
+//! - Existing `Arc<tokio::sync::SetOnce<_>>` clones held by waiters keep
+//!   working after the entry is dropped — removal only releases the
+//!   manager's own `Arc`.
+//!
+//! Why this works for fire-and-forget: while pending, the [`FutureState`]
+//! roots the heap object via [`RootHaver::collect_roots`]. After the
+//! sys-op task completes the entry is removed; if no VM stack still
+//! references the heap object it is correctly reclaimed by the next GC.
+//!
+//! Why this works for the await race (a VM observes `Pending(future_id)`
+//! on the heap, yields `Await(future_id)`, and the engine completes the
+//! future before the event loop calls [`FutureManagerGuard::future_ready`]):
+//! [`FutureManagerGuard::future_ready`] treats a missing-but-previously-issued
+//! `FutureId` as "already resolved" and returns an immediate `Ok(())`. The
+//! VM re-executes the saved `Await` instruction, reads the terminal state
+//! directly from the heap, and proceeds.
+
 use ::bex_heap::{
     HeapPermit, PermitProof, SharedHeapPermit, SharedHeapPermitGuard, Tlab, TlabHolder,
 };
@@ -27,6 +64,11 @@ impl FutureManager {
             inner: self.inner.acquire().await,
         }
     }
+
+    /// Number of `Pending` futures currently tracked. Acquires the manager.
+    pub async fn active_future_count(&self) -> usize {
+        self.inner.acquire().await.active_future_count()
+    }
 }
 
 pub struct FutureManagerGuard<'a> {
@@ -34,6 +76,11 @@ pub struct FutureManagerGuard<'a> {
 }
 
 impl FutureManagerGuard<'_> {
+    /// Number of `Pending` futures currently tracked by the manager.
+    pub fn active_future_count(&self) -> usize {
+        self.inner.active_future_count()
+    }
+
     /// Registers a future with the future manager and returns a unique ID.
     pub fn new_future(&mut self, cancel: CancellationToken) -> (FutureId, HeapPtr) {
         let id = self
@@ -57,58 +104,19 @@ impl FutureManagerGuard<'_> {
         (id, ptr)
     }
     pub fn fulfill_future(&mut self, id: FutureId, value: Value) -> Result<(), EngineError> {
-        let future = self.inner.get_future_mut(id)?;
-        // SAFETY: We shold a heap permit in `self`.
-        let fut = unsafe { future.get_mut() }?;
-        if !matches!(fut, bex_vm_types::Future::Pending(_)) {
-            return Err(EngineError::TypeMismatch {
-                message: format!("Expected Pending Future, got {:?}", FutureType::of(fut)),
-            });
-        }
-
-        *fut = bex_vm_types::Future::Ready(value);
-        let set = future.ready.set(Ok(()));
-        debug_assert!(
-            set.is_ok(),
-            "Should not have been ready if the heap future was pending."
-        );
+        self.complete_pending(id, bex_vm_types::Future::Ready(value), Ok(()))?;
         Ok(())
     }
     pub fn err_future(&mut self, id: FutureId, err: Value) -> Result<(), EngineError> {
-        let future = self.inner.get_future_mut(id)?;
-        // SAFETY: We shold a heap permit in `self`.
-        let fut = unsafe { future.get_mut() }?;
-        if !matches!(fut, bex_vm_types::Future::Pending(_)) {
-            return Err(EngineError::TypeMismatch {
-                message: format!("Expected Pending Future, got {:?}", FutureType::of(fut)),
-            });
-        }
-
-        *fut = bex_vm_types::Future::Error(err);
-        let set = future.ready.set(Ok(()));
-        debug_assert!(
-            set.is_ok(),
-            "Should not have been ready if the heap future was pending."
-        );
+        self.complete_pending(id, bex_vm_types::Future::Error(err), Ok(()))?;
         Ok(())
     }
     pub fn cancel_future(&mut self, id: FutureId) -> Result<(), EngineError> {
-        let future = self.inner.get_future_mut(id)?;
-        // SAFETY: We shold a heap permit in `self`.
-        let fut = unsafe { future.get_mut() }?;
-        if !matches!(fut, bex_vm_types::Future::Pending(_)) {
-            return Err(EngineError::TypeMismatch {
-                message: format!("Expected Pending Future, got {:?}", FutureType::of(fut)),
-            });
-        }
-
-        *fut = bex_vm_types::Future::Cancelled;
-        let set = future.ready.set(Ok(()));
-        debug_assert!(
-            set.is_ok(),
-            "Should not have been ready if the heap future was pending."
-        );
-        future.cancel.cancel();
+        let entry = self.complete_pending(id, bex_vm_types::Future::Cancelled, Ok(()))?;
+        // The token is still cloned by the spawned sys-op task; firing it
+        // here unparks that task even though `entry` itself is about to be
+        // dropped.
+        entry.cancel.cancel();
         Ok(())
     }
     /// Sets the future to `InternalError` and notifies the waiter.
@@ -117,40 +125,84 @@ impl FutureManagerGuard<'_> {
         id: FutureId,
         err: EngineError,
     ) -> Result<(), EngineError> {
-        let future = self.inner.get_future_mut(id)?;
-        // SAFETY: We shold a heap permit in `self`.
-        let fut = unsafe { future.get_mut() }?;
+        self.complete_pending(id, bex_vm_types::Future::InternalError, Err(err))?;
+        Ok(())
+    }
+
+    /// Atomically transition a `Pending` future to a terminal state, signal
+    /// its [`tokio::sync::SetOnce`] waiter, and remove the entry from
+    /// `active_futures`. The dropped [`FutureState`] is returned so callers
+    /// (e.g. [`Self::cancel_future`]) can perform additional Drop-time work
+    /// like firing a [`CancellationToken`] clone before it is released.
+    fn complete_pending(
+        &mut self,
+        id: FutureId,
+        new_state: bex_vm_types::Future,
+        result: Result<(), EngineError>,
+    ) -> Result<FutureState, EngineError> {
+        let mut entry = self
+            .inner
+            .active_futures
+            .remove(&id)
+            .ok_or(EngineError::FutureNotFound { future_id: id })?;
+        // SAFETY: the `FutureManagerGuard` holds an exclusive heap permit.
+        let fut = unsafe { entry.get_mut() }?;
         if !matches!(fut, bex_vm_types::Future::Pending(_)) {
+            let actual = FutureType::of(fut);
+            // The future was already terminal; restore the entry so that
+            // observers continue to see a consistent (heap, map) pair.
+            self.inner.active_futures.insert(id, entry);
             return Err(EngineError::TypeMismatch {
-                message: format!("Expected Pending Future, got {:?}", FutureType::of(fut)),
+                message: format!("Expected Pending Future, got {actual:?}"),
             });
         }
-
-        *fut = bex_vm_types::Future::InternalError;
-        let set = future.ready.set(Err(err));
+        *fut = new_state;
+        let set = entry.ready.set(result);
         debug_assert!(
             set.is_ok(),
             "Should not have been ready if the heap future was pending."
         );
-        Ok(())
+        Ok(entry)
     }
-    /// Returns a Rust future that will resolve when the BAML future is ready.
-    /// Once it is resolved, the future on the heap will be ready (in some form).
+    /// Returns a Rust future that resolves when the BAML future is ready.
+    /// Once it is resolved, the future on the heap will be in a terminal
+    /// state (some variant other than `Pending`).
+    ///
+    /// A `FutureId` that is missing from `active_futures` but has been
+    /// previously issued (i.e. `id.as_usize() < next_future_id`) is treated
+    /// as already resolved: the entry was dropped by the terminal-transition
+    /// helper after the heap object was set. The VM's `Await` re-execution
+    /// reads the terminal state directly from the heap. See the module-level
+    /// docs for the full lifecycle invariant.
     ///
     /// ## Errors
-    /// - Synchronous `EngineError::FutureNotFound` if the future is not found
-    /// - Future returns `EngineError` if the future produces an `InternalError`
+    /// - Synchronous `EngineError::FutureNotFound` for a `FutureId` that was
+    ///   never issued by this manager.
+    /// - The returned future yields `EngineError` if the future produced an
+    ///   `InternalError`.
     pub fn future_ready(
         &self,
         id: FutureId,
     ) -> Result<impl Future<Output = Result<(), EngineError>> + use<>, EngineError> {
-        let future = self
-            .inner
-            .active_futures
-            .get(&id)
-            .ok_or(EngineError::FutureNotFound { future_id: id })?;
-        let waiter = Arc::clone(&future.ready);
-        Ok(async move { waiter.wait().await.clone() })
+        let waiter = match self.inner.active_futures.get(&id) {
+            Some(future) => Some(Arc::clone(&future.ready)),
+            None => {
+                let next = self
+                    .inner
+                    .next_future_id
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                if id.as_usize() >= next {
+                    return Err(EngineError::FutureNotFound { future_id: id });
+                }
+                None
+            }
+        };
+        Ok(async move {
+            match waiter {
+                Some(w) => w.wait().await.clone(),
+                None => Ok(()),
+            }
+        })
     }
 }
 impl TlabHolder for FutureManagerGuard<'_> {
@@ -186,16 +238,12 @@ impl FutureManagerInner {
             active_futures: HashMap::new(),
         }
     }
-    #[expect(dead_code)]
-    fn get_future(&self, id: FutureId) -> Result<&FutureState, EngineError> {
-        self.active_futures
-            .get(&id)
-            .ok_or(EngineError::FutureNotFound { future_id: id })
-    }
-    fn get_future_mut(&mut self, id: FutureId) -> Result<&mut FutureState, EngineError> {
-        self.active_futures
-            .get_mut(&id)
-            .ok_or(EngineError::FutureNotFound { future_id: id })
+
+    /// Number of `Pending` futures currently tracked by the manager. This is
+    /// the same as the number of futures whose heap object is in
+    /// `Future::Pending(_)`. Intended for tests and telemetry.
+    pub fn active_future_count(&self) -> usize {
+        self.active_futures.len()
     }
 }
 impl RootHaver for FutureManagerInner {
@@ -261,5 +309,118 @@ impl RootHaver for FutureState {
         if let Some(new_result) = roots.get(&self.future) {
             self.future = *new_result;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ::bex_heap::{BexHeap, HeapPermitManager};
+    use ::bex_vm_types::Value;
+
+    use super::*;
+
+    async fn make_manager() -> FutureManager {
+        let heap = BexHeap::new(Vec::new());
+        let permit_manager = Arc::new(HeapPermitManager::new());
+        let permit = permit_manager
+            .new_permit(FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap))))
+            .await;
+        FutureManager::new(SharedHeapPermit::new(permit))
+    }
+
+    #[tokio::test]
+    async fn fulfill_removes_entry() {
+        let mgr = make_manager().await;
+        let mut guard = mgr.acquire().await;
+        let (id, _ptr) = guard.new_future(CancellationToken::new());
+        assert_eq!(guard.active_future_count(), 1);
+        guard.fulfill_future(id, Value::Int(42)).unwrap();
+        assert_eq!(guard.active_future_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancel_removes_entry_and_fires_token() {
+        let mgr = make_manager().await;
+        let mut guard = mgr.acquire().await;
+        let token = CancellationToken::new();
+        let (id, _ptr) = guard.new_future(token.clone());
+        assert!(!token.is_cancelled());
+        guard.cancel_future(id).unwrap();
+        assert_eq!(guard.active_future_count(), 0);
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn err_and_internal_error_remove_entry() {
+        let mgr = make_manager().await;
+        let mut guard = mgr.acquire().await;
+        let (id_a, _) = guard.new_future(CancellationToken::new());
+        let (id_b, _) = guard.new_future(CancellationToken::new());
+        assert_eq!(guard.active_future_count(), 2);
+        guard.err_future(id_a, Value::Int(7)).unwrap();
+        guard
+            .internal_error_future(
+                id_b,
+                EngineError::TypeMismatch {
+                    message: "boom".into(),
+                },
+            )
+            .unwrap();
+        assert_eq!(guard.active_future_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn double_complete_returns_not_found() {
+        let mgr = make_manager().await;
+        let mut guard = mgr.acquire().await;
+        let (id, _) = guard.new_future(CancellationToken::new());
+        guard.fulfill_future(id, Value::Int(1)).unwrap();
+        let again = guard.fulfill_future(id, Value::Int(2));
+        assert!(matches!(again, Err(EngineError::FutureNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn future_ready_immediate_for_completed_id() {
+        let mgr = make_manager().await;
+        let mut guard = mgr.acquire().await;
+        let (id, _) = guard.new_future(CancellationToken::new());
+        guard.fulfill_future(id, Value::Int(1)).unwrap();
+        // Entry is gone; future_ready should treat it as already-resolved.
+        let waiter = guard.future_ready(id).expect("expected immediate Ok");
+        drop(guard);
+        waiter.await.expect("should resolve to Ok(())");
+    }
+
+    #[tokio::test]
+    async fn future_ready_for_never_issued_id_errors() {
+        let mgr = make_manager().await;
+        let guard = mgr.acquire().await;
+        // No futures have been issued; any non-zero id is bogus. Use the
+        // unsafe constructor — the safety contract there is "engine only,"
+        // and this test is exercising the engine.
+        #[expect(unsafe_code)]
+        let bogus = unsafe { FutureId::from_usize(99) };
+        let result = guard.future_ready(bogus);
+        assert!(matches!(result, Err(EngineError::FutureNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn future_ready_waiter_resolves_after_fulfill() {
+        // Grab a waiter while the future is still pending; fulfill from a
+        // separate critical section; then the waiter should resolve. This
+        // exercises the path where `future_ready` clones the `Arc<SetOnce>`
+        // before the entry is removed.
+        let mgr = make_manager().await;
+        let mut guard = mgr.acquire().await;
+        let (id, _) = guard.new_future(CancellationToken::new());
+        let waiter = guard.future_ready(id).expect("waiter should be created");
+        drop(guard);
+
+        let mut guard = mgr.acquire().await;
+        guard.fulfill_future(id, Value::Int(123)).unwrap();
+        drop(guard);
+
+        waiter.await.expect("waiter should resolve to Ok(())");
+        assert_eq!(mgr.active_future_count().await, 0);
     }
 }

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -169,12 +169,24 @@ impl FutureManagerGuard<'_> {
         // so we are the unique caller; the heap object is alive because
         // the entry roots it via `RootHaver::collect_roots`.
         let fut = unsafe { entry.future_ref() }?;
+        let observed = FutureType::of(fut);
         debug_assert!(
             matches!(fut.read(), FutureRead::Pending(_)),
             "internal_error_future called on non-Pending future {id:?} \
-             (actual: {:?}); invariant violated",
-            FutureType::of(fut)
+             (actual: {observed:?}); invariant violated"
         );
+        if !matches!(fut.read(), FutureRead::Pending(_)) {
+            // Release-build invariant guard: a previously-resolved future
+            // should never re-enter this path. Surfacing as an error
+            // (rather than the legacy silent overwrite) makes the bug
+            // observable to telemetry / `tracing::error!` in `run_future`.
+            return Err(EngineError::TypeMismatch {
+                message: format!(
+                    "internal_error_future called on non-Pending future {id:?} \
+                     (actual: {observed:?})"
+                ),
+            });
+        }
         // SAFETY: single-writer via future_permit Mutex.
         unsafe { fut.set_internal_error() };
         let set = entry.ready.set(Err(err));
@@ -182,6 +194,14 @@ impl FutureManagerGuard<'_> {
             set.is_ok(),
             "Should not have been ready if the heap future was pending."
         );
+        if set.is_err() {
+            return Err(EngineError::TypeMismatch {
+                message: format!(
+                    "internal_error_future: SetOnce already set for future {id:?}; \
+                     invariant violated"
+                ),
+            });
+        }
         Ok(())
     }
 
@@ -207,29 +227,59 @@ impl FutureManagerGuard<'_> {
         id: FutureId,
         transition: impl FnOnce(&bex_vm_types::Future),
     ) -> Result<FutureState, EngineError> {
+        // Phase 1: pre-check the state without removing. A non-Pending
+        // heap state means the caller has already routed this id through
+        // a terminal helper (or `internal_error_future`'s leak); in that
+        // case we must not remove the entry, since doing so would discard
+        // the leaked `SetOnce` payload and silently lose the error.
+        {
+            let entry_ref = self
+                .inner
+                .active_futures
+                .get(&id)
+                .ok_or(EngineError::FutureNotFound { future_id: id })?;
+            // SAFETY: the `FutureManagerGuard` holds the future_permit Mutex.
+            let fut = unsafe { entry_ref.future_ref() }?;
+            let observed = FutureType::of(fut);
+            debug_assert!(
+                matches!(fut.read(), FutureRead::Pending(_)),
+                "complete_pending called with non-Pending heap state for {id:?} \
+                 (actual: {observed:?}); invariant violated — only fulfill/err/cancel may \
+                 route through this helper"
+            );
+            if !matches!(fut.read(), FutureRead::Pending(_)) {
+                return Err(EngineError::TypeMismatch {
+                    message: format!(
+                        "complete_pending called with non-Pending heap state for {id:?} \
+                         (actual: {observed:?})"
+                    ),
+                });
+            }
+        }
+        // Phase 2: state is Pending. Remove the entry and apply the
+        // transition under the future_permit Mutex (single-writer).
         let entry = self
             .inner
             .active_futures
             .remove(&id)
-            .ok_or(EngineError::FutureNotFound { future_id: id })?;
-        // SAFETY: the `FutureManagerGuard` holds the future_permit Mutex,
-        // so we are the unique caller; the heap object is alive because
-        // we just removed the entry that was rooting it (the entry is
-        // still owned by us locally).
+            .expect("entry was present in phase 1 and we hold the future_permit");
+        // SAFETY: the entry is still rooting the heap object via local
+        // ownership; the future_permit Mutex enforces single-writer.
         let fut = unsafe { entry.future_ref() }?;
-        debug_assert!(
-            matches!(fut.read(), FutureRead::Pending(_)),
-            "complete_pending called with non-Pending heap state for {id:?} \
-             (actual: {:?}); invariant violated — only fulfill/err/cancel may \
-             route through this helper",
-            FutureType::of(fut)
-        );
         transition(fut);
         let set = entry.ready.set(Ok(()));
         debug_assert!(
             set.is_ok(),
             "Should not have been ready if the heap future was pending."
         );
+        if set.is_err() {
+            return Err(EngineError::TypeMismatch {
+                message: format!(
+                    "complete_pending: SetOnce already set for future {id:?}; \
+                     invariant violated"
+                ),
+            });
+        }
         Ok(entry)
     }
     /// Returns a Rust future that resolves when the BAML future is ready.
@@ -469,10 +519,11 @@ mod tests {
     async fn fulfill_after_internal_error_is_disallowed() {
         // Once an entry is in the leaked InternalError state, none of the
         // terminal-transition helpers (fulfill/err/cancel) should subsequently
-        // succeed against it: the `complete_pending` invariant is "entry exists
-        // and heap is Pending". In debug builds the debug_assert fires; in
-        // release builds the heap state is non-Pending and the call still
-        // produces a `FutureNotFound`-or-equivalent error path.
+        // succeed against it. In debug builds the `debug_assert` fires; in
+        // release builds the call returns an `EngineError::TypeMismatch`
+        // *without* removing the entry, so the original error stays pinned
+        // to the registry's `SetOnce` for surfacing through a later VM
+        // `Await(future_id)` yield.
         //
         // We exercise the release-build path by skipping under
         // `cfg(debug_assertions)` — the panic there is the documented
@@ -483,20 +534,31 @@ mod tests {
         let mgr = make_manager().await;
         let mut guard = mgr.acquire().await;
         let (id, _) = guard.new_future(CancellationToken::new());
-        guard
-            .internal_error_future(
-                id,
-                EngineError::TypeMismatch {
-                    message: "stale".into(),
-                },
-            )
-            .unwrap();
-        // The release-build path: `fulfill_future`'s `complete_pending` happily
-        // overwrites the heap to `Ready` and removes the entry. This is
-        // tolerated rather than guaranteed (the `complete_pending` debug_assert
-        // fails in debug builds). The point of the test is to pin the
-        // observable behavior of the leaked state.
-        let _ = guard.fulfill_future(id, Value::Int(0));
+        let original = EngineError::TypeMismatch {
+            message: "stale".into(),
+        };
+        guard.internal_error_future(id, original.clone()).unwrap();
+        assert_eq!(guard.active_future_count(), 1);
+
+        // Release-build behavior: `fulfill_future` rejects the call (the
+        // pre-check observes a non-Pending heap state) and leaves the
+        // leaked entry untouched.
+        let result = guard.fulfill_future(id, Value::Int(0));
+        assert!(
+            matches!(result, Err(EngineError::TypeMismatch { .. })),
+            "fulfill_future after internal_error should reject in release; got {result:?}"
+        );
+        assert_eq!(
+            guard.active_future_count(),
+            1,
+            "leaked InternalError entry must survive a rejected fulfill"
+        );
+
+        // The waiter still resolves to the original error.
+        let waiter = guard.future_ready(id).expect("waiter should be created");
+        drop(guard);
+        let surfaced = waiter.await.expect_err("InternalError should propagate");
+        assert_eq!(surfaced, original);
     }
 
     #[tokio::test]

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -1,0 +1,265 @@
+use ::bex_heap::{
+    HeapPermit, PermitProof, SharedHeapPermit, SharedHeapPermitGuard, Tlab, TlabHolder,
+};
+use ::bex_vm_types::{
+    HeapPtr, Object, ObjectType, RootHaver, Value,
+    types::{FutureId, FutureType},
+};
+use ::core::sync::atomic::AtomicUsize;
+use ::std::{collections::HashMap, sync::Arc};
+use ::sys_types::CancellationToken;
+
+use crate::EngineError;
+
+/// Manages all futures for the Bex engine.
+///
+/// This is a shared resource managed using a [`SharedHeapPermit`].
+pub struct FutureManager {
+    inner: SharedHeapPermit<FutureManagerInner>,
+}
+
+impl FutureManager {
+    pub fn new(inner: SharedHeapPermit<FutureManagerInner>) -> Self {
+        Self { inner }
+    }
+    pub async fn acquire(&self) -> FutureManagerGuard<'_> {
+        FutureManagerGuard {
+            inner: self.inner.acquire().await,
+        }
+    }
+}
+
+pub struct FutureManagerGuard<'a> {
+    inner: SharedHeapPermitGuard<'a, FutureManagerInner>,
+}
+
+impl FutureManagerGuard<'_> {
+    /// Registers a future with the future manager and returns a unique ID.
+    pub fn new_future(&mut self, cancel: CancellationToken) -> (FutureId, HeapPtr) {
+        let id = self
+            .inner
+            .next_future_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // SAFETY: we are the only one allowed to create new future ids
+        let id = unsafe { FutureId::from_usize(id) };
+
+        let ptr = self
+            .inner
+            .tlab
+            .alloc_future(::bex_vm_types::Future::Pending(id));
+
+        let future_state = FutureState {
+            future: ptr,
+            ready: Arc::new(tokio::sync::SetOnce::new()),
+            cancel,
+        };
+        self.inner.active_futures.insert(id, future_state);
+        (id, ptr)
+    }
+    pub fn fulfill_future(&mut self, id: FutureId, value: Value) -> Result<(), EngineError> {
+        let future = self.inner.get_future_mut(id)?;
+        // SAFETY: We shold a heap permit in `self`.
+        let fut = unsafe { future.get_mut() }?;
+        if !matches!(fut, bex_vm_types::Future::Pending(_)) {
+            return Err(EngineError::TypeMismatch {
+                message: format!("Expected Pending Future, got {:?}", FutureType::of(fut)),
+            });
+        }
+
+        *fut = bex_vm_types::Future::Ready(value);
+        let set = future.ready.set(Ok(()));
+        debug_assert!(
+            set.is_ok(),
+            "Should not have been ready if the heap future was pending."
+        );
+        Ok(())
+    }
+    pub fn err_future(&mut self, id: FutureId, err: Value) -> Result<(), EngineError> {
+        let future = self.inner.get_future_mut(id)?;
+        // SAFETY: We shold a heap permit in `self`.
+        let fut = unsafe { future.get_mut() }?;
+        if !matches!(fut, bex_vm_types::Future::Pending(_)) {
+            return Err(EngineError::TypeMismatch {
+                message: format!("Expected Pending Future, got {:?}", FutureType::of(fut)),
+            });
+        }
+
+        *fut = bex_vm_types::Future::Error(err);
+        let set = future.ready.set(Ok(()));
+        debug_assert!(
+            set.is_ok(),
+            "Should not have been ready if the heap future was pending."
+        );
+        Ok(())
+    }
+    pub fn cancel_future(&mut self, id: FutureId) -> Result<(), EngineError> {
+        let future = self.inner.get_future_mut(id)?;
+        // SAFETY: We shold a heap permit in `self`.
+        let fut = unsafe { future.get_mut() }?;
+        if !matches!(fut, bex_vm_types::Future::Pending(_)) {
+            return Err(EngineError::TypeMismatch {
+                message: format!("Expected Pending Future, got {:?}", FutureType::of(fut)),
+            });
+        }
+
+        *fut = bex_vm_types::Future::Cancelled;
+        let set = future.ready.set(Ok(()));
+        debug_assert!(
+            set.is_ok(),
+            "Should not have been ready if the heap future was pending."
+        );
+        future.cancel.cancel();
+        Ok(())
+    }
+    /// Sets the future to `InternalError` and notifies the waiter.
+    pub fn internal_error_future(
+        &mut self,
+        id: FutureId,
+        err: EngineError,
+    ) -> Result<(), EngineError> {
+        let future = self.inner.get_future_mut(id)?;
+        // SAFETY: We shold a heap permit in `self`.
+        let fut = unsafe { future.get_mut() }?;
+        if !matches!(fut, bex_vm_types::Future::Pending(_)) {
+            return Err(EngineError::TypeMismatch {
+                message: format!("Expected Pending Future, got {:?}", FutureType::of(fut)),
+            });
+        }
+
+        *fut = bex_vm_types::Future::InternalError;
+        let set = future.ready.set(Err(err));
+        debug_assert!(
+            set.is_ok(),
+            "Should not have been ready if the heap future was pending."
+        );
+        Ok(())
+    }
+    /// Returns a Rust future that will resolve when the BAML future is ready.
+    /// Once it is resolved, the future on the heap will be ready (in some form).
+    ///
+    /// ## Errors
+    /// - Synchronous `EngineError::FutureNotFound` if the future is not found
+    /// - Future returns `EngineError` if the future produces an `InternalError`
+    pub fn future_ready(
+        &self,
+        id: FutureId,
+    ) -> Result<impl Future<Output = Result<(), EngineError>> + use<>, EngineError> {
+        let future = self
+            .inner
+            .active_futures
+            .get(&id)
+            .ok_or(EngineError::FutureNotFound { future_id: id })?;
+        let waiter = Arc::clone(&future.ready);
+        Ok(async move { waiter.wait().await.clone() })
+    }
+}
+impl TlabHolder for FutureManagerGuard<'_> {
+    fn tlab(&self) -> &Tlab {
+        self.inner.tlab()
+    }
+    fn tlab_mut(&mut self) -> &mut Tlab {
+        self.inner.tlab_mut()
+    }
+}
+impl HeapPermit<FutureManagerInner> for FutureManagerGuard<'_> {
+    fn holder(&self) -> &FutureManagerInner {
+        &self.inner
+    }
+    fn holder_mut(&mut self) -> &mut FutureManagerInner {
+        &mut self.inner
+    }
+    fn proof(&self) -> PermitProof<'_> {
+        self.inner.proof()
+    }
+}
+
+pub struct FutureManagerInner {
+    tlab: Tlab,
+    next_future_id: AtomicUsize,
+    active_futures: HashMap<FutureId, FutureState>,
+}
+impl FutureManagerInner {
+    pub fn new(tlab: Tlab) -> Self {
+        Self {
+            tlab,
+            next_future_id: AtomicUsize::new(0),
+            active_futures: HashMap::new(),
+        }
+    }
+    #[expect(dead_code)]
+    fn get_future(&self, id: FutureId) -> Result<&FutureState, EngineError> {
+        self.active_futures
+            .get(&id)
+            .ok_or(EngineError::FutureNotFound { future_id: id })
+    }
+    fn get_future_mut(&mut self, id: FutureId) -> Result<&mut FutureState, EngineError> {
+        self.active_futures
+            .get_mut(&id)
+            .ok_or(EngineError::FutureNotFound { future_id: id })
+    }
+}
+impl RootHaver for FutureManagerInner {
+    fn collect_roots(&self, roots: &mut Vec<HeapPtr>) {
+        // blocking is fine since we should only ever call this while holding exclusive heap access
+        for future in self.active_futures.values() {
+            future.collect_roots(roots);
+        }
+    }
+    fn forward_roots(&mut self, roots: &HashMap<HeapPtr, HeapPtr>) {
+        for future in self.active_futures.values_mut() {
+            future.forward_roots(roots);
+        }
+    }
+}
+impl TlabHolder for FutureManagerInner {
+    fn tlab(&self) -> &Tlab {
+        &self.tlab
+    }
+    fn tlab_mut(&mut self) -> &mut Tlab {
+        &mut self.tlab
+    }
+}
+
+struct FutureState {
+    future: HeapPtr,
+    /// Set once the `Future` object is no longer `Pending`
+    /// - `Ok(())` means there is a BAML value ready on the heap
+    /// - `Err(err)` means it's `InternalError` and `err` is the error value
+    ready: Arc<tokio::sync::SetOnce<Result<(), EngineError>>>,
+    pub cancel: CancellationToken,
+}
+impl FutureState {
+    /// SAFETY: We must hold a heap permit for the duration of the future object.
+    #[expect(dead_code)]
+    unsafe fn get(&self) -> Result<&bex_vm_types::Future, EngineError> {
+        // SAFETY: We hold a permit, so we can access the future object.
+        let obj = unsafe { self.future.get() };
+        match obj {
+            Object::Future(fut) => Ok(fut),
+            other => Err(EngineError::TypeMismatch {
+                message: format!("Expected Future, got {:?}", ObjectType::of(other)),
+            }),
+        }
+    }
+    /// SAFETY: We must hold a heap permit for the duration of the future object.
+    unsafe fn get_mut(&mut self) -> Result<&mut bex_vm_types::Future, EngineError> {
+        // SAFETY: We hold a permit, so we can access the future object.
+        let obj = unsafe { self.future.get_mut() };
+        match obj {
+            Object::Future(fut) => Ok(fut),
+            other => Err(EngineError::TypeMismatch {
+                message: format!("Expected Future, got {:?}", ObjectType::of(other)),
+            }),
+        }
+    }
+}
+impl RootHaver for FutureState {
+    fn collect_roots(&self, roots: &mut Vec<HeapPtr>) {
+        roots.push(self.future);
+    }
+    fn forward_roots(&mut self, roots: &HashMap<HeapPtr, HeapPtr>) {
+        if let Some(new_result) = roots.get(&self.future) {
+            self.future = *new_result;
+        }
+    }
+}

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -23,10 +23,10 @@
 //! - The heap object alone is sufficient to drive the VM's `Await`
 //!   instruction after it resumes; the engine's "ready" future does not
 //!   carry the value, it is purely a "you may proceed" signal.
-//! - All operations on a [`FutureManagerGuard`] hold an exclusive
-//!   [`SharedHeapPermitGuard`], so terminal-transition-then-remove is
-//!   atomic with respect to any other [`FutureManagerGuard`] operation
-//!   (notably [`FutureManagerGuard::future_ready`]).
+//! - All operations on a [`FutureManagerGuard`] hold the manager's state
+//!   mutex, so terminal-transition-then-remove is atomic with respect to
+//!   any other [`FutureManagerGuard`] operation (notably
+//!   [`FutureManagerGuard::future_ready`]).
 //! - Existing `Arc<tokio::sync::SetOnce<_>>` clones held by waiters keep
 //!   working after the entry is dropped — removal only releases the
 //!   manager's own `Arc`.
@@ -50,7 +50,7 @@
 //! `future_ready` always finds a waiter that yields the original error.
 
 use ::bex_heap::{
-    HeapPermit, PermitProof, SharedHeapPermit, SharedHeapPermitGuard, Tlab, TlabHolder,
+    HeapPermit, HeapPermitManager, InactiveHeapPermit, PermitProof, Tlab, TlabHolder,
 };
 use ::bex_vm_types::{
     FutureRead, HeapPtr, Object, ObjectType, RootHaver, Value,
@@ -59,40 +59,75 @@ use ::bex_vm_types::{
 use ::core::sync::atomic::AtomicUsize;
 use ::std::{collections::HashMap, sync::Arc};
 use ::sys_types::CancellationToken;
+use ::tokio::sync::{Mutex, MutexGuard};
 
 use crate::EngineError;
 
 /// Manages all futures for the Bex engine.
 ///
-/// This is a shared resource managed using a [`SharedHeapPermit`].
+/// The wrapped [`InactiveHeapPermit`] is registered with
+/// [`HeapPermitManager.holders`](::bex_heap::HeapPermitManager) so GC can
+/// `collect_roots` / `forward_roots` on the inner. It is **never activated**
+/// by the manager itself — every method requires a [`PermitProof`] from
+/// the caller's own active permit, witnessing that GC is gated externally.
+/// The wrapping [`tokio::sync::Mutex`] provides the single-writer invariant
+/// that previous releases derived from `SharedHeapPermit`.
 pub struct FutureManager {
-    inner: SharedHeapPermit<FutureManagerInner>,
+    permit: Mutex<InactiveHeapPermit<FutureManagerInner>>,
 }
 
 impl FutureManager {
-    pub fn new(inner: SharedHeapPermit<FutureManagerInner>) -> Self {
-        Self { inner }
-    }
-    pub async fn acquire(&self) -> FutureManagerGuard<'_> {
-        FutureManagerGuard {
-            inner: self.inner.acquire().await,
+    pub fn new(permit: InactiveHeapPermit<FutureManagerInner>) -> Self {
+        Self {
+            permit: Mutex::new(permit),
         }
     }
 
-    /// Number of `Pending` futures currently tracked. Acquires the manager.
-    pub async fn active_future_count(&self) -> usize {
-        self.inner.acquire().await.active_future_count()
+    /// Acquire exclusive access to the future registry.
+    ///
+    /// `proof` is a witness that the caller currently holds an active heap
+    /// permit. Its lifetime `'a` ties the returned guard to it: the
+    /// borrow checker rejects any program that drops the proof source
+    /// while the guard is still live. That tie is what makes the unsafe
+    /// `holder` / `holder_mut` accesses inside the guard's `HeapPermit`
+    /// impl sound — there is no safe way to construct a `FutureManagerGuard`
+    /// without a real `PermitProof`, and no safe way to keep the guard
+    /// past the proof's lifetime.
+    ///
+    /// Engine call sites should scope the guard tightly (a single
+    /// transition: `new_future` / `fulfill_future` / `cancel_future` /
+    /// `future_ready`) and drop it before re-borrowing the permit holder
+    /// mutably (e.g. `vm.stack.push(...)` after `new_future`).
+    pub async fn acquire<'a>(&'a self, proof: PermitProof<'a>) -> FutureManagerGuard<'a> {
+        FutureManagerGuard {
+            permit_guard: self.permit.lock().await,
+            proof,
+        }
+    }
+
+    /// Number of `Pending` futures currently tracked.
+    ///
+    /// Takes a one-shot heap permit internally so external diagnostic callers
+    /// (notably tests) don't need to construct a `PermitProof` themselves.
+    pub async fn active_future_count(&self, mgr: &HeapPermitManager) -> usize {
+        let inactive = mgr.new_permit(()).await;
+        let active = inactive.acquire().await;
+        let guard = self.acquire(active.proof()).await;
+        guard.active_future_count()
     }
 }
 
 pub struct FutureManagerGuard<'a> {
-    inner: SharedHeapPermitGuard<'a, FutureManagerInner>,
+    permit_guard: MutexGuard<'a, InactiveHeapPermit<FutureManagerInner>>,
+    /// Caller-supplied witness; `'a` ties the guard's existence to the
+    /// caller's active heap permit so GC exclusion is type-system-enforced.
+    proof: PermitProof<'a>,
 }
 
 impl FutureManagerGuard<'_> {
     /// Number of `Pending` futures currently tracked by the manager.
     pub fn active_future_count(&self) -> usize {
-        self.inner.active_future_count()
+        self.holder().active_future_count()
     }
 
     /// Registers a future with the future manager and returns a unique ID.
@@ -101,33 +136,41 @@ impl FutureManagerGuard<'_> {
         // usize". We satisfy this by drawing the value from the manager's
         // monotonic `AtomicUsize`; uniqueness is preserved as long as the
         // counter hasn't wrapped (which would take 2^64 calls).
-        let id = self
-            .inner
+        let inner = self.holder_mut();
+        let id = inner
             .next_future_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let id = FutureId::from_usize(id);
 
-        let ptr = self
-            .inner
-            .tlab
-            .alloc_future(::bex_vm_types::Future::pending(id));
+        let ptr = inner.tlab.alloc_future(::bex_vm_types::Future::pending(id));
 
         let future_state = FutureState {
             future: ptr,
             ready: Arc::new(tokio::sync::SetOnce::new()),
             cancel,
         };
-        self.inner.active_futures.insert(id, future_state);
+        inner.active_futures.insert(id, future_state);
         (id, ptr)
     }
     pub fn fulfill_future(&mut self, id: FutureId, value: Value) -> Result<(), EngineError> {
         self.complete_pending(id, |fut| {
-            // SAFETY: complete_pending guarantees we hold the future_permit
+            // SAFETY: complete_pending guarantees we hold the `future_permit`
             // (single-writer invariant) and that `fut` is currently Pending.
             unsafe { fut.set_ready(value) };
         })?;
         Ok(())
     }
+    /// Transition a future to `Future::Error(value)` with the given BAML
+    /// error/panic value.
+    ///
+    /// **Currently unused by the engine in production.** All sys-op errors
+    /// route through [`Self::internal_error_future`] (which preserves the
+    /// original `EngineError` for surfacing). This API is reserved for a
+    /// future capability where user-callable async functions can throw
+    /// BAML values that the VM's `Await` opcode would re-throw via
+    /// [`bex_vm_types::FutureRead::Error`]. The plumbing is kept in place
+    /// (write here → variant in the heap object → throw in `Await`) so
+    /// that wiring it up later is a one-call-site change.
     pub fn err_future(&mut self, id: FutureId, err: Value) -> Result<(), EngineError> {
         self.complete_pending(id, |fut| {
             // SAFETY: see `fulfill_future`.
@@ -161,21 +204,22 @@ impl FutureManagerGuard<'_> {
         err: EngineError,
     ) -> Result<(), EngineError> {
         let entry = self
-            .inner
+            .holder()
             .active_futures
             .get(&id)
             .ok_or(EngineError::FutureNotFound { future_id: id })?;
-        // SAFETY: the `FutureManagerGuard` holds the future_permit Mutex,
+        // SAFETY: the `FutureManagerGuard` holds the `FutureManager` Mutex,
         // so we are the unique caller; the heap object is alive because
         // the entry roots it via `RootHaver::collect_roots`.
         let fut = unsafe { entry.future_ref() }?;
+        let read = fut.read();
         let observed = FutureType::of(fut);
         debug_assert!(
-            matches!(fut.read(), FutureRead::Pending(_)),
+            matches!(read, FutureRead::Pending(_)),
             "internal_error_future called on non-Pending future {id:?} \
              (actual: {observed:?}); invariant violated"
         );
-        if !matches!(fut.read(), FutureRead::Pending(_)) {
+        if !matches!(read, FutureRead::Pending(_)) {
             // Release-build invariant guard: a previously-resolved future
             // should never re-enter this path. Surfacing as an error
             // (rather than the legacy silent overwrite) makes the bug
@@ -187,7 +231,7 @@ impl FutureManagerGuard<'_> {
                 ),
             });
         }
-        // SAFETY: single-writer via future_permit Mutex.
+        // SAFETY: single-writer via `FutureManager` Mutex.
         unsafe { fut.set_internal_error() };
         let set = entry.ready.set(Err(err));
         debug_assert!(
@@ -234,20 +278,21 @@ impl FutureManagerGuard<'_> {
         // the leaked `SetOnce` payload and silently lose the error.
         {
             let entry_ref = self
-                .inner
+                .holder()
                 .active_futures
                 .get(&id)
                 .ok_or(EngineError::FutureNotFound { future_id: id })?;
-            // SAFETY: the `FutureManagerGuard` holds the future_permit Mutex.
+            // SAFETY: the `FutureManagerGuard` holds the `FutureManager` Mutex.
             let fut = unsafe { entry_ref.future_ref() }?;
+            let read = fut.read();
             let observed = FutureType::of(fut);
             debug_assert!(
-                matches!(fut.read(), FutureRead::Pending(_)),
+                matches!(read, FutureRead::Pending(_)),
                 "complete_pending called with non-Pending heap state for {id:?} \
                  (actual: {observed:?}); invariant violated — only fulfill/err/cancel may \
                  route through this helper"
             );
-            if !matches!(fut.read(), FutureRead::Pending(_)) {
+            if !matches!(read, FutureRead::Pending(_)) {
                 return Err(EngineError::TypeMismatch {
                     message: format!(
                         "complete_pending called with non-Pending heap state for {id:?} \
@@ -257,14 +302,14 @@ impl FutureManagerGuard<'_> {
             }
         }
         // Phase 2: state is Pending. Remove the entry and apply the
-        // transition under the future_permit Mutex (single-writer).
+        // transition under the `FutureManager` Mutex (single-writer).
         let entry = self
-            .inner
+            .holder_mut()
             .active_futures
             .remove(&id)
-            .expect("entry was present in phase 1 and we hold the future_permit");
+            .expect("entry was present in phase 1 and we hold the `FutureManager` Mutex");
         // SAFETY: the entry is still rooting the heap object via local
-        // ownership; the future_permit Mutex enforces single-writer.
+        // ownership; the `FutureManager` Mutex enforces single-writer.
         let fut = unsafe { entry.future_ref() }?;
         transition(fut);
         let set = entry.ready.set(Ok(()));
@@ -302,11 +347,15 @@ impl FutureManagerGuard<'_> {
         &self,
         id: FutureId,
     ) -> Result<impl Future<Output = Result<(), EngineError>> + use<>, EngineError> {
-        let waiter = match self.inner.active_futures.get(&id) {
+        let inner = self.holder();
+        let waiter = match inner.active_futures.get(&id) {
             Some(future) => Some(Arc::clone(&future.ready)),
             None => {
-                let next = self
-                    .inner
+                // Relaxed is fine: ordering with respect to the
+                // `active_futures` HashMap is provided by the FutureManager
+                // Mutex that this guard holds. We just need the latest
+                // issued counter to bounds-check the id.
+                let next = inner
                     .next_future_id
                     .load(std::sync::atomic::Ordering::Relaxed);
                 if id.as_usize() >= next {
@@ -325,21 +374,28 @@ impl FutureManagerGuard<'_> {
 }
 impl TlabHolder for FutureManagerGuard<'_> {
     fn tlab(&self) -> &Tlab {
-        self.inner.tlab()
+        self.holder().tlab()
     }
     fn tlab_mut(&mut self) -> &mut Tlab {
-        self.inner.tlab_mut()
+        self.holder_mut().tlab_mut()
     }
 }
 impl HeapPermit<FutureManagerInner> for FutureManagerGuard<'_> {
     fn holder(&self) -> &FutureManagerInner {
-        &self.inner
+        // SAFETY: `InactiveHeapPermit::holder`'s contract is "permit is
+        // active". Here it isn't — but `self.proof: PermitProof<'a>` is a
+        // runtime witness that *some* active heap permit is alive for `'a`,
+        // which is exactly the GC-exclusion guarantee that contract is
+        // meant to encode. The `MutexGuard` provides single-writer.
+        unsafe { self.permit_guard.holder() }
     }
     fn holder_mut(&mut self) -> &mut FutureManagerInner {
-        &mut self.inner
+        // SAFETY: see [`Self::holder`]; `&mut self` plus the MutexGuard
+        // provide exclusive access on this thread.
+        unsafe { self.permit_guard.holder_mut() }
     }
     fn proof(&self) -> PermitProof<'_> {
-        self.inner.proof()
+        self.proof
     }
 }
 
@@ -372,6 +428,11 @@ impl RootHaver for FutureManagerInner {
         }
     }
     fn forward_roots(&mut self, roots: &HashMap<HeapPtr, HeapPtr>) {
+        // Drop the cached TLAB cursor — GC has swapped semispaces and our
+        // `alloc_ptr`/`alloc_limit` now point into a region the heap will
+        // hand out as a fresh chunk. The next `alloc_future` must refill
+        // from the post-GC cursor. Mirrors `BexVm::forward_roots`.
+        self.tlab.invalidate();
         for future in self.active_futures.values_mut() {
             future.forward_roots(roots);
         }
@@ -392,7 +453,7 @@ struct FutureState {
     /// - `Ok(())` means there is a BAML value ready on the heap
     /// - `Err(err)` means it's `InternalError` and `err` is the error value
     ready: Arc<tokio::sync::SetOnce<Result<(), EngineError>>>,
-    pub cancel: CancellationToken,
+    cancel: CancellationToken,
 }
 impl FutureState {
     /// Returns an immutable reference to the heap-allocated `Future`.
@@ -402,13 +463,14 @@ impl FutureState {
     /// terminal-state writes go through the `set_*` methods that take
     /// `&self`. This lets the spawned async task and the VM read/write
     /// the same heap object concurrently without a data race, as long as
-    /// the writer holds the future_permit Mutex (single-writer invariant).
+    /// the writer holds the `FutureManager` Mutex (single-writer invariant).
     ///
     /// # Safety
-    /// Caller must hold the future_permit (i.e., a [`FutureManagerGuard`])
-    /// for the duration of any subsequent access to the returned reference.
+    /// Caller must hold the `FutureManager` Mutex (i.e., a
+    /// [`FutureManagerGuard`]) for the duration of any subsequent access
+    /// to the returned reference.
     unsafe fn future_ref(&self) -> Result<&bex_vm_types::Future, EngineError> {
-        // SAFETY: caller holds the future_permit; heap object is alive.
+        // SAFETY: caller holds the `FutureManager` Mutex; heap object is alive.
         let obj = unsafe { self.future.get() };
         match obj {
             Object::Future(fut) => Ok(fut),
@@ -431,24 +493,33 @@ impl RootHaver for FutureState {
 
 #[cfg(test)]
 mod tests {
-    use ::bex_heap::{BexHeap, HeapPermitManager};
+    use ::bex_heap::{ActiveHeapPermit, BexHeap, HeapPermitManager};
     use ::bex_vm_types::Value;
 
     use super::*;
 
-    async fn make_manager() -> FutureManager {
+    /// Build a fresh `FutureManager` plus the `HeapPermitManager` it was
+    /// registered against. Tests then take a one-shot `ActiveHeapPermit` over
+    /// `()` from `pm` to obtain the `PermitProof` required by
+    /// `FutureManager::acquire`.
+    async fn make_manager() -> (FutureManager, Arc<HeapPermitManager>) {
         let heap = BexHeap::new(Vec::new());
         let permit_manager = Arc::new(HeapPermitManager::new());
         let permit = permit_manager
             .new_permit(FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap))))
             .await;
-        FutureManager::new(SharedHeapPermit::new(permit))
+        (FutureManager::new(permit), permit_manager)
+    }
+
+    async fn temp_permit(pm: &HeapPermitManager) -> ActiveHeapPermit<()> {
+        pm.new_permit(()).await.acquire().await
     }
 
     #[tokio::test]
     async fn fulfill_removes_entry() {
-        let mgr = make_manager().await;
-        let mut guard = mgr.acquire().await;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
         let (id, _ptr) = guard.new_future(CancellationToken::new());
         assert_eq!(guard.active_future_count(), 1);
         guard.fulfill_future(id, Value::Int(42)).unwrap();
@@ -457,8 +528,9 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_removes_entry_and_fires_token() {
-        let mgr = make_manager().await;
-        let mut guard = mgr.acquire().await;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
         let token = CancellationToken::new();
         let (id, _ptr) = guard.new_future(token.clone());
         assert!(!token.is_cancelled());
@@ -473,8 +545,9 @@ mod tests {
         // `internal_error_future` deliberately leaks so the original error stays
         // pinned to the registry's `SetOnce` for surfacing through a later
         // VM `Await(future_id)` yield.
-        let mgr = make_manager().await;
-        let mut guard = mgr.acquire().await;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
         let (id_a, _) = guard.new_future(CancellationToken::new());
         let (id_b, _) = guard.new_future(CancellationToken::new());
         assert_eq!(guard.active_future_count(), 2);
@@ -498,8 +571,9 @@ mod tests {
         // host. This is the key correctness path that the H1+H2 unification
         // restored — without the leak, a race window would collapse the error
         // to `VmInternalError::AwaitedFutureInternalError`.
-        let mgr = make_manager().await;
-        let mut guard = mgr.acquire().await;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
         let (id, _) = guard.new_future(CancellationToken::new());
         let original = EngineError::TypeMismatch {
             message: "synthetic op error".into(),
@@ -531,8 +605,9 @@ mod tests {
         if cfg!(debug_assertions) {
             return;
         }
-        let mgr = make_manager().await;
-        let mut guard = mgr.acquire().await;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
         let (id, _) = guard.new_future(CancellationToken::new());
         let original = EngineError::TypeMismatch {
             message: "stale".into(),
@@ -563,8 +638,9 @@ mod tests {
 
     #[tokio::test]
     async fn double_complete_returns_not_found() {
-        let mgr = make_manager().await;
-        let mut guard = mgr.acquire().await;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
         let (id, _) = guard.new_future(CancellationToken::new());
         guard.fulfill_future(id, Value::Int(1)).unwrap();
         let again = guard.fulfill_future(id, Value::Int(2));
@@ -573,8 +649,9 @@ mod tests {
 
     #[tokio::test]
     async fn future_ready_immediate_for_completed_id() {
-        let mgr = make_manager().await;
-        let mut guard = mgr.acquire().await;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
         let (id, _) = guard.new_future(CancellationToken::new());
         guard.fulfill_future(id, Value::Int(1)).unwrap();
         // Entry is gone; future_ready should treat it as already-resolved.
@@ -585,13 +662,14 @@ mod tests {
 
     #[tokio::test]
     async fn future_ready_for_never_issued_id_errors() {
-        let mgr = make_manager().await;
-        let guard = mgr.acquire().await;
-        // No futures have been issued; any non-zero id is bogus. The contract
-        // on `from_usize` is "no two live ids collide" — for this test we
-        // construct one that is plainly out of range, which is safe since no
-        // other id exists for it to collide with.
-        let bogus = FutureId::from_usize(99);
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let guard = mgr.acquire(temp.proof()).await;
+        // No futures have been issued; any id beyond `next_future_id` is
+        // bogus. `usize::MAX` is unambiguously out of range regardless of
+        // how many futures the test setup happens to issue, so the assertion
+        // doesn't get brittle if the manager initializes its counter.
+        let bogus = FutureId::from_usize(usize::MAX);
         let result = guard.future_ready(bogus);
         assert!(matches!(result, Err(EngineError::FutureNotFound { .. })));
     }
@@ -602,17 +680,20 @@ mod tests {
         // separate critical section; then the waiter should resolve. This
         // exercises the path where `future_ready` clones the `Arc<SetOnce>`
         // before the entry is removed.
-        let mgr = make_manager().await;
-        let mut guard = mgr.acquire().await;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
         let (id, _) = guard.new_future(CancellationToken::new());
         let waiter = guard.future_ready(id).expect("waiter should be created");
         drop(guard);
 
-        let mut guard = mgr.acquire().await;
+        let temp2 = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp2.proof()).await;
         guard.fulfill_future(id, Value::Int(123)).unwrap();
         drop(guard);
+        drop(temp2);
 
         waiter.await.expect("waiter should resolve to Ok(())");
-        assert_eq!(mgr.active_future_count().await, 0);
+        assert_eq!(mgr.active_future_count(&pm).await, 0);
     }
 }

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -53,7 +53,7 @@ use ::bex_heap::{
     HeapPermit, PermitProof, SharedHeapPermit, SharedHeapPermitGuard, Tlab, TlabHolder,
 };
 use ::bex_vm_types::{
-    HeapPtr, Object, ObjectType, RootHaver, Value,
+    FutureRead, HeapPtr, Object, ObjectType, RootHaver, Value,
     types::{FutureId, FutureType},
 };
 use ::core::sync::atomic::AtomicUsize;
@@ -110,7 +110,7 @@ impl FutureManagerGuard<'_> {
         let ptr = self
             .inner
             .tlab
-            .alloc_future(::bex_vm_types::Future::Pending(id));
+            .alloc_future(::bex_vm_types::Future::pending(id));
 
         let future_state = FutureState {
             future: ptr,
@@ -121,15 +121,25 @@ impl FutureManagerGuard<'_> {
         (id, ptr)
     }
     pub fn fulfill_future(&mut self, id: FutureId, value: Value) -> Result<(), EngineError> {
-        self.complete_pending(id, bex_vm_types::Future::Ready(value), Ok(()))?;
+        self.complete_pending(id, |fut| {
+            // SAFETY: complete_pending guarantees we hold the future_permit
+            // (single-writer invariant) and that `fut` is currently Pending.
+            unsafe { fut.set_ready(value) };
+        })?;
         Ok(())
     }
     pub fn err_future(&mut self, id: FutureId, err: Value) -> Result<(), EngineError> {
-        self.complete_pending(id, bex_vm_types::Future::Error(err), Ok(()))?;
+        self.complete_pending(id, |fut| {
+            // SAFETY: see `fulfill_future`.
+            unsafe { fut.set_error(err) };
+        })?;
         Ok(())
     }
     pub fn cancel_future(&mut self, id: FutureId) -> Result<(), EngineError> {
-        let entry = self.complete_pending(id, bex_vm_types::Future::Cancelled, Ok(()))?;
+        let entry = self.complete_pending(id, |fut| {
+            // SAFETY: see `fulfill_future`.
+            unsafe { fut.set_cancelled() };
+        })?;
         // The token is still cloned by the spawned sys-op task; firing it
         // here unparks that task even though `entry` itself is about to be
         // dropped.
@@ -153,16 +163,20 @@ impl FutureManagerGuard<'_> {
         let entry = self
             .inner
             .active_futures
-            .get_mut(&id)
+            .get(&id)
             .ok_or(EngineError::FutureNotFound { future_id: id })?;
-        // SAFETY: the `FutureManagerGuard` holds an exclusive heap permit.
-        let fut = unsafe { entry.get_mut() }?;
+        // SAFETY: the `FutureManagerGuard` holds the future_permit Mutex,
+        // so we are the unique caller; the heap object is alive because
+        // the entry roots it via `RootHaver::collect_roots`.
+        let fut = unsafe { entry.future_ref() }?;
         debug_assert!(
-            matches!(fut, bex_vm_types::Future::Pending(_)),
-            "internal_error_future called on non-Pending future {id:?}; \
-             invariant violated"
+            matches!(fut.read(), FutureRead::Pending(_)),
+            "internal_error_future called on non-Pending future {id:?} \
+             (actual: {:?}); invariant violated",
+            FutureType::of(fut)
         );
-        *fut = bex_vm_types::Future::InternalError(id);
+        // SAFETY: single-writer via future_permit Mutex.
+        unsafe { fut.set_internal_error() };
         let set = entry.ready.set(Err(err));
         debug_assert!(
             set.is_ok(),
@@ -173,9 +187,12 @@ impl FutureManagerGuard<'_> {
 
     /// Atomically transition a `Pending` future to a terminal state, signal
     /// its [`tokio::sync::SetOnce`] waiter, and remove the entry from
-    /// `active_futures`. The dropped [`FutureState`] is returned so callers
-    /// (e.g. [`Self::cancel_future`]) can perform additional Drop-time work
-    /// like firing a [`CancellationToken`] clone before it is released.
+    /// `active_futures`. The `transition` closure is responsible for the
+    /// actual `set_*` call and is passed an immutable reference to the
+    /// `Future` heap object (which uses interior atomic mutation). The
+    /// dropped [`FutureState`] is returned so callers (e.g.
+    /// [`Self::cancel_future`]) can perform additional Drop-time work like
+    /// firing a [`CancellationToken`] clone before it is released.
     ///
     /// # Invariant
     /// Only `fulfill_future`, `err_future`, and `cancel_future` route through
@@ -188,25 +205,27 @@ impl FutureManagerGuard<'_> {
     fn complete_pending(
         &mut self,
         id: FutureId,
-        new_state: bex_vm_types::Future,
-        result: Result<(), EngineError>,
+        transition: impl FnOnce(&bex_vm_types::Future),
     ) -> Result<FutureState, EngineError> {
-        let mut entry = self
+        let entry = self
             .inner
             .active_futures
             .remove(&id)
             .ok_or(EngineError::FutureNotFound { future_id: id })?;
-        // SAFETY: the `FutureManagerGuard` holds an exclusive heap permit.
-        let fut = unsafe { entry.get_mut() }?;
+        // SAFETY: the `FutureManagerGuard` holds the future_permit Mutex,
+        // so we are the unique caller; the heap object is alive because
+        // we just removed the entry that was rooting it (the entry is
+        // still owned by us locally).
+        let fut = unsafe { entry.future_ref() }?;
         debug_assert!(
-            matches!(fut, bex_vm_types::Future::Pending(_)),
+            matches!(fut.read(), FutureRead::Pending(_)),
             "complete_pending called with non-Pending heap state for {id:?} \
              (actual: {:?}); invariant violated — only fulfill/err/cancel may \
              route through this helper",
             FutureType::of(fut)
         );
-        *fut = new_state;
-        let set = entry.ready.set(result);
+        transition(fut);
+        let set = entry.ready.set(Ok(()));
         debug_assert!(
             set.is_ok(),
             "Should not have been ready if the heap future was pending."
@@ -326,10 +345,21 @@ struct FutureState {
     pub cancel: CancellationToken,
 }
 impl FutureState {
-    /// SAFETY: We must hold a heap permit for the duration of the future object.
-    unsafe fn get_mut(&mut self) -> Result<&mut bex_vm_types::Future, EngineError> {
-        // SAFETY: We hold a permit, so we can access the future object.
-        let obj = unsafe { self.future.get_mut() };
+    /// Returns an immutable reference to the heap-allocated `Future`.
+    ///
+    /// The new [`bex_vm_types::Future`] uses interior mutability via an
+    /// `AtomicU8` discriminant + `UnsafeCell<MaybeUninit<Value>>`, so all
+    /// terminal-state writes go through the `set_*` methods that take
+    /// `&self`. This lets the spawned async task and the VM read/write
+    /// the same heap object concurrently without a data race, as long as
+    /// the writer holds the future_permit Mutex (single-writer invariant).
+    ///
+    /// # Safety
+    /// Caller must hold the future_permit (i.e., a [`FutureManagerGuard`])
+    /// for the duration of any subsequent access to the returned reference.
+    unsafe fn future_ref(&self) -> Result<&bex_vm_types::Future, EngineError> {
+        // SAFETY: caller holds the future_permit; heap object is alive.
+        let obj = unsafe { self.future.get() };
         match obj {
             Object::Future(fut) => Ok(fut),
             other => Err(EngineError::TypeMismatch {

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -2,12 +2,21 @@
 //!
 //! # Lifecycle
 //!
-//! An entry exists in [`FutureManagerInner::active_futures`] **iff** the
+//! An entry exists in [`FutureManagerInner::active_futures`] **if** the
 //! corresponding [`bex_vm_types::Future`] heap object is in the `Pending`
-//! state. As soon as any terminal transition succeeds (`fulfill_future`,
-//! `err_future`, `cancel_future`, `internal_error_future`) the entry is
-//! removed in the same critical section that updates the heap object and
-//! signals the cross-task ready notification.
+//! state, **or** in the `InternalError` state (which is leaked by design,
+//! see below).
+//!
+//! - `fulfill_future`, `err_future`, `cancel_future`: terminal transitions
+//!   that update the heap object, signal the cross-task ready notification,
+//!   and remove the entry, all in one critical section.
+//! - `internal_error_future`: terminal transition for unrecoverable engine
+//!   errors that does **not** remove the entry. The entry's `SetOnce` keeps
+//!   the original [`EngineError`] so a later VM `Await` can yield back to
+//!   the engine, which surfaces the error to the host. This intentionally
+//!   leaks the entry — internal errors should never happen in correct
+//!   programs, and the leak buys us never losing the underlying error
+//!   context to a removal/race window.
 //!
 //! Why this is safe:
 //!
@@ -24,16 +33,21 @@
 //!
 //! Why this works for fire-and-forget: while pending, the [`FutureState`]
 //! roots the heap object via [`RootHaver::collect_roots`]. After the
-//! sys-op task completes the entry is removed; if no VM stack still
-//! references the heap object it is correctly reclaimed by the next GC.
+//! sys-op task completes the entry is removed (or, for `InternalError`,
+//! retained); if no VM stack still references the heap object and the
+//! entry has been removed, it is correctly reclaimed by the next GC.
 //!
-//! Why this works for the await race (a VM observes `Pending(future_id)`
-//! on the heap, yields `Await(future_id)`, and the engine completes the
-//! future before the event loop calls [`FutureManagerGuard::future_ready`]):
-//! [`FutureManagerGuard::future_ready`] treats a missing-but-previously-issued
-//! `FutureId` as "already resolved" and returns an immediate `Ok(())`. The
-//! VM re-executes the saved `Await` instruction, reads the terminal state
-//! directly from the heap, and proceeds.
+//! Why this works for the await race on `Pending` → `Ready/Error/Cancelled`
+//! (a VM observes `Pending(future_id)` on the heap, yields
+//! `Await(future_id)`, and the engine completes the future before the event
+//! loop calls [`FutureManagerGuard::future_ready`]):
+//! [`FutureManagerGuard::future_ready`] treats a missing-but-previously-
+//! issued `FutureId` as "already resolved" and returns an immediate
+//! `Ok(())`. The VM re-executes the saved `Await` instruction, reads the
+//! terminal state directly from the heap, and proceeds.
+//!
+//! For `InternalError`, no race is possible: the entry is never removed, so
+//! `future_ready` always finds a waiter that yields the original error.
 
 use ::bex_heap::{
     HeapPermit, PermitProof, SharedHeapPermit, SharedHeapPermitGuard, Tlab, TlabHolder,
@@ -83,12 +97,15 @@ impl FutureManagerGuard<'_> {
 
     /// Registers a future with the future manager and returns a unique ID.
     pub fn new_future(&mut self, cancel: CancellationToken) -> (FutureId, HeapPtr) {
+        // The contract on `FutureId::from_usize` is "no two live ids share a
+        // usize". We satisfy this by drawing the value from the manager's
+        // monotonic `AtomicUsize`; uniqueness is preserved as long as the
+        // counter hasn't wrapped (which would take 2^64 calls).
         let id = self
             .inner
             .next_future_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        // SAFETY: we are the only one allowed to create new future ids
-        let id = unsafe { FutureId::from_usize(id) };
+        let id = FutureId::from_usize(id);
 
         let ptr = self
             .inner
@@ -120,12 +137,37 @@ impl FutureManagerGuard<'_> {
         Ok(())
     }
     /// Sets the future to `InternalError` and notifies the waiter.
+    ///
+    /// Unlike the other terminal-transition helpers, this does **not** remove
+    /// the entry from `active_futures`. The originating `EngineError` is
+    /// preserved on the entry's `SetOnce` so a later VM `Await` (which yields
+    /// `Await(future_id)` even for an InternalError-state heap object) can
+    /// surface the original error from this method's caller. Internal errors
+    /// are bugs that "should never happen", so the resulting permanent leak is
+    /// acceptable in exchange for not losing the underlying error context.
     pub fn internal_error_future(
         &mut self,
         id: FutureId,
         err: EngineError,
     ) -> Result<(), EngineError> {
-        self.complete_pending(id, bex_vm_types::Future::InternalError, Err(err))?;
+        let entry = self
+            .inner
+            .active_futures
+            .get_mut(&id)
+            .ok_or(EngineError::FutureNotFound { future_id: id })?;
+        // SAFETY: the `FutureManagerGuard` holds an exclusive heap permit.
+        let fut = unsafe { entry.get_mut() }?;
+        debug_assert!(
+            matches!(fut, bex_vm_types::Future::Pending(_)),
+            "internal_error_future called on non-Pending future {id:?}; \
+             invariant violated"
+        );
+        *fut = bex_vm_types::Future::InternalError(id);
+        let set = entry.ready.set(Err(err));
+        debug_assert!(
+            set.is_ok(),
+            "Should not have been ready if the heap future was pending."
+        );
         Ok(())
     }
 
@@ -134,6 +176,15 @@ impl FutureManagerGuard<'_> {
     /// `active_futures`. The dropped [`FutureState`] is returned so callers
     /// (e.g. [`Self::cancel_future`]) can perform additional Drop-time work
     /// like firing a [`CancellationToken`] clone before it is released.
+    ///
+    /// # Invariant
+    /// Only `fulfill_future`, `err_future`, and `cancel_future` route through
+    /// this helper. `internal_error_future` deliberately does **not** — its
+    /// entries are leaked to preserve the original error on the `SetOnce` and
+    /// to let the VM yield back to the engine for surfacing. The
+    /// `debug_assert` below encodes that invariant: if `complete_pending` ever
+    /// observes a non-`Pending` heap state, a caller has violated the
+    /// removal/transition contract.
     fn complete_pending(
         &mut self,
         id: FutureId,
@@ -147,15 +198,13 @@ impl FutureManagerGuard<'_> {
             .ok_or(EngineError::FutureNotFound { future_id: id })?;
         // SAFETY: the `FutureManagerGuard` holds an exclusive heap permit.
         let fut = unsafe { entry.get_mut() }?;
-        if !matches!(fut, bex_vm_types::Future::Pending(_)) {
-            let actual = FutureType::of(fut);
-            // The future was already terminal; restore the entry so that
-            // observers continue to see a consistent (heap, map) pair.
-            self.inner.active_futures.insert(id, entry);
-            return Err(EngineError::TypeMismatch {
-                message: format!("Expected Pending Future, got {actual:?}"),
-            });
-        }
+        debug_assert!(
+            matches!(fut, bex_vm_types::Future::Pending(_)),
+            "complete_pending called with non-Pending heap state for {id:?} \
+             (actual: {:?}); invariant violated — only fulfill/err/cancel may \
+             route through this helper",
+            FutureType::of(fut)
+        );
         *fut = new_state;
         let set = entry.ready.set(result);
         debug_assert!(
@@ -278,18 +327,6 @@ struct FutureState {
 }
 impl FutureState {
     /// SAFETY: We must hold a heap permit for the duration of the future object.
-    #[expect(dead_code)]
-    unsafe fn get(&self) -> Result<&bex_vm_types::Future, EngineError> {
-        // SAFETY: We hold a permit, so we can access the future object.
-        let obj = unsafe { self.future.get() };
-        match obj {
-            Object::Future(fut) => Ok(fut),
-            other => Err(EngineError::TypeMismatch {
-                message: format!("Expected Future, got {:?}", ObjectType::of(other)),
-            }),
-        }
-    }
-    /// SAFETY: We must hold a heap permit for the duration of the future object.
     unsafe fn get_mut(&mut self) -> Result<&mut bex_vm_types::Future, EngineError> {
         // SAFETY: We hold a permit, so we can access the future object.
         let obj = unsafe { self.future.get_mut() };
@@ -351,7 +388,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn err_and_internal_error_remove_entry() {
+    async fn err_removes_entry_but_internal_error_leaks() {
+        // `err_future` is a normal terminal transition and removes its entry.
+        // `internal_error_future` deliberately leaks so the original error stays
+        // pinned to the registry's `SetOnce` for surfacing through a later
+        // VM `Await(future_id)` yield.
         let mgr = make_manager().await;
         let mut guard = mgr.acquire().await;
         let (id_a, _) = guard.new_future(CancellationToken::new());
@@ -366,7 +407,66 @@ mod tests {
                 },
             )
             .unwrap();
-        assert_eq!(guard.active_future_count(), 0);
+        // Only `id_a` was removed; `id_b` is the leaked InternalError entry.
+        assert_eq!(guard.active_future_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn internal_error_future_preserves_original_error_via_future_ready() {
+        // The whole point of leaking the entry: `future_ready` must hand back
+        // the original `EngineError` so the engine can re-throw it to the
+        // host. This is the key correctness path that the H1+H2 unification
+        // restored — without the leak, a race window would collapse the error
+        // to `VmInternalError::AwaitedFutureInternalError`.
+        let mgr = make_manager().await;
+        let mut guard = mgr.acquire().await;
+        let (id, _) = guard.new_future(CancellationToken::new());
+        let original = EngineError::TypeMismatch {
+            message: "synthetic op error".into(),
+        };
+        guard.internal_error_future(id, original.clone()).unwrap();
+        // Entry should still be live (deliberate leak).
+        assert_eq!(guard.active_future_count(), 1);
+
+        // A waiter on the leaked entry resolves to the original error.
+        let waiter = guard.future_ready(id).expect("waiter should be created");
+        drop(guard);
+        let surfaced = waiter.await.expect_err("InternalError should propagate");
+        assert_eq!(surfaced, original);
+    }
+
+    #[tokio::test]
+    async fn fulfill_after_internal_error_is_disallowed() {
+        // Once an entry is in the leaked InternalError state, none of the
+        // terminal-transition helpers (fulfill/err/cancel) should subsequently
+        // succeed against it: the `complete_pending` invariant is "entry exists
+        // and heap is Pending". In debug builds the debug_assert fires; in
+        // release builds the heap state is non-Pending and the call still
+        // produces a `FutureNotFound`-or-equivalent error path.
+        //
+        // We exercise the release-build path by skipping under
+        // `cfg(debug_assertions)` — the panic there is the documented
+        // intent of the invariant.
+        if cfg!(debug_assertions) {
+            return;
+        }
+        let mgr = make_manager().await;
+        let mut guard = mgr.acquire().await;
+        let (id, _) = guard.new_future(CancellationToken::new());
+        guard
+            .internal_error_future(
+                id,
+                EngineError::TypeMismatch {
+                    message: "stale".into(),
+                },
+            )
+            .unwrap();
+        // The release-build path: `fulfill_future`'s `complete_pending` happily
+        // overwrites the heap to `Ready` and removes the entry. This is
+        // tolerated rather than guaranteed (the `complete_pending` debug_assert
+        // fails in debug builds). The point of the test is to pin the
+        // observable behavior of the leaked state.
+        let _ = guard.fulfill_future(id, Value::Int(0));
     }
 
     #[tokio::test]
@@ -395,11 +495,11 @@ mod tests {
     async fn future_ready_for_never_issued_id_errors() {
         let mgr = make_manager().await;
         let guard = mgr.acquire().await;
-        // No futures have been issued; any non-zero id is bogus. Use the
-        // unsafe constructor — the safety contract there is "engine only,"
-        // and this test is exercising the engine.
-        #[expect(unsafe_code)]
-        let bogus = unsafe { FutureId::from_usize(99) };
+        // No futures have been issued; any non-zero id is bogus. The contract
+        // on `from_usize` is "no two live ids collide" — for this test we
+        // construct one that is plainly out of range, which is safe since no
+        // other id exists for it to collide with.
+        let bogus = FutureId::from_usize(99);
         let result = guard.future_ready(bogus);
         assert!(matches!(result, Err(EngineError::FutureNotFound { .. })));
     }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -93,7 +93,9 @@ pub use bex_heap::{
     SharedHeapPermitGuard,
 };
 use bex_vm::{BexVm, SpanNotification, VmExecState};
-use bex_vm_types::{FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SysOp, Value};
+use bex_vm_types::{
+    FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SysOp, Value, VmGlobals,
+};
 pub use conversion::test_arg_to_external;
 // Re-export CancellationToken for callers.
 pub use function_call_context::{FunctionCallContext, FunctionCallContextBuilder};
@@ -231,6 +233,23 @@ fn format_unhandled_throw(value: &BexExternalValue, trace: &[bex_vm::StackFrame]
 /// Fully-qualified name of the cancellation panic class.
 pub const CANCELLED_PANIC_CLASS: &str = "baml.panics.Cancelled";
 
+/// True iff `err` is an unhandled `baml.panics.Cancelled` panic.
+///
+/// Centralizes the cancellation-classification logic that bridges (`bridge_cffi`,
+/// `bridge_nodejs`, `bridge_python`, `bridge_wasm`) and `baml_lsp_server` need
+/// for mapping `EngineError` → host-specific cancellation indicator.
+pub fn is_cancelled_engine_error(err: &EngineError) -> bool {
+    matches!(
+        err,
+        EngineError::UnhandledThrow { value, .. }
+            if matches!(
+                value.as_ref(),
+                BexExternalValue::Instance { class_name, .. }
+                    if class_name == CANCELLED_PANIC_CLASS
+            )
+    )
+}
+
 /// Synthesize an `EngineError::UnhandledThrow` representing a cancellation.
 ///
 /// Used when the engine produces a cancellation outside an active VM (pre-call
@@ -321,8 +340,12 @@ fn cancelled_unhandled_throw() -> EngineError {
 pub struct BexEngine {
     /// The unified heap (shared across all VM instances)
     heap: Arc<BexHeap>,
-    /// Global variables pool
-    globals: GlobalPool,
+    /// Frozen global variables shared across every post-`$init` VM.
+    ///
+    /// Populated once during `$init` and immutable thereafter; cloning is a
+    /// cheap refcount bump (see `VmGlobals::Shared`). The VM rejects any
+    /// `StoreGlobal` against this view as a `VmInternalError`.
+    globals: Arc<[Value]>,
     /// Resolved function/class/enum names for lookup
     resolved_function_names: HashMap<String, (HeapPtr, bex_vm_types::FunctionKind)>,
     /// Resolved class names for instance allocation (`IndexMap` preserves definition order)
@@ -483,7 +506,9 @@ impl BexEngine {
             .into_iter()
             .map(|cv| cv.to_value(|idx| heap.compile_time_ptr(idx.into_raw())))
             .collect();
-        let mut globals = GlobalPool::from_vec(globals_vec);
+        // Mutable during `$init` so `StoreGlobal` can populate top-level let
+        // bindings; frozen into `Arc<[Value]>` once `$init` finishes (see below).
+        let mut globals_pool = GlobalPool::from_vec(globals_vec);
 
         #[cfg(not(target_arch = "wasm32"))]
         let park_requested = Arc::new(AtomicBool::new(false));
@@ -496,7 +521,7 @@ impl BexEngine {
             if let Some((init_ptr, _kind)) = resolved_function_names.get(init_name.as_str()) {
                 let mut vm = BexVm::new(
                     Arc::clone(&heap),
-                    globals.clone(),
+                    VmGlobals::Owned(globals_pool.clone()),
                     resolved_class_names
                         .iter()
                         .chain(resolved_enum_names.iter())
@@ -515,7 +540,12 @@ impl BexEngine {
                         Ok(VmExecState::Complete(_)) => {
                             // Extract the (potentially mutated) global pool back
                             // so StoreGlobal writes are visible to subsequent calls.
-                            globals = vm.globals;
+                            globals_pool = match vm.globals {
+                                VmGlobals::Owned(pool) => pool,
+                                VmGlobals::Shared(_) => {
+                                    unreachable!("$init VM constructed with Owned globals")
+                                }
+                            };
                             break;
                         }
                         Ok(VmExecState::Notify(_) | VmExecState::SpanNotify(_)) => {
@@ -543,6 +573,12 @@ impl BexEngine {
                 }
             }
         }
+
+        // Freeze the now-populated globals into a shared `Arc<[Value]>`. Every
+        // post-`$init` VM cloned into a `call_function` invocation reads from
+        // this exact `Arc`. `StoreGlobal` against this shared view is rejected
+        // by the VM as `VmInternalError::StoreGlobalAfterInit`.
+        let globals: Arc<[Value]> = Arc::from(globals_pool.0);
 
         // Build SysOpContext by pre-extracting LLM function metadata from the heap.
         // This avoids passing raw HeapPtrs to sys_ops.
@@ -846,10 +882,11 @@ impl BexEngine {
             return Err(cancelled_unhandled_throw());
         }
 
-        // Create VM with shared heap (each VM gets its own TLAB)
+        // Create VM with shared heap (each VM gets its own TLAB).
+        // Globals are shared as a frozen `Arc<[Value]>` — cloning is a refcount bump.
         let vm = BexVm::new(
             Arc::clone(&self.heap),
-            self.globals.clone(),
+            VmGlobals::Shared(Arc::clone(&self.globals)),
             self.resolved_class_names
                 .iter()
                 .chain(self.resolved_enum_names.iter())
@@ -1338,7 +1375,7 @@ impl BexEngine {
                 VmExecState::ScheduleFuture(unscheduled) => {
                     // Extract data from unscheduled future
                     let unscheduled = vm
-                        .pending_future(unscheduled)
+                        .unscheduled_future(unscheduled)
                         .map_err(EngineError::VmInternalError)?;
                     let args: Vec<BexExternalValue> = unscheduled
                         .args
@@ -1367,16 +1404,36 @@ impl BexEngine {
 
                     match sys_op_result {
                         SysOpResult::Ready(result) => {
-                            // Sync operation - set future to Ready without touching stack.
-                            // The VM will continue to the Await instruction which will
-                            // extract the value from the Ready future.
-                            let result = result.map_err(EngineError::from)?;
-                            let value = self.convert_external_to_vm_value(&mut vm, result);
-
                             // We may be blocked by other threads doing futures stuff,
                             // but since we hold our VM permit it should never be blocked by GC.
                             let mut future_permit = self.futures.acquire().await;
-                            future_permit.fulfill_future(future_id, value)?;
+                            // Cancellation safepoint: if cancellation fires between the
+                            // pre-exec early check and the commit, surface it as a Cancelled
+                            // future rather than fulfilling. The VM's next `Await` will throw
+                            // `baml.panics.Cancelled`.
+                            if cancel.is_cancelled() {
+                                future_permit.cancel_future(future_id)?;
+                                drop(future_permit);
+                                continue;
+                            }
+                            match result {
+                                Ok(external) => {
+                                    let value = self
+                                        .convert_external_to_vm_value(&mut future_permit, external);
+                                    future_permit.fulfill_future(future_id, value)?;
+                                }
+                                Err(op_err) => {
+                                    // Route sync sys-op errors through `internal_error_future`
+                                    // so the original error is preserved on the registry's
+                                    // `SetOnce`. The VM's subsequent `Await` yields back to
+                                    // this loop's `Await` branch, where `future_ready` returns
+                                    // the original error to the caller via `?`.
+                                    future_permit.internal_error_future(
+                                        future_id,
+                                        EngineError::from(op_err),
+                                    )?;
+                                }
+                            }
                             drop(future_permit);
                         }
                         SysOpResult::Async(fut) => {

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -589,7 +589,15 @@ impl BexEngine {
         let enum_definitions = Self::extract_enum_definitions(&resolved_enum_names);
 
         let heap_permit_manager = Arc::new(HeapPermitManager::new());
-        // we just created the permit manager so this will never block
+        // We just created the permit manager so `new_permit` will not block:
+        // the only synchronization inside is the `holders` mutex which is
+        // uncontended at this point. `futures::executor::block_on` (rather
+        // than `tokio::runtime::Handle::block_on`) is used so that this
+        // constructor stays callable from inside a tokio runtime.
+        //
+        // If `new_permit` ever takes a real lock or schedules async work,
+        // this assumption breaks and the constructor would deadlock — at
+        // which point we'd have to make `BexEngine::new` async (TODO).
         let futures_permit = futures::executor::block_on(
             heap_permit_manager
                 .new_permit(FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap)))),
@@ -1390,8 +1398,11 @@ impl BexEngine {
                     let mut future_permit = self.futures.acquire().await;
                     let (future_id, future_ptr) = future_permit.new_future(future_cancel.clone());
                     vm.stack.push(Value::Object(future_ptr));
-                    if future_cancel.is_cancelled() {
+                    if cancel.is_cancelled() {
                         // Early cancellation-- don't need to even start the future.
+                        // (`future_cancel` is a child of `cancel` and is only cancelled
+                        // here via parent inheritance, so checking `cancel` directly is
+                        // equivalent and matches the post-exec safepoint below.)
                         future_permit.cancel_future(future_id)?;
                         drop(future_permit);
                         continue;
@@ -1438,13 +1449,21 @@ impl BexEngine {
                         }
                         SysOpResult::Async(fut) => {
                             let task = Arc::clone(self).run_future(fut, future_id, future_cancel);
+                            // Surface invariant violations from `run_future` (e.g.
+                            // `FutureNotFound` from a double-transition bug). In normal
+                            // operation each future is only transitioned once by this
+                            // task, so any error is a bug worth investigating.
                             #[cfg(not(target_arch = "wasm32"))]
                             tokio::spawn(async move {
-                                let _ = task.await;
+                                if let Err(err) = task.await {
+                                    tracing::error!(?err, "spawned future task failed");
+                                }
                             });
                             #[cfg(target_arch = "wasm32")]
                             wasm_bindgen_futures::spawn_local(async move {
-                                let _ = task.await;
+                                if let Err(err) = task.await {
+                                    tracing::error!(?err, "spawned future task failed");
+                                }
                             });
                         }
                     }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -70,14 +70,17 @@
 
 mod conversion;
 mod function_call_context;
+mod future;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex, atomic::Ordering},
 };
 
+use ::bex_heap::{HeapPermit as _, Tlab};
 // Re-export event types for callers.
-use ::bex_vm_types::RootHaver;
+use ::bex_vm_types::{RootHaver, types::FutureId};
 use ::core::sync::atomic::AtomicBool;
+use ::sys_types::OpFuture;
 use async_trait::async_trait;
 use bex_events::{EventKind, FunctionEnd, FunctionEvent, FunctionStart, SpanContext};
 pub use bex_events::{HostSpanContext, RuntimeEvent, SpanId};
@@ -85,7 +88,10 @@ pub use bex_external_types::{BexExternalValue, Ty, TypeName, UnionMetadata};
 use bex_heap::BexHeap;
 // Re-export GcStats for users of the engine
 pub use bex_heap::GcStats;
-pub use bex_heap::{ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapPermit};
+pub use bex_heap::{
+    ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapPermit, SharedHeapPermit,
+    SharedHeapPermitGuard,
+};
 use bex_vm::{BexVm, SpanNotification, VmExecState};
 use bex_vm_types::{FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SysOp, Value};
 pub use conversion::test_arg_to_external;
@@ -94,9 +100,10 @@ pub use function_call_context::{FunctionCallContext, FunctionCallContextBuilder}
 pub use sys_types::CallId;
 use sys_types::{OpError, SysOpResult};
 use thiserror::Error;
-use tokio::sync::mpsc;
 pub use tokio_util::sync::CancellationToken;
 use web_time::{Instant, SystemTime};
+
+pub use crate::future::{FutureManager, FutureManagerGuard, FutureManagerInner};
 
 // ============================================================================
 // Engine Types
@@ -111,44 +118,6 @@ pub struct UserFunctionInfo {
     pub param_names: Vec<String>,
     pub param_types: Vec<Ty>,
     pub return_type: Ty,
-}
-
-/// Result of an external future.
-struct FutureResult {
-    id: HeapPtr,
-    result: Result<BexExternalValue, EngineError>,
-}
-
-/// RAII guard for in-flight async sys-op task abort handles.
-///
-/// On drop, aborts all tracked tasks so early returns (`?`) do not leave
-/// spawned work running in the background.
-struct AbortHandlesGuard {
-    handles: Vec<futures::future::AbortHandle>,
-}
-
-impl AbortHandlesGuard {
-    fn new() -> Self {
-        Self {
-            handles: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, handle: futures::future::AbortHandle) {
-        self.handles.push(handle);
-    }
-
-    fn abort_all(&self) {
-        for handle in &self.handles {
-            handle.abort();
-        }
-    }
-}
-
-impl Drop for AbortHandlesGuard {
-    fn drop(&mut self) {
-        self.abort_all();
-    }
 }
 
 // ============================================================================
@@ -179,10 +148,13 @@ struct SpanState {
 }
 
 /// Errors that can occur during engine execution.
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, PartialEq, Error, Clone)]
 pub enum EngineError {
     #[error("Function call with ID {call_id} not found")]
     FunctionCallNotFound { call_id: CallId },
+
+    #[error("Future with ID {future_id:?} not found")]
+    FutureNotFound { future_id: FutureId },
 
     #[error("Function not found: {name}")]
     FunctionNotFound { name: String },
@@ -217,9 +189,6 @@ pub enum EngineError {
 
     #[error("Schema inconsistency: {message}")]
     SchemaInconsistency { message: String },
-
-    #[error("Operation cancelled")]
-    Cancelled,
 
     #[cfg(feature = "heap_debug")]
     #[error("Snapshot not possible for type: {type_name}")]
@@ -257,6 +226,30 @@ fn format_unhandled_throw(value: &BexExternalValue, trace: &[bex_vm::StackFrame]
     }));
     write!(out, "uncaught throw: {value:?}").unwrap();
     out
+}
+
+/// Fully-qualified name of the cancellation panic class.
+pub const CANCELLED_PANIC_CLASS: &str = "baml.panics.Cancelled";
+
+/// Synthesize an `EngineError::UnhandledThrow` representing a cancellation.
+///
+/// Used when the engine produces a cancellation outside an active VM (pre-call
+/// fail-fast and post-completion "cancel wins" race). Mirrors the shape of a
+/// `baml.panics.Cancelled` instance produced by the VM's `Await` opcode so
+/// host bridges can detect both cases by inspecting `class_name`.
+fn cancelled_unhandled_throw() -> EngineError {
+    let mut fields = indexmap::IndexMap::new();
+    fields.insert(
+        "message".to_string(),
+        BexExternalValue::String("operation cancelled".to_string()),
+    );
+    EngineError::UnhandledThrow {
+        value: Box::new(BexExternalValue::Instance {
+            class_name: CANCELLED_PANIC_CLASS.to_string(),
+            fields,
+        }),
+        trace: Vec::new(),
+    }
 }
 
 // ============================================================================
@@ -360,6 +353,8 @@ pub struct BexEngine {
 
     /// Map of active function calls by ID.
     active_calls: Mutex<HashMap<CallId, CancellationToken>>,
+
+    futures: FutureManager,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -558,6 +553,11 @@ impl BexEngine {
         let enum_definitions = Self::extract_enum_definitions(&resolved_enum_names);
 
         let heap_permit_manager = Arc::new(HeapPermitManager::new());
+        // we just created the permit manager so this will never block
+        let futures_permit = futures::executor::block_on(
+            heap_permit_manager
+                .new_permit(FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap)))),
+        );
 
         // Build a default RuntimeIo from the SysOps table with an empty context.
         // This is replaced per-call in execute_sys_op with a live context that
@@ -595,6 +595,7 @@ impl BexEngine {
             #[cfg(not(target_arch = "wasm32"))]
             park_requested,
             active_calls: Mutex::new(HashMap::new()),
+            futures: FutureManager::new(SharedHeapPermit::new(futures_permit)),
         })
     }
 
@@ -832,9 +833,10 @@ impl BexEngine {
         copy_objects: bool,
     ) -> Result<BexExternalValue, EngineError> {
         // Fail fast if already cancelled — guarantees pre-cancelled tokens
-        // always produce Err(Cancelled) regardless of function contents.
+        // always produce a `baml.panics.Cancelled` panic regardless of
+        // function contents.
         if cancel.is_cancelled() {
-            return Err(EngineError::Cancelled);
+            return Err(cancelled_unhandled_throw());
         }
 
         // Create VM with shared heap (each VM gets its own TLAB)
@@ -953,8 +955,10 @@ impl BexEngine {
 
         // active_calls cleanup is done by ActiveCallGuard on drop.
         //
-        // Keep genuine engine errors intact. Cancellation is surfaced directly
-        // by engine safepoints as `EngineError::Cancelled`.
+        // Keep genuine engine errors intact. Cancellation is surfaced as a
+        // `baml.panics.Cancelled` panic — either raised by the VM's `Await`
+        // opcode, or synthesized by engine safepoints (see
+        // `cancelled_unhandled_throw`).
     }
 
     /// Cancel a function call by its ID.
@@ -964,8 +968,8 @@ impl BexEngine {
     /// is unknown, this will return an error.
     pub fn cancel_function_call(&self, call_id: CallId) -> Result<(), EngineError> {
         let mut active_calls = self.active_calls.lock().unwrap();
-        if let Some(cancel) = active_calls.remove(&call_id) {
-            cancel.cancel();
+        if let Some(call) = active_calls.remove(&call_id) {
+            call.cancel();
             Ok(())
         } else {
             Err(EngineError::FunctionCallNotFound { call_id })
@@ -1211,21 +1215,6 @@ impl BexEngine {
         }
     }
 
-    /// Engine-level cancellation safepoint.
-    ///
-    /// Keeps cancellation handling centralized in the engine loop instead of
-    /// requiring individual BAML code paths or `sys_ops` to be cancel-aware.
-    fn cancellation_safepoint(
-        cancel: &CancellationToken,
-        abort_handles: &AbortHandlesGuard,
-    ) -> Result<(), EngineError> {
-        if cancel.is_cancelled() {
-            abort_handles.abort_all();
-            return Err(EngineError::Cancelled);
-        }
-        Ok(())
-    }
-
     /// Drive the VM to completion, dispatching sys-ops, awaits, span
     /// notifications, and early-yield events.
     ///
@@ -1244,31 +1233,7 @@ impl BexEngine {
         cancel: &CancellationToken,
         copy_objects: bool,
     ) -> Result<BexExternalValue, EngineError> {
-        let (pending_futures, mut processed_futures) = mpsc::unbounded_channel::<FutureResult>();
-        // Abort handles for spawned async tasks.
-        //
-        // Cancellation design: the engine checks cancellation at centralized
-        // safepoints (VM loop boundaries + ScheduleFuture boundaries), and uses
-        // a biased `tokio::select!` while waiting at `Await`. This keeps
-        // cancellation in the engine, so individual sys_ops don't need to be
-        // cancellation-aware. Without abort handles, async sys-op tasks would
-        // continue as orphans after cancellation until they complete naturally.
-        // For long-running ops (HTTP requests, multi-second sleeps), that
-        // wastes real resources.
-        //
-        // Rather than making individual sys_ops cancel-aware (wrapping each in
-        // its own `tokio::select!`), we store abort handles here and kill all
-        // spawned tasks when cancellation fires. This keeps sys_op
-        // implementations simple — new sys_ops never need to think about
-        // cancellation.
-        //
-        // We use `futures::future::AbortHandle` (not `tokio::task::AbortHandle`)
-        // so the same mechanism works on both native and WASM targets.
-        let mut abort_handles = AbortHandlesGuard::new();
-
-        'vm_exec: loop {
-            Self::cancellation_safepoint(cancel, &abort_handles)?;
-
+        loop {
             // Update the VM's span context so native functions can read it.
             vm.current_span_context = span_state.as_ref().map(Self::build_span_context_from_state);
 
@@ -1304,15 +1269,12 @@ impl BexEngine {
             match exec_result {
                 VmExecState::Complete(value) => {
                     // "Cancel wins" semantics: if cancellation races with a
-                    // completed VM step, report `Cancelled` rather than
-                    // returning a success value.
+                    // completed VM step, report a cancellation panic rather
+                    // than returning a success value.
                     //
                     // Still emit FunctionEnd first so tracing consumers see
                     // a paired root FunctionStart/FunctionEnd span.
                     let cancelled = cancel.is_cancelled();
-                    if cancelled {
-                        abort_handles.abort_all();
-                    }
 
                     // Emit FunctionEnd for the root entry-point span if tracing
                     if let Some(state) = span_state.as_mut() {
@@ -1343,7 +1305,7 @@ impl BexEngine {
                     }
 
                     if cancelled {
-                        return Err(EngineError::Cancelled);
+                        return Err(cancelled_unhandled_throw());
                     }
 
                     // When copy_objects: false and the result is a heap object,
@@ -1366,113 +1328,70 @@ impl BexEngine {
                     );
                 }
 
-                VmExecState::ScheduleFuture(id) => {
-                    let pending = vm
-                        .pending_future(id)
+                VmExecState::ScheduleFuture(unscheduled) => {
+                    // Extract data from unscheduled future
+                    let unscheduled = vm
+                        .pending_future(unscheduled)
                         .map_err(EngineError::VmInternalError)?;
-
-                    // Convert arguments to BexExternalValue
-                    let args: Vec<BexExternalValue> = pending
+                    let args: Vec<BexExternalValue> = unscheduled
                         .args
                         .iter()
                         .map(|v| self.vm_arg_to_bex_value(v))
                         .collect();
+                    let operation = unscheduled.operation;
 
-                    Self::cancellation_safepoint(cancel, &abort_handles)?;
+                    // Setup future
+                    // TODO: detached cancellation
+                    let future_cancel = cancel.child_token();
+                    let mut future_permit = self.futures.acquire().await;
+                    let (future_id, future_ptr) = future_permit.new_future(future_cancel.clone());
+                    vm.stack.push(Value::Object(future_ptr));
+                    if future_cancel.is_cancelled() {
+                        // Early cancellation-- don't need to even start the future.
+                        future_permit.cancel_future(future_id)?;
+                        drop(future_permit);
+                        continue;
+                    }
+                    drop(future_permit);
+
+                    // Execute sys_op
                     let sys_op_result =
-                        self.execute_sys_op(pending.operation, &args, call_id, cancel, vm.proof());
-                    Self::cancellation_safepoint(cancel, &abort_handles)?;
+                        self.execute_sys_op(operation, &args, call_id, cancel, vm.proof());
 
                     match sys_op_result {
                         SysOpResult::Ready(result) => {
-                            // Guard the "commit to VM state" boundary.
-                            Self::cancellation_safepoint(cancel, &abort_handles)?;
-
                             // Sync operation - set future to Ready without touching stack.
                             // The VM will continue to the Await instruction which will
                             // extract the value from the Ready future.
                             let result = result.map_err(EngineError::from)?;
                             let value = self.convert_external_to_vm_value(&mut vm, result);
 
-                            vm.set_future_ready(id, value)
-                                .map_err(EngineError::VmInternalError)?;
+                            // We may be blocked by other threads doing futures stuff,
+                            // but since we hold our VM permit it should never be blocked by GC.
+                            let mut future_permit = self.futures.acquire().await;
+                            future_permit.fulfill_future(future_id, value)?;
+                            drop(future_permit);
                         }
                         SysOpResult::Async(fut) => {
-                            // Guard the "spawn side effect" boundary.
-                            Self::cancellation_safepoint(cancel, &abort_handles)?;
-
-                            // Async operation — wrap in Abortable and spawn.
-                            let pending_futures = pending_futures.clone();
-                            let (abort_handle, abort_reg) =
-                                futures::future::AbortHandle::new_pair();
-                            let abortable = futures::future::Abortable::new(
-                                async move {
-                                    let result = fut.await;
-                                    let _ = pending_futures.send(FutureResult {
-                                        id,
-                                        result: result.map_err(EngineError::from),
-                                    });
-                                },
-                                abort_reg,
-                            );
+                            let task = Arc::clone(self).run_future(fut, future_id, future_cancel);
                             #[cfg(not(target_arch = "wasm32"))]
                             tokio::spawn(async move {
-                                let _ = abortable.await;
+                                let _ = task.await;
                             });
                             #[cfg(target_arch = "wasm32")]
                             wasm_bindgen_futures::spawn_local(async move {
-                                let _ = abortable.await;
+                                let _ = task.await;
                             });
-                            abort_handles.push(abort_handle);
                         }
                     }
                 }
 
                 VmExecState::Await(future_id) => {
-                    Self::cancellation_safepoint(cancel, &abort_handles)?;
                     vm = self.gc_safepoint(vm).await;
-
-                    // First, drain any already-completed futures.
-                    while let Ok(future) = processed_futures.try_recv() {
-                        let external = future.result?;
-                        let value = self.convert_external_to_vm_value(&mut vm, external);
-                        vm.fulfil_future(future.id, value)
-                            .map_err(EngineError::VmInternalError)?;
-
-                        if future.id == future_id {
-                            continue 'vm_exec;
-                        }
-                    }
-
-                    // We gotta wait for the target future.
-                    // Race against cancellation — `biased` ensures the cancel
-                    // branch is checked first, matching legacy orchestrator behavior.
-                    loop {
-                        tokio::select! {
-                            biased;
-                            () = cancel.cancelled() => {
-                                // Abort all in-flight spawned tasks to stop
-                                // HTTP requests, sleeps, etc. immediately.
-                                abort_handles.abort_all();
-                                return Err(EngineError::Cancelled);
-                            }
-                            future = processed_futures.recv() => {
-                                let future = future
-                                    .ok_or(EngineError::FutureChannelClosed)?;
-                                let external = future.result?;
-                                let value = self.convert_external_to_vm_value(
-                                    &mut vm,
-                                    external,
-                                );
-                                vm.fulfil_future(future.id, value)
-                                    .map_err(EngineError::VmInternalError)?;
-
-                                if future.id == future_id {
-                                    break;
-                                }
-                            }
-                        }
-                    }
+                    let future_permit = self.futures.acquire().await;
+                    let future = future_permit.future_ready(future_id)?;
+                    drop(future_permit);
+                    future.await?;
                 }
 
                 VmExecState::Event {
@@ -1642,9 +1561,44 @@ impl BexEngine {
                     }
                 }
                 VmExecState::EarlyYield => {
-                    Self::cancellation_safepoint(cancel, &abort_handles)?;
                     vm = self.gc_safepoint(vm).await;
                 }
+            }
+        }
+    }
+
+    /// Runs a future, handling cancellation.
+    /// When completed, updates the future state on the heap.
+    async fn run_future(
+        self: Arc<Self>,
+        future: OpFuture,
+        future_id: FutureId,
+        cancel: CancellationToken,
+    ) -> Result<(), EngineError> {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                let mut future_guard = self.futures.acquire().await;
+                future_guard.cancel_future(future_id)?;
+                drop(future_guard);
+                Ok(())
+            }
+            result = future => {
+                let mut future_guard = self.futures.acquire().await;
+                match result {
+                    Ok(value) => {
+                        let value = self.convert_external_to_vm_value(
+                            &mut future_guard,
+                            value,
+                        );
+                        future_guard.fulfill_future(future_id, value)?;
+                    }
+                    Err(err) => {
+                        future_guard.internal_error_future(future_id, err.into())?;
+                    }
+                }
+                drop(future_guard);
+                Ok(())
             }
         }
     }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -88,10 +88,7 @@ pub use bex_external_types::{BexExternalValue, Ty, TypeName, UnionMetadata};
 use bex_heap::BexHeap;
 // Re-export GcStats for users of the engine
 pub use bex_heap::GcStats;
-pub use bex_heap::{
-    ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapPermit, SharedHeapPermit,
-    SharedHeapPermitGuard,
-};
+pub use bex_heap::{ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapPermit};
 use bex_vm::{BexVm, SpanNotification, VmExecState};
 use bex_vm_types::{
     FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SysOp, Value, VmGlobals,
@@ -126,6 +123,52 @@ pub struct UserFunctionInfo {
 // Span Tracking (per-invocation, NOT on Arc<BexEngine>)
 // ============================================================================
 
+/// RAII guard that owns a `CallId` slot in `BexEngine::active_calls`. The
+/// slot is inserted by [`Self::register`] and removed on drop, matching
+/// the lifetime of the `call_function` invocation. The constructor and
+/// the registry insert are atomic — there is no window during which the
+/// slot exists without an owning guard, so a panic at the registration
+/// site cannot leak entries.
+struct ActiveCallGuard {
+    engine: Arc<BexEngine>,
+    call_id: CallId,
+}
+
+impl ActiveCallGuard {
+    /// Atomically reserve `call_id` in `engine.active_calls` and return a
+    /// guard that will release the slot on drop. Returns
+    /// [`EngineError::DuplicateCallId`] if the id is already in flight.
+    fn register(
+        engine: Arc<BexEngine>,
+        call_id: CallId,
+        cancel: CancellationToken,
+    ) -> Result<Self, EngineError> {
+        let mut map = engine
+            .active_calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if map.contains_key(&call_id) {
+            return Err(EngineError::DuplicateCallId { call_id });
+        }
+        map.insert(call_id, cancel);
+        drop(map);
+        Ok(Self { engine, call_id })
+    }
+}
+
+impl Drop for ActiveCallGuard {
+    fn drop(&mut self) {
+        // `unwrap_or_else(into_inner)` so a poisoned mutex during unwind
+        // doesn't double-panic.
+        let mut map = self
+            .engine
+            .active_calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.remove(&self.call_id);
+    }
+}
+
 /// A single active span in the engine's per-invocation span stack.
 struct EngineSpan {
     span_id: SpanId,
@@ -155,7 +198,7 @@ pub enum EngineError {
     #[error("Function call with ID {call_id} not found")]
     FunctionCallNotFound { call_id: CallId },
 
-    #[error("Future with ID {future_id:?} not found")]
+    #[error("Future with ID {future_id} not found")]
     FutureNotFound { future_id: FutureId },
 
     #[error("Function not found: {name}")]
@@ -163,9 +206,6 @@ pub enum EngineError {
 
     #[error("{0}")]
     ExternalOpFailed(#[from] OpError),
-
-    #[error("Future channel closed unexpectedly")]
-    FutureChannelClosed,
 
     #[error("VM internal error: {0}")]
     VmInternalError(bex_vm::errors::VmInternalError),
@@ -256,7 +296,11 @@ pub fn is_cancelled_engine_error(err: &EngineError) -> bool {
 /// fail-fast and post-completion "cancel wins" race). Mirrors the shape of a
 /// `baml.panics.Cancelled` instance produced by the VM's `Await` opcode so
 /// host bridges can detect both cases by inspecting `class_name`.
-fn cancelled_unhandled_throw() -> EngineError {
+///
+/// Exposed publicly so bridges and other layers that need to surface a
+/// cancellation outside the engine's normal control flow can produce one
+/// in the canonical shape rather than rolling their own.
+pub fn cancelled_unhandled_throw() -> EngineError {
     let mut fields = indexmap::IndexMap::new();
     fields.insert(
         "message".to_string(),
@@ -639,7 +683,7 @@ impl BexEngine {
             #[cfg(not(target_arch = "wasm32"))]
             park_requested,
             active_calls: Mutex::new(HashMap::new()),
-            futures: FutureManager::new(SharedHeapPermit::new(futures_permit)),
+            futures: FutureManager::new(futures_permit),
         })
     }
 
@@ -775,7 +819,9 @@ impl BexEngine {
     /// for telemetry and tests that verify the future manager cleans up
     /// completed futures.
     pub async fn active_future_count(&self) -> usize {
-        self.futures.active_future_count().await
+        self.futures
+            .active_future_count(&self.heap_permit_manager)
+            .await
     }
 
     /// Resolve a [`bex_external_types::Handle`] to its current [`HeapPtr`].
@@ -889,6 +935,12 @@ impl BexEngine {
         if cancel.is_cancelled() {
             return Err(cancelled_unhandled_throw());
         }
+
+        // Register this call so `cancel_function_call(call_id)` can target
+        // it. The RAII guard removes the entry on drop (including panic
+        // unwind). Insertion and guard construction are atomic, so a panic
+        // here cannot leak registry entries.
+        let _call_guard = ActiveCallGuard::register(Arc::clone(self), call_id, cancel.clone())?;
 
         // Create VM with shared heap (each VM gets its own TLAB).
         // Globals are shared as a frozen `Arc<[Value]>` — cloning is a refcount bump.
@@ -1267,6 +1319,27 @@ impl BexEngine {
         }
     }
 
+    /// Heuristic-driven GC check that does **not** require the caller to
+    /// hold an active heap permit. Use this when the caller is already in a
+    /// permit-released state (e.g., the engine's `Await` branch waiting on
+    /// a `SetOnce`) — calling [`Self::gc_safepoint`] there would do an
+    /// extra release-and-reacquire pair around the heuristic for nothing.
+    async fn maybe_collect_garbage(&self) {
+        let i_am_checking = self
+            .checking_gc
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok();
+        if i_am_checking {
+            if let Some(level) = self.heap.should_collect() {
+                self.collect_garbage(level).await;
+            }
+            self.checking_gc.store(false, Ordering::Release);
+        }
+        // If we are not the checker, the actual checker (some other VM) is
+        // either already waiting in `request_park` or about to. Our caller
+        // is permit-released, so they're not blocking that wait.
+    }
+
     /// Drive the VM to completion, dispatching sys-ops, awaits, span
     /// notifications, and early-yield events.
     ///
@@ -1392,22 +1465,35 @@ impl BexEngine {
                         .collect();
                     let operation = unscheduled.operation;
 
-                    // Setup future
+                    // Setup future. Each `futures.acquire(vm.proof())` is
+                    // scoped tightly so the proof's borrow on `vm` ends
+                    // before any subsequent `vm.stack` mutation; the type
+                    // system enforces GC exclusion via the `'a` tie
+                    // between proof and guard. The cost is one extra
+                    // uncontended Mutex lock on the early-cancel path
+                    // below — far cheaper than restructuring the
+                    // VM-stack-and-cancel choreography.
                     // TODO: detached cancellation
                     let future_cancel = cancel.child_token();
-                    let mut future_permit = self.futures.acquire().await;
-                    let (future_id, future_ptr) = future_permit.new_future(future_cancel.clone());
+                    let (future_id, future_ptr) = {
+                        let mut g = self.futures.acquire(vm.proof()).await;
+                        g.new_future(future_cancel.clone())
+                    };
                     vm.stack.push(Value::Object(future_ptr));
                     if cancel.is_cancelled() {
-                        // Early cancellation-- don't need to even start the future.
-                        // (`future_cancel` is a child of `cancel` and is only cancelled
-                        // here via parent inheritance, so checking `cancel` directly is
-                        // equivalent and matches the post-exec safepoint below.)
-                        future_permit.cancel_future(future_id)?;
-                        drop(future_permit);
+                        // Early cancellation -- don't even start the
+                        // future. (`future_cancel` is a child of `cancel`,
+                        // so checking `cancel` here is equivalent to
+                        // checking the inheriting child.) Re-acquire the
+                        // FutureManager Mutex to cancel the just-created
+                        // entry; see the comment above for why this
+                        // second acquire is structural, not redundant.
+                        self.futures
+                            .acquire(vm.proof())
+                            .await
+                            .cancel_future(future_id)?;
                         continue;
                     }
-                    drop(future_permit);
 
                     // Execute sys_op
                     let sys_op_result =
@@ -1415,9 +1501,11 @@ impl BexEngine {
 
                     match sys_op_result {
                         SysOpResult::Ready(result) => {
-                            // We may be blocked by other threads doing futures stuff,
-                            // but since we hold our VM permit it should never be blocked by GC.
-                            let mut future_permit = self.futures.acquire().await;
+                            // VM permit is still held, gating GC for the
+                            // duration of this critical section. The
+                            // FutureManager Mutex serializes against other
+                            // mutators; no second semaphore acquire here.
+                            let mut future_permit = self.futures.acquire(vm.proof()).await;
                             // Cancellation safepoint: if cancellation fires between the
                             // pre-exec early check and the commit, surface it as a Cancelled
                             // future rather than fulfilling. The VM's next `Await` will throw
@@ -1456,13 +1544,13 @@ impl BexEngine {
                             #[cfg(not(target_arch = "wasm32"))]
                             tokio::spawn(async move {
                                 if let Err(err) = task.await {
-                                    tracing::error!(?err, "spawned future task failed");
+                                    tracing::error!(?err, ?future_id, "spawned future task failed");
                                 }
                             });
                             #[cfg(target_arch = "wasm32")]
                             wasm_bindgen_futures::spawn_local(async move {
                                 if let Err(err) = task.await {
-                                    tracing::error!(?err, "spawned future task failed");
+                                    tracing::error!(?err, ?future_id, "spawned future task failed");
                                 }
                             });
                         }
@@ -1470,11 +1558,23 @@ impl BexEngine {
                 }
 
                 VmExecState::Await(future_id) => {
-                    vm = self.gc_safepoint(vm).await;
-                    let future_permit = self.futures.acquire().await;
-                    let future = future_permit.future_ready(future_id)?;
-                    drop(future_permit);
+                    // Tightly-scoped guard so the proof's borrow on `vm`
+                    // ends before we release the VM permit below.
+                    let future = {
+                        let g = self.futures.acquire(vm.proof()).await;
+                        g.future_ready(future_id)?
+                    };
+                    // Release the VM permit before the SetOnce wait — the
+                    // wait is the safepoint. Holding a permit through the
+                    // wait would deadlock concurrent GC park (which needs
+                    // every permit) against the spawned task that fulfils
+                    // this future (which needs a permit to write the heap).
+                    let inactive = vm.release();
+                    // While parked, run a heuristic-driven GC check (no
+                    // permit dance needed since we're already released).
+                    self.maybe_collect_garbage().await;
                     future.await?;
+                    vm = inactive.acquire().await;
                 }
 
                 VmExecState::Event {
@@ -1652,38 +1752,53 @@ impl BexEngine {
 
     /// Runs a future, handling cancellation.
     /// When completed, updates the future state on the heap.
+    ///
+    /// Holding-no-permit during the long `select!` wait means GC can run
+    /// freely while the inner sys-op is in flight. After `select!` resolves,
+    /// the spawned task takes a one-shot heap permit (`NoOpRootHaver` —
+    /// nothing to root) so its brief writeback to the `FutureManager`'s
+    /// registry is gated against GC just like any in-VM caller.
     async fn run_future(
         self: Arc<Self>,
         future: OpFuture,
         future_id: FutureId,
         cancel: CancellationToken,
     ) -> Result<(), EngineError> {
-        tokio::select! {
+        // Stack-local enum, never stored or sent across threads — the size
+        // mismatch between variants (Cancelled is ZST, Result carries a
+        // ~300-byte BexExternalValue+OpError) doesn't matter here.
+        #[allow(clippy::large_enum_variant)]
+        enum Outcome {
+            Cancelled,
+            Result(Result<BexExternalValue, OpError>),
+        }
+        let outcome = tokio::select! {
             biased;
-            () = cancel.cancelled() => {
-                let mut future_guard = self.futures.acquire().await;
+            () = cancel.cancelled() => Outcome::Cancelled,
+            r = future            => Outcome::Result(r),
+        };
+
+        // One-shot heap permit for GC exclusion during the brief writeback.
+        // `()`'s `RootHaver` impl has no roots — this permit is purely a
+        // "block GC while I write" mechanism.
+        let inactive = self.heap_permit_manager.new_permit(()).await;
+        let active = inactive.acquire().await;
+        let mut future_guard = self.futures.acquire(active.proof()).await;
+        match outcome {
+            Outcome::Cancelled => {
                 future_guard.cancel_future(future_id)?;
-                drop(future_guard);
-                Ok(())
             }
-            result = future => {
-                let mut future_guard = self.futures.acquire().await;
-                match result {
-                    Ok(value) => {
-                        let value = self.convert_external_to_vm_value(
-                            &mut future_guard,
-                            value,
-                        );
-                        future_guard.fulfill_future(future_id, value)?;
-                    }
-                    Err(err) => {
-                        future_guard.internal_error_future(future_id, err.into())?;
-                    }
-                }
-                drop(future_guard);
-                Ok(())
+            Outcome::Result(Ok(value)) => {
+                let value = self.convert_external_to_vm_value(&mut future_guard, value);
+                future_guard.fulfill_future(future_id, value)?;
+            }
+            Outcome::Result(Err(err)) => {
+                future_guard.internal_error_future(future_id, err.into())?;
             }
         }
+        drop(future_guard);
+        drop(active);
+        Ok(())
     }
 
     /// Build a `SpanContext` from the current `SpanState`.

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -727,6 +727,13 @@ impl BexEngine {
         &self.heap_permit_manager
     }
 
+    /// Number of currently `Pending` futures tracked by the engine. Useful
+    /// for telemetry and tests that verify the future manager cleans up
+    /// completed futures.
+    pub async fn active_future_count(&self) -> usize {
+        self.futures.active_future_count().await
+    }
+
     /// Resolve a [`bex_external_types::Handle`] to its current [`HeapPtr`].
     ///
     /// The permit parameter proves GC cannot run while the caller is using the

--- a/baml_language/crates/bex_engine/tests/cancellation.rs
+++ b/baml_language/crates/bex_engine/tests/cancellation.rs
@@ -438,3 +438,221 @@ async fn cancel_is_idempotent() {
     let result = handle.await.expect("task panicked");
     assert_cancelled(&result);
 }
+
+// ============================================================================
+// 8. M1 — `cancel_function_call(call_id)` actually cancels a running call.
+// ============================================================================
+
+#[tokio::test]
+async fn cancel_function_call_by_id_actually_cancels() {
+    // The host calls `engine.cancel_function_call(call_id)` instead of firing
+    // a `CancellationToken` directly. This exercises the `active_calls` /
+    // `ActiveCallGuard` registration path. Pre-fix: the registry was empty
+    // and `cancel_function_call` always returned `FunctionCallNotFound`,
+    // leaving the call to run to completion (10s sleep). Post-fix: the
+    // registered cancel token fires and the call returns Cancelled within
+    // ~1s.
+    let source = r#"
+        function main() -> int {
+            baml.sys.sleep(10000);
+            42
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let call_id = sys_types::CallId::next();
+    let start = std::time::Instant::now();
+
+    let handle = tokio::spawn({
+        let engine = Arc::clone(&engine);
+        async move {
+            engine
+                .call_function(
+                    "main",
+                    vec![],
+                    FunctionCallContextBuilder::new(call_id).build(),
+                    true,
+                )
+                .await
+        }
+    });
+
+    // Let the function reach the sleep, then cancel by id.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    engine
+        .cancel_function_call(call_id)
+        .expect("call_id should be registered while the call is in flight");
+
+    let result = handle.await.expect("task panicked");
+    let elapsed = start.elapsed();
+
+    assert_cancelled(&result);
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "cancel_function_call took too long: {elapsed:?} (expected < 2s)"
+    );
+
+    // After completion, the entry is gone — a second cancel returns NotFound.
+    assert!(matches!(
+        engine.cancel_function_call(call_id),
+        Err(EngineError::FunctionCallNotFound { .. })
+    ));
+}
+
+#[tokio::test]
+async fn duplicate_call_id_is_rejected() {
+    // Two concurrent calls with the same `CallId` should fail-fast on the
+    // second. The first holds the registry slot via `ActiveCallGuard`.
+    let source = r#"
+        function main() -> int {
+            baml.sys.sleep(500);
+            7
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let shared_id = sys_types::CallId::next();
+    let first = tokio::spawn({
+        let engine = Arc::clone(&engine);
+        async move {
+            engine
+                .call_function(
+                    "main",
+                    vec![],
+                    FunctionCallContextBuilder::new(shared_id).build(),
+                    true,
+                )
+                .await
+        }
+    });
+
+    // Give the first call time to register, then start the duplicate.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    let second_result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(shared_id).build(),
+            true,
+        )
+        .await;
+    assert!(
+        matches!(second_result, Err(EngineError::DuplicateCallId { .. })),
+        "expected DuplicateCallId, got {second_result:?}"
+    );
+
+    // First call should still complete normally.
+    let first_result = first.await.expect("task panicked");
+    assert_eq!(
+        first_result.expect("first call failed"),
+        BexExternalValue::Int(7)
+    );
+}
+
+// ============================================================================
+// 9. M3 — engine-synthesized vs VM-thrown Cancelled panic shape equivalence.
+// ============================================================================
+
+#[tokio::test]
+async fn cancelled_panic_shape_equivalence() {
+    // The engine produces two cancellation paths that must be observationally
+    // equivalent for host bridges:
+    //   (a) `cancelled_unhandled_throw()` synthesizes one when the engine
+    //       short-circuits before the VM runs (pre-call check; "cancel wins"
+    //       after Complete).
+    //   (b) The VM's `Await` opcode throws `baml.panics.Cancelled` when the
+    //       awaited future is in `Cancelled` state.
+    //
+    // Both must produce the same `class_name` and the same `message` field
+    // so downstream `is_cancelled_engine_error` works uniformly.
+    use bex_engine::cancelled_unhandled_throw;
+    use indexmap::IndexMap;
+
+    fn extract_instance(v: &BexExternalValue) -> (&str, &IndexMap<String, BexExternalValue>) {
+        match v {
+            BexExternalValue::Instance { class_name, fields } => (class_name.as_str(), fields),
+            other => panic!("expected Instance, got {other:?}"),
+        }
+    }
+
+    let synthesized = cancelled_unhandled_throw();
+    let synthesized_value = match synthesized {
+        EngineError::UnhandledThrow { value, .. } => *value,
+        other => panic!("cancelled_unhandled_throw returned non-UnhandledThrow: {other:?}"),
+    };
+
+    let source = r#"
+        function main() -> int {
+            baml.sys.sleep(5000);
+            42
+        }
+    "#;
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn({
+        let engine = Arc::clone(&engine);
+        async move {
+            engine
+                .call_function(
+                    "main",
+                    vec![],
+                    FunctionCallContextBuilder::new(sys_types::CallId::next())
+                        .with_cancel_token(cancel_clone)
+                        .build(),
+                    true,
+                )
+                .await
+        }
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    cancel.cancel();
+    let vm_result = handle.await.expect("task panicked");
+    let vm_value = match vm_result {
+        Err(EngineError::UnhandledThrow { value, .. }) => *value,
+        other => panic!("expected UnhandledThrow from VM Await, got {other:?}"),
+    };
+
+    let (s_class, s_fields) = extract_instance(&synthesized_value);
+    let (v_class, v_fields) = extract_instance(&vm_value);
+
+    assert_eq!(s_class, CANCELLED_PANIC_CLASS);
+    assert_eq!(v_class, CANCELLED_PANIC_CLASS);
+    assert_eq!(s_fields.len(), v_fields.len(), "field count must match");
+    for (s_key, s_val) in s_fields {
+        let v_val = v_fields
+            .get(s_key)
+            .unwrap_or_else(|| panic!("VM panic missing field {s_key}"));
+        assert_eq!(s_val, v_val, "field {s_key} differs");
+    }
+}

--- a/baml_language/crates/bex_engine/tests/cancellation.rs
+++ b/baml_language/crates/bex_engine/tests/cancellation.rs
@@ -9,10 +9,28 @@ mod common;
 use std::sync::Arc;
 
 use bex_engine::{
-    BexEngine, BexExternalValue, CancellationToken, EngineError, FunctionCallContextBuilder,
+    BexEngine, BexExternalValue, CANCELLED_PANIC_CLASS, CancellationToken, EngineError,
+    FunctionCallContextBuilder,
 };
 use common::compile_for_engine;
 use sys_native::SysOpsExt;
+
+/// Asserts the result is an unhandled `baml.panics.Cancelled` panic.
+#[track_caller]
+fn assert_cancelled<T: std::fmt::Debug>(result: &Result<T, EngineError>) {
+    match result {
+        Err(EngineError::UnhandledThrow { value, .. }) => match value.as_ref() {
+            BexExternalValue::Instance { class_name, .. } => {
+                assert_eq!(
+                    class_name, CANCELLED_PANIC_CLASS,
+                    "expected {CANCELLED_PANIC_CLASS} panic, got class {class_name}"
+                );
+            }
+            other => panic!("expected panic Instance, got {other:?}"),
+        },
+        other => panic!("expected UnhandledThrow({CANCELLED_PANIC_CLASS}), got {other:?}"),
+    }
+}
 
 // ============================================================================
 // 1. Immediate cancellation — token already cancelled before call starts
@@ -53,10 +71,7 @@ async fn cancel_before_call_returns_cancelled() {
         )
         .await;
 
-    assert!(
-        matches!(result, Err(EngineError::Cancelled)),
-        "Expected EngineError::Cancelled, got: {result:?}"
-    );
+    assert_cancelled(&result);
 }
 
 // ============================================================================
@@ -111,10 +126,7 @@ async fn cancel_during_sleep_returns_promptly() {
     let result = handle.await.expect("task panicked");
     let elapsed = start.elapsed();
 
-    assert!(
-        matches!(result, Err(EngineError::Cancelled)),
-        "Expected EngineError::Cancelled, got: {result:?}"
-    );
+    assert_cancelled(&result);
     // Should return well before the 10s sleep completes.
     assert!(
         elapsed < std::time::Duration::from_secs(2),
@@ -189,10 +201,7 @@ async fn cancel_during_http_returns_promptly() {
     let result = handle.await.expect("task panicked");
     let elapsed = start.elapsed();
 
-    assert!(
-        matches!(result, Err(EngineError::Cancelled)),
-        "Expected EngineError::Cancelled, got: {result:?}"
-    );
+    assert_cancelled(&result);
     assert!(
         elapsed < std::time::Duration::from_secs(2),
         "Cancel took too long: {elapsed:?} (expected < 2s)"
@@ -271,10 +280,7 @@ async fn selective_cancellation_only_affects_target() {
     let result_slow = handle_slow.await.expect("task panicked");
     let result_fast = handle_fast.await.expect("task panicked");
 
-    assert!(
-        matches!(result_slow, Err(EngineError::Cancelled)),
-        "Slow call should be cancelled, got: {result_slow:?}"
-    );
+    assert_cancelled(&result_slow);
     assert_eq!(
         result_fast.expect("fast call failed"),
         BexExternalValue::Int(2),
@@ -337,10 +343,7 @@ async fn cancel_interrupts_sequential_sleeps() {
     let result = handle.await.expect("task panicked");
     let elapsed = start.elapsed();
 
-    assert!(
-        matches!(result, Err(EngineError::Cancelled)),
-        "Expected EngineError::Cancelled, got: {result:?}"
-    );
+    assert_cancelled(&result);
     assert!(
         elapsed < std::time::Duration::from_secs(3),
         "Cancel took too long: {elapsed:?} (expected < 3s)"
@@ -433,5 +436,5 @@ async fn cancel_is_idempotent() {
     cancel.cancel(); // third cancel — still harmless
 
     let result = handle.await.expect("task panicked");
-    assert!(matches!(result, Err(EngineError::Cancelled)));
+    assert_cancelled(&result);
 }

--- a/baml_language/crates/bex_engine/tests/future_cleanup.rs
+++ b/baml_language/crates/bex_engine/tests/future_cleanup.rs
@@ -1,0 +1,83 @@
+//! Verify that the engine's `FutureManager` removes entries for completed
+//! futures so the tracking map does not grow unboundedly.
+
+mod common;
+
+use std::sync::Arc;
+
+use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder};
+use common::compile_for_engine;
+use sys_native::SysOpsExt;
+
+fn make_engine(source: &str) -> Arc<BexEngine> {
+    let snapshot = compile_for_engine(source);
+    Arc::new(
+        BexEngine::new(
+            snapshot,
+            Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    )
+}
+
+async fn call_main(engine: &Arc<BexEngine>) -> BexExternalValue {
+    engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("call should succeed")
+}
+
+#[tokio::test]
+async fn active_futures_drains_after_awaited_sleep() {
+    // A function that schedules and awaits several async sys-ops should
+    // leave no entries behind in the future manager once it returns.
+    let source = r#"
+        function main() -> int {
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            42
+        }
+    "#;
+
+    let engine = make_engine(source);
+    assert_eq!(engine.active_future_count().await, 0);
+
+    let result = call_main(&engine).await;
+    assert_eq!(result, BexExternalValue::Int(42));
+    assert_eq!(engine.active_future_count().await, 0);
+}
+
+#[tokio::test]
+async fn active_futures_drains_across_concurrent_calls() {
+    // Run several calls concurrently and verify the count is back to zero
+    // after they all complete. This catches a regression where one call's
+    // entries linger and bias the count.
+    let source = r#"
+        function main() -> int {
+            baml.sys.sleep(0);
+            7
+        }
+    "#;
+
+    let engine = make_engine(source);
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let engine = Arc::clone(&engine);
+        handles.push(tokio::spawn(async move { call_main(&engine).await }));
+    }
+    for handle in handles {
+        let value = handle.await.expect("task should not panic");
+        assert_eq!(value, BexExternalValue::Int(7));
+    }
+
+    assert_eq!(engine.active_future_count().await, 0);
+}

--- a/baml_language/crates/bex_engine/tests/future_cleanup.rs
+++ b/baml_language/crates/bex_engine/tests/future_cleanup.rs
@@ -55,6 +55,45 @@ async fn active_futures_drains_after_awaited_sleep() {
     assert_eq!(engine.active_future_count().await, 0);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn future_state_race_under_multithread_stress() {
+    // Regression test for the data race between the engine's spawned task
+    // (writer of the `Future` heap object) and the VM (reader). Many
+    // fast-resolving sys-ops (`baml.sys.sleep(0)`) on a multi-threaded
+    // tokio runtime exercise the path where the spawned task's write to
+    // `Future::Ready` can land before — or alongside — the VM's first
+    // read in `Await`. The atomic discriminant on `Future` makes this
+    // race-free; without the fix, this test would tear discriminant reads
+    // and (in debug) panic on a non-Pending state.
+    let source = r#"
+        function main() -> int {
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            1
+        }
+    "#;
+
+    let engine = make_engine(source);
+
+    let mut handles = Vec::new();
+    for _ in 0..32 {
+        let engine = Arc::clone(&engine);
+        handles.push(tokio::spawn(async move { call_main(&engine).await }));
+    }
+    for handle in handles {
+        let value = handle.await.expect("task should not panic");
+        assert_eq!(value, BexExternalValue::Int(1));
+    }
+
+    assert_eq!(engine.active_future_count().await, 0);
+}
+
 #[tokio::test]
 async fn active_futures_drains_across_concurrent_calls() {
     // Run several calls concurrently and verify the count is back to zero

--- a/baml_language/crates/bex_engine/tests/gc_during_future_op.rs
+++ b/baml_language/crates/bex_engine/tests/gc_during_future_op.rs
@@ -1,0 +1,145 @@
+//! H1 regression: garbage collection requested concurrently with VMs that
+//! are mid-`ScheduleFuture` / `Await` must not deadlock the engine.
+//!
+//! Pre-fix the engine acquired a *second* heap-permit-semaphore slot from
+//! `FutureManager` while still holding the VM permit, putting two
+//! `acquire(1)` requests in tokio's strict-FIFO wait queue behind a GC's
+//! `acquire_many(MAX_PERMITS)`. With multiple VMs the queue would wedge.
+//!
+//! Post-fix the `FutureManager` state lock is a plain `tokio::sync::Mutex`
+//! independent of the heap semaphore, and the spawned `run_future` task
+//! takes its own one-shot permit only during its brief writeback. GC can
+//! run freely whenever the in-VM critical section drops the futures
+//! mutex; deadlock is structurally impossible.
+
+mod common;
+
+use std::sync::Arc;
+
+use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder};
+use common::compile_for_engine;
+use sys_native::SysOpsExt;
+
+fn make_engine(source: &str) -> Arc<BexEngine> {
+    let snapshot = compile_for_engine(source);
+    Arc::new(
+        BexEngine::new(
+            snapshot,
+            Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_deadlock_between_gc_and_concurrent_schedule_future() {
+    // Pre-fix this hung once a VM started a `ScheduleFuture` critical section
+    // and another VM concurrently entered `request_park`: GC's
+    // `acquire_many(MAX_PERMITS)` queued ahead of the VM's second permit
+    // request, with the VM still holding its first one.
+    //
+    // Post-fix: in-VM callers of `FutureManager::acquire(proof)` only take
+    // the futures Mutex (no second semaphore slot), and the spawned
+    // `run_future` task takes its own one-shot permit only after the long
+    // wait. The Await branch also drops the VM permit while awaiting the
+    // SetOnce so the spawned task's one-shot permit acquire doesn't queue
+    // behind the VM's permit holding.
+    let source = r#"
+        function main() -> int {
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            baml.sys.sleep(0);
+            1
+        }
+    "#;
+    let engine = make_engine(source);
+
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_clone = Arc::clone(&stop);
+    let engine_for_gc = Arc::clone(&engine);
+    let gc_task = tokio::spawn(async move {
+        // Periodic GC — gentle enough to let VMs make progress between
+        // collections. The point is to provoke the GC-vs-engine ordering,
+        // not stress-test heap throughput.
+        while !stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            engine_for_gc
+                .collect_garbage(bex_heap::CollectionLevel::Major)
+                .await;
+        }
+    });
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let engine = Arc::clone(&engine);
+        handles.push(tokio::spawn(async move {
+            engine
+                .call_function(
+                    "main",
+                    vec![],
+                    FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+                    true,
+                )
+                .await
+        }));
+    }
+
+    let calls = async {
+        for handle in handles {
+            let result = handle.await.expect("call task panicked");
+            assert_eq!(result.expect("call failed"), BexExternalValue::Int(1));
+        }
+    };
+
+    tokio::time::timeout(std::time::Duration::from_secs(30), calls)
+        .await
+        .expect("calls did not complete in time — likely a GC vs. ScheduleFuture deadlock");
+
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    gc_task.await.expect("gc task panicked");
+
+    assert_eq!(engine.active_future_count().await, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gc_during_await_completes_promptly() {
+    // Single call that schedules a future and awaits it; concurrent GC
+    // requests must not block that progress. This isolates the `Await`
+    // branch's `gc_safepoint` -> `futures.acquire(proof)` window that
+    // pre-fix could land behind a queued GC.
+    let source = r#"
+        function main() -> int {
+            baml.sys.sleep(50);
+            baml.sys.sleep(50);
+            baml.sys.sleep(50);
+            42
+        }
+    "#;
+    let engine = make_engine(source);
+
+    let engine_for_gc = Arc::clone(&engine);
+    let gc_task = tokio::spawn(async move {
+        for _ in 0..4 {
+            engine_for_gc
+                .collect_garbage(bex_heap::CollectionLevel::Major)
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    });
+
+    let call = engine.call_function(
+        "main",
+        vec![],
+        FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+        true,
+    );
+    let result = tokio::time::timeout(std::time::Duration::from_secs(10), call)
+        .await
+        .expect("call did not complete — likely a GC vs. Await deadlock");
+    assert_eq!(result.expect("call failed"), BexExternalValue::Int(42));
+
+    gc_task.await.expect("gc task panicked");
+}

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -10,7 +10,7 @@ use bex_vm_types::{HeapPtr, Object, Value};
 
 use crate::{BexHeap, heap_guard::PermitProof};
 
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error, Clone)]
 pub enum AccessError {
     #[error("Invalid handle: expected {expected}")]
     InvalidHandle { expected: &'static str },
@@ -592,6 +592,7 @@ fn owned_inner(
                 Object::Class(..) => unconvertible("class"),
                 Object::Enum(..) => unconvertible("enum"),
                 Object::Future(..) => unconvertible("future"),
+                Object::UnscheduledFuture(..) => unconvertible("unscheduled_future"),
 
                 Object::String(s) => Ok(BexExternalValue::String(s.clone())),
                 // Deep-copy path for trace payloads: no declared type is available here,

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -311,20 +311,17 @@ impl BexHeap {
                 worklist.push(var.enm);
             }
             Object::Future(fut) => {
-                use bex_vm_types::Future;
-                match fut {
-                    Future::Ready(value) => {
-                        if let Value::Object(ptr) = value {
-                            worklist.push(*ptr);
-                        }
+                use bex_vm_types::FutureRead;
+                match fut.read() {
+                    FutureRead::Ready(Value::Object(ptr))
+                    | FutureRead::Error(Value::Object(ptr)) => {
+                        worklist.push(ptr);
                     }
-                    Future::Error(Value::Object(ptr)) => {
-                        worklist.push(*ptr);
-                    }
-                    Future::Pending(_)
-                    | Future::Error(_)
-                    | Future::Cancelled
-                    | Future::InternalError(_) => {}
+                    FutureRead::Pending(_)
+                    | FutureRead::Ready(_)
+                    | FutureRead::Error(_)
+                    | FutureRead::Cancelled
+                    | FutureRead::InternalError(_) => {}
                 }
             }
             Object::UnscheduledFuture(future) => {
@@ -407,12 +404,12 @@ impl BexHeap {
                 }
             }
             Object::Future(fut) => {
-                use bex_vm_types::Future;
-                match fut {
-                    Future::Ready(value) | Future::Error(value) => {
-                        self.fixup_value(value, forwarding);
-                    }
-                    Future::Pending(_) | Future::Cancelled | Future::InternalError(_) => {}
+                // GC runs with all permits parked, so no concurrent access to
+                // the Future's atomic state. `value_mut_for_fixup` returns
+                // `Some(&mut Value)` only for `Ready`/`Error` states.
+                // SAFETY: GC holds exclusive access via the parked HeapGuard.
+                if let Some(value) = unsafe { fut.value_mut_for_fixup() } {
+                    self.fixup_value(value, forwarding);
                 }
             }
             Object::UnscheduledFuture(future) => {
@@ -657,16 +654,19 @@ impl BexHeap {
                 }
             }
             Object::Future(fut) => {
-                use bex_vm_types::Future;
-                match fut {
-                    Future::Ready(value) | Future::Error(value) => {
-                        if let Value::Object(ptr) = value
-                            && self.generation_of(*ptr).is_young()
-                        {
-                            worklist.push(*ptr);
-                        }
+                use bex_vm_types::FutureRead;
+                match fut.read() {
+                    FutureRead::Ready(Value::Object(ptr))
+                    | FutureRead::Error(Value::Object(ptr))
+                        if self.generation_of(ptr).is_young() =>
+                    {
+                        worklist.push(ptr);
                     }
-                    Future::Pending(_) | Future::Cancelled | Future::InternalError(_) => {}
+                    FutureRead::Pending(_)
+                    | FutureRead::Ready(_)
+                    | FutureRead::Error(_)
+                    | FutureRead::Cancelled
+                    | FutureRead::InternalError(_) => {}
                 }
             }
             Object::UnscheduledFuture(future) => {
@@ -1788,20 +1788,25 @@ mod tests {
 
     #[test]
     fn test_gc_traces_future_ready_object() {
-        use bex_vm_types::Future;
+        use bex_vm_types::{Future, FutureRead, types::FutureId};
 
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
         let result = tlab.alloc_string("result".to_string());
-        let future_ptr = tlab.alloc(Object::Future(Future::Ready(Value::Object(result))));
+        let future = Future::pending(FutureId::from_usize(0));
+        // SAFETY: single-writer; this Future is local and not yet visible.
+        unsafe { future.set_ready(Value::Object(result)) };
+        let future_ptr = tlab.alloc(Object::Future(future));
 
         let roots = vec![future_ptr];
         let (stats, new_roots, _) = unsafe { heap.collect_garbage(&roots) };
 
         assert_eq!(stats.live_count, 2);
-        let Object::Future(Future::Ready(Value::Object(r))) = (unsafe { new_roots[0].get() })
-        else {
+        let Object::Future(fut) = (unsafe { new_roots[0].get() }) else {
+            panic!("not Future")
+        };
+        let FutureRead::Ready(Value::Object(r)) = fut.read() else {
             panic!("not Future::Ready(Object)")
         };
         let Object::String(s) = (unsafe { r.get() }) else {
@@ -1812,12 +1817,15 @@ mod tests {
 
     #[test]
     fn test_gc_traces_future_ready_primitive() {
-        use bex_vm_types::Future;
+        use bex_vm_types::{Future, types::FutureId};
 
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
-        let future_ptr = tlab.alloc(Object::Future(Future::Ready(Value::Int(99))));
+        let future = Future::pending(FutureId::from_usize(0));
+        // SAFETY: single-writer; this Future is local and not yet visible.
+        unsafe { future.set_ready(Value::Int(99)) };
+        let future_ptr = tlab.alloc(Object::Future(future));
         let roots = vec![future_ptr];
         let (stats, _, _) = unsafe { heap.collect_garbage(&roots) };
 

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -324,7 +324,7 @@ impl BexHeap {
                     Future::Pending(_)
                     | Future::Error(_)
                     | Future::Cancelled
-                    | Future::InternalError => {}
+                    | Future::InternalError(_) => {}
                 }
             }
             Object::UnscheduledFuture(future) => {
@@ -412,7 +412,7 @@ impl BexHeap {
                     Future::Ready(value) | Future::Error(value) => {
                         self.fixup_value(value, forwarding);
                     }
-                    Future::Pending(_) | Future::Cancelled | Future::InternalError => {}
+                    Future::Pending(_) | Future::Cancelled | Future::InternalError(_) => {}
                 }
             }
             Object::UnscheduledFuture(future) => {
@@ -666,7 +666,7 @@ impl BexHeap {
                             worklist.push(*ptr);
                         }
                     }
-                    Future::Pending(_) | Future::Cancelled | Future::InternalError => {}
+                    Future::Pending(_) | Future::Cancelled | Future::InternalError(_) => {}
                 }
             }
             Object::UnscheduledFuture(future) => {

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -313,19 +313,25 @@ impl BexHeap {
             Object::Future(fut) => {
                 use bex_vm_types::Future;
                 match fut {
-                    Future::Pending(pending) => {
-                        for value in &pending.args {
-                            if let Value::Object(ptr) = value {
-                                worklist.push(*ptr);
-                            }
-                        }
-                    }
                     Future::Ready(value) => {
                         if let Value::Object(ptr) = value {
                             worklist.push(*ptr);
                         }
                     }
+                    Future::Error(Value::Object(ptr)) => {
+                        worklist.push(*ptr);
+                    }
+                    Future::Pending(_)
+                    | Future::Error(_)
+                    | Future::Cancelled
+                    | Future::InternalError => {}
                 }
+            }
+            Object::UnscheduledFuture(future) => {
+                worklist.extend(future.args.iter().filter_map(|v| match v {
+                    Value::Object(ptr) => Some(*ptr),
+                    _ => None,
+                }));
             }
             // Primitives have no references
             #[cfg(feature = "heap_debug")]
@@ -403,14 +409,15 @@ impl BexHeap {
             Object::Future(fut) => {
                 use bex_vm_types::Future;
                 match fut {
-                    Future::Pending(pending) => {
-                        for value in &mut pending.args {
-                            self.fixup_value(value, forwarding);
-                        }
-                    }
-                    Future::Ready(value) => {
+                    Future::Ready(value) | Future::Error(value) => {
                         self.fixup_value(value, forwarding);
                     }
+                    Future::Pending(_) | Future::Cancelled | Future::InternalError => {}
+                }
+            }
+            Object::UnscheduledFuture(future) => {
+                for value in &mut future.args {
+                    self.fixup_value(value, forwarding);
                 }
             }
             // Primitives have no references
@@ -652,23 +659,24 @@ impl BexHeap {
             Object::Future(fut) => {
                 use bex_vm_types::Future;
                 match fut {
-                    Future::Pending(pending) => {
-                        worklist.extend(
-                            pending
-                                .args
-                                .iter()
-                                .filter_map(Value::as_object_ptr)
-                                .filter(|ptr| self.generation_of(*ptr).is_young()),
-                        );
-                    }
-                    Future::Ready(value) => {
+                    Future::Ready(value) | Future::Error(value) => {
                         if let Value::Object(ptr) = value
                             && self.generation_of(*ptr).is_young()
                         {
                             worklist.push(*ptr);
                         }
                     }
+                    Future::Pending(_) | Future::Cancelled | Future::InternalError => {}
                 }
+            }
+            Object::UnscheduledFuture(future) => {
+                worklist.extend(
+                    future
+                        .args
+                        .iter()
+                        .filter_map(Value::as_object_ptr)
+                        .filter(|ptr| self.generation_of(*ptr).is_young()),
+                );
             }
             // Primitives/leaf variants have no heap references.
             #[cfg(feature = "heap_debug")]
@@ -1760,17 +1768,17 @@ mod tests {
 
     #[test]
     fn test_gc_traces_future_pending_args() {
-        use bex_vm_types::{Future, PendingFuture, SysOp};
+        use bex_vm_types::{SysOp, UnscheduledFuture};
 
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
         let arg1 = tlab.alloc_string("arg1".to_string());
         let arg2 = tlab.alloc_string("arg2".to_string());
-        let future_ptr = tlab.alloc(Object::Future(Future::Pending(PendingFuture {
+        let future_ptr = tlab.alloc(Object::UnscheduledFuture(UnscheduledFuture {
             operation: SysOp::BamlEnvGet,
             args: vec![Value::Object(arg1), Value::Object(arg2)],
-        })));
+        }));
 
         let roots = vec![future_ptr];
         let (stats, _new_roots, _) = unsafe { heap.collect_garbage(&roots) };
@@ -2218,7 +2226,7 @@ mod tests {
     fn test_tracing_and_fixup_consistency_all_variants() {
         use baml_type::{Name, TyAttr, TypeName};
         use bex_vm_types::{
-            Class, Enum, Future, PendingFuture, SysOp,
+            Class, Enum, SysOp, UnscheduledFuture,
             types::{Cell, Closure, Instance, Variant},
         };
 
@@ -2256,11 +2264,11 @@ mod tests {
             value: Value::Object(leaf_for_cell),
         }));
 
-        // --- Container: Object::Future (Pending) ---
-        let future_container = tlab.alloc(Object::Future(Future::Pending(PendingFuture {
+        // --- Container: Object::UnscheduledFuture ---
+        let future_container = tlab.alloc(Object::UnscheduledFuture(UnscheduledFuture {
             operation: SysOp::BamlEnvGet,
             args: vec![Value::Object(leaf_for_future)],
-        })));
+        }));
 
         // --- Container: Object::Instance ---
         // Instance requires a class pointer.
@@ -2368,8 +2376,8 @@ mod tests {
         assert_eq!(s, "cell_value");
 
         // Future: args[0] should be the (forwarded) future arg string.
-        let Object::Future(Future::Pending(pending)) = (unsafe { new_roots[4].get() }) else {
-            panic!("new_roots[4] not Future::Pending")
+        let Object::UnscheduledFuture(pending) = (unsafe { new_roots[4].get() }) else {
+            panic!("new_roots[4] not UnscheduledFuture")
         };
         let Value::Object(fut_leaf) = pending.args[0] else {
             panic!("future.args[0] not Object")

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -21,6 +21,7 @@ use std::{
     },
 };
 
+use ::bex_vm_types::Value;
 use bex_external_types::{Handle, WeakHeapRef};
 use bex_vm_types::{HeapPtr, Object, ObjectIndex};
 
@@ -472,6 +473,42 @@ impl BexHeap {
     pub(crate) unsafe fn inactive_mut(&self) -> &mut ChunkedVec<Object> {
         // SAFETY: Caller ensures exclusive access
         unsafe { &mut *self.inactive.get() }
+    }
+
+    /// Write barrier for field/element/cell writes.
+    ///
+    /// Called *before* the actual field write at each mutation site. If `container_ptr`
+    /// is in an older generation than the object being written (`written_value`), the
+    /// card containing `container_ptr` is marked dirty so partial GC can discover
+    /// the cross-generation reference.
+    ///
+    /// This is a no-op when either side is not a heap object, or when the container
+    /// is in Gen0 (no card table for Gen0).
+    #[inline]
+    pub fn write_barrier(&self, container_ptr: HeapPtr, written_value: Value) {
+        if let Value::Object(ref_ptr) = written_value {
+            let container_gen = self.generation_of(container_ptr);
+            let ref_gen = self.generation_of(ref_ptr);
+            if container_gen > ref_gen {
+                self.mark_card_for_ptr(container_ptr);
+            }
+        }
+    }
+
+    /// Conservative write barrier for mutable accessor paths (builtin dispatch).
+    ///
+    /// Unconditionally marks the card dirty if `container_ptr` is in an older
+    /// generation. Used by `as_array_mut` / `as_map_mut` where the actual written
+    /// value is not yet known (it's supplied by the callee trait method).
+    ///
+    /// This over-marks (any mutable access to an older-gen object dirties the card),
+    /// but it is always safe and the cost is negligible since most objects are Gen0.
+    #[inline]
+    pub fn conservative_write_barrier(&self, container_ptr: HeapPtr) {
+        let container_gen = self.generation_of(container_ptr);
+        if container_gen > Generation::Gen0 {
+            self.mark_card_for_ptr(container_ptr);
+        }
     }
 
     /// Determine which generation an object pointer belongs to.

--- a/baml_language/crates/bex_heap/src/heap_debugger/real.rs
+++ b/baml_language/crates/bex_heap/src/heap_debugger/real.rs
@@ -335,7 +335,7 @@ impl BexHeap {
                 Future::Ready(value) | Future::Error(value) => {
                     self.debug_assert_valid_value(value);
                 }
-                Future::Pending(_) | Future::Cancelled | Future::InternalError => {}
+                Future::Pending(_) | Future::Cancelled | Future::InternalError(_) => {}
             },
             Object::UnscheduledFuture(future) => {
                 for value in &future.args {

--- a/baml_language/crates/bex_heap/src/heap_debugger/real.rs
+++ b/baml_language/crates/bex_heap/src/heap_debugger/real.rs
@@ -332,15 +332,16 @@ impl BexHeap {
                 );
             }
             Object::Future(fut) => match fut {
-                Future::Pending(pending) => {
-                    for value in &pending.args {
-                        self.debug_assert_valid_value(value);
-                    }
-                }
-                Future::Ready(value) => {
+                Future::Ready(value) | Future::Error(value) => {
                     self.debug_assert_valid_value(value);
                 }
+                Future::Pending(_) | Future::Cancelled | Future::InternalError => {}
             },
+            Object::UnscheduledFuture(future) => {
+                for value in &future.args {
+                    self.debug_assert_valid_value(value);
+                }
+            }
             Object::Closure(closure) => {
                 self.debug_assert_valid_index(closure.function);
                 for value in &closure.captures {

--- a/baml_language/crates/bex_heap/src/heap_debugger/real.rs
+++ b/baml_language/crates/bex_heap/src/heap_debugger/real.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use bex_vm_types::{
-    Future, HeapPtr, Object, ObjectIndex, Value,
+    FutureRead, HeapPtr, Object, ObjectIndex, Value,
     types::{ObjectType, SentinelKind},
 };
 
@@ -331,11 +331,11 @@ impl BexHeap {
                     enm.variants.len()
                 );
             }
-            Object::Future(fut) => match fut {
-                Future::Ready(value) | Future::Error(value) => {
-                    self.debug_assert_valid_value(value);
+            Object::Future(fut) => match fut.read() {
+                FutureRead::Ready(value) | FutureRead::Error(value) => {
+                    self.debug_assert_valid_value(&value);
                 }
-                Future::Pending(_) | Future::Cancelled | Future::InternalError(_) => {}
+                FutureRead::Pending(_) | FutureRead::Cancelled | FutureRead::InternalError(_) => {}
             },
             Object::UnscheduledFuture(future) => {
                 for value in &future.args {

--- a/baml_language/crates/bex_heap/src/heap_guard.rs
+++ b/baml_language/crates/bex_heap/src/heap_guard.rs
@@ -15,6 +15,7 @@ use ::std::{
     collections::HashMap,
     sync::{Arc, Weak},
 };
+use ::tokio::sync::Mutex;
 
 /// The lesser of [`u32::MAX`] and [`tokio::sync::Semaphore::MAX_PERMITS`] (depends on compilation target pointer width).
 const MAX_PERMITS: u32 = {
@@ -31,6 +32,24 @@ const MAX_PERMITS: u32 = {
         tokio::sync::Semaphore::MAX_PERMITS as u32
     }
 };
+
+pub trait HeapPermit<T: RootHaver> {
+    /// Get a reference to the root holder (for example, the active VM)
+    ///
+    /// Callers can also use [`Deref`] which will return the same value.
+    fn holder(&self) -> &T;
+    /// Get a mutable reference to the root holder (for example, the active VM)
+    ///
+    /// Callers can also use [`DerefMut`] which will return the same value.
+    fn holder_mut(&mut self) -> &mut T;
+    /// Get a type-erased [`PermitProof`] tied to this active permit's lifetime.
+    ///
+    /// This lets the GC-exclusion proof flow through APIs (e.g. the sys-op
+    /// dispatch glue) that cannot name the concrete `T`. The returned proof
+    /// is `Copy`, `Send`, and `Sync` and carries no runtime data — the
+    /// guarantee comes purely from the lifetime, which cannot outlive `self`.
+    fn proof(&self) -> PermitProof<'_>;
+}
 
 /// An active heap permit.
 ///
@@ -71,33 +90,17 @@ impl<T: RootHaver> ActiveHeapPermit<T> {
     pub async fn renew(self) -> Self {
         self.release().acquire().await
     }
-
-    /// Get a reference to the root holder (for example, the active VM)
-    ///
-    /// Callers can also use [`Deref`] which will return the same value.
-    #[inline]
-    pub fn holder(&self) -> &T {
+}
+impl<T: RootHaver> HeapPermit<T> for ActiveHeapPermit<T> {
+    fn holder(&self) -> &T {
         // SAFETY: we have a permit to access the heap so we can access the root holder.
         unsafe { self.state.holder() }
     }
-
-    /// Get a mutable reference to the root holder (for example, the active VM)
-    ///
-    /// Callers can also use [`DerefMut`] which will return the same value.
-    #[inline]
-    pub fn holder_mut(&mut self) -> &mut T {
+    fn holder_mut(&mut self) -> &mut T {
         // SAFETY: we have a permit to access the heap so we can access the root holder.
         unsafe { self.state.holder_mut() }
     }
-
-    /// Get a type-erased [`PermitProof`] tied to this active permit's lifetime.
-    ///
-    /// This lets the GC-exclusion proof flow through APIs (e.g. the sys-op
-    /// dispatch glue) that cannot name the concrete `T`. The returned proof
-    /// is `Copy`, `Send`, and `Sync` and carries no runtime data — the
-    /// guarantee comes purely from the lifetime, which cannot outlive `self`.
-    #[inline]
-    pub fn proof(&self) -> PermitProof<'_> {
+    fn proof(&self) -> PermitProof<'_> {
         PermitProof {
             _marker: PhantomData,
         }
@@ -171,6 +174,76 @@ impl<T: RootHaver> InactiveHeapPermit<T> {
         // SAFETY: caller upholds the fn-level contract — the permit is active
         // and `&mut self` proves exclusive access on this thread.
         unsafe { &mut *ptr }
+    }
+}
+
+/// For use when multiple threads need to share a single permit.
+///
+/// Ensures only one thread can use the permit at a time,
+/// and yields to exclusive access whenever the permit is released.
+pub struct SharedHeapPermit<T: RootHaver> {
+    inner: Mutex<InactiveHeapPermit<T>>,
+}
+impl<T: RootHaver> SharedHeapPermit<T> {
+    pub fn new(inner: InactiveHeapPermit<T>) -> Self {
+        Self {
+            inner: Mutex::new(inner),
+        }
+    }
+    pub async fn acquire(&self) -> SharedHeapPermitGuard<'_, T> {
+        let state = self.inner.lock().await;
+        let permit = Arc::clone(&state.active)
+            .acquire_owned()
+            .await
+            .unwrap_or_else(|_| unreachable!("Semaphore should never be closed"));
+        SharedHeapPermitGuard {
+            state,
+            _permit: permit,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct SharedHeapPermitGuard<'a, T: RootHaver> {
+    state: tokio::sync::MutexGuard<'a, InactiveHeapPermit<T>>,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+    /// Ties the auto `Send`/`Sync` of `ActiveHeapPermit` to `T`.
+    ///
+    /// Without this marker, every field of this struct is unconditionally
+    /// `Sync` (notably because [`PermitCell<T>`] has a manual unconditional
+    /// `unsafe impl Sync` — which is itself load-bearing, so that
+    /// `Weak<PermitCell<dyn RootHaver>>` can live in the manager's shared
+    /// `Mutex<Vec<…>>`). That would let the compiler auto-derive
+    /// `ActiveHeapPermit<T>: Sync` even when `T: !Sync`, and two threads
+    /// sharing `&ActiveHeapPermit<T>` could each call [`Self::holder`] to
+    /// observe `&T` at the same time — UB when `T: !Sync`.
+    _marker: PhantomData<T>,
+}
+impl<'a, T: RootHaver> HeapPermit<T> for SharedHeapPermitGuard<'a, T> {
+    fn holder(&self) -> &T {
+        // SAFETY: we have a permit to access the heap so we can access the root holder.
+        unsafe { self.state.holder() }
+    }
+    fn holder_mut(&mut self) -> &mut T {
+        // SAFETY: we have a permit to access the heap so we can access the root holder.
+        unsafe { self.state.holder_mut() }
+    }
+    fn proof(&self) -> PermitProof<'_> {
+        PermitProof {
+            _marker: PhantomData,
+        }
+    }
+}
+impl<'a, T: RootHaver> Deref for SharedHeapPermitGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.holder()
+    }
+}
+impl<'a, T: RootHaver> DerefMut for SharedHeapPermitGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.holder_mut()
     }
 }
 

--- a/baml_language/crates/bex_heap/src/heap_guard.rs
+++ b/baml_language/crates/bex_heap/src/heap_guard.rs
@@ -207,16 +207,16 @@ impl<T: RootHaver> SharedHeapPermit<T> {
 pub struct SharedHeapPermitGuard<'a, T: RootHaver> {
     state: tokio::sync::MutexGuard<'a, InactiveHeapPermit<T>>,
     _permit: tokio::sync::OwnedSemaphorePermit,
-    /// Ties the auto `Send`/`Sync` of `ActiveHeapPermit` to `T`.
+    /// Ties the auto `Send`/`Sync` of `SharedHeapPermitGuard` to `T`.
     ///
     /// Without this marker, every field of this struct is unconditionally
     /// `Sync` (notably because [`PermitCell<T>`] has a manual unconditional
     /// `unsafe impl Sync` — which is itself load-bearing, so that
     /// `Weak<PermitCell<dyn RootHaver>>` can live in the manager's shared
     /// `Mutex<Vec<…>>`). That would let the compiler auto-derive
-    /// `ActiveHeapPermit<T>: Sync` even when `T: !Sync`, and two threads
-    /// sharing `&ActiveHeapPermit<T>` could each call [`Self::holder`] to
-    /// observe `&T` at the same time — UB when `T: !Sync`.
+    /// `SharedHeapPermitGuard<T>: Sync` even when `T: !Sync`, and two threads
+    /// sharing `&SharedHeapPermitGuard<T>` could each call [`Self::holder`]
+    /// to observe `&T` at the same time — UB when `T: !Sync`.
     _marker: PhantomData<T>,
 }
 impl<'a, T: RootHaver> HeapPermit<T> for SharedHeapPermitGuard<'a, T> {

--- a/baml_language/crates/bex_heap/src/lib.rs
+++ b/baml_language/crates/bex_heap/src/lib.rs
@@ -74,6 +74,7 @@ pub use gc::{CollectionLevel, GcStats};
 pub use heap::{BexHeap, DEFAULT_TLAB_SIZE, Generation, HeapStats};
 pub(crate) use heap_debugger::{HeapDebuggerConfig, HeapDebuggerState};
 pub use heap_guard::{
-    ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapPermit, PermitProof,
+    ActiveHeapPermit, HeapGuard, HeapPermit, HeapPermitManager, InactiveHeapPermit, PermitProof,
+    SharedHeapPermit, SharedHeapPermitGuard,
 };
-pub use tlab::Tlab;
+pub use tlab::{Tlab, TlabHolder};

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -175,6 +175,36 @@ impl Tlab {
         self.alloc(Object::Variant(Variant { enm, index }))
     }
 
+    /// Allocate a uint8 array object.
+    #[inline]
+    pub fn alloc_uint8array(&mut self, data: Vec<u8>) -> HeapPtr {
+        self.alloc(Object::Uint8Array(data))
+    }
+
+    /// Allocate opaque Rust data on the heap.
+    #[inline]
+    pub fn alloc_rust_data(&mut self, data: Arc<dyn std::any::Any + Send + Sync>) -> HeapPtr {
+        self.alloc(Object::RustData(data))
+    }
+
+    /// Allocate a collector object on the heap.
+    #[inline]
+    pub fn alloc_collector(&mut self, collector: bex_vm_types::CollectorRef) -> HeapPtr {
+        self.alloc(Object::Collector(collector))
+    }
+
+    /// Allocate a type descriptor object on the heap.
+    #[inline]
+    pub fn alloc_type(&mut self, ty: baml_type::Ty) -> HeapPtr {
+        self.alloc(Object::Type(Box::new(ty)))
+    }
+
+    /// Allocate a future object on the heap.
+    #[inline]
+    pub fn alloc_future(&mut self, future: bex_vm_types::Future) -> HeapPtr {
+        self.alloc(Object::Future(future))
+    }
+
     /// Get a new chunk from the heap (cold path).
     #[cold]
     fn refill(&mut self) {
@@ -250,6 +280,11 @@ impl std::fmt::Debug for Tlab {
             .field("remaining", &self.remaining())
             .finish()
     }
+}
+
+pub trait TlabHolder {
+    fn tlab(&self) -> &Tlab;
+    fn tlab_mut(&mut self) -> &mut Tlab;
 }
 
 #[cfg(test)]

--- a/baml_language/crates/bex_project/src/bex.rs
+++ b/baml_language/crates/bex_project/src/bex.rs
@@ -1,3 +1,4 @@
+use ::bex_heap::HeapPermit as _;
 use ::std::sync::Arc;
 use async_trait::async_trait;
 use baml_type::Ty;

--- a/baml_language/crates/bex_project/src/lib.rs
+++ b/baml_language/crates/bex_project/src/lib.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, sync::Arc};
 
 pub use baml_builtins2::{MediaContent, MediaValue, PromptAst, PromptAstSimple};
 pub use bex::Bex;
-pub use bex_engine::{EngineError, FunctionCallContextBuilder};
+pub use bex_engine::{CANCELLED_PANIC_CLASS, EngineError, FunctionCallContextBuilder};
 pub use bex_events::EventSink;
 pub use bex_external_types::{
     BexExternalAdt, BexExternalValue, Handle, MediaKind, Ty, TyAttr, try_convert_rust_data,

--- a/baml_language/crates/bex_project/src/lib.rs
+++ b/baml_language/crates/bex_project/src/lib.rs
@@ -11,7 +11,9 @@ use std::{collections::HashMap, sync::Arc};
 
 pub use baml_builtins2::{MediaContent, MediaValue, PromptAst, PromptAstSimple};
 pub use bex::Bex;
-pub use bex_engine::{CANCELLED_PANIC_CLASS, EngineError, FunctionCallContextBuilder};
+pub use bex_engine::{
+    CANCELLED_PANIC_CLASS, EngineError, FunctionCallContextBuilder, is_cancelled_engine_error,
+};
 pub use bex_events::EventSink;
 pub use bex_external_types::{
     BexExternalAdt, BexExternalValue, Handle, MediaKind, Ty, TyAttr, try_convert_rust_data,
@@ -56,6 +58,14 @@ pub enum RuntimeError {
 
     #[error("Failed to convert result to owned value: {0}")]
     Access(#[from] bex_heap::AccessError),
+}
+
+/// True iff `err` wraps an engine cancellation panic.
+///
+/// Centralizes the cancellation-classification logic that bridges and the
+/// LSP server need to distinguish cancellation from other runtime errors.
+pub fn is_cancelled_runtime_error(err: &RuntimeError) -> bool {
+    matches!(err, RuntimeError::Engine(e) if is_cancelled_engine_error(e))
 }
 
 /// Keep pass-by-value so the returned `Arc<impl Bex>` does not capture caller locals;

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -30,7 +30,7 @@ use std::fmt::Write;
 use bex_vm_types::{
     ConstValue, HeapPtr,
     bytecode::{CompactCode, Instruction, OpCode, read_i8, read_i32, read_u16, read_u32},
-    indexable::{GlobalIndex, GlobalPool, ObjectPool},
+    indexable::{GlobalIndex, ObjectPool},
     types::{Function, Object, Value},
 };
 use colored::{Color, Colorize};
@@ -50,13 +50,13 @@ pub enum BytecodeFormat {
 /// Resolve a global reference (global slot or callee slot) to display metadata.
 fn display_global_ref(
     index: GlobalIndex,
-    globals: &GlobalPool,
+    globals: &[Value],
     objects: Option<&ObjectPool>,
     compile_time_globals: Option<&[bex_vm_types::ConstValue]>,
 ) -> String {
     // Prefer runtime globals.
     if index.raw() < globals.len() {
-        return format!("({})", display_value(&globals[index]));
+        return format!("({})", display_value(&globals[index.raw()]));
     }
 
     // At compile time, resolve from compile-time globals/object pool.
@@ -113,7 +113,7 @@ fn sanitize_operand_text(text: &str) -> String {
 pub(crate) fn display_instruction(
     instruction_ptr: usize,
     function: &Function,
-    globals: &GlobalPool,
+    globals: &[Value],
     objects: Option<&ObjectPool>,
     compile_time_globals: Option<&[bex_vm_types::ConstValue]>,
 ) -> (String, String) {
@@ -446,7 +446,7 @@ impl Col {
 /// symmetric and returns the entire table.
 pub fn display_bytecode(
     function: &Function,
-    globals: &GlobalPool,
+    globals: &[Value],
     objects: Option<&ObjectPool>,
     compile_time_globals: Option<&[bex_vm_types::ConstValue]>,
     use_colors: bool,

--- a/baml_language/crates/bex_vm/src/errors.rs
+++ b/baml_language/crates/bex_vm/src/errors.rs
@@ -26,6 +26,9 @@ pub enum VmPanic {
     #[error("unreachable code executed")]
     Unreachable,
 
+    #[error("operation cancelled")]
+    Cancelled,
+
     /// A user-caused panic from `baml.sys.panic`.
     #[error("baml.sys.panic: {message}")]
     UserPanic { message: String },
@@ -132,6 +135,9 @@ pub enum VmInternalError {
 
     #[error("invalid compact opcode byte: {0}")]
     InvalidOpcode(u8),
+
+    #[error("awaited future is in InternalError state")]
+    AwaitedFutureInternalError,
 }
 
 /// Any kind of virtual machine error.

--- a/baml_language/crates/bex_vm/src/errors.rs
+++ b/baml_language/crates/bex_vm/src/errors.rs
@@ -136,8 +136,11 @@ pub enum VmInternalError {
     #[error("invalid compact opcode byte: {0}")]
     InvalidOpcode(u8),
 
-    #[error("awaited future is in InternalError state")]
-    AwaitedFutureInternalError,
+    /// `StoreGlobal` was executed outside of an `$init` function. Globals are
+    /// frozen post-`$init` (shared as `Arc<[Value]>` across VMs) and any
+    /// post-init `StoreGlobal` violates that invariant.
+    #[error("StoreGlobal executed outside of $init (globals are frozen post-init)")]
+    StoreGlobalAfterInit,
 }
 
 /// Any kind of virtual machine error.

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -354,6 +354,7 @@ pub fn value_to_serde(vm: &BexVm, v: Value) -> serde_json::Value {
             | Object::Variant(_)
             | Object::Function(_)
             | Object::Future(_)
+            | Object::UnscheduledFuture(_)
             | Object::Collector(_)
             | Object::Type(_)
             | Object::Uint8Array(_)

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, sync::Arc};
 
 use bex_vm_types::{
-    HeapPtr,
-    types::{Future, Instance, Object, Value},
+    FutureRead, HeapPtr,
+    types::{Instance, Object, Value},
 };
 use indexmap::IndexMap;
 
@@ -206,13 +206,15 @@ fn deep_equals_recursive(
 
                 (Object::Function(_), Object::Function(_)) => a_ptr == b_ptr,
 
-                (Object::Future(a_fut), Object::Future(b_fut)) => match (a_fut, b_fut) {
-                    (Future::Ready(a_val), Future::Ready(b_val)) => {
-                        deep_equals_recursive(vm, *a_val, *b_val, visited)
+                (Object::Future(a_fut), Object::Future(b_fut)) => {
+                    match (a_fut.read(), b_fut.read()) {
+                        (FutureRead::Ready(a_val), FutureRead::Ready(b_val)) => {
+                            deep_equals_recursive(vm, a_val, b_val, visited)
+                        }
+                        (FutureRead::Pending(a_id), FutureRead::Pending(b_id)) => a_id == b_id,
+                        _ => false,
                     }
-                    (Future::Pending(a_id), Future::Pending(b_id)) => a_id == b_id,
-                    _ => false,
-                },
+                }
 
                 (Object::UnscheduledFuture(a_fut), Object::UnscheduledFuture(b_fut)) => {
                     a_fut.operation == b_fut.operation

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -34,6 +34,18 @@ fn deep_copy_value_recursive(
                 return Value::Object(new_ptr);
             }
 
+            // Futures are *handles*, not values: a `Future` is the user-
+            // visible name for an entry the engine's `FutureManager` writes
+            // terminal state into. Even after the future completes, its
+            // on-heap representation remains shared mutable state from the
+            // runtime's point of view — there is no notion of "the same
+            // future, but a copy". Short-circuit before cloning the Object
+            // (which would otherwise clone the `Future` struct uselessly).
+            if matches!(vm.get_object(ptr), Object::Future(_)) {
+                copied_objects.insert(ptr, ptr);
+                return Value::Object(ptr);
+            }
+
             let object = vm.get_object(ptr).clone();
 
             let new_ptr = match object {
@@ -97,7 +109,9 @@ fn deep_copy_value_recursive(
                 Object::Enum(e) => vm.tlab.alloc(Object::Enum(e)),
                 Object::Variant(v) => vm.tlab.alloc(Object::Variant(v)),
                 Object::RustData(arc) => vm.tlab.alloc(Object::RustData(Arc::clone(&arc))),
-                Object::Future(f) => vm.tlab.alloc(Object::Future(f)),
+                // `Object::Future(_)` is short-circuited above; it can't
+                // reach this match arm.
+                Object::Future(_) => unreachable!("Future short-circuited above"),
                 Object::UnscheduledFuture(f) => vm.tlab.alloc(Object::UnscheduledFuture(f)),
                 Object::Collector(c) => vm.tlab.alloc(Object::Collector(c)),
                 Object::Type(ty) => vm.tlab.alloc(Object::Type(ty)),

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -98,6 +98,7 @@ fn deep_copy_value_recursive(
                 Object::Variant(v) => vm.tlab.alloc(Object::Variant(v)),
                 Object::RustData(arc) => vm.tlab.alloc(Object::RustData(Arc::clone(&arc))),
                 Object::Future(f) => vm.tlab.alloc(Object::Future(f)),
+                Object::UnscheduledFuture(f) => vm.tlab.alloc(Object::UnscheduledFuture(f)),
                 Object::Collector(c) => vm.tlab.alloc(Object::Collector(c)),
                 Object::Type(ty) => vm.tlab.alloc(Object::Type(ty)),
                 // Closures, bound methods, and cells are shallow-copied: the captured
@@ -209,17 +210,19 @@ fn deep_equals_recursive(
                     (Future::Ready(a_val), Future::Ready(b_val)) => {
                         deep_equals_recursive(vm, *a_val, *b_val, visited)
                     }
-                    (Future::Pending(a_pend), Future::Pending(b_pend)) => {
-                        a_pend.operation == b_pend.operation
-                            && a_pend.args.len() == b_pend.args.len()
-                            && a_pend
-                                .args
-                                .iter()
-                                .zip(b_pend.args.iter())
-                                .all(|(a, b)| deep_equals_recursive(vm, *a, *b, visited))
-                    }
+                    (Future::Pending(a_id), Future::Pending(b_id)) => a_id == b_id,
                     _ => false,
                 },
+
+                (Object::UnscheduledFuture(a_fut), Object::UnscheduledFuture(b_fut)) => {
+                    a_fut.operation == b_fut.operation
+                        && a_fut.args.len() == b_fut.args.len()
+                        && a_fut
+                            .args
+                            .iter()
+                            .zip(b_fut.args.iter())
+                            .all(|(a, b)| deep_equals_recursive(vm, *a, *b, visited))
+                }
 
                 _ => false,
             };

--- a/baml_language/crates/bex_vm/src/package_baml/unstable.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/unstable.rs
@@ -126,6 +126,7 @@ fn format_value_recursive(
             Object::Function(f) => Ok(format!("<function {}>", f.name)),
             Object::Class(c) => Ok(format!("<class {}>", c.name)),
             Object::Future(_) => Ok("<future>".to_string()),
+            Object::UnscheduledFuture(_) => Ok("<unscheduled future>".to_string()),
             Object::Collector(_) => Ok("<collector>".to_string()),
             Object::Type(ty) => Ok(format!("<type: {ty}>")),
             Object::Uint8Array(bytes) => Ok(format!("<uint8array len={}>", bytes.len())),

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -41,8 +41,8 @@ use ::core::any::TypeId;
 use ::core::sync::atomic::AtomicBool;
 use bex_heap::{BexHeap, Tlab};
 use bex_vm_types::{
-    BinOp, CmpOp, FunctionKind, GlobalPool, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool,
-    ObjectType, PanicClass, StackIndex, UnaryOp, Value, Variant,
+    BinOp, CmpOp, FunctionKind, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool, ObjectType,
+    PanicClass, StackIndex, UnaryOp, Value, Variant, VmGlobals,
     bytecode::{self, BlockNotification},
     types::{
         BoundMethod, Cell, Closure, ConstValue, Function, FunctionType, Future, FutureType,
@@ -277,7 +277,13 @@ pub struct BexVm {
     /// Global variables.
     ///
     /// This stores the functions and globally declared variables.
-    pub globals: GlobalPool,
+    ///
+    /// During `$init`, this is `VmGlobals::Owned` so `StoreGlobal` can
+    /// populate top-level let bindings. After `$init` completes, the engine
+    /// freezes the pool into a shared `Arc<[Value]>` and every subsequent VM
+    /// is constructed with `VmGlobals::Shared`; `StoreGlobal` against the
+    /// shared view is a `VmInternalError`.
+    pub globals: VmGlobals,
 
     /// Resolved class names mapping fully-qualified class names to their heap pointers.
     ///
@@ -573,7 +579,7 @@ impl BexVm {
     /// for contention-free allocation.
     pub fn new(
         heap: Arc<BexHeap>,
-        globals: GlobalPool,
+        globals: VmGlobals,
         resolved_class_names: HashMap<String, HeapPtr>,
         #[cfg(not(target_arch = "wasm32"))] park_requested: Arc<AtomicBool>,
         argv: Arc<[String]>,
@@ -873,13 +879,16 @@ impl BexVm {
         // Create heap with compile-time objects
         let heap = BexHeap::new(compile_time_objects);
 
-        // Convert compile-time globals (ConstValue) to runtime globals (Value)
+        // Convert compile-time globals (ConstValue) to runtime globals (Value).
+        // The `from_program` constructor is test-only — we hand the VM an
+        // `Owned` view so that any `$init` bytecode the test happens to drive
+        // can write to globals.
         let globals_vec: Vec<Value> = bytecode
             .globals
             .into_iter()
             .map(|cv| cv.to_value(|idx| heap.compile_time_ptr(idx.into_raw())))
             .collect();
-        let globals = GlobalPool::from_vec(globals_vec);
+        let globals = VmGlobals::Owned(bex_vm_types::GlobalPool::from_vec(globals_vec));
 
         // Build resolved_class_names: convert ObjectIndex -> HeapPtr.
         //
@@ -948,7 +957,7 @@ impl BexVm {
     ///
     /// Returns [`VmInternalError::TypeError`] if the heap object is not an
     /// `Object::UnscheduledFuture`.
-    pub fn pending_future(
+    pub fn unscheduled_future(
         &self,
         future_ptr: HeapPtr,
     ) -> Result<&UnscheduledFuture, VmInternalError> {
@@ -1099,7 +1108,7 @@ impl BexVm {
     /// suitable for hot paths; callers that need repeated lookups should cache
     /// the result.
     pub fn find_function_by_name(&self, name: &str) -> Option<HeapPtr> {
-        for v in &self.globals {
+        for v in self.globals.as_slice() {
             if let Value::Object(ptr) = v {
                 if let Object::Function(f) = self.get_object(*ptr) {
                     if f.name == name {
@@ -2189,7 +2198,7 @@ impl BexVm {
                     let (instruction, metadata) = crate::debug::display_instruction(
                         instruction_ptr,
                         function,
-                        &self.globals,
+                        self.globals.as_slice(),
                         None,
                         None,
                     );
@@ -2375,8 +2384,8 @@ impl BexVm {
             }
 
             Instruction::LoadGlobal(index) => {
-                let value = &self.globals[index];
-                self.stack.push(*value);
+                let value = self.globals.get(index);
+                self.stack.push(value);
             }
 
             Instruction::StoreGlobal(index) => {
@@ -2384,7 +2393,10 @@ impl BexVm {
                 let value = self.stack.ensure_pop();
 
                 // No write barrier: globals is a VM-owned root structure, not a heap object.
-                self.globals[index] = value;
+                // Only valid during `$init`; post-init globals are frozen in `Arc<[Value]>`
+                // and a write here is a VM internal error.
+                self.globals
+                    .set(index, value, VmInternalError::StoreGlobalAfterInit)?;
             }
 
             Instruction::LoadField(index) => {
@@ -3595,12 +3607,17 @@ impl BexVm {
                             ));
                         }
 
-                        // An unrecoverable internal error occurred while executing the future.
-                        // The engine has already recorded this error on the FutureManager
-                        // SetOnce; reaching this state in the VM means the heap object was
-                        // mutated outside of the normal Pending → engine-await handshake.
-                        Future::InternalError => {
-                            return Err(VmInternalError::AwaitedFutureInternalError.into());
+                        // An unrecoverable internal error occurred while executing the
+                        // future. Yield back to the engine so it can surface the original
+                        // error from the FutureManager's `SetOnce` (the entry is leaked by
+                        // design for InternalError, so the engine's `future_ready` will
+                        // always find it and propagate the underlying `EngineError`).
+                        &Future::InternalError(future_id) => {
+                            let Frame::Bytecode(bf) = &mut self.frames[*frame_idx] else {
+                                unreachable!("exec loop frame is always Bytecode");
+                            };
+                            bf.instruction_ptr = instruction_ptr;
+                            return Ok(Some(VmExecState::Await(future_id)));
                         }
                     }
                 };
@@ -5155,7 +5172,10 @@ impl BexVm {
                     let raw = { read_u32_unchecked(code, pc) };
                     let global_idx = bex_vm_types::GlobalIndex::from_raw(raw as usize);
                     let value = self.stack.ensure_pop();
-                    self.globals[global_idx] = value;
+                    // Only valid during `$init`; post-init globals are frozen in `Arc<[Value]>`
+                    // and a write here is a VM internal error.
+                    self.globals
+                        .set(global_idx, value, VmInternalError::StoreGlobalAfterInit)?;
                 }
 
                 // ── LoadField / StoreField / InitField ────────────────────────
@@ -5746,8 +5766,12 @@ impl BexVm {
                                     self.panic_to_exception_value(VmPanic::Cancelled),
                                 ));
                             }
-                            Future::InternalError => {
-                                return Err(VmInternalError::AwaitedFutureInternalError.into());
+                            &Future::InternalError(future_id) => {
+                                // Yield back to the engine; it will surface the original
+                                // error from the FutureManager's `SetOnce` (the entry is
+                                // leaked by design for InternalError).
+                                *pc -= 1;
+                                return Ok(Some(VmExecState::Await(future_id)));
                             }
                         }
                     };

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -31,18 +31,22 @@ fn unlikely(b: bool) -> bool {
     b
 }
 
-use ::bex_vm_types::{EarlyYieldCheck, RootHaver, types::ErrorClass};
+use ::bex_heap::TlabHolder;
+use ::bex_vm_types::{
+    EarlyYieldCheck, RootHaver,
+    types::{ErrorClass, FutureId},
+};
 use ::core::any::TypeId;
 #[cfg(not(target_arch = "wasm32"))]
 use ::core::sync::atomic::AtomicBool;
-use bex_heap::{BexHeap, Generation, Tlab};
+use bex_heap::{BexHeap, Tlab};
 use bex_vm_types::{
     BinOp, CmpOp, FunctionKind, GlobalPool, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool,
     ObjectType, PanicClass, StackIndex, UnaryOp, Value, Variant,
     bytecode::{self, BlockNotification},
     types::{
         BoundMethod, Cell, Closure, ConstValue, Function, FunctionType, Future, FutureType,
-        Instance, PendingFuture, Type,
+        Instance, Type, UnscheduledFuture,
     },
 };
 use indexmap::IndexMap;
@@ -339,10 +343,18 @@ pub struct BexVm {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq)]
 pub enum VmExecState {
-    /// VM cannot proceed. It is awaiting a pending future to complete.
-    Await(HeapPtr),
+    /// Awaiting a pending future.
+    ///
+    /// - Input: a `FutureId` corresponding to a (probably) pending future
+    /// - Output (success): the future's result on top of the stack
+    /// - Output (failure): an exception/panic passed to the VM
+    /// - Output (internal error): engine error
+    Await(FutureId),
 
     /// VM notifies caller about a future that needs to be scheduled.
+    ///
+    /// - Input: an `UnscheduledFuture` object
+    /// - Output: a `Future` object (may be pending or ready) pushed to the top of the stack
     ///
     /// Bytecode execution continues when control flow is handled back to the
     /// VM.
@@ -534,6 +546,7 @@ fn value_type_tag(value: &Value) -> i64 {
                 Object::BoundMethod(_) => type_tags::FUNCTION,
                 Object::Cell(_) => type_tags::UNKNOWN,
                 Object::Future(_) => type_tags::FUTURE,
+                Object::UnscheduledFuture(_) => type_tags::FUTURE,
                 Object::Enum(_) => type_tags::ENUM,
                 Object::RustData(_) => type_tags::UNKNOWN,
                 Object::Collector(_) => type_tags::COLLECTOR,
@@ -658,42 +671,6 @@ impl BexVm {
         unsafe { ptr.get_mut() }
     }
 
-    /// Write barrier for field/element/cell writes.
-    ///
-    /// Called *before* the actual field write at each mutation site. If `container_ptr`
-    /// is in an older generation than the object being written (`written_value`), the
-    /// card containing `container_ptr` is marked dirty so partial GC can discover
-    /// the cross-generation reference.
-    ///
-    /// This is a no-op when either side is not a heap object, or when the container
-    /// is in Gen0 (no card table for Gen0).
-    #[inline]
-    pub fn write_barrier(&self, container_ptr: HeapPtr, written_value: Value) {
-        if let Value::Object(ref_ptr) = written_value {
-            let container_gen = self.heap.generation_of(container_ptr);
-            let ref_gen = self.heap.generation_of(ref_ptr);
-            if container_gen > ref_gen {
-                self.heap.mark_card_for_ptr(container_ptr);
-            }
-        }
-    }
-
-    /// Conservative write barrier for mutable accessor paths (builtin dispatch).
-    ///
-    /// Unconditionally marks the card dirty if `container_ptr` is in an older
-    /// generation. Used by `as_array_mut` / `as_map_mut` where the actual written
-    /// value is not yet known (it's supplied by the callee trait method).
-    ///
-    /// This over-marks (any mutable access to an older-gen object dirties the card),
-    /// but it is always safe and the cost is negligible since most objects are Gen0.
-    #[inline]
-    pub(crate) fn conservative_write_barrier(&self, container_ptr: HeapPtr) {
-        let container_gen = self.heap.generation_of(container_ptr);
-        if container_gen > Generation::Gen0 {
-            self.heap.mark_card_for_ptr(container_ptr);
-        }
-    }
-
     /// Collect all `HeapPtr`s stored in call frames.
     /// - For bytecode frames, the function pointer
     /// - For native frames, the continuation pointer as well as all native-held GC roots
@@ -816,7 +793,7 @@ impl BexVm {
         // array may introduce cross-generation references. Used by builtin dispatch
         // (Array.push, Array.pop, etc.) where the actual written values are not
         // visible at this call site.
-        self.conservative_write_barrier(ptr);
+        self.heap.conservative_write_barrier(ptr);
         // Check type first to avoid borrow issues
         if !matches!(self.get_object(ptr), Object::Array(_)) {
             return Err(VmInternalError::TypeError {
@@ -852,7 +829,7 @@ impl BexVm {
         // Conservative write barrier: any mutable access to an older-generation
         // map may introduce cross-generation references. Used by builtin dispatch
         // (Map.set, etc.) where the actual written values are not visible here.
-        self.conservative_write_barrier(index);
+        self.heap.conservative_write_barrier(index);
         // Check type first to avoid borrow issues
         if !matches!(self.get_object(index), Object::Map(_)) {
             return Err(VmInternalError::TypeError {
@@ -967,69 +944,21 @@ impl BexVm {
         self.frames.clear();
     }
 
-    /// Returns a reference to the pending future.
+    /// Returns a reference to the unscheduled future at `future_ptr`.
     ///
-    /// Returns [`VmInternalError::TypeError`] if the future is not pending, or not a future.
-    pub fn pending_future(&self, future_ptr: HeapPtr) -> Result<&PendingFuture, VmInternalError> {
+    /// Returns [`VmInternalError::TypeError`] if the heap object is not an
+    /// `Object::UnscheduledFuture`.
+    pub fn pending_future(
+        &self,
+        future_ptr: HeapPtr,
+    ) -> Result<&UnscheduledFuture, VmInternalError> {
         match self.get_object(future_ptr) {
-            Object::Future(Future::Pending(future)) => Ok(future),
+            Object::UnscheduledFuture(future) => Ok(future),
             other => Err(VmInternalError::TypeError {
-                expected: FutureType::Pending.into(),
+                expected: Type::Object(ObjectType::UnscheduledFuture),
                 got: ObjectType::of(other).into(),
             }),
         }
-    }
-
-    /// Set a future to Ready state without modifying the stack.
-    ///
-    /// Use this for sync operations that complete during `ScheduleFuture` handling,
-    /// before the VM reaches the `Await` instruction. The `Await` instruction will
-    /// extract the value from the Ready future.
-    pub fn set_future_ready(
-        &mut self,
-        future_ptr: HeapPtr,
-        value: Value,
-    ) -> Result<(), VmInternalError> {
-        // Write barrier before mutating the future object.
-        self.write_barrier(future_ptr, value);
-
-        let Object::Future(future) = self.get_object_mut(future_ptr) else {
-            return Err(VmInternalError::TypeError {
-                expected: FutureType::Any.into(),
-                got: ObjectType::of(self.get_object(future_ptr)).into(),
-            });
-        };
-
-        *future = Future::Ready(value);
-        Ok(())
-    }
-
-    /// Fulfill a future and replace the stack top if the VM is awaiting it.
-    ///
-    /// Use this for async operations that complete while the VM is blocked at
-    /// an `Await` instruction. This replaces the future on the stack with the
-    /// ready value so execution can continue.
-    pub fn fulfil_future(
-        &mut self,
-        future_ptr: HeapPtr,
-        value: Value,
-    ) -> Result<(), VmInternalError> {
-        self.set_future_ready(future_ptr, value)?;
-
-        // At any given moment, the VM can only await a single future, because
-        // we can only call the AWAIT instruction on a future on top of the
-        // stack. If that future being await is fulfilled, we need to replace
-        // the future on the stack with the ready value so that the next
-        // instruction that the VM runs can use the value, not the future
-        // object.
-        if let Some(Value::Object(ptr)) = self.stack.last() {
-            if *ptr == future_ptr {
-                self.stack.pop();
-                self.stack.push(value);
-            }
-        }
-
-        Ok(())
     }
 
     /// Allocates an array on the heap and returns it to the caller.
@@ -1046,7 +975,7 @@ impl BexVm {
     }
 
     pub fn alloc_uint8array(&mut self, data: Vec<u8>) -> Value {
-        Value::Object(self.tlab.alloc(Object::Uint8Array(data)))
+        Value::Object(self.tlab.alloc_uint8array(data))
     }
 
     /// TODO: Seems to low level for an embedder, provide an API that takes
@@ -1071,7 +1000,7 @@ impl BexVm {
 
     /// Allocate a collector object on the heap.
     pub fn alloc_collector(&mut self, collector: bex_vm_types::CollectorRef) -> Value {
-        Value::Object(self.tlab.alloc(Object::Collector(collector)))
+        Value::Object(self.tlab.alloc_collector(collector))
     }
 
     /// Get collector ref from a Value.
@@ -1094,7 +1023,7 @@ impl BexVm {
     ///
     /// Used by generated `copy::` structs for `$rust_type` fields.
     pub fn alloc_rust_data(&mut self, data: Arc<dyn std::any::Any + Send + Sync>) -> Value {
-        Value::Object(self.tlab.alloc(Object::RustData(data)))
+        Value::Object(self.tlab.alloc_rust_data(data))
     }
 
     /// Downcast a `Value::Object` pointing to `Object::RustData` to `&T`.
@@ -1196,7 +1125,7 @@ impl BexVm {
 
     /// Allocate a type descriptor object on the heap.
     pub fn alloc_type(&mut self, ty: baml_type::Ty) -> Value {
-        Value::Object(self.tlab.alloc(Object::Type(Box::new(ty))))
+        Value::Object(self.tlab.alloc_type(ty))
     }
 
     /// Stops the execution of the current bytecode in favor of the given
@@ -1393,6 +1322,10 @@ impl BexVm {
             VmPanic::Unreachable => {
                 let msg = self.alloc_string("unreachable code executed".to_string());
                 (PanicClass::Unreachable, vec![msg])
+            }
+            VmPanic::Cancelled => {
+                let msg = self.alloc_string("operation cancelled".to_string());
+                (PanicClass::Cancelled, vec![msg])
             }
             VmPanic::UserPanic { message } => {
                 let msg = self.alloc_string(message);
@@ -2094,6 +2027,7 @@ impl BexVm {
     /// Wraps `exec_inner` to convert `InternalError` → `TracedInternalError`
     /// with a captured stack trace.
     pub fn exec(&mut self) -> Result<VmExecState, VmError> {
+        self.early_yield.reset();
         match self.exec_inner() {
             Err(VmError::InternalError(err)) => {
                 let trace = self.capture_stack_trace();
@@ -2506,7 +2440,7 @@ impl BexVm {
                 );
 
                 // Write barrier: mark card if instance is in an older generation than the value.
-                self.write_barrier(instance_index, new_value);
+                self.heap.write_barrier(instance_index, new_value);
 
                 // Set the new value.
                 if let Object::Instance(instance) = self.get_object_mut(instance_index) {
@@ -2555,7 +2489,7 @@ impl BexVm {
                 );
 
                 // Write barrier: mark card if instance is in an older generation than the value.
-                self.write_barrier(instance_index, new_value);
+                self.heap.write_barrier(instance_index, new_value);
 
                 // Set the new value.
                 if let Object::Instance(instance) = self.get_object_mut(instance_index) {
@@ -3379,7 +3313,7 @@ impl BexVm {
                 );
 
                 // Write barrier: mark card if array is in an older generation than the value.
-                self.write_barrier(array_object_index, new_value);
+                self.heap.write_barrier(array_object_index, new_value);
 
                 // Set the new value.
                 match self.get_object_mut(array_object_index) {
@@ -3452,7 +3386,7 @@ impl BexVm {
                 );
 
                 // Write barrier: mark card if map is in an older generation than the value.
-                self.write_barrier(map_index, new_value);
+                self.heap.write_barrier(map_index, new_value);
 
                 // Set the new value.
                 if let Object::Map(map) = self.get_object_mut(map_index) {
@@ -3608,22 +3542,14 @@ impl BexVm {
                 // Collect function call args and cleanup consumed stack.
                 let future_args: Vec<Value> = self.stack.drain(args_offset..).collect();
 
-                // Create the pending future with the SysOp enum.
-                let pending_future = PendingFuture {
+                // Create the unscheduled future to hand off to the embedder.
+                let pending_future = UnscheduledFuture {
                     operation: sys_op,
                     args: future_args,
                 };
 
-                // Allocate the future.
-                let future_value = self.alloc_future(Future::Pending(pending_future));
-
-                // Extract the index
-                let Value::Object(object_index) = future_value else {
-                    unreachable!("alloc_future returns Value::Object")
-                };
-
-                // Now leave the future on top of the stack.
-                self.stack.push(future_value);
+                // Allocate the unscheduled future.
+                let object_index = self.tlab.alloc(Object::UnscheduledFuture(pending_future));
 
                 // Yield control flow back to the embedder.
                 return Ok(Some(VmExecState::ScheduleFuture(object_index)));
@@ -3648,12 +3574,34 @@ impl BexVm {
 
                     match awaiting {
                         // Can't do nothing, handle control flow back to embedder.
-                        Future::Pending(_) => {
-                            return Ok(Some(VmExecState::Await(index)));
+                        &Future::Pending(future_id) => {
+                            let Frame::Bytecode(bf) = &mut self.frames[*frame_idx] else {
+                                unreachable!("exec loop frame is always Bytecode");
+                            };
+                            bf.instruction_ptr = instruction_ptr; // we will await again when the future completes
+                            return Ok(Some(VmExecState::Await(future_id)));
                         }
 
                         // Return the ready value
                         Future::Ready(value) => *value,
+
+                        // An error occurred while executing the future.
+                        Future::Error(value) => return Err(VmError::Thrown(*value)),
+
+                        // The future was cancelled before completion.
+                        Future::Cancelled => {
+                            return Err(VmError::Thrown(
+                                self.panic_to_exception_value(VmPanic::Cancelled),
+                            ));
+                        }
+
+                        // An unrecoverable internal error occurred while executing the future.
+                        // The engine has already recorded this error on the FutureManager
+                        // SetOnce; reaching this state in the VM means the heap object was
+                        // mutated outside of the normal Pending → engine-await handshake.
+                        Future::InternalError => {
+                            return Err(VmInternalError::AwaitedFutureInternalError.into());
+                        }
                     }
                 };
 
@@ -4413,7 +4361,7 @@ impl BexVm {
                     .into());
                 };
                 // Write barrier before the mutable borrow so we hold only &self.heap.
-                self.write_barrier(cell_ptr, value);
+                self.heap.write_barrier(cell_ptr, value);
                 // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
                 let obj = unsafe { cell_ptr.get_mut() };
                 let Object::Cell(cell) = obj else {
@@ -4495,7 +4443,7 @@ impl BexVm {
                 // Write barrier: mark card if cell is in an older generation than the value.
                 // The shared borrows of `obj`/`closure` have ended, so `write_barrier`
                 // (which borrows `self` immutably via `self.heap`) is safe here.
-                self.write_barrier(cell_ptr, value);
+                self.heap.write_barrier(cell_ptr, value);
                 // SAFETY: cell_ptr is a VM-owned Cell object; single-threaded.
                 let cell_obj = unsafe { cell_ptr.get_mut() };
                 let Object::Cell(cell) = cell_obj else {
@@ -5250,7 +5198,7 @@ impl BexVm {
                         old_value,
                         new_value,
                     );
-                    self.write_barrier(obj_ptr, new_value);
+                    self.heap.write_barrier(obj_ptr, new_value);
                     let Object::Instance(instance) = self.get_object_mut(obj_ptr) else {
                         unreachable!("already type-checked above");
                     };
@@ -5269,7 +5217,7 @@ impl BexVm {
                     let new_value = self.stack.ensure_pop();
                     let instance_value = self.stack.ensure_pop();
                     let obj_ptr = self.as_object_ptr(&instance_value, ObjectType::Instance)?;
-                    self.write_barrier(obj_ptr, new_value);
+                    self.heap.write_barrier(obj_ptr, new_value);
                     let Object::Instance(instance) = self.get_object_mut(obj_ptr) else {
                         return Err(VmInternalError::TypeError {
                             expected: ObjectType::Instance.into(),
@@ -5443,16 +5391,11 @@ impl BexVm {
                     )?;
                     let args_offset = StackIndex::from_raw(args_offset);
                     let future_args: Vec<Value> = self.stack.drain(args_offset..).collect();
-                    let pending_future = bex_vm_types::types::PendingFuture {
+                    let pending_future = bex_vm_types::types::UnscheduledFuture {
                         operation: sys_op,
                         args: future_args,
                     };
-                    let future_value =
-                        self.alloc_future(bex_vm_types::types::Future::Pending(pending_future));
-                    let Value::Object(object_index) = future_value else {
-                        unreachable!("alloc_future returns Value::Object")
-                    };
-                    self.stack.push(future_value);
+                    let object_index = self.tlab.alloc(Object::UnscheduledFuture(pending_future));
                     return Ok(Some(VmExecState::ScheduleFuture(object_index)));
                 }
 
@@ -5789,10 +5732,23 @@ impl BexVm {
                             .into());
                         };
                         match awaiting {
-                            bex_vm_types::types::Future::Pending(_) => {
-                                return Ok(Some(VmExecState::Await(index)));
+                            &Future::Pending(future_id) => {
+                                // Rewind pc to the Await opcode so the outer loop
+                                // saves a position that re-executes Await once the
+                                // future completes.
+                                *pc -= 1;
+                                return Ok(Some(VmExecState::Await(future_id)));
                             }
-                            bex_vm_types::types::Future::Ready(v) => *v,
+                            Future::Ready(v) => *v,
+                            Future::Error(value) => return Err(VmError::Thrown(*value)),
+                            Future::Cancelled => {
+                                return Err(VmError::Thrown(
+                                    self.panic_to_exception_value(VmPanic::Cancelled),
+                                ));
+                            }
+                            Future::InternalError => {
+                                return Err(VmInternalError::AwaitedFutureInternalError.into());
+                            }
                         }
                     };
                     self.stack.pop();
@@ -6145,7 +6101,7 @@ impl BexVm {
                         }
                         .into());
                     };
-                    self.write_barrier(cell_ptr, value);
+                    self.heap.write_barrier(cell_ptr, value);
                     let obj = unsafe { cell_ptr.get_mut() };
                     let Object::Cell(cell) = obj else {
                         return Err(VmInternalError::TypeError {
@@ -6214,7 +6170,7 @@ impl BexVm {
                         }
                         .into());
                     };
-                    self.write_barrier(cell_ptr, value);
+                    self.heap.write_barrier(cell_ptr, value);
                     let cell_obj = unsafe { cell_ptr.get_mut() };
                     let Object::Cell(cell) = cell_obj else {
                         return Err(VmInternalError::TypeError {
@@ -6410,7 +6366,7 @@ impl BexVm {
                         old_value,
                         new_value,
                     );
-                    self.write_barrier(array_object_index, new_value);
+                    self.heap.write_barrier(array_object_index, new_value);
                     match self.get_object_mut(array_object_index) {
                         Object::Array(array) => {
                             array[index] = new_value;
@@ -6459,7 +6415,7 @@ impl BexVm {
                         old_value,
                         new_value,
                     );
-                    self.write_barrier(map_index, new_value);
+                    self.heap.write_barrier(map_index, new_value);
                     if let Object::Map(map) = self.get_object_mut(map_index) {
                         map.insert(key, new_value);
                     }
@@ -6826,5 +6782,14 @@ impl ::bex_vm_types::RootHaver for BexVm {
         for frame in &mut self.frames {
             frame.forward_roots(roots);
         }
+    }
+}
+
+impl TlabHolder for BexVm {
+    fn tlab(&self) -> &Tlab {
+        &self.tlab
+    }
+    fn tlab_mut(&mut self) -> &mut Tlab {
+        &mut self.tlab
     }
 }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -41,8 +41,8 @@ use ::core::any::TypeId;
 use ::core::sync::atomic::AtomicBool;
 use bex_heap::{BexHeap, Tlab};
 use bex_vm_types::{
-    BinOp, CmpOp, FunctionKind, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool, ObjectType,
-    PanicClass, StackIndex, UnaryOp, Value, Variant, VmGlobals,
+    BinOp, CmpOp, FunctionKind, FutureRead, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool,
+    ObjectType, PanicClass, StackIndex, UnaryOp, Value, Variant, VmGlobals,
     bytecode::{self, BlockNotification},
     types::{
         BoundMethod, Cell, Closure, ConstValue, Function, FunctionType, Future, FutureType,
@@ -3584,9 +3584,9 @@ impl BexVm {
                         .into());
                     };
 
-                    match awaiting {
+                    match awaiting.read() {
                         // Can't do nothing, handle control flow back to embedder.
-                        &Future::Pending(future_id) => {
+                        FutureRead::Pending(future_id) => {
                             let Frame::Bytecode(bf) = &mut self.frames[*frame_idx] else {
                                 unreachable!("exec loop frame is always Bytecode");
                             };
@@ -3595,13 +3595,16 @@ impl BexVm {
                         }
 
                         // Return the ready value
-                        Future::Ready(value) => *value,
+                        FutureRead::Ready(value) => value,
 
-                        // An error occurred while executing the future.
-                        Future::Error(value) => return Err(VmError::Thrown(*value)),
+                        // An error occurred while executing the future. (Reserved
+                        // for future user-callable async functions that throw BAML
+                        // values; the engine today routes all sys-op errors through
+                        // `internal_error_future`.)
+                        FutureRead::Error(value) => return Err(VmError::Thrown(value)),
 
                         // The future was cancelled before completion.
-                        Future::Cancelled => {
+                        FutureRead::Cancelled => {
                             return Err(VmError::Thrown(
                                 self.panic_to_exception_value(VmPanic::Cancelled),
                             ));
@@ -3612,7 +3615,7 @@ impl BexVm {
                         // error from the FutureManager's `SetOnce` (the entry is leaked by
                         // design for InternalError, so the engine's `future_ready` will
                         // always find it and propagate the underlying `EngineError`).
-                        &Future::InternalError(future_id) => {
+                        FutureRead::InternalError(future_id) => {
                             let Frame::Bytecode(bf) = &mut self.frames[*frame_idx] else {
                                 unreachable!("exec loop frame is always Bytecode");
                             };
@@ -5751,22 +5754,25 @@ impl BexVm {
                             }
                             .into());
                         };
-                        match awaiting {
-                            &Future::Pending(future_id) => {
+                        match awaiting.read() {
+                            FutureRead::Pending(future_id) => {
                                 // Rewind pc to the Await opcode so the outer loop
                                 // saves a position that re-executes Await once the
                                 // future completes.
                                 *pc -= 1;
                                 return Ok(Some(VmExecState::Await(future_id)));
                             }
-                            Future::Ready(v) => *v,
-                            Future::Error(value) => return Err(VmError::Thrown(*value)),
-                            Future::Cancelled => {
+                            FutureRead::Ready(v) => v,
+                            // Reserved for future user-callable async functions
+                            // that throw BAML values; the engine today routes all
+                            // sys-op errors through `internal_error_future`.
+                            FutureRead::Error(value) => return Err(VmError::Thrown(value)),
+                            FutureRead::Cancelled => {
                                 return Err(VmError::Thrown(
                                     self.panic_to_exception_value(VmPanic::Cancelled),
                                 ));
                             }
-                            &Future::InternalError(future_id) => {
+                            FutureRead::InternalError(future_id) => {
                                 // Yield back to the engine; it will surface the original
                                 // error from the FutureManager's `SetOnce` (the entry is
                                 // leaked by design for InternalError).

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -45,8 +45,8 @@ use bex_vm_types::{
     ObjectType, PanicClass, StackIndex, UnaryOp, Value, Variant, VmGlobals,
     bytecode::{self, BlockNotification},
     types::{
-        BoundMethod, Cell, Closure, ConstValue, Function, FunctionType, Future, FutureType,
-        Instance, Type, UnscheduledFuture,
+        BoundMethod, Cell, Closure, ConstValue, Function, FunctionType, FutureType, Instance, Type,
+        UnscheduledFuture,
     },
 };
 use indexmap::IndexMap;
@@ -359,8 +359,11 @@ pub enum VmExecState {
 
     /// VM notifies caller about a future that needs to be scheduled.
     ///
-    /// - Input: an `UnscheduledFuture` object
-    /// - Output: a `Future` object (may be pending or ready) pushed to the top of the stack
+    /// - Input: a `HeapPtr` to the `UnscheduledFuture` object the VM allocated.
+    /// - Output: the engine pushes a `Future::Pending(future_id)` heap pointer
+    ///   onto the VM stack. Terminal transitions (`Ready`/`Error`/`Cancelled`/
+    ///   `InternalError`) happen later via the `FutureManager`; the VM only
+    ///   ever sees `Pending` directly after this yield.
     ///
     /// Bytecode execution continues when control flow is handled back to the
     /// VM.
@@ -1000,11 +1003,6 @@ impl BexVm {
     // TODO: Same problem as above. Ideally takes (&str, &str) instead.
     pub fn alloc_variant(&mut self, enm: HeapPtr, index: usize) -> Value {
         Value::Object(self.tlab.alloc(Object::Variant(Variant { enm, index })))
-    }
-
-    /// Allocate a future object.
-    pub fn alloc_future(&mut self, future: Future) -> Value {
-        Value::Object(self.tlab.alloc(Object::Future(future)))
     }
 
     /// Allocate a collector object on the heap.
@@ -2036,6 +2034,11 @@ impl BexVm {
     /// Wraps `exec_inner` to convert `InternalError` → `TracedInternalError`
     /// with a captured stack trace.
     pub fn exec(&mut self) -> Result<VmExecState, VmError> {
+        // Re-arm the long-running-loop detector at every yield boundary so
+        // each `exec()` call starts with a fresh budget; a single `exec()`
+        // call yields back to the embedder eventually (e.g. via `Await`,
+        // `EarlyYield`, etc.), which is the right granularity for the
+        // counter to reset at.
         self.early_yield.reset();
         match self.exec_inner() {
             Err(VmError::InternalError(err)) => {
@@ -5743,6 +5746,12 @@ impl BexVm {
 
                 // ── Await ─────────────────────────────────────────────────────
                 OpCode::Await => {
+                    // Compact opcodes are 1 byte; rewinding by `AWAIT_OPCODE_LEN`
+                    // puts `pc` back at the `OpCode::Await` byte so the outer
+                    // exec loop re-executes the same Await on resume. The
+                    // regular (non-compact) path expresses the same intent by
+                    // explicitly setting `bf.instruction_ptr = instruction_ptr`.
+                    const AWAIT_OPCODE_LEN: usize = 1;
                     let value = self.stack.ensure_stack_top();
                     let wanted_type = bex_vm_types::types::FutureType::Any;
                     let index = self.as_object_ptr(&self.stack[value], wanted_type.into())?;
@@ -5759,7 +5768,7 @@ impl BexVm {
                                 // Rewind pc to the Await opcode so the outer loop
                                 // saves a position that re-executes Await once the
                                 // future completes.
-                                *pc -= 1;
+                                *pc -= AWAIT_OPCODE_LEN;
                                 return Ok(Some(VmExecState::Await(future_id)));
                             }
                             FutureRead::Ready(v) => v,
@@ -5776,7 +5785,7 @@ impl BexVm {
                                 // Yield back to the engine; it will surface the original
                                 // error from the FutureManager's `SetOnce` (the entry is
                                 // leaked by design for InternalError).
-                                *pc -= 1;
+                                *pc -= AWAIT_OPCODE_LEN;
                                 return Ok(Some(VmExecState::Await(future_id)));
                             }
                         }

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -187,6 +187,15 @@ pub enum Instruction {
     ///
     /// Format: `STORE_GLOBAL i` where `i` is the index of the global variable
     /// in the `Vm::globals` array.
+    ///
+    /// # Init-only invariant
+    ///
+    /// Only `$init` (or `$init_test`) functions may emit `StoreGlobal`. The
+    /// compiler enforces this by emitting `StoreGlobal` exclusively from
+    /// `compile_init_function`. Post-`$init` globals are shared across VMs as a
+    /// frozen `Arc<[Value]>`; the runtime treats a `StoreGlobal` against that
+    /// shared view as a `VmInternalError`. Hand-written or fuzzed bytecode that
+    /// emits `StoreGlobal` outside of `$init` will be rejected at runtime.
     StoreGlobal(GlobalIndex),
 
     /// Load a field of an object.

--- a/baml_language/crates/bex_vm_types/src/indexable.rs
+++ b/baml_language/crates/bex_vm_types/src/indexable.rs
@@ -11,7 +11,7 @@
 //! This module provides a vector wrapper that needs specific types to index
 //! into it, thus solving the problem mentioned above at compile time.
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
 use crate::{Object, Value};
 
@@ -241,6 +241,95 @@ impl<'a, T, K> std::iter::IntoIterator for &'a mut Pool<T, K> {
 
 pub type GlobalPool = Pool<Value, GlobalKind>;
 pub type ObjectPool = Pool<Object, ObjectKind>;
+
+/// The view of globals available to a [`crate::Object`]-aware VM.
+///
+/// **Invariant**: only `$init` functions emit [`crate::Instruction::StoreGlobal`].
+/// The compiler enforces this by emitting `StoreGlobal` solely from
+/// `compile_init_function`. The runtime enforces it via the [`VmGlobals::Owned`]
+/// vs [`VmGlobals::Shared`] split: post-`$init` VMs hold a [`VmGlobals::Shared`]
+/// reference into the engine's frozen globals, and a `StoreGlobal` against a
+/// `Shared` view must be turned into a `VmInternalError` by the VM.
+///
+/// # Variants
+/// - [`VmGlobals::Owned`]: a mutable [`GlobalPool`] used during `$init` execution.
+/// - [`VmGlobals::Shared`]: a frozen `Arc<[Value]>` shared by every post-`$init` VM.
+///   Cloning is a refcount bump; reads are direct slice indexing.
+#[derive(Clone, Debug)]
+pub enum VmGlobals {
+    /// Mutable globals pool, used during `$init`.
+    Owned(GlobalPool),
+    /// Frozen globals shared across all post-`$init` VMs.
+    Shared(Arc<[Value]>),
+}
+
+impl VmGlobals {
+    /// Number of globals in the view.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Owned(pool) => pool.len(),
+            Self::Shared(slice) => slice.len(),
+        }
+    }
+
+    /// Whether the view is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Read a global by index. `Value` is `Copy` so this returns by value.
+    ///
+    /// # Panics
+    /// Panics if `index` is out of bounds — same contract as slice indexing.
+    pub fn get(&self, index: GlobalIndex) -> Value {
+        match self {
+            Self::Owned(pool) => pool[index],
+            Self::Shared(slice) => slice[index.into_raw()],
+        }
+    }
+
+    /// Mutably set a global. Only succeeds for [`VmGlobals::Owned`]; returns the
+    /// caller-supplied error for [`VmGlobals::Shared`] (post-`$init` writes
+    /// violate the invariant and the VM should treat them as internal errors).
+    pub fn set<E>(&mut self, index: GlobalIndex, value: Value, on_shared: E) -> Result<(), E> {
+        match self {
+            Self::Owned(pool) => {
+                pool[index] = value;
+                Ok(())
+            }
+            Self::Shared(_) => Err(on_shared),
+        }
+    }
+
+    /// Freeze this view into a shared `Arc<[Value]>`. For [`VmGlobals::Owned`],
+    /// this consumes the underlying `Vec`; for [`VmGlobals::Shared`], it clones
+    /// the existing `Arc`.
+    pub fn freeze(self) -> Arc<[Value]> {
+        match self {
+            Self::Owned(pool) => Arc::from(pool.0),
+            Self::Shared(slice) => slice,
+        }
+    }
+
+    /// View the globals as a slice. Both variants support O(1) slice access.
+    pub fn as_slice(&self) -> &[Value] {
+        match self {
+            Self::Owned(pool) => &pool.0,
+            Self::Shared(slice) => slice,
+        }
+    }
+}
+
+impl std::ops::Index<GlobalIndex> for VmGlobals {
+    type Output = Value;
+
+    fn index(&self, index: GlobalIndex) -> &Self::Output {
+        match self {
+            Self::Owned(pool) => &pool[index],
+            Self::Shared(slice) => &slice[index.into_raw()],
+        }
+    }
+}
 
 pub type StackIndex = Index<StackKind>;
 pub type GlobalIndex = Index<GlobalKind>;

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -25,10 +25,10 @@ pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex
 pub use roots::RootHaver;
 pub use types::{
     Class, ClassField, ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum,
-    EnumVariant, Function, FunctionKind, FunctionMeta, FunctionOrigin, Future, Instance,
-    MediaValue, Object, ObjectType, PanicClass, Program, PromptAst, RetryPolicyMeta, SysOp,
-    SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase, UnscheduledFuture, Value,
-    Variant, format_float, sys_op_for_path, type_tags,
+    EnumVariant, Function, FunctionKind, FunctionMeta, FunctionOrigin, Future, FutureRead,
+    Instance, MediaValue, Object, ObjectType, PanicClass, Program, PromptAst, RetryPolicyMeta,
+    SysOp, SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase, UnscheduledFuture,
+    Value, Variant, format_float, sys_op_for_path, type_tags,
 };
 
 /// Used to check if the VM should yield early.

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -21,7 +21,7 @@ pub use bytecode::{
     VizNodeMeta, VizNodeType,
 };
 pub use heap_ptr::HeapPtr;
-pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex};
+pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex, VmGlobals};
 pub use roots::RootHaver;
 pub use types::{
     Class, ClassField, ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum,

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -26,9 +26,9 @@ pub use roots::RootHaver;
 pub use types::{
     Class, ClassField, ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum,
     EnumVariant, Function, FunctionKind, FunctionMeta, FunctionOrigin, Future, Instance,
-    MediaValue, Object, ObjectType, PanicClass, PendingFuture, Program, PromptAst, RetryPolicyMeta,
-    SysOp, SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase, Value, Variant,
-    format_float, sys_op_for_path, type_tags,
+    MediaValue, Object, ObjectType, PanicClass, Program, PromptAst, RetryPolicyMeta, SysOp,
+    SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase, UnscheduledFuture, Value,
+    Variant, format_float, sys_op_for_path, type_tags,
 };
 
 /// Used to check if the VM should yield early.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -946,13 +946,13 @@ impl std::fmt::Display for Object {
 ///
 /// # Safety
 ///
-/// Writers must hold `future_permit` (the [`FutureManager`]'s
-/// [`SharedHeapPermit`] guard), which the engine uses to enforce a
-/// single-writer invariant. Readers may run on any thread; the
-/// Acquire/Release pairing on `state` provides the necessary happens-before.
+/// Writers must hold the [`FutureManager`]'s state mutex (a
+/// `tokio::sync::Mutex` over the manager's `InactiveHeapPermit`), which
+/// the engine uses to enforce a single-writer invariant. Readers may run
+/// on any thread; the Acquire/Release pairing on `state` provides the
+/// necessary happens-before.
 ///
 /// [`FutureManager`]: <https://docs.rs/bex_engine>
-/// [`SharedHeapPermit`]: <https://docs.rs/bex_heap>
 #[repr(C)]
 pub struct Future {
     /// Atomic discriminant (one of [`FutureTag`]). Loaded with `Acquire`,
@@ -960,7 +960,7 @@ pub struct Future {
     state: AtomicU8,
     /// Set at construction; never modified. Valid for `Pending` and
     /// `InternalError` states.
-    future_id: FutureId,
+    id: FutureId,
     /// Written at most once (preceded by an `Acquire`/`Release` handshake
     /// on `state`). Valid only when `state` indicates `Ready` or `Error`.
     value: UnsafeCell<MaybeUninit<Value>>,
@@ -968,9 +968,18 @@ pub struct Future {
 
 // SAFETY: All access to `value` is gated by the Acquire/Release handshake
 // on `state` and the single-writer invariant enforced by the
-// `FutureManager`'s `SharedHeapPermit` guard.
+// `FutureManager`'s state mutex.
 unsafe impl Send for Future {}
 unsafe impl Sync for Future {}
+
+// `Future::read` calls `MaybeUninit::<Value>::assume_init_read`, which is
+// sound only because `Value: Copy`. If `Value` ever gains a non-trivial
+// `Drop` (e.g. by holding an `Arc<…>` or `Box<…>`), `assume_init_read`
+// becomes UB on the second read. Guard against that at compile time.
+const _: () = {
+    const fn assert_copy<T: Copy>() {}
+    assert_copy::<Value>();
+};
 
 /// Discriminant byte for [`Future::state`].
 #[repr(u8)]
@@ -1022,7 +1031,7 @@ impl Future {
     pub fn pending(id: FutureId) -> Self {
         Self {
             state: AtomicU8::new(FutureTag::Pending as u8),
-            future_id: id,
+            id,
             value: UnsafeCell::new(MaybeUninit::uninit()),
         }
     }
@@ -1035,7 +1044,7 @@ impl Future {
     pub fn read(&self) -> FutureRead {
         let tag = self.state.load(Ordering::Acquire);
         match tag {
-            t if t == FutureTag::Pending as u8 => FutureRead::Pending(self.future_id),
+            t if t == FutureTag::Pending as u8 => FutureRead::Pending(self.id),
             t if t == FutureTag::Ready as u8 => {
                 // SAFETY: the Acquire-load above synchronized with the
                 // writer's Release-store of `Ready`, so the preceding
@@ -1050,7 +1059,7 @@ impl Future {
                 FutureRead::Error(v)
             }
             t if t == FutureTag::Cancelled as u8 => FutureRead::Cancelled,
-            t if t == FutureTag::InternalError as u8 => FutureRead::InternalError(self.future_id),
+            t if t == FutureTag::InternalError as u8 => FutureRead::InternalError(self.id),
             other => unreachable!("invalid Future discriminant byte: {other}"),
         }
     }
@@ -1065,7 +1074,7 @@ impl Future {
     /// # Safety
     ///
     /// The caller must hold exclusive access to the heap (e.g., a parked
-    /// [`HeapGuard`]). Concurrent calls to `set_*` would race.
+    /// `HeapGuard`). Concurrent calls to `set_*` would race.
     pub unsafe fn value_mut_for_fixup(&mut self) -> Option<&mut Value> {
         let tag = *self.state.get_mut();
         if tag == FutureTag::Ready as u8 || tag == FutureTag::Error as u8 {
@@ -1091,21 +1100,36 @@ impl Future {
         self.state.store(FutureTag::Ready as u8, Ordering::Release);
     }
 
-    /// Transition to `Error`. See [`Self::set_ready`] for safety.
+    /// Transition to `Error`.
+    ///
+    /// # Safety
+    ///
+    /// See [`Self::set_ready`] — caller must hold `future_permit` and the
+    /// future must currently be `Pending`.
     pub unsafe fn set_error(&self, value: Value) {
         // SAFETY: single-writer invariant via `future_permit`.
         unsafe { (*self.value.get()).write(value) };
         self.state.store(FutureTag::Error as u8, Ordering::Release);
     }
 
-    /// Transition to `Cancelled`. See [`Self::set_ready`] for safety.
+    /// Transition to `Cancelled`.
+    ///
+    /// # Safety
+    ///
+    /// See [`Self::set_ready`] — caller must hold `future_permit` and the
+    /// future must currently be `Pending`.
     pub unsafe fn set_cancelled(&self) {
         self.state
             .store(FutureTag::Cancelled as u8, Ordering::Release);
     }
 
     /// Transition to `InternalError`. The `FutureId` retained is the one
-    /// from construction. See [`Self::set_ready`] for safety.
+    /// from construction.
+    ///
+    /// # Safety
+    ///
+    /// See [`Self::set_ready`] — caller must hold `future_permit` and the
+    /// future must currently be `Pending`.
     pub unsafe fn set_internal_error(&self) {
         self.state
             .store(FutureTag::InternalError as u8, Ordering::Release);
@@ -1115,12 +1139,26 @@ impl Future {
 impl Clone for Future {
     fn clone(&self) -> Self {
         // Snapshot the current state and clone the corresponding payload.
-        // Used by `deep_copy_value_recursive` and any other site that
-        // duplicates the heap object.
+        // The only legitimate caller is the GC's heap-relocation copy
+        // (`gc.rs` `copy_object_to_inactive`), which clones the heap object
+        // into the inactive space and then `forward_roots` updates the
+        // `FutureManager`'s pointer to the moved object before any reader
+        // observes the clone — so the FutureManager and the heap object
+        // stay in sync.
+        //
+        // Futures are conceptually *handles*, not values: there is no
+        // "the same future, but a copy" in the runtime. User-level
+        // `deep_copy` reflects this by sharing the original `HeapPtr`
+        // for any `Future` rather than calling this `Clone` impl. See
+        // `crates/bex_vm/src/package_baml/root.rs::deep_copy_value_recursive`.
+        // Any other caller of this impl must ensure the `FutureManager`
+        // is taught about the new pointer, otherwise terminal-state writes
+        // will be applied to the original and the clone will be observable
+        // in a permanently stale state.
         let read = self.read();
         let cloned = Self {
             state: AtomicU8::new(0), // placeholder; rewritten below
-            future_id: self.future_id,
+            id: self.id,
             value: UnsafeCell::new(MaybeUninit::uninit()),
         };
         let tag: u8 = match read {
@@ -1176,6 +1214,15 @@ pub struct UnscheduledFuture {
 pub struct FutureId {
     id: usize,
 }
+
+impl std::fmt::Display for FutureId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Render as a bare number so error messages read as
+        // "Future with ID 42 not found" instead of "FutureId { id: 42 }".
+        self.id.fmt(f)
+    }
+}
+
 impl FutureId {
     /// Construct a [`FutureId`] from a raw `usize`.
     ///

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -803,6 +803,8 @@ pub enum Object {
     Map(IndexMap<String, Value>),
 
     Future(Future),
+    /// Only used for requesting scheduling of a future, passed from VM to engine.
+    UnscheduledFuture(UnscheduledFuture),
 
     /// Opaque Rust-managed data, accessed via `Arc<dyn Any>` downcast.
     /// Used for `$rust_type` fields in builtin classes (including media classes Pdf, Audio, Video, Image).
@@ -885,10 +887,14 @@ impl std::fmt::Display for Object {
             Object::Type(ty) => write!(f, "<type: {ty}>"),
             Object::Future(future) => match future {
                 Future::Pending(future) => {
-                    write!(f, "<pending: {}>", future.operation)
+                    write!(f, "<pending: future #{}>", future.id)
                 }
                 Future::Ready(value) => write!(f, "<ready: {value}>"),
+                Future::Error(value) => write!(f, "<error: {value}>"),
+                Future::Cancelled => write!(f, "<cancelled>"),
+                Future::InternalError => write!(f, "<internal error>"),
             },
+            Object::UnscheduledFuture(future) => write!(f, "<unscheduled: {}>", future.operation),
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(kind) => write!(f, "<sentinel {kind:?}>"),
             // Object::BamlType(type_ir) => write!(f, "<baml type: {type_ir}>"),
@@ -900,23 +906,54 @@ impl std::fmt::Display for Object {
 pub enum Future {
     /// Pending future.
     ///
-    /// Only LLM calls for now.
-    Pending(PendingFuture),
+    /// In terms of synchronization, this is "pending" from the heap's point of view.
+    /// It will remain pending until set otherwise, but yielding back to the engine *could* see an immediate completion.
+    Pending(FutureId),
 
     /// Ready value for the future.
     Ready(Value),
+
+    /// A BAML error or panic occurred while executing the future.
+    /// If awaited, the error/panic value will be thrown.
+    Error(Value),
+
+    /// The future was cancelled before completion.
+    /// If awaited, this will throw `baml.panics.Cancelled`.
+    Cancelled,
+
+    /// An unrecoverable internal error occurred while executing the future.
+    /// To surface this error, the VM should await the future yielding control back to the engine.
+    InternalError,
 }
 
-/// A pending external operation.
+/// An operation that should be passed to the engine to be scheduled.
 ///
 /// External operations are async functions that run outside the VM, such as
 /// LLM calls, HTTP requests, file I/O, or shell commands.
 #[derive(Clone, Debug)]
-pub struct PendingFuture {
+pub struct UnscheduledFuture {
     /// The system operation to execute.
     pub operation: SysOp,
     /// Arguments to the operation.
     pub args: Vec<Value>,
+}
+
+/// A unique identifier for a future.
+///
+/// Unlike `bex_engine::CallId`, these are created for every scheduled future (sys op or function call),
+/// not just when there is a new call from the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FutureId {
+    id: usize,
+}
+impl FutureId {
+    /// # Safety
+    ///
+    /// Should only be used by the engine to create new future ids.
+    #[expect(unsafe_code)]
+    pub unsafe fn from_usize(id: usize) -> Self {
+        Self { id }
+    }
 }
 
 /// Types of values.
@@ -980,6 +1017,7 @@ pub enum ObjectType {
     Enum,
     Variant,
     Future(FutureType),
+    UnscheduledFuture,
     Collector,
     Type,
     RustData,
@@ -1004,6 +1042,7 @@ impl ObjectType {
             Object::Collector(_) => Self::Collector,
             Object::Type(_) => Self::Type,
             Object::Future(fut) => Self::Future(fut.into()),
+            Object::UnscheduledFuture(_) => Self::UnscheduledFuture,
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Self::Any,
             // Object::BamlType(_) => Self::Any, // TODO
@@ -1037,6 +1076,7 @@ impl std::fmt::Display for ObjectType {
             ObjectType::Enum => write!(f, "enum"),
             ObjectType::Variant => write!(f, "variant"),
             ObjectType::Future(future_type) => write!(f, "{future_type}"),
+            ObjectType::UnscheduledFuture => write!(f, "unscheduled_future"),
             ObjectType::String => write!(f, "string"),
             ObjectType::Uint8Array => write!(f, "uint8array"),
             ObjectType::Collector => write!(f, "collector"),
@@ -1080,6 +1120,21 @@ pub enum FutureType {
     Any,
     Pending,
     Ready,
+    Error,
+    Cancelled,
+    InternalError,
+}
+
+impl FutureType {
+    pub fn of(future: &Future) -> Self {
+        match future {
+            Future::Pending(_) => Self::Pending,
+            Future::Ready(_) => Self::Ready,
+            Future::Error(_) => Self::Error,
+            Future::Cancelled => Self::Cancelled,
+            Future::InternalError => Self::InternalError,
+        }
+    }
 }
 
 impl std::fmt::Display for FutureType {
@@ -1088,6 +1143,9 @@ impl std::fmt::Display for FutureType {
             FutureType::Any => write!(f, "any"),
             FutureType::Pending => write!(f, "pending"),
             FutureType::Ready => write!(f, "ready"),
+            FutureType::Error => write!(f, "error"),
+            FutureType::Cancelled => write!(f, "cancelled"),
+            FutureType::InternalError => write!(f, "internal_error"),
         }
     }
 }
@@ -1097,6 +1155,9 @@ impl From<&Future> for FutureType {
         match value {
             Future::Pending(_) => Self::Pending,
             Future::Ready(_) => Self::Ready,
+            Future::Error(_) => Self::Error,
+            Future::Cancelled => Self::Cancelled,
+            Future::InternalError => Self::InternalError,
         }
     }
 }

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -954,6 +954,10 @@ impl FutureId {
     pub unsafe fn from_usize(id: usize) -> Self {
         Self { id }
     }
+
+    pub fn as_usize(self) -> usize {
+        self.id
+    }
 }
 
 /// Types of values.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -1,4 +1,22 @@
-use std::{any::Any, collections::HashMap, sync::Arc};
+//! Heap object types and runtime values.
+//!
+//! `Future` uses `AtomicU8` + `UnsafeCell<MaybeUninit<Value>>` to allow
+//! the engine's spawned task and the VM to read/write the heap object
+//! concurrently without a data race. See the `Future` doc for the safety
+//! argument; the unsafe code here is intentional and necessary.
+
+#![allow(unsafe_code)]
+
+use std::{
+    any::Any,
+    cell::UnsafeCell,
+    collections::HashMap,
+    mem::MaybeUninit,
+    sync::{
+        Arc,
+        atomic::{AtomicU8, Ordering},
+    },
+};
 
 use baml_type::Ty;
 use indexmap::IndexMap;
@@ -891,15 +909,15 @@ impl std::fmt::Display for Object {
             Object::RustData(_) => write!(f, "<rust_data>"),
             Object::Collector(_) => write!(f, "<collector>"),
             Object::Type(ty) => write!(f, "<type: {ty}>"),
-            Object::Future(future) => match future {
-                Future::Pending(future) => {
-                    write!(f, "<pending: future #{}>", future.id)
+            Object::Future(future) => match future.read() {
+                FutureRead::Pending(id) => {
+                    write!(f, "<pending: future #{}>", id.id)
                 }
-                Future::Ready(value) => write!(f, "<ready: {value}>"),
-                Future::Error(value) => write!(f, "<error: {value}>"),
-                Future::Cancelled => write!(f, "<cancelled>"),
-                Future::InternalError(future) => {
-                    write!(f, "<internal error: future #{}>", future.id)
+                FutureRead::Ready(value) => write!(f, "<ready: {value}>"),
+                FutureRead::Error(value) => write!(f, "<error: {value}>"),
+                FutureRead::Cancelled => write!(f, "<cancelled>"),
+                FutureRead::InternalError(id) => {
+                    write!(f, "<internal error: future #{}>", id.id)
                 }
             },
             Object::UnscheduledFuture(future) => write!(f, "<unscheduled: {}>", future.operation),
@@ -910,8 +928,66 @@ impl std::fmt::Display for Object {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum Future {
+/// A future heap object.
+///
+/// Replaces a plain enum with a struct exposing an atomic discriminant
+/// (`AtomicU8`) so that the engine's spawned task and the VM can read/write
+/// it concurrently without a data race. Concretely:
+///
+/// - `state` is loaded with `Acquire` and stored with `Release`. When a
+///   reader observes a terminal-state tag, all preceding payload writes by
+///   the writer are visible to it.
+/// - `future_id` is set at construction and never modified. It is the only
+///   field readers consult for `Pending` and `InternalError` tags.
+/// - `value` is wrapped in [`UnsafeCell<MaybeUninit<Value>>`] and is written
+///   *at most once* (during the unique transition from `Pending` to
+///   `Ready` or `Error`). It is only readable when `state` indicates
+///   `Ready` or `Error`.
+///
+/// # Safety
+///
+/// Writers must hold `future_permit` (the [`FutureManager`]'s
+/// [`SharedHeapPermit`] guard), which the engine uses to enforce a
+/// single-writer invariant. Readers may run on any thread; the
+/// Acquire/Release pairing on `state` provides the necessary happens-before.
+///
+/// [`FutureManager`]: <https://docs.rs/bex_engine>
+/// [`SharedHeapPermit`]: <https://docs.rs/bex_heap>
+#[repr(C)]
+pub struct Future {
+    /// Atomic discriminant (one of [`FutureTag`]). Loaded with `Acquire`,
+    /// stored with `Release`.
+    state: AtomicU8,
+    /// Set at construction; never modified. Valid for `Pending` and
+    /// `InternalError` states.
+    future_id: FutureId,
+    /// Written at most once (preceded by an `Acquire`/`Release` handshake
+    /// on `state`). Valid only when `state` indicates `Ready` or `Error`.
+    value: UnsafeCell<MaybeUninit<Value>>,
+}
+
+// SAFETY: All access to `value` is gated by the Acquire/Release handshake
+// on `state` and the single-writer invariant enforced by the
+// `FutureManager`'s `SharedHeapPermit` guard.
+unsafe impl Send for Future {}
+unsafe impl Sync for Future {}
+
+/// Discriminant byte for [`Future::state`].
+#[repr(u8)]
+enum FutureTag {
+    Pending = 0,
+    Ready = 1,
+    Error = 2,
+    Cancelled = 3,
+    InternalError = 4,
+}
+
+/// Snapshot view of a [`Future`] used for pattern matching at read sites.
+///
+/// Returned by [`Future::read`] after an `Acquire`-load of the discriminant
+/// and (for `Ready`/`Error`) a synchronized read of the payload.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FutureRead {
     /// Pending future.
     ///
     /// In terms of synchronization, this is "pending" from the heap's point of view.
@@ -923,6 +999,10 @@ pub enum Future {
 
     /// A BAML error or panic occurred while executing the future.
     /// If awaited, the error/panic value will be thrown.
+    ///
+    /// Note: not currently produced by the engine. Reserved for future
+    /// user-callable async functions that throw BAML values; the engine
+    /// today routes all sys-op errors through `internal_error_future`.
     Error(Value),
 
     /// The future was cancelled before completion.
@@ -935,6 +1015,145 @@ pub enum Future {
     /// error from the `FutureManager`'s registry. Such entries are leaked from
     /// `FutureManager::active_futures` by design.
     InternalError(FutureId),
+}
+
+impl Future {
+    /// Construct a new [`Future`] in the `Pending` state.
+    pub fn pending(id: FutureId) -> Self {
+        Self {
+            state: AtomicU8::new(FutureTag::Pending as u8),
+            future_id: id,
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    /// Read the current state with appropriate atomic ordering.
+    ///
+    /// `Acquire`-loads the discriminant, then dispatches to the right
+    /// payload field. For `Ready`/`Error`, reading `value` is synchronized
+    /// against the writer's `Release`-store so the value is fully visible.
+    pub fn read(&self) -> FutureRead {
+        let tag = self.state.load(Ordering::Acquire);
+        match tag {
+            t if t == FutureTag::Pending as u8 => FutureRead::Pending(self.future_id),
+            t if t == FutureTag::Ready as u8 => {
+                // SAFETY: the Acquire-load above synchronized with the
+                // writer's Release-store of `Ready`, so the preceding
+                // `value` write is visible. `Value: Copy`, so a read here
+                // does not move the underlying data.
+                let v = unsafe { (*self.value.get()).assume_init_read() };
+                FutureRead::Ready(v)
+            }
+            t if t == FutureTag::Error as u8 => {
+                // SAFETY: as for `Ready`. See above.
+                let v = unsafe { (*self.value.get()).assume_init_read() };
+                FutureRead::Error(v)
+            }
+            t if t == FutureTag::Cancelled as u8 => FutureRead::Cancelled,
+            t if t == FutureTag::InternalError as u8 => FutureRead::InternalError(self.future_id),
+            other => unreachable!("invalid Future discriminant byte: {other}"),
+        }
+    }
+
+    /// Mutable access to the embedded `Value` for `Ready`/`Error` states.
+    ///
+    /// Used by the GC's fixup pass to update heap pointers after a move.
+    /// Returns `Some(&mut Value)` only if the current state is `Ready` or
+    /// `Error`. The GC runs with all permits parked, so synchronization is
+    /// not needed — but a `Relaxed` load is used for clarity.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold exclusive access to the heap (e.g., a parked
+    /// [`HeapGuard`]). Concurrent calls to `set_*` would race.
+    pub unsafe fn value_mut_for_fixup(&mut self) -> Option<&mut Value> {
+        let tag = *self.state.get_mut();
+        if tag == FutureTag::Ready as u8 || tag == FutureTag::Error as u8 {
+            // SAFETY: state indicates `Ready`/`Error`; the value is
+            // initialized. `&mut self` proves no concurrent reader.
+            Some(unsafe { (*self.value.get()).assume_init_mut() })
+        } else {
+            None
+        }
+    }
+
+    /// Transition to `Ready`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must hold `future_permit` (single-writer invariant). The
+    /// future must currently be in `Pending` state — overwriting `value`
+    /// after a previous `set_ready`/`set_error` would race with
+    /// concurrent readers.
+    pub unsafe fn set_ready(&self, value: Value) {
+        // SAFETY: single-writer invariant via `future_permit`.
+        unsafe { (*self.value.get()).write(value) };
+        self.state.store(FutureTag::Ready as u8, Ordering::Release);
+    }
+
+    /// Transition to `Error`. See [`Self::set_ready`] for safety.
+    pub unsafe fn set_error(&self, value: Value) {
+        // SAFETY: single-writer invariant via `future_permit`.
+        unsafe { (*self.value.get()).write(value) };
+        self.state.store(FutureTag::Error as u8, Ordering::Release);
+    }
+
+    /// Transition to `Cancelled`. See [`Self::set_ready`] for safety.
+    pub unsafe fn set_cancelled(&self) {
+        self.state
+            .store(FutureTag::Cancelled as u8, Ordering::Release);
+    }
+
+    /// Transition to `InternalError`. The `FutureId` retained is the one
+    /// from construction. See [`Self::set_ready`] for safety.
+    pub unsafe fn set_internal_error(&self) {
+        self.state
+            .store(FutureTag::InternalError as u8, Ordering::Release);
+    }
+}
+
+impl Clone for Future {
+    fn clone(&self) -> Self {
+        // Snapshot the current state and clone the corresponding payload.
+        // Used by `deep_copy_value_recursive` and any other site that
+        // duplicates the heap object.
+        let read = self.read();
+        let cloned = Self {
+            state: AtomicU8::new(0), // placeholder; rewritten below
+            future_id: self.future_id,
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+        };
+        let tag: u8 = match read {
+            FutureRead::Pending(_) => FutureTag::Pending as u8,
+            FutureRead::Ready(v) => {
+                // SAFETY: we just constructed `cloned` and have exclusive
+                // access; no other observer exists yet.
+                unsafe { (*cloned.value.get()).write(v) };
+                FutureTag::Ready as u8
+            }
+            FutureRead::Error(v) => {
+                // SAFETY: as above.
+                unsafe { (*cloned.value.get()).write(v) };
+                FutureTag::Error as u8
+            }
+            FutureRead::Cancelled => FutureTag::Cancelled as u8,
+            FutureRead::InternalError(_) => FutureTag::InternalError as u8,
+        };
+        cloned.state.store(tag, Ordering::Release);
+        cloned
+    }
+}
+
+impl std::fmt::Debug for Future {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.read() {
+            FutureRead::Pending(id) => f.debug_tuple("Pending").field(&id).finish(),
+            FutureRead::Ready(v) => f.debug_tuple("Ready").field(&v).finish(),
+            FutureRead::Error(v) => f.debug_tuple("Error").field(&v).finish(),
+            FutureRead::Cancelled => f.write_str("Cancelled"),
+            FutureRead::InternalError(id) => f.debug_tuple("InternalError").field(&id).finish(),
+        }
+    }
 }
 
 /// An operation that should be passed to the engine to be scheduled.
@@ -1153,12 +1372,12 @@ pub enum FutureType {
 
 impl FutureType {
     pub fn of(future: &Future) -> Self {
-        match future {
-            Future::Pending(_) => Self::Pending,
-            Future::Ready(_) => Self::Ready,
-            Future::Error(_) => Self::Error,
-            Future::Cancelled => Self::Cancelled,
-            Future::InternalError(_) => Self::InternalError,
+        match future.read() {
+            FutureRead::Pending(_) => Self::Pending,
+            FutureRead::Ready(_) => Self::Ready,
+            FutureRead::Error(_) => Self::Error,
+            FutureRead::Cancelled => Self::Cancelled,
+            FutureRead::InternalError(_) => Self::InternalError,
         }
     }
 }
@@ -1178,13 +1397,7 @@ impl std::fmt::Display for FutureType {
 
 impl From<&Future> for FutureType {
     fn from(value: &Future) -> Self {
-        match value {
-            Future::Pending(_) => Self::Pending,
-            Future::Ready(_) => Self::Ready,
-            Future::Error(_) => Self::Error,
-            Future::Cancelled => Self::Cancelled,
-            Future::InternalError(_) => Self::InternalError,
-        }
+        Self::of(value)
     }
 }
 

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -31,6 +31,12 @@ pub struct Program {
     pub objects: ObjectPool,
 
     /// Global variables (converted from `ConstValue` to Value at load time).
+    ///
+    /// # Init-only invariant
+    /// Globals are populated by `$init` (top-level let bindings) at engine
+    /// load time and **not** mutated again. The runtime freezes them into a
+    /// shared `Arc<[Value]>` after `$init` finishes; only `$init` may emit a
+    /// `StoreGlobal` against the still-mutable pool. See `Instruction::StoreGlobal`.
     pub globals: Vec<ConstValue>,
 
     /// Maps function names to their object indices.
@@ -892,7 +898,9 @@ impl std::fmt::Display for Object {
                 Future::Ready(value) => write!(f, "<ready: {value}>"),
                 Future::Error(value) => write!(f, "<error: {value}>"),
                 Future::Cancelled => write!(f, "<cancelled>"),
-                Future::InternalError => write!(f, "<internal error>"),
+                Future::InternalError(future) => {
+                    write!(f, "<internal error: future #{}>", future.id)
+                }
             },
             Object::UnscheduledFuture(future) => write!(f, "<unscheduled: {}>", future.operation),
             #[cfg(feature = "heap_debug")]
@@ -922,8 +930,11 @@ pub enum Future {
     Cancelled,
 
     /// An unrecoverable internal error occurred while executing the future.
-    /// To surface this error, the VM should await the future yielding control back to the engine.
-    InternalError,
+    /// The originating `FutureId` is preserved so the VM can yield control back
+    /// to the engine on `Await`, allowing the engine to surface the underlying
+    /// error from the `FutureManager`'s registry. Such entries are leaked from
+    /// `FutureManager::active_futures` by design.
+    InternalError(FutureId),
 }
 
 /// An operation that should be passed to the engine to be scheduled.
@@ -947,11 +958,22 @@ pub struct FutureId {
     id: usize,
 }
 impl FutureId {
-    /// # Safety
+    /// Construct a [`FutureId`] from a raw `usize`.
     ///
-    /// Should only be used by the engine to create new future ids.
-    #[expect(unsafe_code)]
-    pub unsafe fn from_usize(id: usize) -> Self {
+    /// # Contract
+    ///
+    /// Each `FutureId` constructed for a given engine **must** have a `usize`
+    /// value distinct from every other live `FutureId` in that engine. The
+    /// engine satisfies this by issuing values from a monotonic
+    /// [`AtomicUsize`](::core::sync::atomic::AtomicUsize) counter inside its
+    /// `FutureManager`.
+    ///
+    /// Violating this contract does **not** cause memory unsafety, but it
+    /// causes `FutureManager` lookup collisions (two distinct futures sharing
+    /// the same map key, with all the silent data corruption that implies).
+    /// Outside of the engine and its tests, prefer calls that route through
+    /// `FutureManagerGuard::new_future` instead of constructing ids by hand.
+    pub fn from_usize(id: usize) -> Self {
         Self { id }
     }
 
@@ -1136,7 +1158,7 @@ impl FutureType {
             Future::Ready(_) => Self::Ready,
             Future::Error(_) => Self::Error,
             Future::Cancelled => Self::Cancelled,
-            Future::InternalError => Self::InternalError,
+            Future::InternalError(_) => Self::InternalError,
         }
     }
 }
@@ -1161,7 +1183,7 @@ impl From<&Future> for FutureType {
             Future::Ready(_) => Self::Ready,
             Future::Error(_) => Self::Error,
             Future::Cancelled => Self::Cancelled,
-            Future::InternalError => Self::InternalError,
+            Future::InternalError(_) => Self::InternalError,
         }
     }
 }

--- a/baml_language/crates/bridge_cffi/src/ffi/functions.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/functions.rs
@@ -52,7 +52,7 @@ fn bridge_error_to_string(err: &BridgeError) -> String {
 }
 
 fn runtime_error_to_string(err: &bex_project::RuntimeError) -> String {
-    use bex_project::RuntimeError;
+    use bex_project::{BexExternalValue, CANCELLED_PANIC_CLASS, RuntimeError};
     match err {
         RuntimeError::InvalidArgument { .. } => {
             format!("BamlError: BamlInvalidArgumentError: {err}")
@@ -63,7 +63,13 @@ fn runtime_error_to_string(err: &bex_project::RuntimeError) -> String {
                 EngineError::FunctionNotFound { .. } => {
                     format!("BamlError: BamlInvalidArgumentError: {engine_err}")
                 }
-                EngineError::Cancelled => {
+                EngineError::UnhandledThrow { value, .. }
+                    if matches!(
+                        value.as_ref(),
+                        BexExternalValue::Instance { class_name, .. }
+                            if class_name == CANCELLED_PANIC_CLASS
+                    ) =>
+                {
                     format!("BamlError: BamlCancelledError: {engine_err}")
                 }
                 _ => format!("BamlError: BamlClientError: {engine_err}"),

--- a/baml_language/crates/bridge_cffi/src/ffi/functions.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/functions.rs
@@ -52,7 +52,7 @@ fn bridge_error_to_string(err: &BridgeError) -> String {
 }
 
 fn runtime_error_to_string(err: &bex_project::RuntimeError) -> String {
-    use bex_project::{BexExternalValue, CANCELLED_PANIC_CLASS, RuntimeError};
+    use bex_project::RuntimeError;
     match err {
         RuntimeError::InvalidArgument { .. } => {
             format!("BamlError: BamlInvalidArgumentError: {err}")
@@ -63,13 +63,7 @@ fn runtime_error_to_string(err: &bex_project::RuntimeError) -> String {
                 EngineError::FunctionNotFound { .. } => {
                     format!("BamlError: BamlInvalidArgumentError: {engine_err}")
                 }
-                EngineError::UnhandledThrow { value, .. }
-                    if matches!(
-                        value.as_ref(),
-                        BexExternalValue::Instance { class_name, .. }
-                            if class_name == CANCELLED_PANIC_CLASS
-                    ) =>
-                {
+                e if bex_project::is_cancelled_engine_error(e) => {
                     format!("BamlError: BamlCancelledError: {engine_err}")
                 }
                 _ => format!("BamlError: BamlClientError: {engine_err}"),

--- a/baml_language/crates/bridge_nodejs/src/errors.rs
+++ b/baml_language/crates/bridge_nodejs/src/errors.rs
@@ -66,7 +66,7 @@ pub fn bridge_error_to_napi(err: bridge_cffi::error::BridgeError) -> napi::Error
 }
 
 pub fn runtime_error_to_napi(err: bex_project::RuntimeError) -> napi::Error {
-    use bex_project::RuntimeError;
+    use bex_project::{BexExternalValue, CANCELLED_PANIC_CLASS, RuntimeError};
     match &err {
         RuntimeError::InvalidArgument { .. } => napi::Error::new(
             Status::InvalidArg,
@@ -79,10 +79,18 @@ pub fn runtime_error_to_napi(err: bex_project::RuntimeError) -> napi::Error {
                     Status::InvalidArg,
                     format!("BamlError: BamlInvalidArgumentError: {err}"),
                 ),
-                EngineError::Cancelled => napi::Error::new(
-                    Status::Cancelled,
-                    format!("BamlError: BamlCancelledError: {err}"),
-                ),
+                EngineError::UnhandledThrow { value, .. }
+                    if matches!(
+                        value.as_ref(),
+                        BexExternalValue::Instance { class_name, .. }
+                            if class_name == CANCELLED_PANIC_CLASS
+                    ) =>
+                {
+                    napi::Error::new(
+                        Status::Cancelled,
+                        format!("BamlError: BamlCancelledError: {err}"),
+                    )
+                }
                 _ => napi::Error::new(
                     Status::GenericFailure,
                     format!("BamlError: BamlClientError: {err}"),

--- a/baml_language/crates/bridge_nodejs/src/errors.rs
+++ b/baml_language/crates/bridge_nodejs/src/errors.rs
@@ -66,7 +66,7 @@ pub fn bridge_error_to_napi(err: bridge_cffi::error::BridgeError) -> napi::Error
 }
 
 pub fn runtime_error_to_napi(err: bex_project::RuntimeError) -> napi::Error {
-    use bex_project::{BexExternalValue, CANCELLED_PANIC_CLASS, RuntimeError};
+    use bex_project::RuntimeError;
     match &err {
         RuntimeError::InvalidArgument { .. } => napi::Error::new(
             Status::InvalidArg,
@@ -79,18 +79,10 @@ pub fn runtime_error_to_napi(err: bex_project::RuntimeError) -> napi::Error {
                     Status::InvalidArg,
                     format!("BamlError: BamlInvalidArgumentError: {err}"),
                 ),
-                EngineError::UnhandledThrow { value, .. }
-                    if matches!(
-                        value.as_ref(),
-                        BexExternalValue::Instance { class_name, .. }
-                            if class_name == CANCELLED_PANIC_CLASS
-                    ) =>
-                {
-                    napi::Error::new(
-                        Status::Cancelled,
-                        format!("BamlError: BamlCancelledError: {err}"),
-                    )
-                }
+                e if bex_project::is_cancelled_engine_error(e) => napi::Error::new(
+                    Status::Cancelled,
+                    format!("BamlError: BamlCancelledError: {err}"),
+                ),
                 _ => napi::Error::new(
                     Status::GenericFailure,
                     format!("BamlError: BamlClientError: {err}"),

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -66,24 +66,6 @@ pub use wasm_lsp::LspNotification;
 
 static LOGGER_INIT: std::sync::Once = std::sync::Once::new();
 
-/// True if `err` is an unhandled `baml.panics.Cancelled` panic.
-fn is_cancelled_engine_error(err: &bex_project::EngineError) -> bool {
-    matches!(
-        err,
-        bex_project::EngineError::UnhandledThrow { value, .. }
-            if matches!(
-                value.as_ref(),
-                bex_project::BexExternalValue::Instance { class_name, .. }
-                    if class_name == bex_project::CANCELLED_PANIC_CLASS
-            )
-    )
-}
-
-/// True if `err` is a runtime error wrapping a cancellation panic.
-fn is_cancelled_error(err: &bex_project::RuntimeError) -> bool {
-    matches!(err, bex_project::RuntimeError::Engine(e) if is_cancelled_engine_error(e))
-}
-
 /// Initialize the WASM module with panic hook (auto-called by wasm-bindgen).
 #[wasm_bindgen(start)]
 pub fn start() {
@@ -318,7 +300,7 @@ impl BamlWasmRuntime {
 
         // Handle cancellation error.
         let result = result.map_err(|e| -> JsValue {
-            if is_cancelled_error(&e) {
+            if bex_project::is_cancelled_runtime_error(&e) {
                 let err = js_sys::Error::new("Operation cancelled");
                 err.set_name("BamlCancelledError");
                 err.into()
@@ -449,7 +431,7 @@ impl BamlWasmRuntime {
                     .map_err(|e| JsError::new(&format!("Failed to encode result: {e}")))?;
                 Ok(baml_value.encode_to_vec())
             }
-            Err(e) if is_cancelled_engine_error(&e) => {
+            Err(e) if bex_project::is_cancelled_engine_error(&e) => {
                 let error = js_sys::Error::new("Function call was cancelled");
                 error.set_name("BamlCancelledError");
                 Err(error.into())

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -66,6 +66,24 @@ pub use wasm_lsp::LspNotification;
 
 static LOGGER_INIT: std::sync::Once = std::sync::Once::new();
 
+/// True if `err` is an unhandled `baml.panics.Cancelled` panic.
+fn is_cancelled_engine_error(err: &bex_project::EngineError) -> bool {
+    matches!(
+        err,
+        bex_project::EngineError::UnhandledThrow { value, .. }
+            if matches!(
+                value.as_ref(),
+                bex_project::BexExternalValue::Instance { class_name, .. }
+                    if class_name == bex_project::CANCELLED_PANIC_CLASS
+            )
+    )
+}
+
+/// True if `err` is a runtime error wrapping a cancellation panic.
+fn is_cancelled_error(err: &bex_project::RuntimeError) -> bool {
+    matches!(err, bex_project::RuntimeError::Engine(e) if is_cancelled_engine_error(e))
+}
+
 /// Initialize the WASM module with panic hook (auto-called by wasm-bindgen).
 #[wasm_bindgen(start)]
 pub fn start() {
@@ -300,10 +318,7 @@ impl BamlWasmRuntime {
 
         // Handle cancellation error.
         let result = result.map_err(|e| -> JsValue {
-            if matches!(
-                e,
-                bex_project::RuntimeError::Engine(bex_project::EngineError::Cancelled)
-            ) {
+            if is_cancelled_error(&e) {
                 let err = js_sys::Error::new("Operation cancelled");
                 err.set_name("BamlCancelledError");
                 err.into()
@@ -434,7 +449,7 @@ impl BamlWasmRuntime {
                     .map_err(|e| JsError::new(&format!("Failed to encode result: {e}")))?;
                 Ok(baml_value.encode_to_vec())
             }
-            Err(bex_project::EngineError::Cancelled) => {
+            Err(e) if is_cancelled_engine_error(&e) => {
                 let error = js_sys::Error::new("Function call was cancelled");
                 error.set_name("BamlCancelledError");
                 Err(error.into())

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -1456,6 +1456,7 @@ pub type SysOpsBuilder = IoSysOpsBuilder;
 
 #[cfg(test)]
 mod tests {
+    use bex_heap::HeapPermit;
     use bex_vm_types::SysOp;
 
     use super::*;

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -92,7 +92,7 @@ impl std::fmt::Display for CallId {
 
 /// Errors that can occur during external operation execution.
 /// Every error is tied to the operation (`fn_name`) that was being called.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct OpError {
     pub fn_name: SysOp,
     pub kind: OpErrorKind,
@@ -137,7 +137,7 @@ pub use bex_vm_types::{SysOpErrorCategory, SysOpPanicCategory};
 // ============================================================================
 
 /// Errors that can occur during external operation execution.
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error, Clone)]
 pub enum OpErrorKind {
     #[error("Invalid number of arguments: expected {expected}, got {actual}")]
     InvalidArgumentCount { expected: usize, actual: usize },

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -4970,6 +4970,7 @@ fn format_vm_value(value: &bex_vm_types::Value, vm: &bex_vm::BexVm) -> String {
                 Object::Class(c) => format!("<class {}>", c.name),
                 Object::Enum(e) => format!("<enum {}>", e.name),
                 Object::Future(_) => "<future>".to_string(),
+                Object::UnscheduledFuture(_) => "<unscheduled future>".to_string(),
                 Object::Collector(_) => "<collector>".to_string(),
                 Object::Type(ty) => format!("<type: {ty}>"),
                 Object::Closure(c) => format!("<closure captures={}>", c.captures.len()),

--- a/baml_language/sdks/python/rust/bridge_python/src/errors.rs
+++ b/baml_language/sdks/python/rust/bridge_python/src/errors.rs
@@ -101,7 +101,7 @@ pub fn bridge_error_to_py(err: bridge_cffi::error::BridgeError) -> PyErr {
 
 /// Convert a `bex_project::RuntimeError` into a Python exception.
 pub fn runtime_error_to_py(err: bex_project::RuntimeError) -> PyErr {
-    use bex_project::{BexExternalValue, CANCELLED_PANIC_CLASS, RuntimeError};
+    use bex_project::RuntimeError;
 
     match &err {
         RuntimeError::InvalidArgument { .. } => {
@@ -113,13 +113,7 @@ pub fn runtime_error_to_py(err: bex_project::RuntimeError) -> PyErr {
                 EngineError::FunctionNotFound { .. } => {
                     PyErr::new::<BamlInvalidArgumentError, _>(err.to_string())
                 }
-                EngineError::UnhandledThrow { value, .. }
-                    if matches!(
-                        value.as_ref(),
-                        BexExternalValue::Instance { class_name, .. }
-                            if class_name == CANCELLED_PANIC_CLASS
-                    ) =>
-                {
+                e if bex_project::is_cancelled_engine_error(e) => {
                     PyErr::new::<BamlCancelledError, _>(err.to_string())
                 }
                 _ => PyErr::new::<BamlClientError, _>(err.to_string()),

--- a/baml_language/sdks/python/rust/bridge_python/src/errors.rs
+++ b/baml_language/sdks/python/rust/bridge_python/src/errors.rs
@@ -101,7 +101,7 @@ pub fn bridge_error_to_py(err: bridge_cffi::error::BridgeError) -> PyErr {
 
 /// Convert a `bex_project::RuntimeError` into a Python exception.
 pub fn runtime_error_to_py(err: bex_project::RuntimeError) -> PyErr {
-    use bex_project::RuntimeError;
+    use bex_project::{BexExternalValue, CANCELLED_PANIC_CLASS, RuntimeError};
 
     match &err {
         RuntimeError::InvalidArgument { .. } => {
@@ -113,7 +113,15 @@ pub fn runtime_error_to_py(err: bex_project::RuntimeError) -> PyErr {
                 EngineError::FunctionNotFound { .. } => {
                     PyErr::new::<BamlInvalidArgumentError, _>(err.to_string())
                 }
-                EngineError::Cancelled => PyErr::new::<BamlCancelledError, _>(err.to_string()),
+                EngineError::UnhandledThrow { value, .. }
+                    if matches!(
+                        value.as_ref(),
+                        BexExternalValue::Instance { class_name, .. }
+                            if class_name == CANCELLED_PANIC_CLASS
+                    ) =>
+                {
+                    PyErr::new::<BamlCancelledError, _>(err.to_string())
+                }
                 _ => PyErr::new::<BamlClientError, _>(err.to_string()),
             }
         }


### PR DESCRIPTION
We previously had a bug https://github.com/BoundaryML/baml/pull/3409, investigation of which uncovered the issue that futures are VM-scoped, in addition to the bug as described in the PR.
This PR fixes both by overhauling the futures system:
- Futures are now global, registered in `BexEngine`
- The flow now involves: 1. VM creates an `UnscheduledFuture` which it immediately yields to the engine for scheduling. 2. The engine registers and allocates new future and schedules execution with the future (unless it is an early-exit future then it returns immediately). 3. Once the future is completed, it updates the heap future and notifies all waiters.
- Cancellation is now a BAML panic rather than a separate engine error.
- The future registry acts as the root for incomplete futures. They are removed from the registry once completed, at which point the future can be garbage collected if it has no other threads/root havers that reference it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry: report active async futures via new active_future_count.
* **Improvements**
  * Unified async-future lifecycle for more reliable scheduling, cleanup, and concurrency.
  * Globals are frozen after initialization for safer, thread-shared execution.
  * Better GC and write-barrier handling for future-related heap objects.
* **Bug Fixes**
  * Cancellation consistently surfaced as a cancellable panic/exception across runtimes and language bridges.
* **Tests**
  * New and updated tests for futures, cancellation, GC, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->