### PR TITLE
feat(codegen-python): preserve /// into generated docstrings

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -6631,6 +6631,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rig_docstrings_etc"
+version = "0.1.0"
+dependencies = [
+ "baml_codegen_types",
+ "baml_db",
+ "baml_project",
+ "baml_workspace",
+ "codegen_python",
+]
+
+[[package]]
 name = "rig_llm_functions"
 version = "0.1.0"
 dependencies = [

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -342,16 +342,13 @@ pub fn write_description(
 
     let mut lines_used = 1;
 
-    // ── Docstring ────────────────────────────────────────────────────────────
-    if let Some(ref doc) = desc.docstring {
-        writeln!(w)?;
-        for line in doc.lines() {
-            writeln!(w, "/// {line}")?;
-            lines_used += 1;
-        }
-    }
-
     // ── Body ─────────────────────────────────────────────────────────────────
+    // The body slice already includes any leading `///` doc-comments
+    // (the CST parser attaches them as the first children of the item
+    // node, so they fall inside `node.text_range()` and round-trip
+    // through `slice_text`). Rendering `desc.docstring` separately
+    // would just duplicate the same lines, so leave the docstring
+    // surfacing to JSON consumers and let the body show it once.
     let is_local = matches!(
         desc.kind,
         baml_lsp2_actions::DefinitionKind::Parameter | baml_lsp2_actions::DefinitionKind::Binding

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -998,6 +998,8 @@ pub struct FunctionDef {
     pub declarative_meta: Option<DeclarativeMeta>,
     pub origin: FunctionOrigin,
     pub attributes: Vec<RawAttribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<std::string::String>,
     pub span: TextRange,
     pub name_span: TextRange,
 }
@@ -1059,6 +1061,8 @@ pub struct ClassDef {
     pub fields: Vec<FieldDef>,
     pub methods: Vec<FunctionDef>,
     pub attributes: Vec<RawAttribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<std::string::String>,
     pub span: TextRange,
     pub name_span: TextRange,
 }
@@ -1068,6 +1072,8 @@ pub struct FieldDef {
     pub name: Name,
     pub type_expr: Option<SpannedTypeExpr>,
     pub attributes: Vec<RawAttribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<std::string::String>,
     pub span: TextRange,
     pub name_span: TextRange,
 }
@@ -1077,6 +1083,8 @@ pub struct EnumDef {
     pub name: Name,
     pub variants: Vec<VariantDef>,
     pub attributes: Vec<RawAttribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<std::string::String>,
     pub span: TextRange,
     pub name_span: TextRange,
 }
@@ -1085,6 +1093,8 @@ pub struct EnumDef {
 pub struct VariantDef {
     pub name: Name,
     pub attributes: Vec<RawAttribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<std::string::String>,
     pub span: TextRange,
     pub name_span: TextRange,
 }

--- a/baml_language/crates/baml_compiler2_ast/src/companions.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/companions.rs
@@ -103,6 +103,7 @@ fn llm_parse(parent: &FunctionDef) -> Option<FunctionDef> {
         declarative_meta: None,
         origin: crate::ast::FunctionOrigin::Companion,
         attributes: vec![],
+        docstring: parent.docstring.clone(),
         span: parent.span,
         name_span: parent.name_span,
     })
@@ -145,6 +146,7 @@ fn make_llm_companion(
         declarative_meta: None,
         origin: crate::ast::FunctionOrigin::Companion,
         attributes: vec![],
+        docstring: parent.docstring.clone(),
         span: parent.span,
         name_span: parent.name_span,
     }

--- a/baml_language/crates/baml_compiler2_ast/src/docstring.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/docstring.rs
@@ -1,0 +1,54 @@
+//! Docstring extraction from CST trivia.
+//!
+//! `///`-prefixed line comments preceding an item declaration are collected
+//! during CST → AST lowering and stored on the corresponding AST node.
+
+use baml_compiler_syntax::{SyntaxKind, SyntaxNode};
+
+/// Extract `///` doc comments attached to `node`.
+///
+/// The BAML parser captures leading line comments as the *first children*
+/// of the item node they precede (rather than as siblings before it), so
+/// this walks `node.children_with_tokens()` from the start. Logic mirrors
+/// what readers expect: only the contiguous run of `///` lines *immediately
+/// before the declaration body* counts as its docstring. A non-doc `// …`
+/// line interleaved among the leading comments resets the accumulator —
+/// e.g. file-header `// …` blocks separated by a blank line from a `///`
+/// block don't pollute the docstring, and a stray `// …` after the `///`
+/// block detaches the docstring entirely. The walk stops at the first
+/// non-trivia token or child node.
+///
+/// Returns `None` when no `///` lines are immediately attached; otherwise
+/// returns the joined lines (one `\n` between originals, with a single
+/// optional leading space stripped from each `///` body).
+pub fn extract_docstring(node: &SyntaxNode) -> Option<String> {
+    let mut doc_lines: Vec<String> = Vec::new();
+
+    for child in node.children_with_tokens() {
+        match child {
+            rowan::NodeOrToken::Token(tok) => match tok.kind() {
+                SyntaxKind::LINE_COMMENT => {
+                    let text = tok.text();
+                    if let Some(doc) = text.strip_prefix("///") {
+                        let doc = doc.strip_prefix(' ').unwrap_or(doc);
+                        doc_lines.push(doc.to_string());
+                    } else {
+                        // Regular `// …` line interleaved with leading
+                        // trivia detaches any earlier `///` accumulation
+                        // from the declaration.
+                        doc_lines.clear();
+                    }
+                }
+                SyntaxKind::WHITESPACE | SyntaxKind::NEWLINE => {}
+                _ => break,
+            },
+            rowan::NodeOrToken::Node(_) => break,
+        }
+    }
+
+    if doc_lines.is_empty() {
+        return None;
+    }
+
+    Some(doc_lines.join("\n"))
+}

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod ast;
 pub(crate) mod companions;
 pub(crate) mod disambiguate;
+pub mod docstring;
 pub(crate) mod lower_config_item;
 pub(crate) mod lower_cst;
 pub(crate) mod lower_expr_body;
@@ -18,6 +19,7 @@ pub mod lowering_diagnostic;
 
 pub use ast::*;
 pub use disambiguate::is_field_attr;
+pub use docstring::extract_docstring;
 pub use lower_cst::{
     lower_file, lower_file_with_file_id, synthesize_llm_builtin_call,
     synthesize_llm_make_stream_call,

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -244,6 +244,7 @@ fn lower_function(node: &SyntaxNode, diags: &mut Vec<LoweringDiagnostic>) -> Opt
     };
 
     let attributes = lower_attributes_from_node(node);
+    let docstring = crate::docstring::extract_docstring(node);
 
     Some(FunctionDef {
         name,
@@ -255,6 +256,7 @@ fn lower_function(node: &SyntaxNode, diags: &mut Vec<LoweringDiagnostic>) -> Opt
         declarative_meta,
         origin: crate::ast::FunctionOrigin::UserDefined,
         attributes,
+        docstring,
         span: node.text_range(),
         name_span,
     })
@@ -751,10 +753,12 @@ fn lower_class(
                     span: te_span,
                 }
             });
+            let field_docstring = crate::docstring::extract_docstring(f.syntax());
             Some(FieldDef {
                 name: Name::new(&field_name_str),
                 type_expr,
                 attributes: hoisted_field_attrs,
+                docstring: field_docstring,
                 span: f.syntax().text_range(),
                 name_span: fname.text_range(),
             })
@@ -776,6 +780,7 @@ fn lower_class(
         fields,
         methods,
         attributes: lower_attributes_from_node(node),
+        docstring: crate::docstring::extract_docstring(node),
         span: node.text_range(),
         name_span: name_token.text_range(),
     })
@@ -831,9 +836,11 @@ fn lower_enum(node: &SyntaxNode, diags: &mut Vec<LoweringDiagnostic>) -> Option<
                 });
                 return None;
             };
+            let variant_docstring = crate::docstring::extract_docstring(v.syntax());
             Some(VariantDef {
                 name: Name::new(vname.text()),
                 attributes: lower_variant_attributes(&v),
+                docstring: variant_docstring,
                 span: v.syntax().text_range(),
                 name_span: vname.text_range(),
             })
@@ -844,6 +851,7 @@ fn lower_enum(node: &SyntaxNode, diags: &mut Vec<LoweringDiagnostic>) -> Option<
         name: Name::new(name_token.text()),
         variants,
         attributes: lower_attributes_from_node(node),
+        docstring: crate::docstring::extract_docstring(node),
         span: node.text_range(),
         name_span: name_token.text_range(),
     })
@@ -1094,6 +1102,7 @@ fn synthesize_init_test_function(
         declarative_meta: None,
         origin: crate::ast::FunctionOrigin::Internal,
         attributes: vec![],
+        docstring: None,
         span,
         name_span: span,
     }
@@ -1131,6 +1140,7 @@ fn synthesize_register_call(
                 declarative_meta: None,
                 origin: crate::ast::FunctionOrigin::Internal,
                 attributes: vec![],
+                docstring: None,
                 span,
                 name_span: span,
             };
@@ -1199,6 +1209,7 @@ fn synthesize_register_call(
                 declarative_meta: None,
                 origin: crate::ast::FunctionOrigin::Internal,
                 attributes: vec![],
+                docstring: None,
                 span,
                 name_span: span,
             };
