### PR TITLE
feat: teach pyi codegen to emit classes/enums correctly

### DIFF
--- a/baml_language/languages/python/rust/codegen_python/src/leaf.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/leaf.rs
@@ -171,54 +171,22 @@ impl LeafBody {
         set.into_iter().collect()
     }
 
-    /// First segments for the `.pyi` companion. Class fields are not
-    /// mirrored into `.pyi` (only methods get typed signatures), so
-    /// they don't contribute.
+    /// First segments for the `.pyi` companion. Now that class fields
+    /// are mirrored into `.pyi`, the walk shape matches `.py` exactly —
+    /// properties, methods, function/alias types all contribute.
     pub(crate) fn cross_leaf_first_segments_pyi(&self) -> Vec<String> {
-        let mut set: BTreeSet<String> = BTreeSet::new();
-        let current = &self.leaf;
-        for (sym, _) in &self.symbols {
-            match sym {
-                EmittedSymbol::Class(c) => {
-                    for m in &c.static_methods {
-                        for ty in &m.arg_tys {
-                            collect_cross_leaf(ty, current, &mut set);
-                        }
-                        collect_cross_leaf(&m.return_ty, current, &mut set);
-                    }
-                    for m in &c.instance_methods {
-                        for ty in &m.arg_tys {
-                            collect_cross_leaf(ty, current, &mut set);
-                        }
-                        collect_cross_leaf(&m.return_ty, current, &mut set);
-                    }
-                }
-                EmittedSymbol::Function(f) => {
-                    for ty in &f.arg_tys {
-                        collect_cross_leaf(ty, current, &mut set);
-                    }
-                    collect_cross_leaf(&f.return_ty, current, &mut set);
-                }
-                EmittedSymbol::TypeAlias(a) => {
-                    collect_cross_leaf(&a.resolves_to, current, &mut set);
-                }
-                EmittedSymbol::Enum(_) => {}
-            }
-        }
-        set.into_iter().collect()
+        self.cross_leaf_first_segments_py()
     }
 
     /// Whether this leaf's `.pyi` needs `import typing`. Any rendered
