### PR TITLE
fix: preserve `.0` in float-to-string conversion

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1650,6 +1650,7 @@ version = "0.0.0-beta"
 dependencies = [
  "baml_type",
  "bex_external_types",
+ "bex_vm_types",
  "derive_more",
  "indexmap 2.13.0",
  "log",

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -1567,14 +1567,7 @@ fn format_value(value: &BexExternalValue) -> String {
     match value {
         BexExternalValue::Null => "null".to_string(),
         BexExternalValue::Int(i) => i.to_string(),
-        BexExternalValue::Float(f) => {
-            let s = f.to_string();
-            if s.contains('.') || !f.is_finite() {
-                s
-            } else {
-                format!("{s}.0")
-            }
-        }
+        BexExternalValue::Float(f) => bex_vm_types::format_float(*f),
         BexExternalValue::Bool(b) => b.to_string(),
         BexExternalValue::String(s) => format!("{s:?}"),
         BexExternalValue::Array { items, .. } => {

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -1127,13 +1127,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             Constant::Float(v) => {
                 let idx = self.add_constant(ConstValue::Float(*v));
                 let inst = self.emit(Instruction::LoadConst(idx));
-                let s = v.to_string();
-                let display = if s.contains('.') || !v.is_finite() {
-                    s
-                } else {
-                    format!("{s}.0")
-                };
-                self.set_operand(inst, OperandMeta::Const(display));
+                self.set_operand(inst, OperandMeta::Const(bex_vm_types::format_float(*v)));
             }
             Constant::String(s) => {
                 let display = Self::display_string_operand(s);

--- a/baml_language/crates/baml_tests/tests/builtins.rs
+++ b/baml_language/crates/baml_tests/tests/builtins.rs
@@ -134,3 +134,24 @@ async fn any_value_to_string() {
         ))
     );
 }
+
+#[tokio::test]
+async fn float_to_string_preserves_decimal() {
+    let output = baml_test!(
+        r#"
+        function main() -> string {
+            let a = baml.unstable.string(1.0);
+            let b = baml.unstable.string(0.0);
+            let c = baml.unstable.string(-1.0);
+            let d = baml.unstable.string(3.14);
+            let e = baml.unstable.string(2);
+            a + " " + b + " " + c + " " + d + " " + e
+        }
+    "#
+    );
+
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("1.0 0.0 -1.0 3.14 2".to_string()))
+    );
+}

--- a/baml_language/crates/bex_events/Cargo.toml
+++ b/baml_language/crates/bex_events/Cargo.toml
@@ -20,15 +20,13 @@ workspace = true
 [dependencies]
 baml_builtins2 = { workspace = true }
 bex_external_types = { workspace = true }
+bex_vm_types = { workspace = true }
 sys_types = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 web-time = { workspace = true }
-
-[dev-dependencies]
-bex_vm_types = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = [ "js" ] }

