### PR TITLE
remove explorer order from workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,5 +57,4 @@
   },
   "baml.enablePlaygroundProxy": true,
   "editor.accessibilitySupport": "off",
-  "explorer.sortOrder": "mixed",
 }


### PR DESCRIPTION
Explorer file/directory order should be a user setting, not enforced at the project level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration settings.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->