### PR TITLE
[codex] Fix media union matching

### DIFF
--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -5,7 +5,7 @@
 //! representation (`BexValue`, `BexExternalValue`).
 
 use ::bex_vm_types::ObjectType;
-use baml_type::Literal;
+use baml_type::{Literal, MediaKind};
 use bex_external_types::{BexExternalAdt, BexExternalValue, Ty, UnionMetadata};
 use bex_heap::{ActiveHeapPermit, BexValue, PermitProof};
 use bex_vm::BexVm;
@@ -489,6 +489,9 @@ fn value_matches_type(value: &BexExternalValue, ty: &Ty) -> bool {
         (BexExternalValue::Bool(_), Ty::Literal(Literal::Bool(_), _)) => true,
         (BexExternalValue::Array { .. }, Ty::List(_, _)) => true,
         (BexExternalValue::Map { .. }, Ty::Map { .. }) => true,
+        (value, Ty::Media(kind, _)) => {
+            external_media_kind(value).is_some_and(|actual| media_kind_matches(actual, *kind))
+        }
         (BexExternalValue::Instance { class_name, .. }, Ty::Class(tn, _)) => {
             type_name_matches_external_name(class_name, tn)
         }
@@ -544,6 +547,14 @@ fn find_matching_union_member<'a>(value: &Value, members: &'a [Ty]) -> Option<&'
             .find(|m| matches!(m, Ty::Bool { .. } | Ty::Literal(Literal::Bool(_), _))),
         Value::Object(ptr) => {
             let obj = unsafe { ptr.get() };
+            if let Some(actual_media_kind) = object_media_kind(obj) {
+                if let Some(member) = members.iter().find(|m| {
+                    matches!(m, Ty::Media(kind, _) if media_kind_matches(actual_media_kind, *kind))
+                }) {
+                    return Some(member);
+                }
+            }
+
             match obj {
                 Object::String(_) => members
                     .iter()
@@ -603,6 +614,99 @@ fn find_matching_union_member<'a>(value: &Value, members: &'a [Ty]) -> Option<&'
                 Object::Sentinel(_) => None,
             }
         }
