### PR TITLE
fix: recognize \\ as escaped backslash in string literals

### DIFF
--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -1362,10 +1362,8 @@ impl<'a> Parser<'a> {
 
                 if p.at_raw(TokenKind::Backslash) {
                     p.bump_raw(); // Consume backslash
-                    if let Some(directly_after) = p.tokens.get(p.current)
-                        && directly_after.kind == TokenKind::Quote
-                    {
-                        p.bump_raw(); // Consume quote without ending string
+                    if p.current < p.tokens.len() {
+                        p.bump_raw(); // Consume the escaped character (whatever it is)
                     }
                     continue;
                 }
@@ -1428,10 +1426,8 @@ impl<'a> Parser<'a> {
 
                 if p.at_raw(TokenKind::Backslash) {
                     p.bump_raw(); // Consume backslash
-                    if let Some(directly_after) = p.tokens.get(p.current)
-                        && directly_after.kind == TokenKind::Quote
-                    {
-                        p.bump_raw(); // Consume escaped quote
+                    if p.current < p.tokens.len() {
+                        p.bump_raw(); // Consume the escaped character (whatever it is)
                     }
                     continue;
                 }

--- a/baml_language/crates/baml_tests/src/string_literals.rs
+++ b/baml_language/crates/baml_tests/src/string_literals.rs
@@ -32,6 +32,19 @@ function json_body() -> string {
 // Raw strings must NOT unescape — they should round-trip byte-for-byte.
 function raw_keeps_backslash_n() -> string { #"a\nb"# }
 function raw_keeps_quote() -> string { ##"""##  }
+
+// Escaped backslash at string boundary — the minimal repro for the \\-before-closing-quote bug.
+function lone_backslash() -> string { "\\" }
+function lone_backslash_length() -> int { "\\".length() }
+function double_backslash() -> string { "\\\\" }
+function double_backslash_length() -> int { "\\\\".length() }
+function trailing_double_backslash() -> string { "a\\\\" }
+function trailing_double_backslash_length() -> int { "a\\\\".length() }
+function replace_backslash() -> string { "a\\b\\c".replaceAll("\\", "/") }
+
+// Raw strings with backslash sequences — must preserve them verbatim.
+function raw_double_backslash() -> string { #"\\"# }
+function raw_quad_backslash() -> string { #"\\\\"# }
 "####;
 
     macro_rules! run_str {
@@ -92,5 +105,79 @@ function raw_keeps_quote() -> string { ##"""##  }
         // backslashes and quotes verbatim or the workaround breaks too.
         assert_eq!(run_str!("raw_keeps_backslash_n"), "a\\nb");
         assert_eq!(run_str!("raw_keeps_quote"), "\"");
+    }
+
+    // ── Escaped backslash at string boundary ────────────────────────────
+
+    #[tokio::test]
+    async fn escaped_backslash_at_string_boundary() {
+        // "\\" must parse as a single backslash character.
+        assert_eq!(run_str!("lone_backslash"), "\\");
+        // "\\\\" must parse as two backslashes.
+        assert_eq!(run_str!("double_backslash"), "\\\\");
+        // "a\\\\" must parse as 'a' followed by two backslashes.
+        assert_eq!(run_str!("trailing_double_backslash"), "a\\\\");
+    }
+
+    #[tokio::test]
+    async fn escaped_backslash_boundary_lengths() {
+        assert_eq!(run_int!("lone_backslash_length"), 1);
+        assert_eq!(run_int!("double_backslash_length"), 2);
+        assert_eq!(run_int!("trailing_double_backslash_length"), 3);
+    }
+
+    #[tokio::test]
+    async fn replace_all_with_backslash_arguments() {
+        // replaceAll("\\", "/") should replace each backslash with a forward slash.
+        assert_eq!(run_str!("replace_backslash"), "a/b/c");
+    }
+
+    // ── Raw strings preserve backslash sequences verbatim ───────────────
+
+    #[tokio::test]
+    async fn raw_strings_preserve_backslash_sequences() {
+        // #"\\"# contains two literal characters: \ and \
+        assert_eq!(run_str!("raw_double_backslash"), "\\\\");
+        // #"\\\\"# contains four literal characters: \ \ \ \
+        assert_eq!(run_str!("raw_quad_backslash"), "\\\\\\\\");
+    }
+
+    // ── Negative tests: invalid strings must still produce errors ───────
+
+    #[test]
+    fn invalid_strings_still_produce_errors() {
+        use baml_compiler_diagnostics::Severity;
+        use baml_project::{collect_diagnostics, testing::setup_test_db};
+
+        let cases = [
+            // Unterminated string — no closing quote at all
+            (
+                r#"function f() -> string { "hello }"#,
+                "unterminated string",
+            ),
+            // Backslash at EOF — backslash escapes nothing, string never closes
+            (r#"function f() -> string { "hello\"#, "backslash at EOF"),
+            // Escaped quote with no closing quote — \" eats the quote
+            (
+                r#"function f() -> string { "hello\"}"#,
+                "escaped quote eats closing quote",
+            ),
+        ];
+
+        for (source, label) in &cases {
+            let db = setup_test_db(source);
+            let project = db.get_project().expect("project must be set");
+            let all_files = db.get_source_files();
+            let diagnostics = collect_diagnostics(&db, project, &all_files);
+            let has_error = diagnostics
+                .iter()
+                .any(|d| matches!(d.severity, Severity::Error));
+            assert!(
+                has_error,
+                "Expected compilation error for case '{}', but got none.\nDiagnostics: {:?}",
+                label,
+                diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fix parser bug where `\\` before a closing quote was misinterpreted as `\"` (escaped quote), causing `"\\"` to produce an "unclosed string literal" error
- The parser now unconditionally consumes the character after a backslash in both `parse_string()` and `parse_byte_string()`, matching standard escape semantics
- The downstream `unescape_string_literal()` already handled `\\` → `\` correctly — this was purely a parser string-boundary detection bug

## Test plan

- [x] New tests for escaped backslash at string boundary: `"\\"` → `\`, `"\\\\"` → `\\`, `"a\\\\"` → `a\\`
- [x] New length tests: `"\\".length()` → 1, `"\\\\".length()` → 2, etc.
- [x] New `replaceAll` test: `"a\\b\\c".replaceAll("\\", "/")` → `"a/b/c"`
- [x] New raw string tests confirm no regression: `#"\\"#` preserves `\\` verbatim
- [x] New negative tests confirm invalid strings still produce errors (unterminated, backslash at EOF, escaped quote with no closing quote)
- [x] All 1860+ existing tests pass with zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escape sequence handling in strings and byte-strings, particularly for backslash escapes and boundary conditions. Parser now correctly processes escape sequences in all contexts.

* **Tests**
  * Expanded regression test suite for string literals, adding edge-case scenarios including escaped backslashes, multiple escapes, and error detection for malformed strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->