### PR TITLE
fixes: plumb generic type vars through $stream types, allow -1 as a literal type

### DIFF
--- a/baml_language/crates/baml_compiler2_ppir/src/expand.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/expand.rs
@@ -140,16 +140,36 @@ fn requalify_for_caller(ty: PpirTy, alias_ns: &[Name], caller_ns: &[Name]) -> Pp
         return ty;
     }
     match ty {
-        PpirTy::Named { path, attrs } if path.len() == 1 && path[0].as_str() != "root" => {
+        PpirTy::Named {
+            path,
+            generic_args,
+            attrs,
+        } if path.len() == 1 && path[0].as_str() != "root" => {
             let mut qualified = Vec::with_capacity(alias_ns.len() + 2);
             qualified.push(SmolStr::from("root"));
             qualified.extend(alias_ns.iter().cloned());
             qualified.extend(path);
             PpirTy::Named {
                 path: qualified,
+                generic_args: generic_args
+                    .into_iter()
+                    .map(|ga| requalify_for_caller(ga, alias_ns, caller_ns))
+                    .collect(),
                 attrs,
             }
         }
+        PpirTy::Named {
+            path,
+            generic_args,
+            attrs,
+        } => PpirTy::Named {
+            path,
+            generic_args: generic_args
+                .into_iter()
+                .map(|ga| requalify_for_caller(ga, alias_ns, caller_ns))
+                .collect(),
+            attrs,
+        },
         PpirTy::Union { variants, attrs } => PpirTy::Union {
             variants: variants
                 .into_iter()
@@ -276,7 +296,9 @@ pub fn expand_partial(ty: &PpirTy, ctx: &ExpandCtx<'_>) -> PpirTy {
         | PpirTy::CannotBeStreamed { .. } => ty.clone_without_attrs(),
 
         // Named types — depends on classification
-        PpirTy::Named { path, .. } => {
+        PpirTy::Named {
+            path, generic_args, ..
+        } => {
             // Already *$stream → unchanged
             if path.last().is_some_and(|n| n.as_str().ends_with("$stream")) {
                 return ty.clone_without_attrs();
@@ -290,6 +312,10 @@ pub fn expand_partial(ty: &PpirTy, ctx: &ExpandCtx<'_>) -> PpirTy {
                             .iter()
                             .cloned()
                             .chain(std::iter::once(SmolStr::new(format!("{bare_name}$stream"))))
+                            .collect(),
+                        generic_args: generic_args
+                            .iter()
+                            .map(|ga| expand_partial(ga, ctx))
                             .collect(),
                         attrs: d,
                     }
@@ -408,7 +434,9 @@ fn stream_expand_inner(ty: &PpirTy, ctx: &ExpandCtx<'_>, depth: u32) -> (PpirTy,
         ),
 
         // Named types
-        PpirTy::Named { path, .. } => {
+        PpirTy::Named {
+            path, generic_args, ..
+        } => {
             // Already *$stream → treat like T$stream
             if path.last().is_some_and(|n| n.as_str().ends_with("$stream")) {
                 (
@@ -436,9 +464,17 @@ fn stream_expand_inner(ty: &PpirTy, ctx: &ExpandCtx<'_>, depth: u32) -> (PpirTy,
                             .cloned()
                             .chain(std::iter::once(SmolStr::new(format!("{bare_name}$stream"))))
                             .collect();
+                        // Thread the original generic args through, so that
+                        // `Foo<X>` becomes `Foo$stream<expand_partial(X)>` and
+                        // matches the synthesized class's generic arity.
+                        let stream_args: Vec<PpirTy> = generic_args
+                            .iter()
+                            .map(|ga| expand_partial(ga, ctx))
+                            .collect();
                         (
                             PpirTy::Named {
                                 path: stream_path,
+                                generic_args: stream_args,
                                 attrs: d.clone(),
                             },
                             DefaultWhenPending::PrependNull,
@@ -487,9 +523,14 @@ fn stream_expand_inner(ty: &PpirTy, ctx: &ExpandCtx<'_>, depth: u32) -> (PpirTy,
                             .cloned()
                             .chain(std::iter::once(SmolStr::new(format!("{bare_name}$stream"))))
                             .collect();
+                        let stream_args: Vec<PpirTy> = generic_args
+                            .iter()
+                            .map(|ga| expand_partial(ga, ctx))
+                            .collect();
                         (
                             PpirTy::Named {
                                 path: stream_path,
+                                generic_args: stream_args,
                                 attrs: d.clone(),
                             },
                             DefaultWhenPending::PrependNull,

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -183,9 +183,11 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                 // Clone the original class and rename it
                 let mut stream_class = c.clone();
                 stream_class.name = SmolStr::new(format!("{}$stream", c.name));
-                // $stream classes don't have methods or generic params
+                // $stream classes don't have methods. Generic params are
+                // preserved so that field types referencing them (e.g. `v: T`)
+                // round-trip through TIR as `Ty::TypeVar` instead of collapsing
+                // to `Ty::Unknown`.
                 stream_class.methods.clear();
-                stream_class.generic_params.clear();
                 // Use a dummy span so the synthetic class doesn't shadow the
                 // original in offset-based scope lookup (scope_at_offset
                 // iterates in reverse and would find this scope first if it

--- a/baml_language/crates/baml_compiler2_ppir/src/ty.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/ty.rs
@@ -47,6 +47,9 @@ pub struct PpirTypeAttrs {
 pub enum PpirTy {
     Named {
         path: Vec<Name>,
+        /// Generic args passed at the use site (e.g. `Box<int>` → `[int]`).
+        /// Empty for non-generic types and references that omit args.
+        generic_args: Vec<PpirTy>,
         attrs: PpirTypeAttrs,
     },
     Int {
@@ -139,8 +142,11 @@ impl PpirTy {
     pub fn clone_without_attrs(&self) -> Self {
         let d = PpirTypeAttrs::default();
         match self {
-            Self::Named { path, .. } => Self::Named {
+            Self::Named {
+                path, generic_args, ..
+            } => Self::Named {
                 path: path.clone(),
+                generic_args: generic_args.clone(),
                 attrs: d,
             },
             Self::Int { .. } => Self::Int { attrs: d },
@@ -182,6 +188,7 @@ impl PpirTy {
     pub fn named(name: impl Into<Name>) -> Self {
         PpirTy::Named {
             path: vec![name.into()],
+            generic_args: vec![],
             attrs: PpirTypeAttrs::default(),
         }
     }
@@ -240,8 +247,13 @@ impl PpirTy {
             TypeExpr::Null { .. } => PpirTy::Null { attrs },
             TypeExpr::Never { .. } => PpirTy::Never { attrs },
             TypeExpr::Void { .. } => PpirTy::Never { attrs },
-            TypeExpr::Path { segments, .. } => PpirTy::Named {
+            TypeExpr::Path {
+                segments,
+                generic_args,
+                ..
+            } => PpirTy::Named {
                 path: segments.clone(),
+                generic_args: generic_args.iter().map(Self::convert_type_expr).collect(),
                 attrs,
             },
             TypeExpr::Optional { inner, .. } => PpirTy::Optional {
@@ -300,9 +312,11 @@ impl PpirTy {
     /// Convert a `PpirTy` back to a `TypeExpr` for synthesized AST items.
     pub fn to_type_expr(&self) -> TypeExpr {
         match self {
-            PpirTy::Named { path, .. } => TypeExpr::Path {
+            PpirTy::Named {
+                path, generic_args, ..
+            } => TypeExpr::Path {
                 segments: path.clone(),
-                generic_args: vec![],
+                generic_args: generic_args.iter().map(PpirTy::to_type_expr).collect(),
                 attrs: vec![],
             },
             PpirTy::Int { .. } => TypeExpr::Int { attrs: vec![] },

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -357,7 +357,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Check if the current token can start a type expression.
-    /// Valid type starts: Word (type name), string literal, integer/float literal, `LParen` (tuple).
+    /// Valid type starts: Word (type name), string literal, integer/float literal,
+    /// `-` followed by an integer/float literal (negative literal type), `LParen` (tuple).
     fn is_at_type_start(&self) -> bool {
         self.at(TokenKind::Word)
             || self.at(TokenKind::Quote) // string literal type
@@ -365,6 +366,11 @@ impl<'a> Parser<'a> {
             || self.at(TokenKind::IntegerLiteral)
             || self.at(TokenKind::FloatLiteral)
             || self.at(TokenKind::LParen) // tuple/parenthesized type
+            || (self.at(TokenKind::Minus)
+                && matches!(
+                    self.peek(1).map(|t| t.kind),
+                    Some(TokenKind::IntegerLiteral | TokenKind::FloatLiteral)
+                ))
     }
 
     /// Check if a token kind is basic trivia (whitespace/newlines, not comments).
@@ -7278,6 +7284,118 @@ function Demo() -> int {
         assert!(
             text.contains("-1"),
             "expected `-1` inside GENERIC_ARGS, got `{text}`"
+        );
+    }
+
+    #[test]
+    fn class_field_negative_integer_literal_type_with_colon() {
+        // `field: -1` — `is_at_type_start` must accept `Minus` followed by an
+        // integer literal so the class-field gate doesn't reject negative
+        // literal types and fall through to "missing a type annotation".
+        let source = r#"
+class Foo {
+  literal_neg_one: -1
+}
+"#;
+
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let field = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::FIELD)
+            .expect("expected FIELD node");
+        let type_expr = field
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+            .expect("expected TYPE_EXPR inside FIELD");
+        assert!(
+            type_expr.text().to_string().contains("-1"),
+            "expected field type to contain `-1`, got: {}",
+            type_expr.text()
+        );
+    }
+
+    #[test]
+    fn class_field_negative_integer_literal_type_no_colon() {
+        // BEP-019 colon-less form: `field -1`. Same gate, exercises the path
+        // where `has_colon == false` so the type must start on the same line.
+        let source = r#"
+class Foo {
+  literal_neg_one -1
+}
+"#;
+
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let field = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::FIELD)
+            .expect("expected FIELD node");
+        let type_expr = field
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+            .expect("expected TYPE_EXPR inside FIELD");
+        assert!(
+            type_expr.text().to_string().contains("-1"),
+            "expected field type to contain `-1`, got: {}",
+            type_expr.text()
+        );
+    }
+
+    #[test]
+    fn class_field_negative_literal_in_union_type() {
+        // `-1 | 0 | 1` in field position — combines the field-start gate with
+        // the union-continuation path inside `parse_type_with`.
+        let source = r#"
+class Foo {
+  bounded: -1 | 0 | 1
+}
+"#;
+
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let field = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::FIELD)
+            .expect("expected FIELD node");
+        let type_expr = field
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+            .expect("expected TYPE_EXPR inside FIELD");
+        let text = type_expr.text().to_string();
+        assert!(
+            text.contains("-1") && text.contains('0') && text.contains('1'),
+            "expected union to contain -1, 0, 1; got: {text}"
+        );
+    }
+
+    #[test]
+    fn function_parameter_negative_integer_literal_type() {
+        // `(x: -1) -> int` — same gate is consulted by `parse_parameter`.
+        let source = r#"
+function Demo(x: -1) -> int {
+  0
+}
+"#;
+
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let param = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::PARAMETER)
+            .expect("expected PARAMETER node");
+        let type_expr = param
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+            .expect("expected TYPE_EXPR inside PARAMETER");
+        assert!(
+            type_expr.text().to_string().contains("-1"),
+            "expected parameter type to contain `-1`, got: {}",
+            type_expr.text()
         );
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -829,7 +829,7 @@ class baml.llm.Stream$stream {
   _client: null | baml.llm.PrimitiveClient$stream
   _acc: null | baml.llm.StreamAccumulator$stream
   _sse: null | baml.http.SseStream$stream
-  _cache: null | baml.llm.StreamCache$stream
+  _cache: null | baml.llm.StreamCache$stream<T, S>
 }
 class baml.llm.PrimitiveClient$stream {
   name: null | string

--- a/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__04_tir.snap
@@ -186,7 +186,7 @@ class user.Encoder$stream {
   charset: null | string
 }
 class user.Box$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.Calculator$stream {
   op: null | string

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_field_chain/baml_tests__compiles__generic_field_chain__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_field_chain/baml_tests__compiles__generic_field_chain__04_tir.snap
@@ -32,7 +32,7 @@ function user.test_generic_capture(box: user.Box<user.User>) -> string throws ne
 lambda user.test_generic_capture {
 }
 class user.Box$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.User$stream {
   name: null | string

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__04_tir.snap
@@ -133,8 +133,8 @@ class user.llm.openai.Response$stream {
   score: null | int
 }
 class user.llm.openai.Box$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.llm.openai.Outer$stream {
-  inner: null | user.llm.openai.Box$stream
+  inner: null | user.llm.openai.Box$stream<T>
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generics/baml_tests__diagnostic_errors__generics__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generics/baml_tests__diagnostic_errors__generics__04_tir.snap
@@ -234,7 +234,7 @@ class user.Plain$stream {
   name: null | string
 }
 class user.Container$stream {
-  inner: null | user.Box$stream
+  inner: null | user.Box$stream<T>
 }
 class user.Factory$stream {
   data: null | T
@@ -246,7 +246,7 @@ class user.Stack$stream {
   items: T[]
 }
 class user.Foo$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.Todo {
   id: int

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generics/baml_tests__diagnostic_errors__generics__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generics/baml_tests__diagnostic_errors__generics__04_tir.snap
@@ -212,23 +212,23 @@ function user.bare_in_union_param(f: user.Foo<int> | user.Foo) -> string throws 
   !! 5777..5783: class `Foo` expects 1 type argument(s), got 0
 }
 class user.Box$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.Wrapper$stream {
-  data: null | unknown
+  data: null | T
 }
 class user.Pair$stream {
-  first: null | unknown
-  second: null | unknown
+  first: null | A
+  second: null | B
 }
 class user.Maker$stream {
-  data: null | unknown
+  data: null | T
 }
 class user.Holder$stream {
   data: null | string
 }
 class user.Shadow$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.Plain$stream {
   name: null | string
@@ -237,13 +237,13 @@ class user.Container$stream {
   inner: null | user.Box$stream
 }
 class user.Factory$stream {
-  data: null | unknown
+  data: null | T
 }
 class user.MaybeBox$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.Stack$stream {
-  items: unknown[]
+  items: T[]
 }
 class user.Foo$stream {
   value: null | unknown

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__04_tir.snap
@@ -295,7 +295,7 @@ class user.SameNameOuter$stream {
   other: null | user.SameNameInner$stream
 }
 class user.Box$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.OptionalPerson$stream {
   age: null | int

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure_namespaces/baml_tests__diagnostic_errors__patterns_class_destructure_namespaces__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure_namespaces/baml_tests__diagnostic_errors__patterns_class_destructure_namespaces__04_tir.snap
@@ -53,7 +53,7 @@ class user.llm.openai.Response {
   score: int
 }
 class user.llm.openai.Box$stream {
-  value: null | unknown
+  value: null | T
 }
 class user.llm.openai.Response$stream {
   score: null | int

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__stream_expansion__stream_companion_preserves_generic_args_for_llm_return_type.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__stream_expansion__stream_companion_preserves_generic_args_for_llm_return_type.snap
@@ -1,0 +1,34 @@
+---
+source: crates/baml_tests/src/compiler2_tir/stream_expansion.rs
+expression: "render_tir(&db, file)"
+---
+class user.Box {
+  value: T
+}
+function user.Dummy$new() -> ? throws never {
+  baml.llm.PrimitiveClient { name: "Dummy", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : baml.llm.PrimitiveClient
+}
+function user.GetBoxedInt() -> user.Box<int> throws never {
+  baml.llm.call_llm_function<T>(Dummy, "GetBoxedInt", map {  }) : user.Box<int>
+}
+function user.GetBoxedInt$render_prompt() -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(Dummy, "GetBoxedInt", map {  }) : baml.llm.PromptAst
+}
+function user.GetBoxedInt$build_request() -> baml.http.Request throws never {
+  baml.llm.build_request(Dummy, "GetBoxedInt", map {  }) : baml.http.Request
+}
+function user.GetBoxedInt$build_request_stream() -> baml.http.Request throws never {
+  baml.llm.build_request_stream(Dummy, "GetBoxedInt", map {  }) : baml.http.Request
+}
+function user.GetBoxedInt$parse(json: string) -> user.Box<int> throws never {
+  baml.llm.parse<T>("GetBoxedInt", json) : user.Box<int>
+}
+class user.Box$stream {
+  value: null | T
+}
+function user.GetBoxedInt$stream() -> baml.llm.Stream<user.Box<int>, null | user.Box$stream<int>> throws never {
+  baml.llm.stream_llm_function(Dummy, "GetBoxedInt", map {  }) : baml.llm.Stream<user.Box<int>, null | user.Box$stream<int>>
+}
+function user.GetBoxedInt$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<user.Box<int>, null | user.Box$stream<int>> throws never {
+  Dummy.__make_stream(sse, "GetBoxedInt") : unknown
+}

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__stream_expansion__stream_companion_preserves_generic_args_in_class_field.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__stream_expansion__stream_companion_preserves_generic_args_in_class_field.snap
@@ -1,0 +1,16 @@
+---
+source: crates/baml_tests/src/compiler2_tir/stream_expansion.rs
+expression: "render_tir(&db, file)"
+---
+class user.Box {
+  value: T
+}
+class user.Container {
+  inner: user.Box<int>
+}
+class user.Box$stream {
+  value: null | T
+}
+class user.Container$stream {
+  inner: null | user.Box$stream<int>
+}

--- a/baml_language/crates/baml_tests/src/compiler2_tir/stream_expansion.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/stream_expansion.rs
@@ -398,3 +398,57 @@ class WithDesc {
 // don't leak into user types with the same name.
 // TODO: Add project-based test in projects/stream_crosspackage/ once
 // multi-package test support is available.
+
+// ── Generic args threaded through stream-expanded references ────────────────
+
+#[test]
+fn stream_companion_preserves_generic_args_in_class_field() {
+    // `Container.inner: Box<int>` should round-trip into `Container$stream`
+    // with `inner: null | Box$stream<int>`. Without threading `generic_args`
+    // through PPIR's stream rewrite, `Box$stream` would lose its arg and
+    // mismatch the synthesized `Box$stream<T>` arity.
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Box<T> {
+    value T
+}
+
+class Container {
+    inner Box<int>
+}
+"#,
+    );
+    insta::assert_snapshot!(render_tir(&db, file));
+}
+
+#[test]
+fn stream_companion_preserves_generic_args_for_llm_return_type() {
+    // Reviewer's exact scenario: an LLM function returning `Box<int>` builds
+    // a synthesized `$stream`/`$parse_stream` companion whose return type is
+    // `baml.llm.Stream<Box<int>, null | Box$stream<int>>`. With generic-arg
+    // threading, the second type arg matches `Box$stream<T>`'s arity.
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Box<T> {
+    value T
+}
+
+client<llm> Dummy {
+    provider openai
+    options {
+        model "gpt-4"
+    }
+}
+
+function GetBoxedInt() -> Box<int> {
+    client Dummy
+    prompt "Give me a box"
+}
+"#,
+    );
+    insta::assert_snapshot!(render_tir(&db, file));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve generic type arguments when synthesizing stream/companion types so generic field and return types round-trip correctly.
  * Recognize negative numeric literal types (e.g., -1) in type annotations.

* **Tests**
  * Added regression tests for negative numeric literal types in fields, unions, and parameters.
  * Added tests ensuring generic arguments are threaded through synthesized stream/companion types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->