### PR TITLE
refactor(bridge_python): switch BamlPyHandle to handle_key + handle_type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,8 @@ fail_fast: false
 
 exclude: |
   (?x)^(
-    crates/.*/snapshots/.*
+    crates/.*/snapshots/.*|
+    baml_language/.*\.pyi
   )$
 
 repos:

--- a/baml_language/languages/python/rust/bridge_python/src/media.rs
+++ b/baml_language/languages/python/rust/bridge_python/src/media.rs
@@ -1,7 +1,7 @@
 //! PyO3 types for BAML media (`baml.media.{Image,Video,Audio,Pdf}`).
 //!
 //! Per 15b: each Python media class is a re-export of a Rust PyO3 type
-//! that wraps a `BamlPyHandle` whose entry is a
+//! that wraps a `BamlPyHandle` whose backing `HANDLE_TABLE` row is a
 //! `CffiHandleTableEntry::Adt(BexExternalAdt::Media(arc))`. Static and
 //! instance methods dispatch natively here instead of round-tripping
 //! through the BAML engine.
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use bex_project::{BexExternalAdt, MediaKind, MediaValue};
-use bridge_ctypes::CffiHandleTableEntry;
+use bridge_ctypes::{CffiHandleTableEntry, HANDLE_TABLE, baml::cffi::BamlHandleType};
 use pyo3::{
     Bound, Py, PyAny, PyResult, Python,
     exceptions::{PyRuntimeError, PyTypeError},
@@ -45,7 +45,7 @@ fn pydantic_is_instance_schema<'py>(
 // ---------------------------------------------------------------------------
 
 macro_rules! define_media_pyclass {
-    ($name:ident, $kind:expr) => {
+    ($name:ident, $kind:expr, $expected_ht:expr) => {
         #[gen_stub_pyclass]
         #[pyclass]
         pub struct $name {
@@ -60,8 +60,9 @@ macro_rules! define_media_pyclass {
             fn from_url(py: Python<'_>, url: String, mime_type: Option<String>) -> PyResult<Self> {
                 let inner = MediaValue::from_url($kind, &url, mime_type.as_deref());
                 let entry = CffiHandleTableEntry::Adt(BexExternalAdt::Media(inner));
+                let key = HANDLE_TABLE.insert(entry);
                 Ok(Self {
-                    handle: Py::new(py, BamlPyHandle::new(entry))?,
+                    handle: Py::new(py, BamlPyHandle::new(key, $expected_ht))?,
                 })
             }
 
@@ -74,8 +75,9 @@ macro_rules! define_media_pyclass {
             ) -> PyResult<Self> {
                 let inner = MediaValue::from_file($kind, &file, mime_type.as_deref());
                 let entry = CffiHandleTableEntry::Adt(BexExternalAdt::Media(inner));
+                let key = HANDLE_TABLE.insert(entry);
                 Ok(Self {
-                    handle: Py::new(py, BamlPyHandle::new(entry))?,
+                    handle: Py::new(py, BamlPyHandle::new(key, $expected_ht))?,
                 })
             }
 
@@ -88,8 +90,9 @@ macro_rules! define_media_pyclass {
             ) -> PyResult<Self> {
                 let inner = MediaValue::from_base64($kind, &base64, mime_type.as_deref());
                 let entry = CffiHandleTableEntry::Adt(BexExternalAdt::Media(inner));
+                let key = HANDLE_TABLE.insert(entry);
                 Ok(Self {
-                    handle: Py::new(py, BamlPyHandle::new(entry))?,
+                    handle: Py::new(py, BamlPyHandle::new(key, $expected_ht))?,
                 })
             }
 
@@ -110,8 +113,8 @@ macro_rules! define_media_pyclass {
             }
 
             /// Internal: build a `$name` from a `BamlPyHandle`. Used by
-            /// `_decode_handle`. Validates the entry is a media of the
-            /// right kind.
+            /// `_decode_handle`. Validates the handle's `handle_type`
+            /// tag matches the expected media kind.
             #[classmethod]
             fn _from_pyhandle(
                 _cls: &Bound<'_, pyo3::types::PyType>,
@@ -119,23 +122,16 @@ macro_rules! define_media_pyclass {
             ) -> PyResult<Self> {
                 Python::attach(|py| {
                     let pyh = pyhandle.borrow(py);
-                    match &pyh.entry {
-                        CffiHandleTableEntry::Adt(BexExternalAdt::Media(arc))
-                            if arc.kind == $kind =>
-                        {
-                            drop(pyh);
-                            Ok(Self { handle: pyhandle })
-                        }
-                        CffiHandleTableEntry::Adt(BexExternalAdt::Media(arc)) => {
-                            Err(PyTypeError::new_err(format!(
-                                "media handle kind mismatch: expected {:?}, got {:?}",
-                                $kind, arc.kind
-                            )))
-                        }
-                        _ => Err(PyTypeError::new_err(
-                            "BamlPyHandle does not point to a media value",
-                        )),
+                    if pyh.handle_type != $expected_ht {
+                        return Err(PyTypeError::new_err(format!(
+                            "BamlPyHandle.handle_type is {}, expected {} for {}",
+                            pyh.handle_type,
+                            $expected_ht,
+                            stringify!($name),
+                        )));
                     }
+                    drop(pyh);
+                    Ok(Self { handle: pyhandle })
                 })
             }
 
@@ -159,10 +155,18 @@ macro_rules! define_media_pyclass {
         impl $name {
             fn media_arc(&self, py: Python<'_>) -> PyResult<Arc<MediaValue>> {
                 let pyh = self.handle.borrow(py);
-                match &pyh.entry {
-                    CffiHandleTableEntry::Adt(BexExternalAdt::Media(arc)) => Ok(Arc::clone(arc)),
+                let entry = HANDLE_TABLE.resolve(pyh.handle_key).ok_or_else(|| {
+                    PyRuntimeError::new_err(format!(
+                        "media handle key {} no longer in HANDLE_TABLE",
+                        pyh.handle_key
+                    ))
+                })?;
+                match &*entry {
+                    CffiHandleTableEntry::Adt(BexExternalAdt::Media(arc)) if arc.kind == $kind => {
+                        Ok(Arc::clone(arc))
+                    }
                     _ => Err(PyRuntimeError::new_err(
-                        "media handle no longer points to a media value",
+                        "media handle no longer points to a media value of the expected kind",
                     )),
                 }
             }
@@ -170,10 +174,22 @@ macro_rules! define_media_pyclass {
     };
 }
 
-define_media_pyclass!(BamlImage, MediaKind::Image);
-define_media_pyclass!(BamlAudio, MediaKind::Audio);
-define_media_pyclass!(BamlVideo, MediaKind::Video);
-define_media_pyclass!(BamlPdf, MediaKind::Pdf);
+define_media_pyclass!(
+    BamlImage,
+    MediaKind::Image,
+    BamlHandleType::AdtMediaImage as u64
+);
+define_media_pyclass!(
+    BamlAudio,
+    MediaKind::Audio,
+    BamlHandleType::AdtMediaAudio as u64
+);
+define_media_pyclass!(
+    BamlVideo,
+    MediaKind::Video,
+    BamlHandleType::AdtMediaVideo as u64
+);
+define_media_pyclass!(BamlPdf, MediaKind::Pdf, BamlHandleType::AdtMediaPdf as u64);
 
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     use pyo3::types::PyModuleMethods;

--- a/baml_language/languages/python/rust/bridge_python/src/py_handle.rs
+++ b/baml_language/languages/python/rust/bridge_python/src/py_handle.rs
@@ -1,9 +1,25 @@
-//! `BamlPyHandle` — owning Python wrapper for a `CffiHandleTableEntry`.
+//! `BamlPyHandle` — Python wrapper for a `HANDLE_TABLE` row.
 //!
-//! Replaces the previous `BamlHandle(key, handle_type)` (a wire-table token)
-//! and `UnknownHandle` (a Python shim around it). The entry is held inline;
-//! no global table indirection. The `HANDLE_TABLE` is only used to bridge
-//! the FFI wire (insert on the encode side, drain on the decode side).
+//! Holds a `(handle_key, handle_type)` pair. The actual
+//! `CffiHandleTableEntry` lives in `bridge_ctypes::HANDLE_TABLE`; the
+//! Python object is just a token. This matches what Go/Rust client
+//! bindings will look like — they can only see `u64` handles across the
+//! CFFI boundary, so Python uses the same model for uniformity.
+//!
+//! Lifecycle:
+//!  - Construct (decode side): `BamlPyHandle::new(key, ht)`. The wire
+//!    encoder is responsible for having inserted under `key`. The Python
+//!    object now owns the row; nobody else may drain it.
+//!  - `__copy__` / `__deepcopy__`: allocate a new row via
+//!    `HANDLE_TABLE.clone_handle(key)` and wrap. Sharing the same key
+//!    between two `BamlPyHandle`s would double-release on drop.
+//!  - Drop: `HANDLE_TABLE.release(key)`. Without this every handle leaks
+//!    one row.
+//!
+//! There is no public `handle_type()` method. The wire transmits
+//! `BamlHandle.handle_type`, the Python object stores it on construction,
+//! and Rust-internal callers (`put_pyhandle_into_table`, media class
+//! validation) read the field directly.
 
 use bridge_ctypes::{CffiHandleTableEntry, HANDLE_TABLE};
 use pyo3::prelude::*;
@@ -12,83 +28,107 @@ use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyfunction, gen_stub_pyme
 #[gen_stub_pyclass]
 #[pyclass]
 pub struct BamlPyHandle {
-    pub(crate) entry: CffiHandleTableEntry,
+    pub(crate) handle_key: u64,
+    /// `BamlHandleType` as u64 — same width as `handle_key` for uniformity
+    /// across the CFFI surface. Set at construction from the wire field
+    /// (decode path) or from the entry's intrinsic kind (encode/seed
+    /// paths). Read by inbound encode (`put_pyhandle_into_table`) and by
+    /// media `_from_pyhandle` validation.
+    pub(crate) handle_type: u64,
 }
 
 #[gen_stub_pymethods]
 #[pymethods]
 impl BamlPyHandle {
-    /// Derived host-side `BamlHandleType` tag, as i32. Source of truth
-    /// for opaque-handle dispatch on the Python side; the wire field of
-    /// the same name is redundant and ignored after decode.
-    fn handle_type(&self) -> i32 {
-        self.entry.handle_type() as i32
+    fn __copy__(&self) -> PyResult<Self> {
+        let new_key = HANDLE_TABLE.clone_handle(self.handle_key).ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "BamlPyHandle.__copy__: key {} not in HANDLE_TABLE",
+                self.handle_key
+            ))
+        })?;
+        Ok(Self {
+            handle_key: new_key,
+            handle_type: self.handle_type,
+        })
     }
 
-    fn __copy__(&self) -> Self {
-        Self {
-            entry: self.entry.clone(),
-        }
-    }
-
-    fn __deepcopy__(&self, _memo: &Bound<'_, PyAny>) -> Self {
+    fn __deepcopy__(&self, _memo: &Bound<'_, PyAny>) -> PyResult<Self> {
         self.__copy__()
     }
 }
 
 impl BamlPyHandle {
-    pub fn new(entry: CffiHandleTableEntry) -> Self {
-        Self { entry }
+    pub fn new(handle_key: u64, handle_type: u64) -> Self {
+        Self {
+            handle_key,
+            handle_type,
+        }
     }
 }
 
-/// Drain `HANDLE_TABLE[key]` into a fresh `BamlPyHandle`. Used by
-/// `proto.py::_decode_handle`. Raises `RuntimeError` if the key is
-/// absent (which would mean the encoder failed to insert, or the same
-/// key was decoded twice).
+impl Drop for BamlPyHandle {
+    fn drop(&mut self) {
+        HANDLE_TABLE.release(self.handle_key);
+    }
+}
+
+/// Wrap a `HANDLE_TABLE` key as a `BamlPyHandle`. Used by
+/// `proto.py::_decode_handle`. Does **not** drain — the entry stays in
+/// the table and is owned by the returned `BamlPyHandle`. Validates the
+/// key exists so a malformed wire payload errors here rather than on
+/// later use.
 #[gen_stub_pyfunction]
 #[pyfunction]
-pub fn take_pyhandle_from_table(key: u64) -> PyResult<BamlPyHandle> {
-    let arc_entry = HANDLE_TABLE.drain(key).ok_or_else(|| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!(
+pub fn take_pyhandle_from_table(key: u64, handle_type: u64) -> PyResult<BamlPyHandle> {
+    if HANDLE_TABLE.resolve(key).is_none() {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
             "BAML handle key {key} is not in HANDLE_TABLE"
-        ))
-    })?;
-    Ok(BamlPyHandle {
-        entry: (*arc_entry).clone(),
-    })
+        )));
+    }
+    Ok(BamlPyHandle::new(key, handle_type))
 }
 
-/// Insert a clone of `pyhandle.entry` into `HANDLE_TABLE`, return
-/// `(key, handle_type as i32)`. The original `BamlPyHandle` stays
-/// usable — Python may pass the same handle to multiple calls.
+/// Allocate a fresh `HANDLE_TABLE` row sharing the same `Arc` as
+/// `pyhandle.handle_key`, return `(new_key, handle_type)`. The original
+/// `BamlPyHandle` keeps its key and stays usable — Python may pass the
+/// same handle to multiple calls.
 #[gen_stub_pyfunction]
 #[pyfunction]
-pub fn put_pyhandle_into_table(pyhandle: &BamlPyHandle) -> (u64, i32) {
-    let entry = pyhandle.entry.clone();
-    let ht = entry.handle_type() as i32;
-    let key = HANDLE_TABLE.insert(entry);
-    (key, ht)
+pub fn put_pyhandle_into_table(pyhandle: &BamlPyHandle) -> PyResult<(u64, u64)> {
+    let new_key = HANDLE_TABLE
+        .clone_handle(pyhandle.handle_key)
+        .ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "BamlPyHandle key {} is not in HANDLE_TABLE",
+                pyhandle.handle_key
+            ))
+        })?;
+    Ok((new_key, pyhandle.handle_type))
 }
 
-/// Test-only: seed a `FunctionRef` entry directly into `HANDLE_TABLE`.
-/// Used by pytest fixtures that need to exercise decoder paths for
-/// handle kinds that no Python-facing API constructs.
+/// Test-only: seed a `FunctionRef` entry directly into `HANDLE_TABLE`,
+/// returning `(key, handle_type)` so test code can construct a
+/// `BamlPyHandle` or stage a wire `BamlHandle`.
 #[gen_stub_pyfunction]
 #[pyfunction]
-pub fn _seed_function_ref_handle(global_index: u64) -> u64 {
+pub fn _seed_function_ref_handle(global_index: u64) -> (u64, u64) {
     let entry = CffiHandleTableEntry::FunctionRef {
         global_index: global_index as usize,
     };
-    HANDLE_TABLE.insert(entry)
+    let ht = entry.handle_type() as u64;
+    let key = HANDLE_TABLE.insert(entry);
+    (key, ht)
 }
 
 /// Test-only: seed an `Adt(Media(generic))` entry directly into `HANDLE_TABLE`.
 #[gen_stub_pyfunction]
 #[pyfunction]
-pub fn _seed_generic_media_handle() -> u64 {
+pub fn _seed_generic_media_handle() -> (u64, u64) {
     use bex_project::{BexExternalAdt, MediaKind, MediaValue};
     let media = MediaValue::from_url(MediaKind::Generic, "https://example.com/", None);
     let entry = CffiHandleTableEntry::Adt(BexExternalAdt::Media(media));
-    HANDLE_TABLE.insert(entry)
+    let ht = entry.handle_type() as u64;
+    let key = HANDLE_TABLE.insert(entry);
+    (key, ht)
 }

--- a/baml_language/languages/python/src/baml/baml_core/baml_py.pyi
+++ b/baml_language/languages/python/src/baml/baml_core/baml_py.pyi
@@ -33,7 +33,7 @@ __all__ = [
 class AbortController:
     r"""
     An abort controller for cancelling BAML function calls.
-
+    
     Usage from Python:
     ```python
     controller = AbortController()
@@ -52,7 +52,7 @@ class AbortController:
     def abort(self) -> None:
         r"""
         Cancel the associated function call.
-
+        
         If the function is still running, it will be interrupted at the next
         cancellation check point (before HTTP calls, between retries, etc.).
         Calling `abort()` multiple times is harmless.
@@ -74,8 +74,8 @@ class BamlAudio:
     def _from_pyhandle(cls, pyhandle: BamlPyHandle) -> BamlAudio:
         r"""
         Internal: build a `$name` from a `BamlPyHandle`. Used by
-        `_decode_handle`. Validates the entry is a media of the
-        right kind.
+        `_decode_handle`. Validates the handle's `handle_type`
+        tag matches the expected media kind.
         """
     def _to_pyhandle(self) -> BamlPyHandle:
         r"""
@@ -110,8 +110,8 @@ class BamlImage:
     def _from_pyhandle(cls, pyhandle: BamlPyHandle) -> BamlImage:
         r"""
         Internal: build a `$name` from a `BamlPyHandle`. Used by
-        `_decode_handle`. Validates the entry is a media of the
-        right kind.
+        `_decode_handle`. Validates the handle's `handle_type`
+        tag matches the expected media kind.
         """
     def _to_pyhandle(self) -> BamlPyHandle:
         r"""
@@ -139,8 +139,8 @@ class BamlPdf:
     def _from_pyhandle(cls, pyhandle: BamlPyHandle) -> BamlPdf:
         r"""
         Internal: build a `$name` from a `BamlPyHandle`. Used by
-        `_decode_handle`. Validates the entry is a media of the
-        right kind.
+        `_decode_handle`. Validates the handle's `handle_type`
+        tag matches the expected media kind.
         """
     def _to_pyhandle(self) -> BamlPyHandle:
         r"""
@@ -151,12 +151,6 @@ class BamlPdf:
 
 @typing.final
 class BamlPyHandle:
-    def handle_type(self) -> builtins.int:
-        r"""
-        Derived host-side `BamlHandleType` tag, as i32. Source of truth
-        for opaque-handle dispatch on the Python side; the wire field of
-        the same name is redundant and ignored after decode.
-        """
     def __copy__(self) -> BamlPyHandle: ...
     def __deepcopy__(self, _memo: typing.Any) -> BamlPyHandle: ...
 
@@ -171,11 +165,11 @@ class BamlRuntime:
     def initialize_runtime(root_path: builtins.str, files: typing.Mapping[builtins.str, builtins.str], *, sdk_root: builtins.str) -> BamlRuntime:
         r"""
         Initialize the process-global runtime from in-memory BAML source files.
-
+        
         Mirrors `bridge_cffi::engine::initialize_runtime`: the same
         single-slot singleton is used, so a second call replaces the prior
         runtime.
-
+        
         # Arguments
         * `root_path` - Root path for BAML files
         * `files` - Map of filename to file content
@@ -209,8 +203,8 @@ class BamlVideo:
     def _from_pyhandle(cls, pyhandle: BamlPyHandle) -> BamlVideo:
         r"""
         Internal: build a `$name` from a `BamlPyHandle`. Used by
-        `_decode_handle`. Validates the entry is a media of the
-        right kind.
+        `_decode_handle`. Validates the handle's `handle_type`
+        tag matches the expected media kind.
         """
     def _to_pyhandle(self) -> BamlPyHandle:
         r"""
@@ -222,7 +216,7 @@ class BamlVideo:
 class Collector:
     r"""
     Python-facing Collector that tracks BAML function call logs.
-
+    
     Usage:
     ```python
     from baml_py import Collector
@@ -310,7 +304,7 @@ class FunctionLog:
 class FunctionResult:
     r"""
     Result of a BAML function call.
-
+    
     Contains the parsed Python object returned by the function.
     """
     def __new__(cls, value: typing.Any) -> FunctionResult:
@@ -328,7 +322,7 @@ class FunctionResult:
 class HostSpanManager:
     r"""
     Manages host-side span tracking for `@trace` in Python.
-
+    
     This is a thin PyO3 wrapper around `bridge_cffi::host_spans::HostSpanManager`.
     All core logic (span stack, event emission) lives in bridge_cffi.
     """
@@ -424,14 +418,14 @@ class Usage:
         """
     def __repr__(self) -> builtins.str: ...
 
-def _seed_function_ref_handle(global_index: builtins.int) -> builtins.int:
+def _seed_function_ref_handle(global_index: builtins.int) -> tuple[builtins.int, builtins.int]:
     r"""
-    Test-only: seed a `FunctionRef` entry directly into `HANDLE_TABLE`.
-    Used by pytest fixtures that need to exercise decoder paths for
-    handle kinds that no Python-facing API constructs.
+    Test-only: seed a `FunctionRef` entry directly into `HANDLE_TABLE`,
+    returning `(key, handle_type)` so test code can construct a
+    `BamlPyHandle` or stage a wire `BamlHandle`.
     """
 
-def _seed_generic_media_handle() -> builtins.int:
+def _seed_generic_media_handle() -> tuple[builtins.int, builtins.int]:
     r"""
     Test-only: seed an `Adt(Media(generic))` entry directly into `HANDLE_TABLE`.
     """
@@ -445,7 +439,7 @@ def get_runtime() -> BamlRuntime:
     r"""
     Return the process-global `BamlRuntime`, or raise `BamlError` if
     `BamlRuntime.initialize_runtime(...)` has not been called yet.
-
+    
     Used by the pure-Python factories in `baml.baml_core` so generated
     leaves don't have to thread a runtime reference through every call
     site.
@@ -455,16 +449,18 @@ def get_version() -> builtins.str: ...
 
 def put_pyhandle_into_table(pyhandle: BamlPyHandle) -> tuple[builtins.int, builtins.int]:
     r"""
-    Insert a clone of `pyhandle.entry` into `HANDLE_TABLE`, return
-    `(key, handle_type as i32)`. The original `BamlPyHandle` stays
-    usable — Python may pass the same handle to multiple calls.
+    Allocate a fresh `HANDLE_TABLE` row sharing the same `Arc` as
+    `pyhandle.handle_key`, return `(new_key, handle_type)`. The original
+    `BamlPyHandle` keeps its key and stays usable — Python may pass the
+    same handle to multiple calls.
     """
 
-def take_pyhandle_from_table(key: builtins.int) -> BamlPyHandle:
+def take_pyhandle_from_table(key: builtins.int, handle_type: builtins.int) -> BamlPyHandle:
     r"""
-    Drain `HANDLE_TABLE[key]` into a fresh `BamlPyHandle`. Used by
-    `proto.py::_decode_handle`. Raises `RuntimeError` if the key is
-    absent (which would mean the encoder failed to insert, or the same
-    key was decoded twice).
+    Wrap a `HANDLE_TABLE` key as a `BamlPyHandle`. Used by
+    `proto.py::_decode_handle`. Does **not** drain — the entry stays in
+    the table and is owned by the returned `BamlPyHandle`. Validates the
+    key exists so a malformed wire payload errors here rather than on
+    later use.
     """
 

--- a/baml_language/languages/python/src/baml/baml_core/proto.py
+++ b/baml_language/languages/python/src/baml/baml_core/proto.py
@@ -7,8 +7,8 @@ structural mismatches surface as `CallAck.error` → `BamlError`.
 
 Outbound (09e): `baml_outbound.proto` → Python value. Decoding is driven
 by the FQN metadata embedded on `BamlValueClass` / `BamlValueEnum` and
-the host-derived `handle_type()` of `BamlPyHandle`; the caller's declared
-Python return type plays no runtime role.
+the wire `BamlHandle.handle_type` tag (read by `_decode_handle`); the
+caller's declared Python return type plays no runtime role.
 """
 
 from __future__ import annotations
@@ -188,8 +188,13 @@ def _set_inbound_value(inbound_value: baml_inbound_pb2.InboundValue, value: Any,
         from .baml_py import put_pyhandle_into_table
         key, ht = put_pyhandle_into_table(value)
         inbound_value.handle.key = key
-        # Wire field stays populated for cross-bridge compat.
-        inbound_value.handle.handle_type = baml_inbound_pb2.BamlHandleType(ht)
+        # Wire field stays populated for cross-bridge compat. The proto
+        # field is typed as the enum class, but `BamlHandleType` is an
+        # `int` subclass so the runtime accepts a bare int — cast for
+        # the static checker.
+        inbound_value.handle.handle_type = typing.cast(
+            baml_inbound_pb2.BamlHandleType, ht
+        )
         return
 
     # Media PyO3 types — wrap into an `InboundClassValue` per 15b. The
@@ -433,15 +438,17 @@ def _decode_enum(enum_value) -> Any:
 
 
 def _decode_handle(handle) -> Any:
-    """Drain `HANDLE_TABLE[handle.key]`, wrap in `BamlPyHandle`, dispatch
-    on its host-derived `handle_type()`. The wire `handle.handle_type`
-    field is not consulted — `BamlPyHandle.handle_type()` is the source
-    of truth.
+    """Wrap `HANDLE_TABLE[handle.key]` in a `BamlPyHandle` and dispatch
+    on the wire `handle.handle_type` field. The `BamlPyHandle` itself
+    holds the `handle_type` tag (set at construction from the wire) so
+    it round-trips on inbound encode without needing to consult the
+    table; we read directly from the wire here to avoid a redundant
+    field access.
     """
     from .baml_py import take_pyhandle_from_table
-    pyhandle = take_pyhandle_from_table(handle.key)
     HT = baml_inbound_pb2.BamlHandleType
-    ht = pyhandle.handle_type()
+    ht = handle.handle_type
+    pyhandle = take_pyhandle_from_table(handle.key, int(ht))
 
     if ht == HT.ADT_MEDIA_IMAGE:
         return BamlImage._from_pyhandle(pyhandle)

--- a/baml_language/languages/python/tests/test_decode_handle.py
+++ b/baml_language/languages/python/tests/test_decode_handle.py
@@ -1,11 +1,17 @@
-"""Decoder-side tests for `BamlPyHandle` round-tripping (15j Phase 8).
+"""Decoder-side tests for `BamlPyHandle` round-tripping.
 
 These tests exercise `_decode_handle` with handle kinds that have no
 Python-facing constructor (FunctionRef, ADT_MEDIA_GENERIC). The
-HANDLE_TABLE entries are seeded via the `_seed_*_handle` PyO3 helpers.
+HANDLE_TABLE entries are seeded via the `_seed_*_handle` PyO3 helpers,
+which return `(key, handle_type)` so tests can stage a wire
+`BamlHandle` and exercise the decoder dispatch.
 """
 
 from __future__ import annotations
+
+import typing
+
+import pytest
 
 from baml.baml_core import BamlPyHandle
 from baml.baml_core.baml_py import (
@@ -16,34 +22,34 @@ from baml.baml_core.proto import _decode_handle
 from baml.cffi.v1 import baml_inbound_pb2
 
 
-def _make_handle(key: int) -> "baml_inbound_pb2.BamlHandle":
+def _make_handle(key: int, handle_type: int) -> "baml_inbound_pb2.BamlHandle":
     h = baml_inbound_pb2.BamlHandle()
     h.key = key
+    # `BamlHandleType` is an `int` subclass at runtime; the proto field
+    # accepts bare ints. Cast for the static checker.
+    h.handle_type = typing.cast(baml_inbound_pb2.BamlHandleType, handle_type)
     return h
 
 
 def test_function_ref_decodes_to_pyhandle():
-    key = _seed_function_ref_handle(123)
-    result = _decode_handle(_make_handle(key))
+    key, ht = _seed_function_ref_handle(123)
+    result = _decode_handle(_make_handle(key, ht))
     assert isinstance(result, BamlPyHandle)
-    assert result.handle_type() == baml_inbound_pb2.BamlHandleType.FUNCTION_REF
 
 
 def test_adt_media_generic_decodes_to_pyhandle():
-    key = _seed_generic_media_handle()
-    result = _decode_handle(_make_handle(key))
+    key, ht = _seed_generic_media_handle()
+    result = _decode_handle(_make_handle(key, ht))
     assert isinstance(result, BamlPyHandle)
-    assert (
-        result.handle_type() == baml_inbound_pb2.BamlHandleType.ADT_MEDIA_GENERIC
-    )
 
 
-def test_decode_handle_drains_the_table_entry():
-    """A second drain on the same key fails — the first decode removed it."""
-    import pytest
-
-    key = _seed_function_ref_handle(7)
-    first = _decode_handle(_make_handle(key))
-    assert isinstance(first, BamlPyHandle)
+def test_decoded_pyhandle_releases_on_drop():
+    """Dropping a `BamlPyHandle` removes its row from `HANDLE_TABLE` —
+    a subsequent decode of the same key fails because the entry is gone.
+    """
+    key, ht = _seed_function_ref_handle(7)
+    pyh = _decode_handle(_make_handle(key, ht))
+    assert isinstance(pyh, BamlPyHandle)
+    del pyh  # CPython refcount drops to 0; Drop runs HANDLE_TABLE.release.
     with pytest.raises(RuntimeError, match="not in HANDLE_TABLE"):
-        _decode_handle(_make_handle(key))
+        _decode_handle(_make_handle(key, ht))


### PR DESCRIPTION
Per 15k-handle-more.md: BamlPyHandle now wraps (handle_key, handle_type) instead of an inline CffiHandleTableEntry. This matches what Go/Rust client bindings will need when they only see u64 handles across the CFFI boundary.

- BamlPyHandle stores handle_key + handle_type (not the entry inline)
- __copy__/__deepcopy__ allocate a fresh table row via clone_handle
- Drop releases the table row to prevent leaks
- handle_type() method removed; the wire BamlHandle.handle_type field is now the source of truth, stored on construction and read directly by inbound encode and media _from_pyhandle validation
- _decode_handle dispatches on the wire handle_type, no longer drains
- take_pyhandle_from_table validates the key without draining
- _seed_*_handle helpers return (key, handle_type) tuple

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Stronger media handle validation and guaranteed resource release to prevent leaks and mismatches for images, audio, video, and PDFs.

* **API Changes**
  - Handle-transfer helpers now require an explicit handle type; the previous implicit handle-type accessor was removed and handle representation simplified.

* **Tests**
  - Decoder tests updated to use new seeding helpers and focus on decode behavior and release semantics.

* **Documentation**
  - Clarified docstrings for handle encoding/decoding and runtime initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->