--- a/baml_language/crates/bex_events/src/serialize.rs
+++ b/baml_language/crates/bex_events/src/serialize.rs
@@ -438,13 +438,7 @@ fn bex_value_to_debug_impl(value: &BexExternalValue, depth: usize) -> String {
         BexExternalValue::Null => "null".to_string(),
         BexExternalValue::Bool(b) => b.to_string(),
         BexExternalValue::Int(i) => i.to_string(),
-        BexExternalValue::Float(f) => {
-            if f.fract() == 0.0 {
-                format!("{f:.1}")
-            } else {
-                f.to_string()
-            }
-        }
+        BexExternalValue::Float(f) => bex_vm_types::format_float(*f),
         BexExternalValue::String(s) => format!("{s:?}"),
         BexExternalValue::Array { items, .. } => {
             if items.is_empty() {

--- a/baml_language/crates/bex_sap/Cargo.toml
+++ b/baml_language/crates/bex_sap/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 baml_type = { workspace = true }
 bex_external_types = { workspace = true }
+bex_vm_types = { workspace = true }
 sys_types = { workspace = true }
 derive_more = { workspace = true }
 indexmap = { workspace = true }

--- a/baml_language/crates/bex_sap/src/deserializer/types.rs
+++ b/baml_language/crates/bex_sap/src/deserializer/types.rs
@@ -292,7 +292,7 @@ impl<N: TypeIdent> std::fmt::Display for BamlValueWithFlags<'_, '_, '_, N> {
                 write!(f, "{}", i.value)?;
             }
             BamlValue::Float(fl) => {
-                write!(f, "{}", fl.value)?;
+                write!(f, "{}", bex_vm_types::format_float(fl.value))?;
             }
             BamlValue::Bool(b) => {
                 write!(f, "{}", b.value)?;

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -246,7 +246,7 @@ fn display_const_value(value: &bex_vm_types::ConstValue, objects: Option<&Object
     match value {
         bex_vm_types::ConstValue::Null => "null".to_string(),
         bex_vm_types::ConstValue::Int(i) => i.to_string(),
-        bex_vm_types::ConstValue::Float(f) => f.to_string(),
+        bex_vm_types::ConstValue::Float(f) => bex_vm_types::format_float(*f),
         bex_vm_types::ConstValue::Bool(b) => b.to_string(),
         bex_vm_types::ConstValue::Object(idx) => {
             if let Some(objs) = objects {

--- a/baml_language/crates/bex_vm/src/package_baml/unstable.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/unstable.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use bex_vm_types::types::{Object, Value};
+use bex_vm_types::types::{Object, Value, format_float};
 
 use super::{BamlNamespaceUnstable, PackageBamlImpl};
 use crate::{
@@ -28,7 +28,7 @@ fn format_value_recursive(
     match value {
         Value::Null => Ok("null".to_string()),
         Value::Int(i) => Ok(i.to_string()),
-        Value::Float(f) => Ok(f.to_string()),
+        Value::Float(f) => Ok(format_float(*f)),
         Value::Bool(b) => Ok(b.to_string()),
 
         Value::Object(obj_idx) => match vm.get_object(*obj_idx) {

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -28,7 +28,7 @@ pub use types::{
     EnumVariant, Function, FunctionKind, FunctionMeta, FunctionOrigin, Future, Instance,
     MediaValue, Object, ObjectType, PanicClass, PendingFuture, Program, PromptAst, RetryPolicyMeta,
     SysOp, SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase, Value, Variant,
-    sys_op_for_path, type_tags,
+    format_float, sys_op_for_path, type_tags,
 };
 
 /// Used to check if the VM should yield early.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -549,11 +549,34 @@ impl std::fmt::Display for Value {
         match self {
             Value::Null => write!(f, "null"),
             Value::Int(int) => write!(f, "{int}"),
-            Value::Float(float) => write!(f, "{float}"),
+            Value::Float(float) => write!(f, "{}", format_float(*float)),
             Value::Bool(bool) => write!(f, "{bool}"),
             Value::Object(ptr) => write!(f, "{ptr}"),
         }
     }
+}
+
+/// Format an f64 to string, following JS/TS conventions for special values
+/// and preserving `.0` for whole-number floats.
+///
+/// - `1.0` → `"1.0"` (not `"1"` — preserves float identity)
+/// - `3.14` → `"3.14"`
+/// - `f64::INFINITY` → `"Infinity"` (JS-style)
+/// - `f64::NEG_INFINITY` → `"-Infinity"` (JS-style)
+/// - `f64::NAN` → `"NaN"` (JS-style)
+pub fn format_float(f: f64) -> String {
+    if f.is_nan() {
+        return "NaN".to_string();
+    }
+    if f.is_infinite() {
+        return if f.is_sign_positive() {
+            "Infinity".to_string()
+        } else {
+            "-Infinity".to_string()
+        };
+    }
+    let s = f.to_string();
+    if s.contains('.') { s } else { format!("{s}.0") }
 }
 
 // Error class / instance enums — generated from `errors.baml` class definitions.
@@ -996,5 +1019,30 @@ impl From<&Future> for FutureType {
             Future::Pending(_) => Self::Pending,
             Future::Ready(_) => Self::Ready,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_float;
+
+    #[test]
+    fn test_format_float() {
+        // Whole-number floats must include ".0"
+        assert_eq!(format_float(0.0), "0.0");
+        assert_eq!(format_float(1.0), "1.0");
+        assert_eq!(format_float(-1.0), "-1.0");
+        assert_eq!(format_float(100.0), "100.0");
+        assert_eq!(format_float(999_999_999_999_999.0), "999999999999999.0");
+
+        // Fractional floats unchanged
+        assert_eq!(format_float(2.5), "2.5");
+        assert_eq!(format_float(0.1), "0.1");
+        assert_eq!(format_float(-0.001), "-0.001");
+
+        // Non-finite values: JS-style names, no ".0"
+        assert_eq!(format_float(f64::INFINITY), "Infinity");
+        assert_eq!(format_float(f64::NEG_INFINITY), "-Infinity");
+        assert_eq!(format_float(f64::NAN), "NaN");
     }
 }

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -4953,7 +4953,7 @@ fn format_vm_value(value: &bex_vm_types::Value, vm: &bex_vm::BexVm) -> String {
     match value {
         Value::Null => "null".to_string(),
         Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
+        Value::Float(f) => bex_vm_types::format_float(*f),
         Value::Bool(b) => b.to_string(),
         Value::Object(idx) => {
             let obj = vm.get_object(*idx);


### PR DESCRIPTION
## Summary

- `baml.unstable.string(1.0)` was returning `"1"` instead of `"1.0"`, silently destroying float type identity (indistinguishable from `baml.unstable.string(1)`)
- Added a canonical `format_float(f64) -> String` in `bex_vm_types` that preserves `.0` for whole-number floats and uses JS-style names for special values (`Infinity`, `-Infinity`, `NaN`)
- Replaced 8 duplicated/broken float formatting sites across the codebase (`bex_vm`, `baml_cli`, `baml_compiler2_emit`, `bex_events`, `bex_sap`, `tools_onionskin`) with calls to the shared function
- `baml_compiler2_tir` keeps its own local `format_float` because stow policy forbids it from depending on `bex_vm_types`

## Test plan

- [x] Unit test for `format_float` covering whole numbers, fractionals, `Infinity`, `-Infinity`, `NaN`
- [x] Integration test: `baml.unstable.string()` end-to-end for `1.0`, `0.0`, `-1.0`, `3.14`, and int `2`
- [x] Full `cargo test -p baml_tests` suite (1390+ tests) passes with no regressions
- [x] Pre-commit hooks (fmt, clippy, stow) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floating-point number formatting inconsistencies across all outputs. Float values now consistently display with decimal points (e.g., `1.0` instead of `1`), and special values like `NaN` and `Infinity` are properly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->