@@ -1883,6 +1894,7 @@ fn synthesize_client_new_companion(
         declarative_meta: None,
         origin: crate::ast::FunctionOrigin::Internal,
         attributes: vec![],
+        docstring: None,
         span,
         name_span: name_token.text_range(),
     }

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -2196,6 +2196,7 @@ impl LoweringContext {
             declarative_meta: None,
             origin: crate::ast::FunctionOrigin::Internal,
             attributes: Vec::new(),
+            docstring: None,
             span: node.text_range(),
             name_span: node.text_range(), // synthetic: use the lambda span
         };
@@ -2645,6 +2646,7 @@ impl LoweringContext {
             declarative_meta: None,
             origin: crate::ast::FunctionOrigin::Internal,
             attributes: vec![],
+            docstring: None,
             span,
             name_span: span,
         };
@@ -2731,6 +2733,7 @@ impl LoweringContext {
             declarative_meta: None,
             origin: crate::ast::FunctionOrigin::Internal,
             attributes: vec![],
+            docstring: None,
             span,
             name_span: span,
         };

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree.rs
@@ -73,6 +73,8 @@ pub struct Function {
     /// Declarative metadata, if this function was declared with declarative syntax.
     pub declarative_meta: Option<ast::DeclarativeMeta>,
     pub origin: ast::FunctionOrigin,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<String>,
     /// Full source span of the function.
     pub span: TextRange,
 }
@@ -91,6 +93,8 @@ pub struct ClassField {
     pub name: Name,
     pub type_expr: Option<ast::SpannedTypeExpr>,
     pub attributes: Vec<Attribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -106,6 +110,8 @@ pub struct Class {
     pub methods: Vec<LocalItemId<FunctionMarker>>,
     /// Block-level attributes (@@description, @@alias, etc.).
     pub attributes: Vec<Attribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<String>,
     /// Full source span of the class declaration.
     pub span: TextRange,
 }
@@ -116,6 +122,8 @@ pub struct EnumVariant {
     pub name: Name,
     /// Field-level attributes (@description, @alias, @skip, etc.).
     pub attributes: Vec<Attribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,6 +133,8 @@ pub struct Enum {
     pub variants: Vec<EnumVariant>,
     /// Block-level attributes (@@description, @@alias, etc.).
     pub attributes: Vec<Attribute>,
+    /// Joined `///` doc-comment lines preceding this declaration.
+    pub docstring: Option<String>,
     /// Full source span of the enum declaration.
     pub span: TextRange,
 }
@@ -330,6 +340,7 @@ impl ItemTree {
                 body: f.body.clone(),
                 declarative_meta: f.declarative_meta.clone(),
                 origin: f.origin,
+                docstring: f.docstring.clone(),
                 span: f.span,
             },
         );
@@ -345,6 +356,7 @@ impl ItemTree {
                 name: f.name.clone(),
                 type_expr: f.type_expr.clone(),
                 attributes: f.attributes.iter().map(Attribute::from).collect(),
+                docstring: f.docstring.clone(),
             })
             .collect();
         self.classes.insert(
@@ -355,6 +367,7 @@ impl ItemTree {
                 fields,
                 methods: Vec::new(),
                 attributes: c.attributes.iter().map(Attribute::from).collect(),
+                docstring: c.docstring.clone(),
                 span: c.span,
             },
         );
@@ -380,6 +393,7 @@ impl ItemTree {
             .map(|v| EnumVariant {
                 name: v.name.clone(),
                 attributes: v.attributes.iter().map(Attribute::from).collect(),
+                docstring: v.docstring.clone(),
             })
             .collect();
         self.enums.insert(
@@ -388,6 +402,7 @@ impl ItemTree {
                 name: e.name.clone(),
                 variants,
                 attributes: e.attributes.iter().map(Attribute::from).collect(),
+                docstring: e.docstring.clone(),
                 span: e.span,
             },
         );

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -414,6 +414,7 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                         declarative_meta: None,
                         origin: ast::FunctionOrigin::Companion,
                         attributes: vec![],
+                        docstring: func.docstring.clone(),
                         span,
                         name_span,
                     };
@@ -454,6 +455,7 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                         declarative_meta: None,
                         origin: ast::FunctionOrigin::Companion,
                         attributes: vec![],
+                        docstring: func.docstring.clone(),
                         span,
                         name_span,
                     };

--- a/baml_language/crates/baml_lsp2_actions/src/describe.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/describe.rs
@@ -873,7 +873,6 @@ fn resolve_type_for_item(db: &dyn Db, file: SourceFile, sym: &SymbolInfo) -> Opt
 fn extract_docstring(db: &dyn Db, file: SourceFile, item_range: TextRange) -> Option<String> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
 
-    // Find the item node.
     let token = match tree.token_at_offset(item_range.start()) {
         rowan::TokenAtOffset::Single(t) => t,
         rowan::TokenAtOffset::Between(_, right) => right,
@@ -881,47 +880,7 @@ fn extract_docstring(db: &dyn Db, file: SourceFile, item_range: TextRange) -> Op
     };
 
     let item_node = token.parent_ancestors().find(|n| is_item_node(n.kind()))?;
-
-    // Walk backward through siblings/trivia before the item node looking for
-    // consecutive /// comments.
-    let mut doc_lines: Vec<String> = Vec::new();
-
-    // Get all tokens before the item node's start that are trivia.
-    // We look at preceding siblings of the item node.
-    let mut prev = item_node.prev_sibling_or_token();
-    while let Some(node_or_token) = prev {
-        match node_or_token {
-            rowan::NodeOrToken::Token(ref tok) => {
-                match tok.kind() {
-                    SyntaxKind::LINE_COMMENT => {
-                        let text = tok.text();
-                        if let Some(doc) = text.strip_prefix("///") {
-                            // Strip one leading space if present.
-                            let doc = doc.strip_prefix(' ').unwrap_or(doc);
-                            doc_lines.push(doc.to_string());
-                        } else {
-                            // Regular comment, stop collecting.
-                            break;
-                        }
-                    }
-                    SyntaxKind::WHITESPACE | SyntaxKind::NEWLINE => {
-                        // Skip whitespace between doc comments.
-                    }
-                    _ => break,
-                }
-            }
-            rowan::NodeOrToken::Node(_) => break,
-        }
-        prev = node_or_token.prev_sibling_or_token();
-    }
-
-    if doc_lines.is_empty() {
-        return None;
-    }
-
-    // Lines were collected in reverse order.
-    doc_lines.reverse();
-    Some(doc_lines.join("\n"))
+    baml_compiler2_ast::extract_docstring(&item_node)
 }
 
 // ── Dependency discovery ─────────────────────────────────────────────────────

--- a/baml_language/crates/baml_lsp2_actions/src/snapshots/baml_lsp2_actions__describe_tests__describe_function.snap
+++ b/baml_language/crates/baml_lsp2_actions/src/snapshots/baml_lsp2_actions__describe_tests__describe_function.snap
@@ -3,5 +3,6 @@ source: crates/baml_lsp2_actions/src/describe_tests.rs
 expression: "project.format_description(&descs[0])"
 ---
 function ExtractPoint  funcs.baml:3
+/// Extract a point from text.
 shape: function ExtractPoint(text: string) -> Point
 deps: Point

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -137,7 +137,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                     )?;
                     Some(cg::ClassProperty {
                         name: field.name.clone(),
-                        docstring: None,
+                        docstring: field.docstring.clone(),
                         ty,
                     })
                 })