+    }
+}
+
+fn media_kind_matches(actual: MediaKind, expected: MediaKind) -> bool {
+    expected == MediaKind::Generic || actual == expected
+}
+
+fn external_media_kind(value: &BexExternalValue) -> Option<MediaKind> {
+    match value {
+        BexExternalValue::Adt(BexExternalAdt::Media(media)) => Some(media.kind),
+        BexExternalValue::Instance { fields, .. } => {
+            fields.get("_data").and_then(external_media_kind)
+        }
+        BexExternalValue::Union { value, .. } => external_media_kind(value),
+        _ => None,
+    }
+}
+
+fn object_media_kind(obj: &Object) -> Option<MediaKind> {
+    match obj {
+        Object::RustData(arc) => {
+            external_media_kind(&bex_external_types::try_convert_rust_data(arc)?)
+        }
+        Object::Instance(instance) => instance_media_kind(instance),
+        _ => None,
+    }
+}
+
+fn instance_media_kind(instance: &bex_vm_types::Instance) -> Option<MediaKind> {
+    let class_obj = unsafe { instance.class.get() };
+    let Object::Class(class) = class_obj else {
+        return None;
+    };
+
+    class
+        .fields
+        .iter()
+        .zip(instance.fields.iter())
+        .find_map(|(class_field, value)| {
+            if class_field.name == "_data" {
+                vm_value_media_kind(value)
+            } else {
+                None
+            }
+        })
+}
+
+fn vm_value_media_kind(value: &Value) -> Option<MediaKind> {
+    match value {
+        Value::Object(ptr) => object_media_kind(unsafe { ptr.get() }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use baml_type::TyAttr;
+
+    fn media_ty(kind: MediaKind) -> Ty {
+        Ty::Media(kind, TyAttr::default())
+    }
+
+    #[test]
+    fn wraps_raw_media_values_in_matching_union_member() {
+        let image =
+            BexExternalValue::Adt(BexExternalAdt::Media(baml_builtins2::MediaValue::from_url(
+                MediaKind::Image,
+                "https://example.test/image.png",
+                Some("image/png"),
+            )));
+        let union_ty = Ty::union([media_ty(MediaKind::Image), Ty::string()]);
+
+        let wrapped =
+            maybe_wrap_union(image, &union_ty).expect("image should match image union arm");
+
+        let BexExternalValue::Union { metadata, .. } = wrapped else {
+            panic!("expected union wrapper");
+        };
+        assert_eq!(metadata.selected_option, media_ty(MediaKind::Image));
+    }
+
+    #[test]
+    fn raw_media_values_reject_wrong_media_union_member() {
+        let audio =
+            BexExternalValue::Adt(BexExternalAdt::Media(baml_builtins2::MediaValue::from_url(
+                MediaKind::Audio,
+                "https://example.test/audio.mp3",
+                Some("audio/mpeg"),
+            )));
+        let union_ty = Ty::union([media_ty(MediaKind::Image), Ty::string()]);
+
+        assert!(maybe_wrap_union(audio, &union_ty).is_err());
     }
 }
 

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -670,8 +670,9 @@ fn vm_value_media_kind(value: &Value) -> Option<MediaKind> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use baml_type::TyAttr;
+
+    use super::*;
 
     fn media_ty(kind: MediaKind) -> Ty {
         Ty::Media(kind, TyAttr::default())

--- a/baml_language/crates/bex_engine/tests/media_roundtrip.rs
+++ b/baml_language/crates/bex_engine/tests/media_roundtrip.rs
@@ -14,7 +14,7 @@ mod common;
 use std::sync::Arc;
 
 use baml_builtins2::{MediaContent, MediaValue};
-use baml_type::MediaKind;
+use baml_type::{MediaKind, Ty, TyAttr};
 use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder};
 use bex_external_types::BexExternalAdt;
 use common::compile_for_engine;
@@ -114,5 +114,67 @@ class Holder {
             }
         }
         other => panic!("expected Instance for unwrapped pdf, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn media_pdf_matches_union_member() {
+    let source = r#"
+class Holder {
+  inner pdf
+
+  function unwrap_union(self, prefer_text: bool) -> pdf | string {
+    if prefer_text {
+      "fallback"
+    } else {
+      self.inner
+    }
+  }
+}
+"#;
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let original = pdf_media();
+    let mut holder_fields: IndexMap<String, BexExternalValue> = IndexMap::new();
+    holder_fields.insert("inner".to_string(), pdf_instance(Arc::clone(&original)));
+    let holder_arg = BexExternalValue::Instance {
+        class_name: "user.Holder".to_string(),
+        fields: holder_fields,
+    };
+
+    let result = engine
+        .call_function(
+            "user.Holder.unwrap_union",
+            vec![holder_arg, BexExternalValue::Bool(false)],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("Holder.unwrap_union should select the pdf union member");
+
+    let BexExternalValue::Union { value, metadata } = result else {
+        panic!("expected union-wrapped pdf result");
+    };
+    assert_eq!(
+        metadata.selected_option,
+        Ty::Media(MediaKind::Pdf, TyAttr::default())
+    );
+    match *value {
+        BexExternalValue::Instance { fields, .. } => match fields.get("_data") {
+            Some(BexExternalValue::Adt(BexExternalAdt::Media(arc))) => {
+                assert_eq!(arc.kind, MediaKind::Pdf);
+            }
+            other => panic!("expected media _data field, got {other:?}"),
+        },
+        other => panic!("expected media instance inside union, got {other:?}"),
     }
 }


### PR DESCRIPTION
## Summary

Fix runtime union discrimination for BAML media values so media outputs can match media union arms such as `image | string`.

## Root Cause

Media values were converted to external `Adt(Media(_))` values, but union matching did not inspect the underlying `MediaValue.kind`. That made the matcher report a generic `media` value as not matching `image` or `string`.

## Changes

- Teach external value matching to compare `MediaValue.kind` against `Ty::Media` union members.
- Teach VM-side union discrimination to recognize both raw Rust media data and class-shaped media instances with `_data`.
- Add coverage for raw media union wrapping and engine-level `pdf | string` returns.

## Validation

- `cargo fmt --check`
- `cargo test -p bex_engine media`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core value/union matching in `conversion.rs` used on every typed external return; scope is narrow but incorrect matching could mis-tag union metadata for media-heavy APIs.
> 
> **Overview**
> Fixes **runtime union discrimination** for BAML media so values like `pdf | string` pick the correct arm instead of failing type matching.
> 
> **External path:** `value_matches_type` now treats `Ty::Media` as a match when the value’s `MediaKind` aligns with the member (including via `Adt(Media)`, class instances with `_data`, and nested unions). `MediaKind::Generic` accepts any concrete kind.
> 
> **VM path:** `find_matching_union_member` resolves media **before** string/class handling by walking `RustData`, media instances, and `_data` fields so outbound conversion and union wrapping see the right `Ty::Media` member.
> 
> Unit tests cover `maybe_wrap_union` for matching/mismatching media arms; an integration test asserts `pdf | string` returns a union with `selected_option` = `Ty::Media(Pdf, ...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a358bffb8d58db94663a886d66f0b1c200ab286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media values now correctly integrate with union types, with intelligent type matching based on media kind (e.g., PDF, Generic)
  * Enhanced support for media value handling across different internal representations and nested structures

* **Tests**
  * Expanded test coverage for PDF media behavior in union member scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->