### PR TITLE
feat: add default max_tokens (8192) for Anthropic provider

### DIFF
--- a/baml_language/crates/bex_engine/tests/build_request.rs
+++ b/baml_language/crates/bex_engine/tests/build_request.rs
@@ -1548,7 +1548,7 @@ function get_body() -> string {
         serde_json::json!({
             "model": "claude-sonnet-4-20250514",
             "anthropic_version": "vertex-2023-10-16",
-            "max_tokens": 4096,
+            "max_tokens": 8192,
             "messages": [
                 {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
                 {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
@@ -1585,7 +1585,7 @@ function get_body() -> string {
         serde_json::json!({
             "model": "claude-sonnet-4-20250514",
             "anthropic_version": "vertex-2023-10-16",
-            "max_tokens": 4096,
+            "max_tokens": 8192,
             "system": [{"type": "text", "text": "You are helpful."}],
             "messages": [
                 {"role": "user", "content": [{"type": "text", "text": "Hi"}]}

--- a/baml_language/crates/sys_llm/src/build_request/anthropic.rs
+++ b/baml_language/crates/sys_llm/src/build_request/anthropic.rs
@@ -66,6 +66,35 @@ struct RequestBody {
 }
 
 // ============================================================================
+// Default max_tokens by model name
+// ============================================================================
+
+/// Returns a sensible default `max_tokens` based on the model identifier.
+///
+/// The Anthropic API requires `max_tokens` and has no server-side default, so
+/// we pick one that matches each model family's documented max output limit.
+fn default_max_tokens_for_model(model: &str) -> i64 {
+    // Opus 4.6+ support up to 128k output tokens.
+    if model.contains("opus-4-6") || model.contains("opus-4-7") {
+        return 128_000;
+    }
+    // Sonnet 4.x and Haiku 4.5 support up to 64k output tokens.
+    if model.contains("sonnet-4") || model.contains("haiku-4-5") {
+        return 64_000;
+    }
+    // Opus 4.0 and 4.1 support up to 32k output tokens.
+    if model.contains("opus-4") {
+        return 32_000;
+    }
+    // Claude 3.5 models supported up to 8192 output tokens.
+    if model.contains("3-5") {
+        return 8_192;
+    }
+    // Fallback for Claude 3 and any unknown models.
+    4_096
+}
+
+// ============================================================================
 // Request builder
 // ============================================================================
 
@@ -78,11 +107,13 @@ pub(crate) fn build_request(
     headers.insert("content-type".to_string(), "application/json".to_string());
     headers.insert("anthropic-version".to_string(), "2023-06-01".to_string());
 
-    // Body
+    // Body — use the user-provided max_tokens, or fall back to a model-aware default.
     let max_tokens = match &client.provider_options {
         Some(crate::baml_std::ProviderOptions::Anthropic(opts)) => opts.max_tokens,
         _ => None,
     };
+    let max_tokens =
+        Some(max_tokens.unwrap_or_else(|| default_max_tokens_for_model(&client.model)));
     let body_str = build_anthropic_body_str(&client.model, prompt, max_tokens, &client.extra_body)?;
 
     Ok(crate::baml_std::HttpRequest {
@@ -729,6 +760,145 @@ mod tests {
                 ]
             })
         );
+    }
+
+    // ========================================================================
+    // default_max_tokens_for_model tests
+    // ========================================================================
+
+    #[test]
+    fn default_max_tokens_opus_4_7() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-opus-4-7-20260301"),
+            128_000
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_opus_4_6() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-opus-4-6-20251001"),
+            128_000
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_sonnet_4_6() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-sonnet-4-6-20260101"),
+            64_000
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_sonnet_4_5() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-sonnet-4-5-20250929"),
+            64_000
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_sonnet_4() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-sonnet-4-20250514"),
+            64_000
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_haiku_4_5() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-haiku-4-5-20251001"),
+            64_000
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_opus_4_1() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-opus-4-1-20250805"),
+            32_000
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_opus_4() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-opus-4-20250514"),
+            32_000
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_claude_3_5_sonnet() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-3-5-sonnet-20241022"),
+            8_192
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_claude_3_5_haiku() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-3-5-haiku-20241022"),
+            8_192
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_claude_3_opus() {
+        assert_eq!(
+            default_max_tokens_for_model("claude-3-opus-20240229"),
+            4_096
+        );
+    }
+
+    #[test]
+    fn default_max_tokens_unknown_model() {
+        assert_eq!(default_max_tokens_for_model("some-unknown-model"), 4_096);
+    }
+
+    // ========================================================================
+    // Integration test: default max_tokens applied when not set by user
+    // ========================================================================
+
+    fn make_client_without_max_tokens(model: &str) -> crate::baml_std::PrimitiveClient {
+        crate::baml_std::PrimitiveClient::new(
+            "test".to_string(),
+            "anthropic".to_string(),
+            crate::baml_std::PrimitiveClientOptions {
+                model: Some(model.to_string()),
+                request_body: IndexMap::new(),
+                base_url: Some("https://api.anthropic.com".to_string()),
+                provider_options: crate::baml_std::AnthropicOptions { max_tokens: None }
+                    .into_bex_external_value(),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn anthropic_default_max_tokens_when_not_specified() {
+        let client = make_client_without_max_tokens("claude-sonnet-4-6-20260101");
+        let prompt = msg("user", "Hello");
+        let result = build_request(&client, &prompt).unwrap();
+        let body: serde_json::Value = serde_json::from_str(&result.body).unwrap();
+        assert_eq!(body["max_tokens"], serde_json::json!(64_000));
+    }
+
+    #[test]
+    fn anthropic_explicit_max_tokens_not_overridden() {
+        let client = make_client(vec![(
+            "model",
+            BexExternalValue::String("claude-sonnet-4-6-20260101".into()),
+        )]);
+        let prompt = msg("user", "Hello");
+        let result = build_request(&client, &prompt).unwrap();
+        let body: serde_json::Value = serde_json::from_str(&result.body).unwrap();
+        // make_client sets max_tokens: Some(4096), so it should stay 4096 not 64000
+        assert_eq!(body["max_tokens"], serde_json::json!(4096));
     }
 
     #[test]

--- a/baml_language/crates/sys_llm/src/build_request/anthropic.rs
+++ b/baml_language/crates/sys_llm/src/build_request/anthropic.rs
@@ -71,7 +71,7 @@ struct RequestBody {
 /// 8 192 is a safe middle ground: large enough for most structured outputs,
 /// small enough to avoid non-streaming timeout errors from the Anthropic SDK
 /// (which rejects requests estimated to take >10 minutes).
-const DEFAULT_MAX_TOKENS: i64 = 8_192;
+pub(super) const DEFAULT_MAX_TOKENS: i64 = 8_192;
 
 // ============================================================================
 // Request builder

--- a/baml_language/crates/sys_llm/src/build_request/anthropic.rs
+++ b/baml_language/crates/sys_llm/src/build_request/anthropic.rs
@@ -65,34 +65,13 @@ struct RequestBody {
     extra: serde_json::Map<String, serde_json::Value>,
 }
 
-// ============================================================================
-// Default max_tokens by model name
-// ============================================================================
-
-/// Returns a sensible default `max_tokens` based on the model identifier.
+/// Default `max_tokens` when the user does not specify one.
 ///
-/// The Anthropic API requires `max_tokens` and has no server-side default, so
-/// we pick one that matches each model family's documented max output limit.
-fn default_max_tokens_for_model(model: &str) -> i64 {
-    // Opus 4.6+ support up to 128k output tokens.
-    if model.contains("opus-4-6") || model.contains("opus-4-7") {
-        return 128_000;
-    }
-    // Sonnet 4.x and Haiku 4.5 support up to 64k output tokens.
-    if model.contains("sonnet-4") || model.contains("haiku-4-5") {
-        return 64_000;
-    }
-    // Opus 4.0 and 4.1 support up to 32k output tokens.
-    if model.contains("opus-4") {
-        return 32_000;
-    }
-    // Claude 3.5 models supported up to 8192 output tokens.
-    if model.contains("3-5") {
-        return 8_192;
-    }
-    // Fallback for Claude 3 and any unknown models.
-    4_096
-}
+/// The Anthropic API requires `max_tokens` and has no server-side default.
+/// 8 192 is a safe middle ground: large enough for most structured outputs,
+/// small enough to avoid non-streaming timeout errors from the Anthropic SDK
+/// (which rejects requests estimated to take >10 minutes).
+const DEFAULT_MAX_TOKENS: i64 = 8_192;
 
 // ============================================================================
 // Request builder
@@ -107,13 +86,12 @@ pub(crate) fn build_request(
     headers.insert("content-type".to_string(), "application/json".to_string());
     headers.insert("anthropic-version".to_string(), "2023-06-01".to_string());
 
-    // Body — use the user-provided max_tokens, or fall back to a model-aware default.
+    // Body — use the user-provided max_tokens, or fall back to a safe default.
     let max_tokens = match &client.provider_options {
         Some(crate::baml_std::ProviderOptions::Anthropic(opts)) => opts.max_tokens,
         _ => None,
     };
-    let max_tokens =
-        Some(max_tokens.unwrap_or_else(|| default_max_tokens_for_model(&client.model)));
+    let max_tokens = Some(max_tokens.unwrap_or(DEFAULT_MAX_TOKENS));
     let body_str = build_anthropic_body_str(&client.model, prompt, max_tokens, &client.extra_body)?;
 
     Ok(crate::baml_std::HttpRequest {
@@ -763,104 +741,7 @@ mod tests {
     }
 
     // ========================================================================
-    // default_max_tokens_for_model tests
-    // ========================================================================
-
-    #[test]
-    fn default_max_tokens_opus_4_7() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-opus-4-7-20260301"),
-            128_000
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_opus_4_6() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-opus-4-6-20251001"),
-            128_000
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_sonnet_4_6() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-sonnet-4-6-20260101"),
-            64_000
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_sonnet_4_5() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-sonnet-4-5-20250929"),
-            64_000
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_sonnet_4() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-sonnet-4-20250514"),
-            64_000
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_haiku_4_5() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-haiku-4-5-20251001"),
-            64_000
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_opus_4_1() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-opus-4-1-20250805"),
-            32_000
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_opus_4() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-opus-4-20250514"),
-            32_000
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_claude_3_5_sonnet() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-3-5-sonnet-20241022"),
-            8_192
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_claude_3_5_haiku() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-3-5-haiku-20241022"),
-            8_192
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_claude_3_opus() {
-        assert_eq!(
-            default_max_tokens_for_model("claude-3-opus-20240229"),
-            4_096
-        );
-    }
-
-    #[test]
-    fn default_max_tokens_unknown_model() {
-        assert_eq!(default_max_tokens_for_model("some-unknown-model"), 4_096);
-    }
-
-    // ========================================================================
-    // Integration test: default max_tokens applied when not set by user
+    // default max_tokens tests
     // ========================================================================
 
     fn make_client_without_max_tokens(model: &str) -> crate::baml_std::PrimitiveClient {
@@ -885,7 +766,7 @@ mod tests {
         let prompt = msg("user", "Hello");
         let result = build_request(&client, &prompt).unwrap();
         let body: serde_json::Value = serde_json::from_str(&result.body).unwrap();
-        assert_eq!(body["max_tokens"], serde_json::json!(64_000));
+        assert_eq!(body["max_tokens"], serde_json::json!(8192));
     }
 
     #[test]
@@ -897,7 +778,7 @@ mod tests {
         let prompt = msg("user", "Hello");
         let result = build_request(&client, &prompt).unwrap();
         let body: serde_json::Value = serde_json::from_str(&result.body).unwrap();
-        // make_client sets max_tokens: Some(4096), so it should stay 4096 not 64000
+        // make_client sets max_tokens: Some(4096), so it should stay 4096
         assert_eq!(body["max_tokens"], serde_json::json!(4096));
     }
 

--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -101,7 +101,7 @@ fn build_vertex_anthropic_request(
     let max_tokens = extra
         .remove("max_tokens")
         .and_then(|v| v.as_i64())
-        .or(Some(4096));
+        .or(Some(anthropic::DEFAULT_MAX_TOKENS));
 
     let body_str = anthropic::build_anthropic_body_str(&client.model, prompt, max_tokens, &extra)?;
 
@@ -1242,7 +1242,7 @@ mod tests {
             serde_json::json!({
                 "model": "claude-sonnet-4-20250514",
                 "anthropic_version": "vertex-2023-10-16",
-                "max_tokens": 4096,
+                "max_tokens": 8192,
                 "system": [{"type": "text", "text": "You are helpful."}],
                 "messages": [
                     {"role": "user", "content": [{"type": "text", "text": "Hi"}]},


### PR DESCRIPTION
## Summary
- The Anthropic API requires `max_tokens` but has no server-side default — requests fail without it.
- Added a flat `DEFAULT_MAX_TOKENS = 8192` constant that is used when the user doesn't explicitly set `max_tokens`.
- 8192 is a safe middle ground: large enough for most structured outputs, small enough to avoid non-streaming timeout errors from the Anthropic SDK (which rejects requests estimated to take >10 minutes).
- Explicit user-provided `max_tokens` is always respected and never overridden.

## Test plan
- [x] Integration test verifying default 8192 is applied when `max_tokens` is not set
- [x] Integration test verifying explicit `max_tokens` is not overridden
- [x] All 53 existing + new anthropic tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic & Vertex AI requests now default to a sensible max_tokens value (8192) when not explicitly configured, ensuring requests always include a token limit.
* **Tests**
  * Added tests verifying defaulting behavior and that explicitly set max_tokens values (e.g., 4096) remain unchanged to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->