-    /// signature pulls it in (`typing.TypeAlias`, `typing.Optional`,
-    /// etc.). Property-only classes don't (fields aren't mirrored into
-    /// `.pyi`), but generic classes do (`typing.Generic[T]` base).
+    /// signature, type alias, or class pulls it in — class field types
+    /// may resolve to `typing.Optional[…]` / `typing.List[…]` / etc.,
+    /// and the generic base is `typing.Generic[…]`. Mirrors the `.py`
+    /// "be generous" rule (`stdlib_imports`).
     pub(crate) fn needs_typing_pyi(&self) -> bool {
         self.symbols.iter().any(|(s, _)| match s {
-            EmittedSymbol::Function(_) | EmittedSymbol::TypeAlias(_) => true,
-            EmittedSymbol::Class(c) => {
-                !c.static_methods.is_empty()
-                    || !c.instance_methods.is_empty()
-                    || !c.generic_params.is_empty()
+            EmittedSymbol::Class(_) | EmittedSymbol::Function(_) | EmittedSymbol::TypeAlias(_) => {
+                true
             }
             EmittedSymbol::Enum(_) => false,
         })
@@ -818,10 +786,16 @@ pub(crate) fn render_leaf_body(body: &LeafBody) -> String {
 
 #[derive(askama::Template)]
 #[template(
-    source = r#"{%- if static_methods.is_empty() && instance_methods.is_empty() -%}
+    source = r#"{%- if properties.is_empty() && static_methods.is_empty() && instance_methods.is_empty() -%}
 class {{ py_name }}({{ bases }}): ...
 {%- else -%}
 class {{ py_name }}({{ bases }}):
+{%- for prop in properties %}
+    {{ prop.name }}: {{ prop.ty_py }}
+{%- endfor %}
+{%- if !properties.is_empty() && (!static_methods.is_empty() || !instance_methods.is_empty()) %}
+
+{%- endif %}
 {%- for m in static_methods %}
 {%- if !loop.first && !m.tight_to_prev %}
 
@@ -844,6 +818,7 @@ class {{ py_name }}({{ bases }}):
 struct ClassBodyPyi {
     py_name: String,
     bases: String,
+    properties: Vec<ClassPropertyView>,
     static_methods: Vec<MethodBlockView>,
     instance_methods: Vec<MethodBlockView>,
 }
@@ -851,16 +826,6 @@ struct ClassBodyPyi {
 struct MethodBlockView {
     block: String,
     tight_to_prev: bool,
-}
-
-#[derive(askama::Template)]
-#[template(
-    source = "class {{ py_name }}(str, enum.Enum): ...",
-    ext = "py.j2",
-    escape = "none"
-)]
-struct EnumBodyPyi {
-    py_name: String,
 }
 
 /// One method's `.pyi` signature block: a single `def` line for
@@ -905,9 +870,11 @@ fn build_method_block_views(
     out
 }
 
-/// Render one symbol into its `.pyi` source block. Classes and enums
-/// render name-only with `...`; type aliases mirror the `.py` shape;
-/// functions render as typed `def`/`async def` signatures.
+/// Render one symbol into its `.pyi` source block. Classes carry
+/// typed field declarations and method signature stubs; enums carry
+/// their variant lines verbatim; type aliases mirror the `.py` shape;
+/// functions render as typed `def`/`async def` signatures. An empty
+/// class (no fields, no methods) collapses to `class Foo(...): ...`.
 fn render_symbol_pyi(s: &EmittedSymbol, leaf: &LeafPath) -> String {
     use askama::Template;
     let ctx = TranslateCtx {
@@ -923,9 +890,18 @@ fn render_symbol_pyi(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                     py_name = c.py_name,
                 );
             }
+            let properties = c
+                .properties
+                .iter()
+                .map(|prop| ClassPropertyView {
+                    name: prop.name.clone(),
+                    ty_py: translate_ty(&prop.ty, &ctx),
+                })
+                .collect();
             let mut out = ClassBodyPyi {
                 py_name: c.py_name.clone(),
                 bases: render_class_bases(&c.generic_params),
+                properties,
                 static_methods: build_method_block_views(&c.static_methods, &ctx),
                 instance_methods: build_method_block_views(&c.instance_methods, &ctx),
             }
@@ -935,11 +911,22 @@ fn render_symbol_pyi(s: &EmittedSymbol, leaf: &LeafPath) -> String {
             out
         }
         EmittedSymbol::Enum(e) => {
-            let mut out = EnumBodyPyi {
+            // Enum body is identical between `.py` and `.pyi` —
+            // reuse the `.py` template directly.
+            let variants = e
+                .variants
+                .iter()
+                .map(|v| EnumVariantView {
+                    ident: v.ident.clone(),
+                    value: py_string(&v.value),
+                })
+                .collect();
+            let mut out = EnumBodyPy {
                 py_name: e.py_name.clone(),
+                variants,
             }
             .render()
-            .expect("enum_body.pyi template should always render");
+            .expect("enum_body template should always render");
             out.push('\n');
             out
         }

--- a/baml_language/languages/python/rust/codegen_python/src/lib.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/lib.rs
@@ -1589,7 +1589,7 @@ mod tests {
     }
 
     #[test]
-    fn pyi_class_renders_name_only_with_ellipsis() {
+    fn pyi_class_renders_typed_field_declarations() {
         let mut pool: SymbolPool = HashMap::new();
         let n = cg_name("user", &["lorem"], "Resume");
         pool.insert(
@@ -1608,18 +1608,23 @@ mod tests {
         let out = to_source_code(&pool, &[]);
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
 
-        // Class is name-only with ellipsis (12d §3.1).
-        assert!(leaf.contains("class Resume(pydantic.BaseModel): ...\n"));
-        // Field declarations and pydantic config are NOT mirrored.
+        // Field declarations are mirrored into the stub so type
+        // checkers can see the public Pydantic surface.
+        let expected = "class Resume(pydantic.BaseModel):\n\
+                        \x20   name: str\n\
+                        \x20   email: typing.Optional[str]\n";
+        assert!(leaf.contains(expected), "pyi missing class body:\n{leaf}");
+        // The collapsed `class Foo(...): ...` form must not appear here.
+        assert!(!leaf.contains("class Resume(pydantic.BaseModel): ..."));
+        // `model_config` is a runtime concern and stays out of the stub.
         assert!(!leaf.contains("model_config"));
-        assert!(!leaf.contains("name: str"));
-        assert!(!leaf.contains("email:"));
-        // pydantic is still imported (for the class base).
         assert!(leaf.contains("import pydantic"));
+        // Property type uses `typing.Optional`, so typing is required.
+        assert!(leaf.contains("import typing"));
     }
 
     #[test]
-    fn pyi_enum_renders_name_only_with_ellipsis() {
+    fn pyi_enum_renders_each_variant() {
         let mut pool: SymbolPool = HashMap::new();
         let n = cg_name("user", &["ipsum"], "Sentiment");
         pool.insert(
@@ -1646,11 +1651,10 @@ mod tests {
         let out = to_source_code(&pool, &[]);
         let leaf = &out[&PathBuf::from("ipsum/__init__.pyi")];
 
-        // Enum is name-only with ellipsis (12d §3.2).
-        assert!(leaf.contains("class Sentiment(str, enum.Enum): ...\n"));
-        // Variants are NOT mirrored.
-        assert!(!leaf.contains("POSITIVE = "));
-        assert!(!leaf.contains("NEGATIVE = "));
+        let expected = "class Sentiment(str, enum.Enum):\n\
+                        \x20   POSITIVE = \"POSITIVE\"\n\
+                        \x20   NEGATIVE = \"NEGATIVE\"\n";
+        assert!(leaf.contains(expected), "pyi missing enum body:\n{leaf}");
         assert!(leaf.contains("import enum"));
     }
 
@@ -1860,9 +1864,8 @@ mod tests {
         let out = to_source_code(&pool, &[]);
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
 
-        // No methods → name-only stub, even when the `.py` carries
-        // properties.
-        assert!(leaf.contains("class Resume(pydantic.BaseModel): ...\n"));
+        // Field declaration is mirrored, but no method block exists.
+        assert!(leaf.contains("class Resume(pydantic.BaseModel):\n    a: int\n"));
         assert!(!leaf.contains("def "));
     }
 
@@ -1882,22 +1885,20 @@ mod tests {
     }
 
     #[test]
-    fn pyi_typing_imported_when_signatures_present() {
-        // Pure-class leaf with no methods does not need typing in
-        // its `.pyi` (no signatures, no field declarations mirrored).
+    fn pyi_typing_imported_for_class_or_signature() {
+        // Any class (now that fields are mirrored), function, or alias
+        // pulls `import typing` into the `.pyi`. Mirrors the `.py`
+        // "be generous" rule so field types like `typing.Optional[…]`
+        // and the `typing.Generic[…]` base resolve.
         let mut pool: SymbolPool = HashMap::new();
         let n = cg_name("user", &["lorem"], "Resume");
         pool.insert(n.clone(), class(n));
 
         let out = to_source_code(&pool, &[]);
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
-        assert!(
-            !leaf.contains("import typing"),
-            "no typing expected in:\n{leaf}"
-        );
+        assert!(leaf.contains("import typing"), "typing expected:\n{leaf}");
 
-        // Add a function — typing now required (signatures may use
-        // `typing.Optional` / `typing.List` / etc., per 12d §7).
+        // Adding a function still results in typing being imported.
         let f = cg_name("user", &["lorem"], "ping");
         pool.insert(f, func_sym("ping", "x.baml", 100));
         let out = to_source_code(&pool, &[]);
@@ -1967,14 +1968,16 @@ mod tests {
             py.contains("if typing.TYPE_CHECKING:\n    from .. import ipsum\n"),
             "py missing guarded ipsum import:\n{py}"
         );
-        // The pyi mirrors the `.py` import block (12f §4.2).
+        // The pyi mirrors the `.py` import block: a class field whose
+        // type lives in another leaf now triggers the same guarded
+        // relative import on the stub side, since fields are typed
+        // there too.
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
-        // `.pyi` only needs the import when a *signature* (not a class
-        // field) references the cross-leaf type. This class has only a
-        // property; methods/aliases would also trigger the import.
-        // Property-only classes don't mirror fields into `.pyi`, so the
-        // pyi here legitimately has no cross-leaf segments.
-        assert!(!pyi.contains("if typing.TYPE_CHECKING:"));
+        assert!(
+            pyi.contains("if typing.TYPE_CHECKING:\n    from .. import ipsum\n"),
+            "pyi missing guarded ipsum import:\n{pyi}"
+        );
+        assert!(pyi.contains("    sentiment: ipsum.Sentiment\n"));
     }
 
     #[test]
@@ -2392,15 +2395,22 @@ mod tests {
             "TypeVar should be declared exactly once:\n{leaf}"
         );
 
-        // The .pyi mirrors the same generic shape.
+        // The .pyi mirrors the same generic shape, including the
+        // typed field declaration.
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
         assert!(
             pyi.contains("T = typing.TypeVar(\"T\")"),
             "pyi missing TypeVar:\n{pyi}",
         );
         assert!(
-            pyi.contains("class Box(pydantic.BaseModel, typing.Generic[T]): ..."),
+            pyi.contains("class Box(pydantic.BaseModel, typing.Generic[T]):\n    item: T\n"),
             "pyi missing Generic[T] on Box:\n{pyi}",
+        );
+        assert!(
+            pyi.contains(
+                "class Crate(pydantic.BaseModel, typing.Generic[T]):\n    contents: typing.List[Box[T]]\n",
+            ),
+            "pyi missing typed Crate body:\n{pyi}",
         );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced Python type stub (.pyi) generation with explicit type declarations for class properties, fields, and generic classes
- Improved .pyi/.py file consistency for better IDE autocomplete and type checking support

**Improvements**
- Type stubs now include full type information for enums, classes, and properties

<!-- end of auto-generated comment: release notes by coderabbit.ai -->