### PR TITLE
Add Non-Blocking Format Hints to BAML Run

### DIFF
--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -46,7 +46,7 @@ pub(crate) enum Commands {
 
     // #[command(about = "Login to Boundary Cloud (alias for `baml auth login`)", hide = true)]
     // Login(crate::auth::LoginArgs),
-    #[command(about = "Format BAML source files", name = "fmt", hide = true)]
+    #[command(about = "Format BAML source files", name = "fmt")]
     Format(crate::format::FormatArgs),
 
     // #[command(about = "Run BAML tests")]

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -3355,6 +3355,56 @@ hidden = "--function $init_test"
         (tmp, args)
     }
 
+    #[test]
+    fn run_does_not_mutate_unformatted_project_sources() {
+        let (tmp, mut args) = e2e_project("function main()->string {\n\"ok\"\n}\n");
+        let baml_path = tmp.path().join("baml_src").join("main.baml");
+        let original = std::fs::read_to_string(&baml_path).unwrap();
+        args.function = Some(s("main"));
+
+        let exit = args.run().expect("run should not hard-fail");
+
+        assert!(matches!(exit, crate::ExitCode::Success));
+        assert_eq!(std::fs::read_to_string(&baml_path).unwrap(), original);
+    }
+
+    #[test]
+    fn standalone_run_does_not_mutate_unformatted_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("hello.baml");
+        let original = "function main()->string {\n\"hello\"\n}\n";
+        std::fs::write(&file, original).unwrap();
+
+        let mut args = run_args();
+        args.from = tmp.path().to_path_buf();
+        args.target = Some(file.to_string_lossy().into_owned());
+
+        let exit = args.run().expect("run should not hard-fail");
+
+        assert!(matches!(exit, crate::ExitCode::Success));
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), original);
+    }
+
+    #[test]
+    fn expression_run_does_not_mutate_project_sources_for_format_hints() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("baml.toml"), "").unwrap();
+        let src = tmp.path().join("baml_src");
+        std::fs::create_dir_all(&src).unwrap();
+        let file = src.join("foo.baml");
+        let original = "class Foo { x int }\n";
+        std::fs::write(&file, original).unwrap();
+
+        let mut args = run_args();
+        args.from = tmp.path().to_path_buf();
+        args.expression = Some(s("Foo { x: 1 }"));
+
+        let exit = args.run().expect("run should not hard-fail");
+
+        assert!(matches!(exit, crate::ExitCode::Success));
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), original);
+    }
+
     /// `--function FN` runs the named function end-to-end.
     #[test]
     fn test_run_function_flag_e2e() {

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -162,6 +162,12 @@ pub enum OutputFormat {
 // ============================================================================
 
 impl RunArgs {
+    fn emit_format_hint_if_needed(needs_format_hint: bool) {
+        if needs_format_hint {
+            println!("{FORMAT_HINT}");
+        }
+    }
+
     /// Print a `[verbose]`-prefixed line when `--verbose` is set; no-op otherwise.
     fn vlog(&self, args: std::fmt::Arguments<'_>) {
         if self.verbose {
@@ -274,16 +280,18 @@ impl RunArgs {
 
         let argv = self.build_argv();
 
-        let (db, engine) = if self.target.as_ref().is_some_and(|t| t.ends_with(".baml")) {
-            self.load_and_compile_standalone(
-                self.target.as_ref().unwrap(),
-                event_sink.clone(),
-                argv,
-            )?
-        } else {
-            self.load_and_compile(event_sink.clone(), argv)?
-        };
+        let (db, engine, needs_format_hint) =
+            if self.target.as_ref().is_some_and(|t| t.ends_with(".baml")) {
+                self.load_and_compile_standalone(
+                    self.target.as_ref().unwrap(),
+                    event_sink.clone(),
+                    argv,
+                )?
+            } else {
+                self.load_and_compile(event_sink.clone(), argv)?
+            };
         let _ = db; // keep db alive for engine lifetime
+        Self::emit_format_hint_if_needed(needs_format_hint);
 
         let toml_content = std::fs::read_to_string(self.from.join("baml.toml")).unwrap_or_default();
         let scripts = Self::parse_scripts(&toml_content);
@@ -412,13 +420,18 @@ impl RunArgs {
         &self,
         event_sink: Option<Arc<dyn bex_events::EventSink>>,
         argv: Vec<String>,
-    ) -> Result<(ProjectDatabase, BexEngine)> {
+    ) -> Result<(ProjectDatabase, BexEngine, bool)> {
         let (db, from, baml_files) = load_project_from(&self.from)?;
         self.vlog(format_args!("Loading project from {}", from.display()));
         if baml_files.is_empty() {
             anyhow::bail!("No .baml files found in {}", from.display());
         }
         self.vlog(format_args!("Found {} .baml file(s)", baml_files.len()));
+        let needs_format_hint = baml_files.iter().any(|path| {
+            std::fs::read_to_string(path)
+                .map(|source| source_needs_format_hint(&source))
+                .unwrap_or(false)
+        });
 
         self.check_project_diagnostics(&db, "Cannot run: compilation errors found")?;
         self.vlog(format_args!("Compiling..."));
@@ -427,7 +440,7 @@ impl RunArgs {
             "Compiled {} user function(s)",
             engine.user_functions().len()
         ));
-        Ok((db, engine))
+        Ok((db, engine, needs_format_hint))
     }
 
     /// Load a single .baml file in hermetic standalone mode.
@@ -439,7 +452,7 @@ impl RunArgs {
         file_path: &str,
         event_sink: Option<Arc<dyn bex_events::EventSink>>,
         argv: Vec<String>,
-    ) -> Result<(ProjectDatabase, BexEngine)> {
+    ) -> Result<(ProjectDatabase, BexEngine, bool)> {
         let canonical = std::fs::canonicalize(Path::new(file_path))
             .with_context(|| format!("File not found: {file_path}"))?;
         self.vlog(format_args!(
@@ -449,6 +462,7 @@ impl RunArgs {
 
         let content = std::fs::read_to_string(&canonical)
             .with_context(|| format!("Failed to read {}", canonical.display()))?;
+        let needs_format_hint = source_needs_format_hint(&content);
 
         // Project root is the file's parent so relative imports resolve.
         let parent = canonical.parent().unwrap_or_else(|| Path::new("."));
@@ -466,7 +480,7 @@ impl RunArgs {
             "Compiled {} function(s) from standalone file",
             engine.user_functions().len()
         ));
-        Ok((db, engine))
+        Ok((db, engine, needs_format_hint))
     }
 
     // ========================================================================
@@ -1143,6 +1157,16 @@ impl RunArgs {
 // Reserved verbs & namespace helpers
 // ============================================================================
 
+const FORMAT_HINT: &str = "[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml format`.";
+
+fn source_needs_format_hint(source: &str) -> bool {
+    let options = baml_fmt::FormatOptions::default();
+    match baml_fmt::format(source, &options) {
+        Ok(formatted) => formatted != source,
+        Err(_) => false,
+    }
+}
+
 /// BEP-027 Appendix A: names that cannot be used as `[scripts]` keys.
 const RESERVED_VERBS: &[&str] = &[
     "run", "test", "repl", "init", "help", "version", "fmt", "lint", "check", "build", "generate",
@@ -1657,6 +1681,32 @@ mod tests {
         Ty::Bool {
             attr: Default::default(),
         }
+    }
+
+    #[test]
+    fn source_needs_format_hint_returns_false_for_formatted_source() {
+        let source = "function main() -> string {\n    \"ok\"\n}\n";
+        assert!(!source_needs_format_hint(source));
+    }
+
+    #[test]
+    fn source_needs_format_hint_returns_true_for_unformatted_source() {
+        let source = "function main()->string {\n\"ok\"\n}\n";
+        assert!(source_needs_format_hint(source));
+    }
+
+    #[test]
+    fn source_needs_format_hint_returns_false_on_formatter_error() {
+        let source = "function main( -> string {";
+        assert!(!source_needs_format_hint(source));
+    }
+
+    #[test]
+    fn format_hint_text_matches_ticket() {
+        assert_eq!(
+            FORMAT_HINT,
+            "[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml format`."
+        );
     }
 
     // Tests that touch the filesystem build paths under $TMPDIR. Appending
@@ -3058,7 +3108,7 @@ mod tests {
         args.from = project.to_path_buf();
         args.target = Some(s("eval"));
 
-        let (_db, engine) = args
+        let (_db, engine, _needs_format_hint) = args
             .load_and_compile(None, Vec::new())
             .expect("compile should succeed");
         match args.resolve_target(&engine, &no_scripts()).unwrap() {
@@ -3096,7 +3146,8 @@ backfill = "--function scripts.Backfill"
         let mut args_dev = run_args();
         args_dev.from = project.to_path_buf();
         args_dev.target = Some(s("dev"));
-        let (_db, engine) = args_dev.load_and_compile(None, Vec::new()).unwrap();
+        let (_db, engine, _needs_format_hint) =
+            args_dev.load_and_compile(None, Vec::new()).unwrap();
         let toml = std::fs::read_to_string(project.join("baml.toml")).unwrap();
         let scripts = RunArgs::parse_scripts(&toml);
         match args_dev.resolve_target(&engine, &scripts).unwrap() {
@@ -3111,7 +3162,7 @@ backfill = "--function scripts.Backfill"
         let mut args_bf = run_args();
         args_bf.from = project.to_path_buf();
         args_bf.target = Some(s("backfill"));
-        let (_db, engine) = args_bf.load_and_compile(None, Vec::new()).unwrap();
+        let (_db, engine, _needs_format_hint) = args_bf.load_and_compile(None, Vec::new()).unwrap();
         match args_bf.resolve_target(&engine, &scripts).unwrap() {
             ResolvedTarget::Script(expansion) => {
                 assert_eq!(expansion.function.as_deref(), Some("scripts.Backfill"));

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -1157,7 +1157,7 @@ impl RunArgs {
 // Reserved verbs & namespace helpers
 // ============================================================================
 
-const FORMAT_HINT: &str = "[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml format`.";
+const FORMAT_HINT: &str = "[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml fmt`.";
 
 fn source_needs_format_hint(source: &str) -> bool {
     let options = baml_fmt::FormatOptions::default();
@@ -1705,7 +1705,7 @@ mod tests {
     fn format_hint_text_matches_ticket() {
         assert_eq!(
             FORMAT_HINT,
-            "[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml format`."
+            "[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml fmt`."
         );
     }
 

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -164,7 +164,7 @@ pub enum OutputFormat {
 impl RunArgs {
     fn emit_format_hint_if_needed(needs_format_hint: bool) {
         if needs_format_hint {
-            println!("{FORMAT_HINT}");
+            eprintln!("{FORMAT_HINT}");
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a non-blocking `[INFO]` format hint to `baml run` when real `.baml` source differs from canonical `baml format` output.
- Checks project-mode and standalone `.baml` runs without mutating source files; expression mode remains excluded.
- Adds regression coverage proving unformatted project, standalone, and expression-context runs do not rewrite source files.

## Testing

- `cargo test -p baml_cli format_hint`
- `cargo test -p baml_cli run_does_not_mutate_unformatted_project_sources`
- `cargo test -p baml_cli standalone_run_does_not_mutate_unformatted_source`
- `cargo test -p baml_cli test_expression_resolves_project_class`
- Pre-commit hooks passed, including `cargo fmt` and `cargo clippy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Displays an informational format hint when sources would be reformatted, shown immediately after compilation without modifying files.
  * The formatter (fmt) subcommand is now visible in CLI help so users can discover and run it.

* **Tests**
  * Added unit and end-to-end tests to verify format-hint detection and to ensure running the tool does not alter unformatted sources across modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->