### PR TITLE
fix(oncall): require complete rotation assignments

### DIFF
--- a/tools/bctl_src/oncall/schedule.py
+++ b/tools/bctl_src/oncall/schedule.py
@@ -105,6 +105,16 @@ def validate(sched: ScheduleFile, raw_text: str) -> list[ValidationError]:
                 )
             )
 
+        for rot in rotations_order:
+            if rot not in shift.assignments:
+                errors.append(
+                    ValidationError(
+                        line=None,
+                        message=f"{date_s}: missing assignment for rotation {rot!r}",
+                        fixable=False,
+                    )
+                )
+
         for rot, assignee in shift.assignments.items():
             if rot == "none":
                 continue

--- a/tools/bctl_src/tests/test_oncall.py
+++ b/tools/bctl_src/tests/test_oncall.py
@@ -28,6 +28,26 @@ METADATA = textwrap.dedent("""\
 """)
 
 
+MULTI_ROTATION_METADATA = textwrap.dedent("""\
+    # BEGIN_ONCALL_METADATA
+    # slack_config:
+    #   notification_channel: "#oncall"
+    #
+    # roster_by_rotation:
+    #   founders: [vbv, aaron]
+    #   discord: [kai, paulo]
+    #   none: [greg]
+    #
+    # roster_by_human:
+    #   aaron: [founders]
+    #   greg: [none]
+    #   kai: [discord]
+    #   paulo: [discord]
+    #   vbv: [founders]
+    # END_ONCALL_METADATA
+""")
+
+
 def _blocking(sched, text):
     return [e for e in validate(sched, text) if not e.fixable]
 
@@ -65,3 +85,13 @@ def test_fill_horizon_extends_when_horizon_short():
     assert len(filled.shifts) > len(sched.shifts)
     for prev, curr in zip(filled.shifts, filled.shifts[1:]):
         assert prev.date < curr.date
+
+
+def test_check_flags_missing_rotation_assignment():
+    text = MULTI_ROTATION_METADATA + "\n2026-04-24 founders=aaron\n"
+    sched = parse(text)
+    blocking = _blocking(sched, text)
+    assert any(
+        "2026-04-24: missing assignment for rotation 'discord'" in e.message
+        for e in blocking
+    ), [e.message for e in blocking]


### PR DESCRIPTION
## Issue Reference
No linked issue found; this fixes a validation gap in the weekly on-call notification workflow.

## Changes
- Treat a shift line that omits any non-`none` rotation as a blocking validation error.
- Add a regression test for a schedule that declares both `founders` and `discord` rotations but only assigns `founders` for a shift.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Tested in production environment

Commands run:

```bash
uv run --project tools/bctl_src pytest tools/bctl_src/tests/test_oncall.py
./tools/bctl oncall check
```

## Additional Notes
The weekly workflow validates the schedule before `bctl oncall notify`. Previously, a shift could omit one declared rotation and still reach `compose_handoff()`, which then raised `RuntimeError` while building the Slack handoff. This moves that failure into validation with a clear error message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced oncall schedule validation to ensure all rotations have assignments on every shift date, with explicit error reporting for missing assignments.

* **Tests**
  * Added validation test for missing rotation assignment detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->