@@ -206,7 +206,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 let cg_method = cg::Function {
                     name: method.name.clone(),
                     generic_params: method.generic_params.clone(),
-                    docstring: None,
+                    docstring: method.docstring.clone(),
                     arguments,
                     return_type,
                     watchers: Vec::new(),
@@ -228,7 +228,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 cg::Symbol::Class(cg::Class {
                     name: cg_name,
                     generic_params: class_generic_params,
-                    docstring: None,
+                    docstring: class.docstring.clone(),
                     properties,
                     static_methods: Vec::new(),
                     instance_methods: Vec::new(),
@@ -252,7 +252,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 .iter()
                 .map(|v| cg::EnumVariant {
                     name: v.name.clone(),
-                    docstring: None,
+                    docstring: v.docstring.clone(),
                     value: v.name.to_string(),
                 })
                 .collect();
@@ -260,7 +260,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 cg_name.clone(),
                 cg::Symbol::Enum(cg::Enum {
                     name: cg_name,
-                    docstring: None,
+                    docstring: enum_def.docstring.clone(),
                     variants,
                     origin: Origin {
                         source_file_path: source_file_path.clone(),
@@ -370,7 +370,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
             let cg_func = cg::Function {
                 name: func.name.clone(),
                 generic_params: func_generic_params,
-                docstring: None,
+                docstring: func.docstring.clone(),
                 arguments,
                 return_type,
                 watchers: Vec::new(),
@@ -734,6 +734,69 @@ mod tests {
                 "{expected} must be a Function symbol",
             );
         }
+    }
+
+    /// Smoke test: `///` on classes / fields / enums / variants must reach the
+    /// `SymbolPool`. Pre-existing failure mode here was that the symbol pool
+    /// was built but every `docstring` was `None` despite the AST carrying
+    /// it — hence the codegen produced bodies with no `"""…"""`.
+    #[test]
+    fn test_doc_comments_reach_symbol_pool() {
+        let root = Path::new("/tmp/docstrings_repro");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("main.baml").as_path(),
+            "/// A document with a title.\nclass Doc {\n  /// Title shown in lists.\n  title string\n}\n\n/// Sentiment labels.\nenum Sentiment {\n  /// Smiling face.\n  HAPPY\n  SAD\n}\n",
+        );
+
+        let pool = build_symbol_pool(&db);
+
+        let doc_key = pool
+            .keys()
+            .find(|k| k.name.as_str() == "Doc")
+            .expect("Doc class missing from pool");
+        let cg::Symbol::Class(doc) = &pool[doc_key] else {
+            panic!("Doc must be a Class");
+        };
+        assert_eq!(
+            doc.docstring.as_deref(),
+            Some("A document with a title."),
+            "class /// must reach pool",
+        );
+        let title = doc
+            .properties
+            .iter()
+            .find(|p| p.name.as_str() == "title")
+            .expect("title field missing");
+        assert_eq!(
+            title.docstring.as_deref(),
+            Some("Title shown in lists."),
+            "field /// must reach pool",
+        );
+
+        let enum_key = pool
+            .keys()
+            .find(|k| k.name.as_str() == "Sentiment")
+            .expect("Sentiment enum missing");
+        let cg::Symbol::Enum(en) = &pool[enum_key] else {
+            panic!("Sentiment must be an Enum");
+        };
+        assert_eq!(
+            en.docstring.as_deref(),
+            Some("Sentiment labels."),
+            "enum /// must reach pool",
+        );
+        let happy = en
+            .variants
+            .iter()
+            .find(|v| v.name.as_str() == "HAPPY")
+            .expect("HAPPY variant missing");
+        assert_eq!(
+            happy.docstring.as_deref(),
+            Some("Smiling face."),
+            "variant /// must reach pool",
+        );
     }
 
     /// Verifies that user-package classes with static and instance methods

--- a/baml_language/languages/python/rust/codegen_python/src/emit/class.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/emit/class.rs
@@ -24,6 +24,12 @@ pub(crate) struct PyClass {
     /// `typing.Generic[T, …]` second base and the leaf-level `TypeVar`
     /// declarations include each name.
     pub(crate) generic_params: Vec<String>,
+    /// Joined `///` doc-comment lines from the BAML class declaration.
+    /// Combined with `PyClassProperty.docstring` from each entry in
+    /// `properties` to produce the `"""…"""` Python class docstring;
+    /// `Class.__doc__` carries the summary plus an `Attributes:`
+    /// section (see `crate::utils::format_class_docstring`).
+    pub(crate) docstring: Option<String>,
     /// Class fields, in IR declaration order. Field names are emitted
     /// verbatim per 09b §5 ("agent-friendly" naming).
     pub(crate) properties: Vec<PyClassProperty>,
@@ -39,4 +45,10 @@ pub(crate) struct PyClass {
 pub(crate) struct PyClassProperty {
     pub(crate) name: String,
     pub(crate) ty: Ty,
+    /// Joined `///` doc-comment lines preceding the field. Folded into
+    /// the parent `PyClass`'s `"""…"""` docstring under an
+    /// `Attributes:` section — never rendered as an inline `# …`
+    /// comment next to the field declaration. The visibility rule
+    /// for the section lives in `crate::utils::format_class_docstring`.
+    pub(crate) docstring: Option<String>,
 }

--- a/baml_language/languages/python/rust/codegen_python/src/emit/enum_.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/emit/enum_.rs
@@ -10,7 +10,12 @@ pub(crate) struct PyEnum {
     pub(crate) source: Name,
     /// Enum variants in IR declaration order.
     pub(crate) variants: Vec<PyEnumVariant>,
-    // deferred to G4+: docstring: Option<String>,
+    /// Joined `///` doc-comment lines from the BAML enum declaration.
+    /// Combined with `PyEnumVariant.docstring` from each entry in
+    /// `variants` to produce the `"""…"""` Python enum docstring;
+    /// `Enum.__doc__` carries the summary plus a `Members:` section
+    /// (see `crate::utils::format_class_docstring`).
+    pub(crate) docstring: Option<String>,
 }
 
 pub(crate) struct PyEnumVariant {
@@ -18,4 +23,11 @@ pub(crate) struct PyEnumVariant {
     pub(crate) ident: String,
     /// RHS string literal (IR's `EnumVariant.value`, verbatim).
     pub(crate) value: String,
+    /// Joined `///` doc-comment lines preceding the variant. Folded
+    /// into the parent `PyEnum`'s `"""…"""` docstring under a
+    /// `Members:` section — never rendered as an inline `# …` comment
+    /// or PEP-257 attribute docstring next to the variant. The
+    /// visibility rule for the section lives in
+    /// `crate::utils::format_class_docstring`.
+    pub(crate) docstring: Option<String>,
 }

--- a/baml_language/languages/python/rust/codegen_python/src/emit/function.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/emit/function.rs
@@ -46,4 +46,8 @@ pub(crate) struct PyFunction {
     /// functions. Surfaces only in `.pyi` rendering — the `.py` factory
     /// binding is type-erased.
     pub(crate) generic_params: Vec<String>,
+    /// Joined `///` doc-comment lines from the BAML function declaration.
+    /// Surfaced only by `.pyi` rendering as a `"""..."""` body so
+    /// `__doc__` resolves at runtime.
+    pub(crate) docstring: Option<String>,
 }

--- a/baml_language/languages/python/rust/codegen_python/src/emit/method.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/emit/method.rs
@@ -35,6 +35,10 @@ pub(crate) struct PyMethodBinding {
     /// methods. Surfaces only in `.pyi` rendering — the `.py` factory
     /// binding is type-erased.
     pub(crate) generic_params: Vec<String>,
+    /// Joined `///` doc-comment lines from the BAML method declaration.
+    /// Surfaced only by `.pyi` rendering as a `"""..."""` body, since
+    /// `.py` factory bindings have no meaningful body.
+    pub(crate) docstring: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/baml_language/languages/python/rust/codegen_python/src/emit/mod.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/emit/mod.rs
@@ -78,6 +78,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                     .map(|p| PyClassProperty {
                         name: p.name.as_str().to_string(),
                         ty: p.ty.clone(),
+                        docstring: p.docstring.clone(),
                     })
                     .collect();
                 // The class's pool key Display form is already the
@@ -100,6 +101,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                         py_name: bare,
                         source: key.clone(),
                         generic_params,
+                        docstring: c.docstring.clone(),
                         properties,
                         static_methods,
                         instance_methods,
@@ -115,6 +117,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                     .map(|v| PyEnumVariant {
                         ident: v.name.as_str().to_string(),
                         value: v.value.clone(),
+                        docstring: v.docstring.clone(),
                     })
                     .collect();
                 out.push((
@@ -123,6 +126,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                         py_name: bare,
                         source: key.clone(),
                         variants,
+                        docstring: e.docstring.clone(),
                     }),
                     sort_key,
                 ));
@@ -173,6 +177,7 @@ fn expand_function(
         .iter()
         .map(|n| n.as_str().to_string())
         .collect();
+    let func_docstring = f.docstring.clone();
     expand_callable(
         &bare,
         &fqn_root,
@@ -189,6 +194,7 @@ fn expand_function(
                     arg_tys,
                     return_ty,
                     generic_params: func_generic_params.clone(),
+                    docstring: func_docstring.clone(),
                 }),
                 sort_key.clone(),
             ));
@@ -219,6 +225,7 @@ fn expand_methods(
             .iter()
             .map(|n| n.as_str().to_string())
             .collect();
+        let method_docstring = m.docstring.clone();
         expand_callable(
             &bare,
             &fqn_root,
@@ -243,6 +250,7 @@ fn expand_methods(
                     arg_tys,
                     return_ty,
                     generic_params: method_generic_params.clone(),
+                    docstring: method_docstring.clone(),
                 });
             },
         );

--- a/baml_language/languages/python/rust/codegen_python/src/leaf.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/leaf.rs
@@ -366,6 +366,9 @@ fn is_media_reexport(s: &EmittedSymbol) -> bool {
 #[derive(askama::Template)]
 #[template(
     source = r#"class {{ py_name }}({{ bases }}):
+{%- if let Some(doc) = docstring %}
+    {{ doc }}
+{%- endif %}
     model_config = pydantic.ConfigDict(extra="forbid")
 {%- for prop in properties %}
     {{ prop.name }}: {{ prop.ty_py }}
@@ -394,6 +397,13 @@ fn is_media_reexport(s: &EmittedSymbol) -> bool {
 struct ClassBodyPy {
     py_name: String,
     bases: String,
+    /// Pre-rendered `"""…"""` body docstring (class summary plus a
+    /// folded `Attributes:` section listing each `///`-documented
+    /// field). `None` when neither the class nor any field carries a
+    /// `///`. Field-level `///` is intentionally not emitted as an
+    /// inline `# …` comment — the `Attributes:` section is the sole
+    /// channel.
+    docstring: Option<String>,
     properties: Vec<ClassPropertyView>,
     static_methods: Vec<MethodLineView>,
     instance_methods: Vec<MethodLineView>,
@@ -414,6 +424,9 @@ struct MethodLineView {
 #[derive(askama::Template)]
 #[template(
     source = r#"class {{ py_name }}(str, enum.Enum):
+{%- if let Some(doc) = docstring %}
+    {{ doc }}
+{%- endif %}
 {%- if variants.is_empty() %}
     pass
 {%- else %}
@@ -426,6 +439,11 @@ struct MethodLineView {
 )]
 struct EnumBodyPy {
     py_name: String,
+    /// Pre-rendered `"""…"""` body docstring (enum summary plus a
+    /// folded `Members:` section listing each `///`-documented
+    /// variant). `None` when neither the enum nor any variant carries
+    /// a `///`.
+    docstring: Option<String>,
     variants: Vec<EnumVariantView>,
 }
 
@@ -491,9 +509,21 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                     ty_py: translate_ty(&prop.ty, &ctx),
                 })
                 .collect();
+            let attrs: Vec<(String, Option<String>)> = c
+                .properties
+                .iter()
+                .map(|p| (p.name.clone(), p.docstring.clone()))
+                .collect();
+            let docstring = crate::utils::format_class_docstring(
+                c.docstring.as_deref(),
+                &attrs,
+                "Attributes",
+                "    ",
+            );
             let mut out = ClassBodyPy {
                 py_name: c.py_name.clone(),
                 bases: render_class_bases(&c.generic_params),
+                docstring,
                 properties,
                 static_methods: build_method_line_views(&c.static_methods),
                 instance_methods: build_method_line_views(&c.instance_methods),
@@ -512,8 +542,20 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                     value: py_string(&v.value),
                 })
                 .collect();
+            let members: Vec<(String, Option<String>)> = e
+                .variants
+                .iter()
+                .map(|v| (v.ident.clone(), v.docstring.clone()))
+                .collect();
+            let docstring = crate::utils::format_class_docstring(
+                e.docstring.as_deref(),
+                &members,
+                "Members",
+                "    ",
+            );
             let mut out = EnumBodyPy {
                 py_name: e.py_name.clone(),
+                docstring,
                 variants,
             }
             .render()
@@ -829,7 +871,9 @@ struct MethodBlockView {
 }
 
 /// One method's `.pyi` signature block: a single `def` line for
-/// instance methods, prefixed by `@staticmethod` for statics.
+/// instance methods, prefixed by `@staticmethod` for statics. When the
+/// method carries a `///` docstring, replaces the trailing `...` with a
+/// `"""..."""` body so `__doc__` resolves at runtime.
 fn render_method_block_pyi(m: &PyMethodBinding, ctx: &TranslateCtx) -> String {
     let async_kw = if matches!(m.mode, SyncAsync::Async) {
         "async "
@@ -838,10 +882,19 @@ fn render_method_block_pyi(m: &PyMethodBinding, ctx: &TranslateCtx) -> String {
     };
     let typed_params = render_method_params_pyi(m, ctx);
     let ret_py = translate_ty(&m.return_ty, ctx);
-    let signature = format!(
-        "    {async_kw}def {name}({typed_params}) -> {ret_py}: ...",
-        name = m.py_name
-    );
+    let signature = match m.docstring.as_deref() {
+        Some(doc) => {
+            let rendered = crate::utils::format_docstring(doc, "        ");
+            format!(
+                "    {async_kw}def {name}({typed_params}) -> {ret_py}:\n        {rendered}",
+                name = m.py_name
+            )
+        }
+        None => format!(
+            "    {async_kw}def {name}({typed_params}) -> {ret_py}: ...",
+            name = m.py_name
+        ),
+    };
     match m.kind {
         MethodKind::Static => format!("    @staticmethod\n{signature}"),
         MethodKind::Instance => signature,
@@ -912,7 +965,9 @@ fn render_symbol_pyi(s: &EmittedSymbol, leaf: &LeafPath) -> String {
         }
         EmittedSymbol::Enum(e) => {
             // Enum body is identical between `.py` and `.pyi` —
-            // reuse the `.py` template directly.
+            // reuse the `.py` template directly. The `.pyi` form
+            // omits the body docstring; `__doc__` resolves against
+            // the `.py` definition.
             let variants = e
                 .variants
                 .iter()
@@ -923,6 +978,7 @@ fn render_symbol_pyi(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 .collect();
             let mut out = EnumBodyPy {
                 py_name: e.py_name.clone(),
+                docstring: None,
                 variants,
             }
             .render()
@@ -977,10 +1033,19 @@ fn render_function_signature_pyi(f: &PyFunction, ctx: &TranslateCtx) -> String {
     };
     let typed_params = render_typed_params(&f.param_names, &f.arg_tys, ctx);
     let ret_py = translate_ty(&f.return_ty, ctx);
-    format!(
-        "{async_kw}def {name}({typed_params}) -> {ret_py}: ...",
-        name = f.py_name
-    )
+    match f.docstring.as_deref() {
+        Some(doc) => {
+            let rendered = crate::utils::format_docstring(doc, "    ");
+            format!(
+                "{async_kw}def {name}({typed_params}) -> {ret_py}:\n    {rendered}",
+                name = f.py_name
+            )
+        }
+        None => format!(
+            "{async_kw}def {name}({typed_params}) -> {ret_py}: ...",
+            name = f.py_name
+        ),
+    }
 }
 
 fn render_typed_params(names: &[String], tys: &[Ty], ctx: &TranslateCtx) -> String {

--- a/baml_language/languages/python/rust/codegen_python/src/lib.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/lib.rs
@@ -8,6 +8,7 @@ mod emit;
 mod leaf;
 mod routing;
 mod translate_ty;
+mod utils;
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -540,6 +541,367 @@ mod tests {
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(leaf.contains("import typing\n"));
         assert!(leaf.contains("Foo: typing.TypeAlias = int\n"));
+    }
+
+    // ── /// docstring emission ──────────────────────────────────────────────
+
+    fn class_with_docs(
+        name: Name,
+        docstring: Option<&str>,
+        properties: Vec<ClassProperty>,
+    ) -> Symbol {
+        Symbol::Class(Class {
+            generic_params: Vec::new(),
+            name,
+            docstring: docstring.map(String::from),
+            properties,
+            static_methods: vec![],
+            instance_methods: vec![],
+            origin: origin("x.baml", 0),
+        })
+    }
+
+    #[test]
+    fn class_summary_only_emits_single_line_docstring() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Resume");
+        pool.insert(
+            n.clone(),
+            class_with_docs(
+                n,
+                Some("Job applicant resume."),
+                vec![ClassProperty {
+                    name: BaseName::new("a"),
+                    docstring: None,
+                    ty: Ty::Int,
+                }],
+            ),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains(
+                "class Resume(pydantic.BaseModel):\n    \"\"\"Job applicant resume.\"\"\"\n"
+            ),
+            "got:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn field_doc_folds_into_attributes_section() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Resume");
+        pool.insert(
+            n.clone(),
+            class_with_docs(
+                n,
+                None,
+                vec![ClassProperty {
+                    name: BaseName::new("a"),
+                    docstring: Some("Identifier".to_string()),
+                    ty: Ty::Int,
+                }],
+            ),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        // Field /// goes into the class body docstring as an
+        // Attributes: section — there is no inline `# ` comment.
+        assert!(
+            leaf.contains(
+                "class Resume(pydantic.BaseModel):\n    \"\"\"\n    Attributes:\n        a: Identifier\n    \"\"\"\n"
+            ),
+            "got:\n{leaf}"
+        );
+        assert!(
+            !leaf.contains("# Identifier"),
+            "field /// must not emit inline `# …` comments; got:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn class_summary_plus_field_docs_block_form() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Doc");
+        pool.insert(
+            n.clone(),
+            class_with_docs(
+                n,
+                Some("A document with a title and an optional body."),
+                vec![
+                    ClassProperty {
+                        name: BaseName::new("title"),
+                        docstring: Some("Title shown in lists.".to_string()),
+                        ty: Ty::String,
+                    },
+                    ClassProperty {
+                        name: BaseName::new("body"),
+                        docstring: Some("Free-form body text.".to_string()),
+                        ty: Ty::Optional(Box::new(Ty::String)),
+                    },
+                ],
+            ),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains(
+                "class Doc(pydantic.BaseModel):\n    \"\"\"\n    A document with a title and an optional body.\n\n    Attributes:\n        title: Title shown in lists.\n        body: Free-form body text.\n    \"\"\"\n"
+            ),
+            "got:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn class_multiline_summary_uses_block_form() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Resume");
+        pool.insert(
+            n.clone(),
+            class_with_docs(
+                n,
+                Some("first line\nsecond line"),
+                vec![ClassProperty {
+                    name: BaseName::new("a"),
+                    docstring: None,
+                    ty: Ty::Int,
+                }],
+            ),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("    \"\"\"\n    first line\n    second line\n    \"\"\""),
+            "got:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn enum_doc_folds_variants_into_members_section() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Sentiment");
+        pool.insert(
+            n.clone(),
+            Symbol::Enum(Enum {
+                name: n,
+                docstring: Some("Sentiment scale".to_string()),
+                variants: vec![
+                    EnumVariant {
+                        name: BaseName::new("HAPPY"),
+                        docstring: Some("Smiling".to_string()),
+                        value: "HAPPY".to_string(),
+                    },
+                    EnumVariant {
+                        name: BaseName::new("SAD"),
+                        docstring: None,
+                        value: "SAD".to_string(),
+                    },
+                ],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        // Once at least one variant carries a `///`, the Members: block
+        // appears and lists *every* variant — undocumented ones render
+        // as bare names. No inline `"""…"""` attribute docstrings
+        // remain.
+        assert!(
+            leaf.contains(
+                "class Sentiment(str, enum.Enum):\n    \"\"\"\n    Sentiment scale\n\n    Members:\n        HAPPY: Smiling\n        SAD\n    \"\"\"\n    HAPPY = \"HAPPY\"\n    SAD = \"SAD\"\n"
+            ),
+            "got:\n{leaf}"
+        );
+    }
+
+    /// Enum has a summary but no variant carries a `///` — the
+    /// Members: section is suppressed entirely.
+    #[test]
+    fn enum_summary_only_skips_members_section() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Sentiment");
+        pool.insert(
+            n.clone(),
+            Symbol::Enum(Enum {
+                name: n,
+                docstring: Some("Sentiment scale".to_string()),
+                variants: vec![
+                    EnumVariant {
+                        name: BaseName::new("HAPPY"),
+                        docstring: None,
+                        value: "HAPPY".to_string(),
+                    },
+                    EnumVariant {
+                        name: BaseName::new("SAD"),
+                        docstring: None,
+                        value: "SAD".to_string(),
+                    },
+                ],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains(
+                "class Sentiment(str, enum.Enum):\n    \"\"\"Sentiment scale\"\"\"\n    HAPPY = \"HAPPY\"\n    SAD = \"SAD\"\n"
+            ),
+            "got:\n{leaf}"
+        );
+        assert!(
+            !leaf.contains("Members:"),
+            "Members: section must not appear when no variant is documented; got:\n{leaf}"
+        );
+    }
+
+    /// Class has a summary but no field carries a `///` — the
+    /// Attributes: section is suppressed entirely.
+    #[test]
+    fn class_summary_only_skips_attributes_section() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Resume");
+        pool.insert(
+            n.clone(),
+            class_with_docs(
+                n,
+                Some("Job applicant resume."),
+                vec![
+                    ClassProperty {
+                        name: BaseName::new("a"),
+                        docstring: None,
+                        ty: Ty::Int,
+                    },
+                    ClassProperty {
+                        name: BaseName::new("b"),
+                        docstring: None,
+                        ty: Ty::Int,
+                    },
+                ],
+            ),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            !leaf.contains("Attributes:"),
+            "Attributes: section must not appear when no field is documented; got:\n{leaf}"
+        );
+    }
+
+    /// Once any field carries a `///`, the Attributes: section appears
+    /// and lists *every* field — undocumented ones render as bare
+    /// names.
+    #[test]
+    fn class_partial_field_docs_lists_all_fields_in_attributes() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Resume");
+        pool.insert(
+            n.clone(),
+            class_with_docs(
+                n,
+                None,
+                vec![
+                    ClassProperty {
+                        name: BaseName::new("a"),
+                        docstring: Some("First.".to_string()),
+                        ty: Ty::Int,
+                    },
+                    ClassProperty {
+                        name: BaseName::new("b"),
+                        docstring: None,
+                        ty: Ty::Int,
+                    },
+                ],
+            ),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains(
+                "class Resume(pydantic.BaseModel):\n    \"\"\"\n    Attributes:\n        a: First.\n        b\n    \"\"\"\n"
+            ),
+            "got:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn class_no_docs_unchanged() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Resume");
+        pool.insert(n.clone(), class(n));
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.py")];
+        assert!(!leaf.contains("\"\"\""));
+        assert!(
+            !leaf.contains("    # "),
+            "unexpected docstring comment in:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn function_docstring_emits_in_pyi_body() {
+        let mut pool: SymbolPool = HashMap::new();
+        let mut f = bare_func("ExtractResume", "x.baml", 0);
+        f.docstring = Some("Extract resume from PDF.".to_string());
+        pool.insert(
+            cg_name("user", &["lorem"], "ExtractResume"),
+            Symbol::Function(f),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            leaf.contains(
+                "def ExtractResume(x: int) -> int:\n    \"\"\"Extract resume from PDF.\"\"\"\n"
+            ),
+            "got:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn function_no_docstring_keeps_ellipsis() {
+        let mut pool: SymbolPool = HashMap::new();
+        let f = bare_func("ExtractResume", "x.baml", 0);
+        pool.insert(
+            cg_name("user", &["lorem"], "ExtractResume"),
+            Symbol::Function(f),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(leaf.contains("def ExtractResume(x: int) -> int: ..."));
+    }
+
+    #[test]
+    fn instance_method_docstring_emits_in_pyi_body() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Resume");
+        let mut method = bare_func("summarize", "x.baml", 100);
+        method.docstring = Some("Summarize the resume.".to_string());
+        method.arguments = vec![FunctionArgument {
+            name: BaseName::new("self"),
+            docstring: None,
+            ty: Ty::Class(n.clone(), vec![]),
+        }];
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: Vec::new(),
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("a"),
+                    docstring: None,
+                    ty: Ty::Int,
+                }],
+                static_methods: vec![],
+                instance_methods: vec![method],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let leaf = &to_source_code(&pool, &[])[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            leaf.contains(":\n        \"\"\"Summarize the resume.\"\"\"\n"),
+            "got:\n{leaf}"
+        );
     }
 
     #[test]

--- a/baml_language/languages/python/rust/codegen_python/src/utils.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/utils.rs
@@ -1,0 +1,334 @@
+//! Helpers shared between the `codegen_python` emit modules.
+
+/// Format a string as a Python docstring with proper indentation.
+/// The first line starts with `"""`, subsequent lines are indented with
+/// `indent`, and the closing `"""` sits on the same line as the last
+/// content. Backslashes and `"""` sequences in `s` are escaped so the
+/// emitted string is always syntactically valid Python.
+///
+/// Used for method/function bodies — class and enum docstrings go
+/// through `format_class_docstring` instead so that field/variant
+/// `///` lines fold into the body as an `Attributes:` / `Members:`
+/// section.
+pub(crate) fn format_docstring(s: &str, indent: &str) -> String {
+    if s.is_empty() {
+        return "\"\"\"\"\"\"".to_string();
+    }
+
+    let escaped = escape_for_docstring(s);
+
+    let lines: Vec<&str> = escaped.lines().collect();
+    if lines.len() == 1 {
+        return format!("\"\"\"{}\"\"\"", lines[0]);
+    }
+
+    let mut result = String::new();
+    result.push_str("\"\"\"");
+    result.push_str(lines[0]);
+    for line in &lines[1..] {
+        result.push('\n');
+        result.push_str(indent);
+        result.push_str(line);
+    }
+    result.push_str("\"\"\"");
+    result
+}
+
+/// Render a class- or enum-level docstring that folds per-field /
+/// per-variant `///` lines into a single `Attributes:` / `Members:`
+/// section, e.g.:
+///
+/// ```text
+/// """
+/// Application configuration.
+///
+/// Attributes:
+///     timeout: Timeout in seconds.
+///     retries: Number of retry attempts.
+///     debug
+/// """
+/// ```
+///
+/// `summary` is the class/enum's own `///` text, if any.
+/// `members` is `(name, Option<doc>)` pairs for **every** field /
+/// variant in declaration order — `Some(doc)` for those that carry a
+/// `///`, `None` for those that don't.
+/// `section_label` is `"Attributes"` for classes and `"Members"`
+/// for enums.
+/// `body_indent` is the indentation prepended to every line *after*
+/// the opening `"""` — the caller's template emits the leading
+/// indent for the first line itself.
+///
+/// Section visibility rule: the `Attributes:` / `Members:` section
+/// appears iff **at least one** member carries a `///`. When it
+/// appears, **all** members are listed — undocumented entries render
+/// as a bare `name` (no trailing colon), and documented entries as
+/// `name: <doc>`. This way the section, when present, faithfully
+/// reflects every public child of the type.
+///
+/// Returns `None` when there's nothing to render (no summary and no
+/// member carries a `///`). Returns a single-line `"""…"""` when
+/// only a single-line summary is present and no member carries a
+/// `///`. Otherwise returns the block form shown above.
+pub(crate) fn format_class_docstring(
+    summary: Option<&str>,
+    members: &[(String, Option<String>)],
+    section_label: &str,
+    body_indent: &str,
+) -> Option<String> {
+    let summary = summary.filter(|s| !s.is_empty());
+    let any_member_doc = members.iter().any(|(_, d)| d.is_some());
+
+    if summary.is_none() && !any_member_doc {
+        return None;
+    }
+
+    if let Some(s) = summary {
+        if !s.contains('\n') && !any_member_doc {
+            return Some(format!("\"\"\"{}\"\"\"", escape_for_docstring(s)));
+        }
+    }
+
+    let mut out = String::from("\"\"\"\n");
+    if let Some(s) = summary {
+        for line in s.lines() {
+            out.push_str(body_indent);
+            out.push_str(&escape_for_docstring(line));
+            out.push('\n');
+        }
+    }
+    if any_member_doc {
+        if summary.is_some() {
+            out.push('\n');
+        }
+        out.push_str(body_indent);
+        out.push_str(section_label);
+        out.push_str(":\n");
+        for (name, doc) in members {
+            match doc {
+                Some(d) => {
+                    let mut lines = d.lines();
+                    if let Some(first) = lines.next() {
+                        out.push_str(body_indent);
+                        out.push_str("    ");
+                        out.push_str(name);
+                        out.push_str(": ");
+                        out.push_str(&escape_for_docstring(first));
+                        out.push('\n');
+                        for line in lines {
+                            out.push_str(body_indent);
+                            out.push_str("        ");
+                            out.push_str(&escape_for_docstring(line));
+                            out.push('\n');
+                        }
+                    } else {
+                        // Empty docstring — fall through to bare-name form.
+                        out.push_str(body_indent);
+                        out.push_str("    ");
+                        out.push_str(name);
+                        out.push('\n');
+                    }
+                }
+                None => {
+                    out.push_str(body_indent);
+                    out.push_str("    ");
+                    out.push_str(name);
+                    out.push('\n');
+                }
+            }
+        }
+    }
+    out.push_str(body_indent);
+    out.push_str("\"\"\"");
+    Some(out)
+}
+
+/// Escape `\` and `"""` so they don't break the surrounding
+/// `"""…"""` fence. `\` first so a later `\"""` substitution isn't
+/// itself doubled.
+fn escape_for_docstring(s: &str) -> String {
+    s.replace('\\', "\\\\").replace("\"\"\"", "\\\"\"\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_docstring_empty() {
+        assert_eq!(format_docstring("", "    "), "\"\"\"\"\"\"");
+    }
+
+    #[test]
+    fn format_docstring_single_line() {
+        assert_eq!(format_docstring("hello", "    "), "\"\"\"hello\"\"\"");
+    }
+
+    #[test]
+    fn format_docstring_multi_line() {
+        assert_eq!(
+            format_docstring("a\nb\nc", "    "),
+            "\"\"\"a\n    b\n    c\"\"\""
+        );
+    }
+
+    #[test]
+    fn format_docstring_escapes_triple_quote() {
+        assert_eq!(
+            format_docstring("hello\"\"\"world", "    "),
+            "\"\"\"hello\\\"\"\"world\"\"\""
+        );
+    }
+
+    #[test]
+    fn format_docstring_escapes_trailing_backslash() {
+        assert_eq!(format_docstring("text\\", "    "), "\"\"\"text\\\\\"\"\"");
+    }
+
+    #[test]
+    fn format_class_docstring_none_when_empty() {
+        assert_eq!(
+            format_class_docstring(None, &[], "Attributes", "    "),
+            None
+        );
+        assert_eq!(
+            format_class_docstring(Some(""), &[], "Attributes", "    "),
+            None
+        );
+    }
+
+    #[test]
+    fn format_class_docstring_single_line_summary_only() {
+        assert_eq!(
+            format_class_docstring(Some("Job applicant resume."), &[], "Attributes", "    "),
+            Some("\"\"\"Job applicant resume.\"\"\"".to_string()),
+        );
+    }
+
+    #[test]
+    fn format_class_docstring_multi_line_summary_uses_block_form() {
+        assert_eq!(
+            format_class_docstring(Some("Line one.\nLine two."), &[], "Attributes", "    "),
+            Some("\"\"\"\n    Line one.\n    Line two.\n    \"\"\"".to_string()),
+        );
+    }
+
+    #[test]
+    fn format_class_docstring_summary_plus_members_attributes_section() {
+        let members = vec![
+            (
+                "title".to_string(),
+                Some("Title shown in lists.".to_string()),
+            ),
+            ("body".to_string(), Some("Free-form body text.".to_string())),
+        ];
+        let out = format_class_docstring(
+            Some("A document with a title and an optional body."),
+            &members,
+            "Attributes",
+            "    ",
+        );
+        assert_eq!(
+            out,
+            Some(
+                "\"\"\"\n    A document with a title and an optional body.\n\n    Attributes:\n        title: Title shown in lists.\n        body: Free-form body text.\n    \"\"\""
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn format_class_docstring_members_only_no_leading_summary_blank() {
+        let members = vec![("HAPPY".to_string(), Some("Smiling face.".to_string()))];
+        let out = format_class_docstring(None, &members, "Members", "    ");
+        assert_eq!(
+            out,
+            Some("\"\"\"\n    Members:\n        HAPPY: Smiling face.\n    \"\"\"".to_string())
+        );
+    }
+
+    #[test]
+    fn format_class_docstring_member_doc_continuation_lines_indent_under_name() {
+        let members = vec![("a".to_string(), Some("First.\nContinuation.".to_string()))];
+        let out = format_class_docstring(None, &members, "Attributes", "    ");
+        assert_eq!(
+            out,
+            Some(
+                "\"\"\"\n    Attributes:\n        a: First.\n            Continuation.\n    \"\"\""
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn format_class_docstring_escapes_triple_quote_in_summary_and_member() {
+        let members = vec![("a".to_string(), Some("she said \"\"\" thrice".to_string()))];
+        let out = format_class_docstring(
+            Some("contains \"\"\" inside"),
+            &members,
+            "Attributes",
+            "    ",
+        );
+        let expected = "\"\"\"\n    contains \\\"\"\" inside\n\n    Attributes:\n        a: she said \\\"\"\" thrice\n    \"\"\"";
+        assert_eq!(out.as_deref(), Some(expected));
+    }
+
+    // ── Section visibility: "any-doc" rule ──────────────────────────────────
+
+    /// No summary and zero documented members -> no docstring at all,
+    /// even when undocumented members exist.
+    #[test]
+    fn format_class_docstring_no_section_when_no_member_documented() {
+        let members = vec![("a".to_string(), None), ("b".to_string(), None)];
+        assert_eq!(
+            format_class_docstring(None, &members, "Attributes", "    "),
+            None,
+        );
+    }
+
+    /// Summary present but no member documented -> emit the summary
+    /// alone, no `Attributes:` / `Members:` block.
+    #[test]
+    fn format_class_docstring_summary_only_skips_section_when_all_members_undocumented() {
+        let members = vec![("a".to_string(), None), ("b".to_string(), None)];
+        assert_eq!(
+            format_class_docstring(Some("Just a summary."), &members, "Attributes", "    "),
+            Some("\"\"\"Just a summary.\"\"\"".to_string()),
+        );
+    }
+
+    /// At least one documented member -> the section appears and lists
+    /// **every** member: documented as `name: doc`, undocumented as bare
+    /// `name`. Order matches the input.
+    #[test]
+    fn format_class_docstring_section_lists_all_members_when_any_documented() {
+        let members = vec![
+            ("HAPPY".to_string(), Some("Smiling face.".to_string())),
+            ("SAD".to_string(), None),
+            ("NEUTRAL".to_string(), None),
+        ];
+        let out = format_class_docstring(Some("Sentiment scale"), &members, "Members", "    ");
+        assert_eq!(
+            out,
+            Some(
+                "\"\"\"\n    Sentiment scale\n\n    Members:\n        HAPPY: Smiling face.\n        SAD\n        NEUTRAL\n    \"\"\""
+                    .to_string()
+            ),
+        );
+    }
+
+    /// Same rule with no summary: the section still appears once any
+    /// member is documented, and still lists every member.
+    #[test]
+    fn format_class_docstring_section_appears_without_summary_when_any_documented() {
+        let members = vec![
+            ("a".to_string(), Some("First.".to_string())),
+            ("b".to_string(), None),
+        ];
+        let out = format_class_docstring(None, &members, "Attributes", "    ");
+        assert_eq!(
+            out,
+            Some("\"\"\"\n    Attributes:\n        a: First.\n        b\n    \"\"\"".to_string()),
+        );
+    }
+}

--- a/baml_language/languages/python/uv.lock
+++ b/baml_language/languages/python/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "2026-04-29T01:52:21.264903Z"
+exclude-newer-span = "-P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -574,26 +578,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.34"
+version = "0.0.33"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/69/e24eefe2c35c0fdbdec9b60e162727af669bb76d64d993d982eb67b24c38/ty-0.0.34.tar.gz", hash = "sha256:a6efe66b0f13c03a65e6c72ec9abfe2792e2fd063c74fa67e2c4930e29d661be", size = 5585933, upload-time = "2026-05-01T23:06:46.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/7b/8b85003d6639ef17a97dcbb31f4511cfe78f1c81a964470db100c8c883e7/ty-0.0.34-py3-none-linux_armv6l.whl", hash = "sha256:9ecc3d14f07a95a6ceb88e07f8e62358dbd37325d3d5bd56da7217ff1fef7fb8", size = 11067094, upload-time = "2026-05-01T23:06:21.133Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/25/b0098f65b020b015c40567c763fc66fffbec88b2ba6f584bca1e92f05ebb/ty-0.0.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0dccffd8a9d02321cd2dee3249df205e26d62694e741f4eeca36b157fd8b419f", size = 10840909, upload-time = "2026-05-01T23:06:18.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/55/5e4adcf7d2a1006b844903b27cb81244a9b748d850433a46a6c21776c401/ty-0.0.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0ea47a2998e167ab3b21d2f4b5309a9cf33c297809f6d7e3e753252223174d0", size = 10279378, upload-time = "2026-05-01T23:06:37.962Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/91/f537dca0db8fe2558e8ab04d8941d687b384fcc1df5eb9023b2db75ac26c/ty-0.0.34-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37da00b41a118a459ae56d8947e70651073fb33ebfbceb820e4a10b22d5023", size = 10817423, upload-time = "2026-05-01T23:06:26.247Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c4/55a3ad1da2815af1009bdc1b8c90dc11a364cd314e4b48c5128ba9d38859/ty-0.0.34-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81cbbb93c2342fe3de43e625d3a9eb149633e9f485e816ebf6395d08685355d8", size = 10851826, upload-time = "2026-05-01T23:06:24.198Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/8c/9c7606af22d73fb43ea4369472d9c66ece11231be73b0efe8e3c61655559/ty-0.0.34-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c5b4dea1594a021289e172582df9cde7089dce14b276fc650e7b212b1772e12", size = 11356318, upload-time = "2026-05-01T23:06:51.139Z" },
-    { url = "https://files.pythonhosted.org/packages/20/54/bb423f663721ab4138b216425c6b55eaefd3a068243b24d6d8fe988f4e13/ty-0.0.34-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:030fb00aa2d2a5b5ae9d9183d574e0c82dae80566700a7490c43669d8ece40cd", size = 11902968, upload-time = "2026-05-01T23:06:35.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/22/01122b21ab6b534a2f618c6bbe5f1f7f49fd56f4b2ec8887cd6d40d08fb3/ty-0.0.34-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae9555e24e36c63a8218e037a5a63f15579eb6aa94f41017e57cd41d335cfb5", size = 11548860, upload-time = "2026-05-01T23:06:42.155Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/50/86008b1392ec64bed1957bbcc7aaa43b466b50dfc91bb131841c21d7c5c3/ty-0.0.34-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99eb23df9ed129fc26d1ab00d6f0b8dfe5253b09c2ac6abdb11523fa70d67f10", size = 11457097, upload-time = "2026-05-01T23:06:53.477Z" },
-    { url = "https://files.pythonhosted.org/packages/92/3e/4558b2296963ba99c58d8409c57d7db4f3061b656c3613cb21c02c1ef4c2/ty-0.0.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85de45382016eceae69e104815eb2cfa200787df104002e262a86cbd43ed2c02", size = 10798192, upload-time = "2026-05-01T23:06:40.004Z" },
-    { url = "https://files.pythonhosted.org/packages/76/bf/650d24402be2ef678528d60caac1d9477a40fc37e3792ecef07834fd7a4a/ty-0.0.34-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:14cb575fb8fa5131f5129d100cfe23c1575d23faf5dfc5158432749a3e38c9b5", size = 10890390, upload-time = "2026-05-01T23:06:33.076Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ef/ccd2ca13906079f7935fd7e067661b24233017f57d987d51d6a121d85bb5/ty-0.0.34-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fc0b69d8450e6910ba9db34572b959b81329a97ae273c391f70e9fb6c1aade", size = 11031564, upload-time = "2026-05-01T23:06:55.812Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/2d/d27b72005b6f43599e3bcabab0d7135ac0c230b7a307bb99f9eea02c1cda/ty-0.0.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:30dfcec2f0fde3993f4f912ed0e057dcbebc8615299f610a4c2ddb7b5a3e1e06", size = 11553430, upload-time = "2026-05-01T23:06:31.096Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
-    { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
+    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
+    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
+    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
 ]
 
 [[package]]

--- a/baml_language/rig_tests/crates/docstrings_etc/Cargo.toml
+++ b/baml_language/rig_tests/crates/docstrings_etc/Cargo.toml
@@ -1,0 +1,18 @@
+# Rig crate covering BAML `///` doc-comment lowering. Each `ns_*/`
+# subnamespace exercises a specific doc-comment shape and the Python
+# tests assert on the runtime `__doc__` of the generated symbols.
+[package]
+name = "rig_docstrings_etc"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[build-dependencies]
+codegen_python = { path = "../../../languages/python/rust/codegen_python" }
+baml_codegen_types = { path = "../../../crates/baml_codegen_types" }
+baml_db = { path = "../../../crates/baml_db" }
+baml_project = { path = "../../../crates/baml_project" }
+baml_workspace = { path = "../../../crates/baml_workspace" }
+
+[package.metadata.ci]
+wasm_support = false

--- a/baml_language/rig_tests/crates/docstrings_etc/baml_src/ns_docs/types.baml
+++ b/baml_language/rig_tests/crates/docstrings_etc/baml_src/ns_docs/types.baml
@@ -1,0 +1,55 @@
+// Doc-comment coverage. Each `///`-annotated declaration below pins a
+// specific Python emission rule:
+//
+//   * /// on class           -> """...""" body docstring on the class
+//   * /// on field           -> folded into class docstring under
+//                                "Attributes:" (no inline `# …` line)
+//   * /// on enum            -> """...""" body docstring on the enum
+//   * /// on enum variant    -> folded into enum docstring under
+//                                "Members:" (no inline PEP-257 form)
+//
+// Attributes:/Members: section visibility follows an "any-doc" rule:
+//   * if no field/variant carries a ///, the section is suppressed
+//     entirely — even when the class/enum itself has a ///
+//   * if at least one carries a ///, the section appears and lists
+//     **every** member: documented as `name: doc`, undocumented as
+//     a bare `name` (no trailing colon)
+
+/// A document with a title and an optional body.
+class Doc {
+  /// Title shown in lists and search results.
+  title string
+  /// Free-form body text.
+  body string?
+}
+
+/// A multi-line summary.
+/// Continuation line of the summary, preserved verbatim in the
+/// rendered block-form docstring.
+class Note {
+  /// Stable identifier — surfaces in URLs.
+  id string
+  // `text` carries no `///`. With the "any-doc" rule above, it still
+  // appears under Attributes: as a bare `text` because `id` is
+  // documented.
+  text string
+}
+
+/// Sentiment labels surfaced by the model.
+enum Sentiment {
+  /// Smiling face.
+  HAPPY
+  /// Frowning face.
+  SAD
+  // `NEUTRAL` is undocumented; it appears under Members: as a bare
+  // `NEUTRAL` because the enum has at least one documented variant.
+  NEUTRAL
+}
+
+/// Pin the "summary only, no member rollup" case: this enum has a
+/// class-level `///` but every variant is bare.
+enum Priority {
+  HIGH
+  MEDIUM
+  LOW
+}

--- a/baml_language/rig_tests/crates/docstrings_etc/build.rs
+++ b/baml_language/rig_tests/crates/docstrings_etc/build.rs
@@ -1,0 +1,242 @@
+// Hand-written; drives codegen from real `.baml` source rather than an
+// in-memory `SymbolPool`. Mirrors the pipeline `baml-cli generate`
+// uses: discover files → ProjectDatabase → diagnostics gate →
+// `build_symbol_pool` → `to_source_code`. Same shape as
+// `python_example_09a/build.rs`.
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use baml_db::baml_compiler_diagnostics::Severity;
+use baml_project::ProjectDatabase;
+use codegen_python::UserBamlFile;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let baml_src = manifest_dir.join("baml_src");
+    let generated_dir = manifest_dir.join("generated");
+    let baml_sdk_dir = generated_dir.join("baml_sdk");
+
+    if generated_dir.exists() {
+        fs::remove_dir_all(&generated_dir).unwrap();
+    }
+    fs::create_dir_all(&baml_sdk_dir).unwrap();
+
+    // 1. Discover + load .baml files into the project DB.
+    let canonical = fs::canonicalize(&baml_src)
+        .unwrap_or_else(|_| panic!("baml_src not found at {}", baml_src.display()));
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(&canonical);
+    let baml_files = baml_workspace::discover_baml_files(&canonical);
+    assert!(
+        !baml_files.is_empty(),
+        "no .baml files discovered under {}",
+        canonical.display()
+    );
+    for file_path in &baml_files {
+        let content = fs::read_to_string(file_path)
+            .unwrap_or_else(|_| panic!("failed to read {}", file_path.display()));
+        db.add_or_update_file(file_path, &content);
+    }
+
+    // 2. Diagnostics gate — bail loudly on any compile error so a
+    //    broken `.baml` source doesn't masquerade as a codegen bug.
+    let project = db.get_project().expect("no project context");
+    let source_files = db.get_source_files();
+    let diagnostics = baml_project::collect_diagnostics(&db, project, &source_files);
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    if !errors.is_empty() {
+        let messages: Vec<String> = errors.iter().map(|d| format!("{d:?}")).collect();
+        panic!("baml_src has compile errors:\n{}", messages.join("\n"));
+    }
+
+    // 3. Build the codegen `SymbolPool` and the inlined-files list.
+    let pool = baml_project::build_symbol_pool(&db);
+    let user_baml_files: Vec<UserBamlFile> = source_files
+        .iter()
+        .map(|sf| {
+            let path = sf.path(&db);
+            let rel = path.strip_prefix(&canonical).unwrap_or(&path).to_path_buf();
+            (rel, sf.text(&db).to_string())
+        })
+        .collect();
+
+    // 4. Codegen.
+    let output = codegen_python::to_source_code(&pool, &user_baml_files);
+    for (path, content) in output {
+        let file_path = baml_sdk_dir.join(&path);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&file_path, &content).unwrap();
+    }
+
+    // 5. Symlink customizable/ files into generated/.
+    let customizable_dir = manifest_dir.join("customizable");
+    if customizable_dir.exists() {
+        for entry in fs::read_dir(&customizable_dir).unwrap() {
+            let entry = entry.unwrap();
+            let src = entry.path();
+            let file_name = entry.file_name();
+            let dst = generated_dir.join(&file_name);
+
+            if !src.is_file() {
+                continue;
+            }
+            if dst.exists() || dst.symlink_metadata().is_ok() {
+                let _ = fs::remove_file(&dst);
+            }
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&src, &dst).unwrap_or_else(|_| {
+                panic!(
+                    "Failed to symlink {} from {}",
+                    file_name.to_string_lossy(),
+                    src.display()
+                )
+            });
+            #[cfg(windows)]
+            std::os::windows::fs::symlink_file(&src, &dst).unwrap_or_else(|_| {
+                panic!(
+                    "Failed to symlink {} from {}",
+                    file_name.to_string_lossy(),
+                    src.display()
+                )
+            });
+        }
+    }
+
+    // 6. pyproject.toml + test.sh + test.ps1. Test runner does
+    //    `uv sync` then `maturin develop` against bridge_python's
+    //    Cargo.toml, installing the real `baml.baml_core` (PyO3
+    //    extension) into the project venv. `[tool.uv] package =
+    //    false` keeps uv from trying to install this directory as
+    //    a wheel; the empty `dev` group satisfies maturin's
+    //    `uv pip install --group dev` step.
+    let pyproject_toml = r#"[project]
+name = "baml-test-docstrings-etc"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "baml",
+    "pydantic>=2",
+    "typing-extensions",
+    "pytest>=7",
+    "ruff",
+    "pyright>=1.1",
+]
+
+[dependency-groups]
+dev = []
+
+[tool.uv]
+package = false
+
+[tool.uv.sources]
+baml = { path = "../../../../languages/python", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-v"
+
+[tool.ruff]
+line-length = 120
+extend-exclude = ["*.pyi"]
+
+[tool.ruff.lint]
+ignore = ["F401", "F821", "E402"]
+"#;
+    fs::write(generated_dir.join("pyproject.toml"), pyproject_toml).unwrap();
+
+    let test_sh = r#"#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+export UV_CACHE_DIR="$(pwd)/.uv-cache"
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv is not installed"
+    exit 1
+fi
+echo "==> uv sync (installs baml + deps, builds Rust extension if needed)"
+uv sync
+echo "==> ruff check"
+uv run ruff check --config pyproject.toml baml_sdk
+echo "==> pyright"
+uv run pyright baml_sdk
+echo "==> pytest"
+uv run pytest -v
+echo "==> All checks passed!"
+"#;
+    fs::write(generated_dir.join("test.sh"), test_sh).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(generated_dir.join("test.sh"))
+            .unwrap()
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(generated_dir.join("test.sh"), perms).unwrap();
+    }
+
+    let test_ps1 = r#"$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot
+$env:UV_CACHE_DIR = Join-Path $PSScriptRoot ".uv-cache"
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Error "Error: uv is not installed"
+    exit 1
+}
+$BridgePythonDir = (Resolve-Path "../../../../languages/python/rust/bridge_python").Path
+Write-Host "==> uv sync"
+uv sync
+Write-Host "==> maturin develop (builds bridge_python's PyO3 extension into .venv)"
+uv run maturin develop --manifest-path (Join-Path $BridgePythonDir "Cargo.toml")
+Write-Host "==> Running Python syntax check..."
+$pythonFiles = Get-ChildItem -Recurse -Include *.py,*.pyi | ForEach-Object { $_.FullName }
+if ($pythonFiles) {
+    foreach ($file in $pythonFiles) {
+        uv run python -m py_compile $file
+    }
+}
+Write-Host "==> Running ruff lint..."
+uv run ruff check --config pyproject.toml baml_sdk
+Write-Host "==> Running pytest..."
+uv run pytest -v
+Write-Host "==> All checks passed!"
+"#;
+    fs::write(generated_dir.join("test.ps1"), test_ps1).unwrap();
+
+    // 7. rerun-if-changed for build.rs + every BAML and customizable
+    //    file.
+    println!("cargo:rerun-if-changed=build.rs");
+    watch_dir(&baml_src);
+    if customizable_dir.exists() {
+        watch_dir(&customizable_dir);
+    }
+}
+
+fn watch_dir(dir: &Path) {
+    let walker = walk_files(dir);
+    for path in walker {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn walk_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                out.push(path);
+            } else if path.is_dir() {
+                out.extend(walk_files(&path));
+            }
+        }
+    }
+    out
+}

--- a/baml_language/rig_tests/crates/docstrings_etc/customizable/test_main.py
+++ b/baml_language/rig_tests/crates/docstrings_etc/customizable/test_main.py
@@ -1,0 +1,111 @@
+"""BAML `///` doc-comment lowering coverage.
+
+Asserts on the runtime `__doc__` of generated classes and enums so the
+rules in `ns_docs/types.baml` are pinned end-to-end (CST → AST → HIR →
+IR → codegen → import).
+"""
+
+
+def test_root_imports_cleanly():
+    import baml_sdk  # noqa: F401
+
+
+def test_docs_namespace_reachable():
+    import baml_sdk
+
+    # `ns_` prefix on the baml_src/ directory is stripped by
+    # baml_project; the Python namespace is what's left.
+    assert hasattr(baml_sdk, "docs"), "baml_sdk.docs missing"
+
+
+def test_docs_imports_cleanly():
+    from baml_sdk.docs import Doc, Note, Priority, Sentiment  # noqa: F401
+
+
+def test_class_doc_summary_and_attributes_section_in_dunder_doc():
+    import inspect
+
+    from baml_sdk.docs import Doc
+
+    # `inspect.getdoc` normalizes leading/trailing whitespace and dedents
+    # so the assertions are stable against the body indent.
+    doc = inspect.getdoc(Doc)
+    assert doc is not None
+    expected = (
+        "A document with a title and an optional body.\n"
+        "\n"
+        "Attributes:\n"
+        "    title: Title shown in lists and search results.\n"
+        "    body: Free-form body text."
+    )
+    assert doc == expected, f"got:\n{doc!r}"
+
+
+def test_undocumented_field_listed_as_bare_name_under_attributes():
+    # Note: `id` is documented, `text` is not. The "any-doc" rule says
+    # the Attributes: section appears (because `id` carries a `///`)
+    # and lists every field, with `text` rendered as a bare name.
+    import inspect
+
+    from baml_sdk.docs import Note
+
+    doc = inspect.getdoc(Note)
+    assert doc is not None
+    assert doc.startswith("A multi-line summary.\nContinuation line")
+    assert "\n\nAttributes:\n    id: Stable identifier" in doc
+    # Bare-name entry: just the identifier, no trailing colon, no doc.
+    assert doc.rstrip().endswith("\n    text"), f"got:\n{doc!r}"
+
+
+def test_enum_doc_summary_and_members_section_in_dunder_doc():
+    import inspect
+
+    from baml_sdk.docs import Sentiment
+
+    doc = inspect.getdoc(Sentiment)
+    assert doc is not None
+    expected = (
+        "Sentiment labels surfaced by the model.\n"
+        "\n"
+        "Members:\n"
+        "    HAPPY: Smiling face.\n"
+        "    SAD: Frowning face.\n"
+        "    NEUTRAL"
+    )
+    assert doc == expected, f"got:\n{doc!r}"
+
+
+def test_enum_summary_only_omits_members_section_when_no_variant_documented():
+    # Priority has a class-level /// but no variant carries one — the
+    # Members: section should be suppressed entirely. Variants are
+    # still importable / iterable normally.
+    import inspect
+
+    from baml_sdk.docs import Priority
+
+    doc = inspect.getdoc(Priority)
+    assert doc is not None
+    assert doc == (
+        "Pin the \"summary only, no member rollup\" case: this enum has a\n"
+        "class-level `///` but every variant is bare."
+    ), f"got:\n{doc!r}"
+    assert "Members:" not in doc, f"Members: section leaked in:\n{doc}"
+    assert {m.value for m in Priority} == {"HIGH", "MEDIUM", "LOW"}
+
+
+def test_no_inline_field_or_variant_doc_artifacts():
+    # Field/variant `///` lines must not produce inline `# …` comments
+    # or `"""…"""` attribute docstrings — they live exclusively inside
+    # the parent's Attributes:/Members: section.
+    import importlib
+
+    mod = importlib.import_module("baml_sdk.docs")
+    with open(mod.__file__) as f:
+        src = f.read()
+    assert "# Title shown in lists" not in src, src
+    assert "# Smiling face" not in src, src
+    # Triple-quoted strings only ever come in pairs (open + close), one
+    # per parent that emits a docstring. Doc/Note/Sentiment/Priority
+    # all have one each → 4 docstrings × 2 fences = 8.
+    triples = src.count('"""')
+    assert triples == 8, f"unexpected triple-quote count: {triples}\n{src}"

--- a/baml_language/rig_tests/crates/docstrings_etc/src/lib.rs
+++ b/baml_language/rig_tests/crates/docstrings_etc/src/lib.rs
@@ -1,0 +1,44 @@
+// Hand-written; same shape as the generated rig harnesses.
+#[cfg(test)]
+mod tests {
+    use std::{path::PathBuf, process::Command};
+
+    #[test]
+    fn test_generated_code() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("generated");
+
+        // Use appropriate test script based on platform
+        #[cfg(windows)]
+        let (script_name, command, arg) = ("test.ps1", "powershell", "-File");
+
+        #[cfg(not(windows))]
+        let (script_name, command, arg) = ("test.sh", "bash", "");
+
+        let test_script = dir.join(script_name);
+
+        assert!(
+            test_script.exists(),
+            "{} not found in generated directory",
+            script_name
+        );
+
+        // Run the test script
+        let mut cmd = Command::new(command);
+        if !arg.is_empty() {
+            cmd.arg(arg);
+        }
+        let output = cmd
+            .arg(&test_script)
+            .current_dir(&dir)
+            .output()
+            .unwrap_or_else(|_| panic!("Failed to run {}", script_name));
+
+        assert!(
+            output.status.success(),
+            "{} failed:\nstdout: {}\nstderr: {}",
+            script_name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}


### PR DESCRIPTION
Allow /// comments on classes, class fields, enums, enum variants, to get propagated to the generated Python clients.

`@description` no longer pipes through to the Pydantic fields because it can now be dynamically rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Triple-slash doc comments are now extracted and preserved across the toolchain, surfacing as docstrings in generated Python (.py/.pyi) outputs for functions, classes, enums, and fields.
* **Tests**
  * Added end-to-end tests validating runtime __doc__ content and generated documentation rendering.
* **Chores**
  * New test harness/crate and utilities to format and emit docstrings; CLI description rendering updated to include doc-comment content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->