### PR TITLE
fix(codegen-python): generate bindings to all BAML fns

### DIFF
--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use baml_codegen_types::{self as cg, Origin, SymbolPool};
-use baml_compiler2_ast::{DeclarativeMeta, FunctionOrigin};
+use baml_compiler2_ast::FunctionOrigin;
 use baml_compiler2_hir::{
     compiler2_all_files, file_package,
     ids::{FunctionMarker, LocalItemId},
@@ -325,14 +325,13 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 continue;
             }
 
-            let func_name_str = func.name.as_str();
-            let is_companion = func_name_str.contains('$');
-
-            // For parent functions, require declarative LLM meta.
-            // Companion functions inherit validity from their parent.
-            if !is_companion && !matches!(&func.declarative_meta, Some(DeclarativeMeta::Llm(_))) {
-                continue;
-            }
+            // Companion functions arrive as their own pool entries (names
+            // containing `$`); they share the parent's span so
+            // `group_and_sort` keeps them contiguous. No further
+            // parent-vs-companion gating needed: companion validity is
+            // encoded by the suffix; non-LLM parents (pure-expression
+            // bodies, etc.) are valid too. `FunctionOrigin::Internal` is
+            // already filtered above.
 
             let func_generic_params: Vec<Name> = func.generic_params.clone();
             let arguments: Vec<cg::FunctionArgument> = func
@@ -870,5 +869,32 @@ mod tests {
             key.namespace_path,
         );
         assert!(!key.is_stream(), "Sentiment must not be marked as stream");
+    }
+
+    /// Pure-expression functions (no `llm` declarative meta) must reach the
+    /// pool as `Symbol::Function` entries so Python codegen emits a factory
+    /// binding for them. Regression for 18b §2 / 18c2: a non-LLM,
+    /// non-internal parent function used to be filtered out, leaving the
+    /// only emission path through synthetic class-field workarounds.
+    #[test]
+    fn test_pure_expression_function_reaches_pool() {
+        let root = Path::new("/tmp/18c2_pure_expression_function");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("main.baml").as_path(),
+            "function ReturnInt() -> int { 42 }\n",
+        );
+
+        let pool = build_symbol_pool(&db);
+
+        let key = pool
+            .keys()
+            .find(|k| k.name.as_str() == "ReturnInt")
+            .expect("ReturnInt must be in the pool");
+        assert!(
+            matches!(pool.get(key), Some(cg::Symbol::Function(_))),
+            "ReturnInt must be a Function symbol",
+        );
     }
 }

--- a/baml_language/languages/python/rust/codegen_python/src/leaf.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/leaf.rs
@@ -697,6 +697,12 @@ pub(crate) fn render_leaf_body(body: &LeafBody) -> String {
     if !cross_leaf_segments.is_empty() && !stdlibs.contains(&"typing") {
         stdlibs.push("typing");
     }
+    // Generic functions emit `T = typing.TypeVar("T")` lines below; the
+    // `Class`/`TypeAlias` rule in `stdlib_imports` doesn't catch the
+    // function-only-but-generic case (e.g. stdlib `baml.unstable.string<T>`).
+    if !body.generic_typevars().is_empty() && !stdlibs.contains(&"typing") {
+        stdlibs.push("typing");
+    }
     let needs_pydantic = body.needs_pydantic();
     let needs_factory = body.needs_define_function();
     let has_stdlib_block = !stdlibs.is_empty() || needs_pydantic;

--- a/baml_language/languages/python/rust/codegen_python/src/routing.rs
+++ b/baml_language/languages/python/rust/codegen_python/src/routing.rs
@@ -58,6 +58,26 @@ pub(crate) fn route(name: &Name, symbol: &Symbol) -> LeafPath {
     route_inner(name, !matches!(symbol, Symbol::Function(_)))
 }
 
+/// Sanitize a path segment so it's a usable Python module identifier.
+/// Today only handles `assert` (the BAML stdlib package whose name
+/// collides with Python's `assert` keyword — `from . import assert` is
+/// a `SyntaxError`); the routed leaf becomes `vendor/assert_/…` and any
+/// cross-leaf type reference renders as `vendor.assert_.…`. The runtime
+/// BAML FQN passed to `_define_function` (e.g. `"assert.is_true"`) is
+/// built from `Name`, not from `LeafPath`, so it is *not* affected.
+///
+/// TODO(reserved-keywords): generalize to all Python keywords and any
+/// other invalid identifiers. User packages or namespaces named after
+/// keywords (`class`, `def`, `pass`, …) would hit the same issue, but
+/// none exist today; broaden this set when one shows up.
+fn sanitize_python_module_segment(seg: &str) -> String {
+    if seg == "assert" {
+        "assert_".to_string()
+    } else {
+        seg.to_string()
+    }
+}
+
 /// Route a `Name` referenced from a type position (`Ty::Class`,
 /// `Ty::Enum`, `Ty::TypeAlias`). Type references always point at
 /// class-like symbols, so the `$stream` suffix routes under
@@ -78,12 +98,12 @@ fn route_inner(name: &Name, honor_stream_suffix: bool) -> LeafPath {
         "baml" => segs.push("baml".to_string()),
         other => {
             segs.push("vendor".to_string());
-            segs.push(other.to_string());
+            segs.push(sanitize_python_module_segment(other));
         }
     }
 
     for seg in &name.namespace_path {
-        segs.push(seg.as_str().to_string());
+        segs.push(sanitize_python_module_segment(seg.as_str()));
     }
 
     LeafPath { segments: segs }
@@ -264,5 +284,28 @@ mod tests {
         let n = name("user", &["lorem"], "Foo");
         let lp = route(&n, &enum_sym(&n));
         assert_eq!(lp.segments, vec!["lorem".to_string()]);
+    }
+
+    #[test]
+    fn assert_package_segment_is_sanitized() {
+        // BAML stdlib `assert` package collides with Python's `assert`
+        // keyword (`from . import assert` is a SyntaxError). The routed
+        // leaf renames the segment to `assert_`; the BAML FQN is
+        // unaffected because it's built from `Name`, not `LeafPath`.
+        let n = name("assert", &[], "is_true");
+        let lp = route(&n, &func_sym());
+        assert_eq!(
+            lp.segments,
+            vec!["vendor".to_string(), "assert_".to_string()]
+        );
+    }
+
+    #[test]
+    fn assert_namespace_segment_is_sanitized() {
+        // Defense: a namespace path segment named `assert` (today
+        // unreachable in user BAML, but cheap to cover) is also renamed.
+        let n = name("user", &["assert"], "Foo");
+        let lp = route(&n, &class_sym(&n));
+        assert_eq!(lp.segments, vec!["assert_".to_string()]);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client codegen now emits additional non-internal functions (including pure-expression helpers) and treats companion helpers as separate generated symbols.
  * Python codegen for generic functions now ensures typing imports are included when needed.

* **Bug Fixes**
  * Python module path segments that are reserved words are automatically sanitized.

* **Tests**
  * Added a regression test to ensure pure-expression helpers appear in the generated symbol pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->