### PR TITLE
Fix TypeBuilder recursive class cycles

### DIFF
--- a/engine/baml-runtime/src/type_builder/mod.rs
+++ b/engine/baml-runtime/src/type_builder/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 type MetaData = Arc<Mutex<IndexMap<String, BamlValue>>>;
+type ClassPropertySnapshot = Vec<(String, Option<TypeIR>, PropertyAttributes)>;
 
 trait Meta {
     fn meta(&self) -> MetaData;
@@ -735,12 +736,37 @@ impl TypeBuilder {
         Vec<IndexMap<String, TypeIR>>,
     ) {
         log::debug!("Converting types to overrides");
-        let cls = self
+        let class_entries = self
             .classes
             .lock()
             .unwrap()
             .iter()
             .map(|(name, cls)| {
+                let properties = {
+                    let cls = cls.lock().unwrap();
+                    cls.properties.lock().unwrap().clone()
+                };
+                let property_snapshot = properties
+                    .iter()
+                    .map(|(property_name, f)| {
+                        let attrs = PropertyAttributes::from(f);
+                        let t = {
+                            let property = f.lock().unwrap();
+                            let t = property.r#type.lock().unwrap();
+                            t.clone()
+                        };
+                        (property_name.clone(), t, attrs)
+                    })
+                    .collect::<ClassPropertySnapshot>();
+                (name.clone(), property_snapshot)
+            })
+            .collect::<Vec<_>>();
+
+        let detected_recursive_class_cycles = detect_recursive_class_cycles(&class_entries);
+
+        let cls = class_entries
+            .into_iter()
+            .map(|(name, properties)| {
                 log::debug!("Converting class: {name}");
                 let mut overrides = RuntimeClassOverride {
                     alias: None,
@@ -748,33 +774,17 @@ impl TypeBuilder {
                     update_fields: Default::default(),
                 };
 
-                cls.lock()
-                    .unwrap()
-                    .properties
-                    .lock()
-                    .unwrap()
-                    .iter()
-                    .for_each(|(property_name, f)| {
-                        let attrs = PropertyAttributes::from(f);
-                        let t = {
-                            let property = f.lock().unwrap();
-                            let t = property.r#type.lock().unwrap();
-                            t.clone()
-                        };
-                        match t.as_ref() {
-                            Some(r#type) => {
-                                overrides
-                                    .new_fields
-                                    .insert(property_name.to_string(), (r#type.clone(), attrs));
-                            }
-                            None => {
-                                overrides
-                                    .update_fields
-                                    .insert(property_name.to_string(), attrs);
-                            }
+                for (property_name, t, attrs) in properties {
+                    match t {
+                        Some(r#type) => {
+                            overrides.new_fields.insert(property_name, (r#type, attrs));
                         }
-                    });
-                (name.clone(), overrides)
+                        None => {
+                            overrides.update_fields.insert(property_name, attrs);
+                        }
+                    }
+                }
+                (name, overrides)
             })
             .collect();
 
@@ -823,97 +833,121 @@ impl TypeBuilder {
 
         let recursive_aliases = self.recursive_type_aliases.lock().unwrap().clone();
         let mut recursive_classes = self.recursive_classes.lock().unwrap().clone();
-        for cycle in self.detect_recursive_class_cycles() {
-            if !recursive_classes
-                .iter()
-                .any(|existing| same_class_cycle(existing, &cycle))
-            {
+        for cycle in detected_recursive_class_cycles {
+            if !recursive_classes.iter().any(|existing| {
+                existing.len() == cycle.len()
+                    && existing.iter().all(|class_name| cycle.contains(class_name))
+            }) {
                 recursive_classes.push(cycle);
             }
         }
 
         (cls, enm, aliases, recursive_classes, recursive_aliases)
     }
-
-    fn detect_recursive_class_cycles(&self) -> Vec<IndexSet<String>> {
-        let class_entries = self
-            .classes
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(name, class)| {
-                let property_types = class
-                    .lock()
-                    .unwrap()
-                    .properties
-                    .lock()
-                    .unwrap()
-                    .values()
-                    .filter_map(|property| property.lock().unwrap().r#type())
-                    .collect::<Vec<_>>();
-                (name.clone(), property_types)
-            })
-            .collect::<Vec<_>>();
-
-        let class_names = class_entries
-            .iter()
-            .map(|(name, _)| name.clone())
-            .collect::<IndexSet<_>>();
-        let graph = class_entries
-            .into_iter()
-            .map(|(name, property_types)| {
-                let mut references = IndexSet::new();
-                for property_type in property_types {
-                    collect_class_references(&property_type, &class_names, &mut references);
-                }
-                (name, references)
-            })
-            .collect::<IndexMap<_, _>>();
-
-        let mut cycles = Vec::new();
-        for class_name in graph.keys() {
-            let mut path = Vec::new();
-            collect_cycles_from(class_name, class_name, &graph, &mut path, &mut cycles);
-        }
-        cycles
-    }
 }
 
-fn same_class_cycle(left: &IndexSet<String>, right: &IndexSet<String>) -> bool {
-    left.len() == right.len() && left.iter().all(|class_name| right.contains(class_name))
-}
-
-fn push_class_cycle(cycles: &mut Vec<IndexSet<String>>, cycle: IndexSet<String>) {
-    if !cycles
+fn detect_recursive_class_cycles(
+    class_entries: &[(String, ClassPropertySnapshot)],
+) -> Vec<IndexSet<String>> {
+    let class_names = class_entries
         .iter()
-        .any(|existing| same_class_cycle(existing, &cycle))
-    {
-        cycles.push(cycle);
-    }
+        .map(|(name, _)| name.clone())
+        .collect::<IndexSet<_>>();
+    let graph = class_entries
+        .iter()
+        .map(|(name, properties)| {
+            let mut references = IndexSet::new();
+            for (_, property_type, _) in properties {
+                if let Some(property_type) = property_type {
+                    collect_class_references(property_type, &class_names, &mut references);
+                }
+            }
+            (name.clone(), references)
+        })
+        .collect::<IndexMap<_, _>>();
+
+    strongly_connected_class_components(&graph)
 }
 
-fn collect_cycles_from(
-    start: &str,
-    current: &str,
+fn strongly_connected_class_components(
     graph: &IndexMap<String, IndexSet<String>>,
-    path: &mut Vec<String>,
-    cycles: &mut Vec<IndexSet<String>>,
-) {
-    if path.iter().any(|class_name| class_name == current) {
-        return;
+) -> Vec<IndexSet<String>> {
+    fn visit(
+        node: &str,
+        graph: &IndexMap<String, IndexSet<String>>,
+        visited: &mut IndexSet<String>,
+        order: &mut Vec<String>,
+    ) {
+        if !visited.insert(node.to_string()) {
+            return;
+        }
+
+        if let Some(neighbors) = graph.get(node) {
+            for neighbor in neighbors {
+                if graph.contains_key(neighbor) {
+                    visit(neighbor, graph, visited, order);
+                }
+            }
+        }
+        order.push(node.to_string());
     }
 
-    path.push(current.to_string());
-    if let Some(neighbors) = graph.get(current) {
-        for neighbor in neighbors {
-            if neighbor == start {
-                push_class_cycle(cycles, path.iter().cloned().collect());
-            } else if graph.contains_key(neighbor) {
-                collect_cycles_from(start, neighbor, graph, path, cycles);
+    fn collect_component(
+        node: &str,
+        reverse_graph: &IndexMap<String, IndexSet<String>>,
+        visited: &mut IndexSet<String>,
+        component: &mut IndexSet<String>,
+    ) {
+        if !visited.insert(node.to_string()) {
+            return;
+        }
+
+        component.insert(node.to_string());
+        if let Some(neighbors) = reverse_graph.get(node) {
+            for neighbor in neighbors {
+                collect_component(neighbor, reverse_graph, visited, component);
             }
         }
     }
-    path.pop();
+
+    let mut visited = IndexSet::new();
+    let mut order = Vec::new();
+    for class_name in graph.keys() {
+        visit(class_name, graph, &mut visited, &mut order);
+    }
+
+    let mut reverse_graph = graph
+        .keys()
+        .map(|class_name| (class_name.clone(), IndexSet::new()))
+        .collect::<IndexMap<_, _>>();
+    for (class_name, references) in graph {
+        for reference in references {
+            if let Some(reverse_references) = reverse_graph.get_mut(reference) {
+                reverse_references.insert(class_name.clone());
+            }
+        }
+    }
+
+    let mut assigned = IndexSet::new();
+    let mut components = Vec::new();
+    for class_name in order.iter().rev() {
+        if assigned.contains(class_name) {
+            continue;
+        }
+
+        let mut component = IndexSet::new();
+        collect_component(class_name, &reverse_graph, &mut assigned, &mut component);
+        let has_self_loop = component.iter().any(|name| {
+            graph
+                .get(name)
+                .is_some_and(|references| references.contains(name))
+        });
+        if component.len() > 1 || has_self_loop {
+            components.push(component);
+        }
+    }
+
+    components
 }
 
 fn collect_class_references(

--- a/engine/baml-runtime/src/type_builder/mod.rs
+++ b/engine/baml-runtime/src/type_builder/mod.rs
@@ -4,7 +4,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use baml_types::{BamlValue, EvaluationContext, TypeIR};
+use baml_types::{
+    ir_type::{TypeGeneric, UnionTypeViewGeneric},
+    BamlValue, EvaluationContext, TypeIR,
+};
 use indexmap::{IndexMap, IndexSet};
 use internal_baml_core::{
     internal_baml_parser_database::ParserDatabase, ir::repr::TypeBuilderEntry,
@@ -819,9 +822,143 @@ impl TypeBuilder {
         log::debug!("Dynamic types: \n {cls:#?} \n Dynamic enums\n {enm:#?} enums");
 
         let recursive_aliases = self.recursive_type_aliases.lock().unwrap().clone();
-        let recursive_classes = self.recursive_classes.lock().unwrap().clone();
+        let mut recursive_classes = self.recursive_classes.lock().unwrap().clone();
+        for cycle in self.detect_recursive_class_cycles() {
+            if !recursive_classes
+                .iter()
+                .any(|existing| same_class_cycle(existing, &cycle))
+            {
+                recursive_classes.push(cycle);
+            }
+        }
 
         (cls, enm, aliases, recursive_classes, recursive_aliases)
+    }
+
+    fn detect_recursive_class_cycles(&self) -> Vec<IndexSet<String>> {
+        let class_entries = self
+            .classes
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(name, class)| {
+                let property_types = class
+                    .lock()
+                    .unwrap()
+                    .properties
+                    .lock()
+                    .unwrap()
+                    .values()
+                    .filter_map(|property| property.lock().unwrap().r#type())
+                    .collect::<Vec<_>>();
+                (name.clone(), property_types)
+            })
+            .collect::<Vec<_>>();
+
+        let class_names = class_entries
+            .iter()
+            .map(|(name, _)| name.clone())
+            .collect::<IndexSet<_>>();
+        let graph = class_entries
+            .into_iter()
+            .map(|(name, property_types)| {
+                let mut references = IndexSet::new();
+                for property_type in property_types {
+                    collect_class_references(&property_type, &class_names, &mut references);
+                }
+                (name, references)
+            })
+            .collect::<IndexMap<_, _>>();
+
+        let mut cycles = Vec::new();
+        for class_name in graph.keys() {
+            let mut path = Vec::new();
+            collect_cycles_from(class_name, class_name, &graph, &mut path, &mut cycles);
+        }
+        cycles
+    }
+}
+
+fn same_class_cycle(left: &IndexSet<String>, right: &IndexSet<String>) -> bool {
+    left.len() == right.len() && left.iter().all(|class_name| right.contains(class_name))
+}
+
+fn push_class_cycle(cycles: &mut Vec<IndexSet<String>>, cycle: IndexSet<String>) {
+    if !cycles
+        .iter()
+        .any(|existing| same_class_cycle(existing, &cycle))
+    {
+        cycles.push(cycle);
+    }
+}
+
+fn collect_cycles_from(
+    start: &str,
+    current: &str,
+    graph: &IndexMap<String, IndexSet<String>>,
+    path: &mut Vec<String>,
+    cycles: &mut Vec<IndexSet<String>>,
+) {
+    if path.iter().any(|class_name| class_name == current) {
+        return;
+    }
+
+    path.push(current.to_string());
+    if let Some(neighbors) = graph.get(current) {
+        for neighbor in neighbors {
+            if neighbor == start {
+                push_class_cycle(cycles, path.iter().cloned().collect());
+            } else if graph.contains_key(neighbor) {
+                collect_cycles_from(start, neighbor, graph, path, cycles);
+            }
+        }
+    }
+    path.pop();
+}
+
+fn collect_class_references(
+    r#type: &TypeIR,
+    class_names: &IndexSet<String>,
+    references: &mut IndexSet<String>,
+) {
+    match r#type {
+        TypeGeneric::Class { name, .. } => {
+            if class_names.contains(name) {
+                references.insert(name.clone());
+            }
+        }
+        TypeGeneric::List(inner, _) => collect_class_references(inner, class_names, references),
+        TypeGeneric::Map(key, value, _) => {
+            collect_class_references(key, class_names, references);
+            collect_class_references(value, class_names, references);
+        }
+        TypeGeneric::Tuple(items, _) => {
+            for item in items {
+                collect_class_references(item, class_names, references);
+            }
+        }
+        TypeGeneric::Arrow(arrow, _) => {
+            for param in &arrow.param_types {
+                collect_class_references(param, class_names, references);
+            }
+            collect_class_references(&arrow.return_type, class_names, references);
+        }
+        TypeGeneric::Union(union, _) => match union.view() {
+            UnionTypeViewGeneric::Null => {}
+            UnionTypeViewGeneric::Optional(inner) => {
+                collect_class_references(inner, class_names, references)
+            }
+            UnionTypeViewGeneric::OneOf(items) | UnionTypeViewGeneric::OneOfOptional(items) => {
+                for item in items {
+                    collect_class_references(item, class_names, references);
+                }
+            }
+        },
+        TypeGeneric::Top(_)
+        | TypeGeneric::Primitive(_, _)
+        | TypeGeneric::Enum { .. }
+        | TypeGeneric::Literal(_, _)
+        | TypeGeneric::RecursiveTypeAlias { .. } => {}
     }
 }
 
@@ -1087,7 +1224,7 @@ mod tests {
             node.upsert_property("child")
                 .lock()
                 .unwrap()
-                .set_type(TypeIR::class("Node"))
+                .set_type(TypeIR::class("Node").as_list())
                 .with_meta(
                     "description",
                     BamlValue::String("recursive self reference".to_string()),
@@ -1104,7 +1241,7 @@ mod tests {
                 r#"TypeBuilder(
   Classes: [
     Node {
-      child Node (description=String("recursive self reference"))
+      child Node[] (description=String("recursive self reference"))
     }
   ]
 )"#
@@ -1113,8 +1250,11 @@ mod tests {
         );
 
         // Verify via to_overrides() that the recursive field is set correctly.
-        let (class_overrides, _enum_overrides, _aliases, _recursive_classes, _recursive_aliases) =
+        let (class_overrides, _enum_overrides, _aliases, recursive_classes, _recursive_aliases) =
             builder.to_overrides();
+        assert!(recursive_classes
+            .iter()
+            .any(|cycle| cycle.len() == 1 && cycle.contains("Node")));
         let node_override = class_overrides
             .get("Node")
             .expect("Expected override for Node");
@@ -1126,8 +1266,8 @@ mod tests {
         // The child's field type should exactly be a recursive reference to 'Node'
         assert_eq!(
             child_field_type,
-            &TypeIR::class("Node"),
-            "The 'child' field is not correctly set as a recursive reference to 'Node'"
+            &TypeIR::class("Node").as_list(),
+            "The 'child' field is not correctly set as a recursive list reference to 'Node'"
         );
     }
 


### PR DESCRIPTION
## What

Fixes #3390 by detecting recursive class cycles that are assembled imperatively through `TypeBuilder` before returning runtime overrides.

`TypeBuilder::add_baml` already receives recursive class cycle metadata from the validation pipeline, but `tb.add_class(...)` + `class.add_property(...)` did not populate `recursive_classes`. When such a class referenced itself, `ctx.output_format` could render it without recursive-class overrides and recurse until a native stack overflow.

This change:

- walks the classes currently stored in `TypeBuilder`
- builds a class-reference graph from property types, including lists, maps, tuples, arrows, and unions
- adds any detected class cycles to the recursive class overrides returned by `to_overrides()`
- extends the existing recursive property test to cover a `Node[]` self-reference and assert that it is reported as a recursive class cycle

## Tests

- `cargo fmt --manifest-path engine/Cargo.toml --package baml-runtime --check`
- `git diff --check`

I also attempted:

```bash
cargo test --manifest-path engine/Cargo.toml -p baml-runtime type_builder::tests::test_recursive_property
```

but this local machine cannot link Rust build scripts because its Xcode Command Line Tools install has an architecture mismatch in `libxcrun.dylib` (`x86_64`, while the active toolchain is building for `arm64`). The failure happens before `baml-runtime` is compiled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of recursive class cycles during conversion, merged with any existing cycle info to avoid duplicates.
  * Recursive properties now display as collection types (e.g., child → Node[]) and recursive cycle metadata correctly includes the Node cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->