### PR TITLE
feat(beps): add tag management system for BEPs

### DIFF
--- a/typescript/apps/beps/convex/_generated/api.d.ts
+++ b/typescript/apps/beps/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as lib_prompts from "../lib/prompts.js";
 import type * as migrations from "../migrations.js";
 import type * as presence from "../presence.js";
 import type * as slack from "../slack.js";
+import type * as tags from "../tags.js";
 import type * as userStances from "../userStances.js";
 import type * as users from "../users.js";
 
@@ -42,6 +43,7 @@ declare const fullApi: ApiFromModules<{
   migrations: typeof migrations;
   presence: typeof presence;
   slack: typeof slack;
+  tags: typeof tags;
   userStances: typeof userStances;
   users: typeof users;
 }>;

--- a/typescript/apps/beps/convex/beps.ts
+++ b/typescript/apps/beps/convex/beps.ts
@@ -11,27 +11,43 @@ export const list = query({
   args: {
     status: v.optional(bepStatus),
     limit: v.optional(v.number()),
+    tagId: v.optional(v.id("tags")),
   },
   handler: async (ctx, args) => {
     let beps;
+
+    // If filtering by tag, get BEP IDs from bepTags first
+    let tagFilteredBepIds: Set<string> | null = null;
+    if (args.tagId) {
+      const bepTags = await ctx.db
+        .query("bepTags")
+        .withIndex("by_tag", (q) => q.eq("tagId", args.tagId!))
+        .collect();
+      tagFilteredBepIds = new Set(bepTags.map((bt) => bt.bepId));
+    }
 
     if (args.status) {
       beps = await ctx.db
         .query("beps")
         .withIndex("by_status", (q) => q.eq("status", args.status!))
-        .take(args.limit ?? 50);
+        .take(args.limit ?? 100);
     } else {
       beps = await ctx.db
         .query("beps")
         .withIndex("by_updatedAt")
         .order("desc")
-        .take(args.limit ?? 50);
+        .take(args.limit ?? 100);
     }
 
-    // Enrich with counts and shepherd info
+    // Apply tag filter if specified
+    if (tagFilteredBepIds !== null) {
+      beps = beps.filter((bep) => tagFilteredBepIds!.has(bep._id));
+    }
+
+    // Enrich with counts, shepherd info, and tags
     return Promise.all(
       beps.map(async (bep) => {
-        const [commentCount, issueCount, shepherds] = await Promise.all([
+        const [commentCount, issueCount, shepherds, bepTags] = await Promise.all([
           ctx.db
             .query("comments")
             .withIndex("by_bep", (q) => q.eq("bepId", bep._id))
@@ -45,7 +61,20 @@ export const list = query({
             .collect()
             .then((i) => i.length),
           Promise.all(bep.shepherds.map((id) => ctx.db.get(id))),
+          ctx.db
+            .query("bepTags")
+            .withIndex("by_bep", (q) => q.eq("bepId", bep._id))
+            .collect(),
         ]);
+
+        // Fetch tag details
+        const tags = await Promise.all(
+          bepTags.map(async (bt) => {
+            const tag = await ctx.db.get(bt.tagId);
+            return tag;
+          })
+        );
+
         return {
           ...bep,
           commentCount,
@@ -53,6 +82,9 @@ export const list = query({
           shepherdNames: shepherds
             .filter((s) => s !== null)
             .map((s) => s!.name),
+          tags: tags
+            .filter((t) => t !== null)
+            .map((t) => ({ _id: t!._id, name: t!.name, color: t!.color })),
         };
       })
     );
@@ -69,8 +101,8 @@ export const getByNumber = query({
 
     if (!bep) return null;
 
-    // Get pages, comments, decisions, issues, versions, shepherds, and implementers
-    const [pages, comments, decisions, issues, versions, shepherds, implementers] =
+    // Get pages, comments, decisions, issues, versions, shepherds, implementers, and tags
+    const [pages, comments, decisions, issues, versions, shepherds, implementers, bepTags] =
       await Promise.all([
         ctx.db
           .query("bepPages")
@@ -97,7 +129,19 @@ export const getByNumber = query({
         bep.implementedBy
           ? Promise.all(bep.implementedBy.map((id) => ctx.db.get(id)))
           : Promise.resolve([]),
+        ctx.db
+          .query("bepTags")
+          .withIndex("by_bep", (q) => q.eq("bepId", bep._id))
+          .collect(),
       ]);
+
+    // Fetch tag details
+    const tags = await Promise.all(
+      bepTags.map(async (bt) => {
+        const tag = await ctx.db.get(bt.tagId);
+        return tag;
+      })
+    );
 
     return {
       ...bep,
@@ -108,6 +152,9 @@ export const getByNumber = query({
       versions,
       shepherdNames: shepherds.filter((s) => s !== null).map((s) => s!.name),
       implementedByNames: implementers.filter((i) => i !== null).map((i) => i!.name),
+      tags: tags
+        .filter((t) => t !== null)
+        .map((t) => ({ _id: t!._id, name: t!.name, color: t!.color, description: t!.description })),
     };
   },
 });

--- a/typescript/apps/beps/convex/schema.ts
+++ b/typescript/apps/beps/convex/schema.ts
@@ -51,6 +51,32 @@ export const userRole = v.union(
 
 export default defineSchema({
   // ─────────────────────────────────────────────────────────────────────────
+  // TAGS (for categorizing BEPs)
+  // ─────────────────────────────────────────────────────────────────────────
+  tags: defineTable({
+    name: v.string(),
+    description: v.optional(v.string()),
+    color: v.string(),
+    createdBy: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_name", ["name"]),
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // BEP TAGS (many-to-many relationship between BEPs and tags)
+  // ─────────────────────────────────────────────────────────────────────────
+  bepTags: defineTable({
+    bepId: v.id("beps"),
+    tagId: v.id("tags"),
+    addedBy: v.id("users"),
+    addedAt: v.number(),
+  })
+    .index("by_bep", ["bepId"])
+    .index("by_tag", ["tagId"])
+    .index("by_bep_tag", ["bepId", "tagId"]),
+
+  // ─────────────────────────────────────────────────────────────────────────
   // USERS (GitHub OAuth or passkey auth)
   // ─────────────────────────────────────────────────────────────────────────
   users: defineTable({

--- a/typescript/apps/beps/convex/tags.ts
+++ b/typescript/apps/beps/convex/tags.ts
@@ -1,0 +1,292 @@
+import { query, mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+// Helper to check if a role has team-level permissions (team, bdfl, or legacy equivalents)
+function hasTeamPermissions(role: string): boolean {
+  return role === "bdfl" || role === "team" || role === "admin" || role === "shepherd";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TAG QUERIES
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    const tags = await ctx.db.query("tags").collect();
+    return tags.sort((a, b) => a.name.localeCompare(b.name));
+  },
+});
+
+export const get = query({
+  args: { id: v.id("tags") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});
+
+export const getByName = query({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("tags")
+      .withIndex("by_name", (q) => q.eq("name", args.name))
+      .unique();
+  },
+});
+
+// Get tags for a specific BEP
+export const getForBep = query({
+  args: { bepId: v.id("beps") },
+  handler: async (ctx, args) => {
+    const bepTags = await ctx.db
+      .query("bepTags")
+      .withIndex("by_bep", (q) => q.eq("bepId", args.bepId))
+      .collect();
+
+    const tags = await Promise.all(
+      bepTags.map(async (bt) => {
+        const tag = await ctx.db.get(bt.tagId);
+        return tag;
+      })
+    );
+
+    return tags.filter((t) => t !== null).sort((a, b) => a!.name.localeCompare(b!.name));
+  },
+});
+
+// Get tag usage counts
+export const listWithCounts = query({
+  args: {},
+  handler: async (ctx) => {
+    const tags = await ctx.db.query("tags").collect();
+
+    const tagsWithCounts = await Promise.all(
+      tags.map(async (tag) => {
+        const bepTags = await ctx.db
+          .query("bepTags")
+          .withIndex("by_tag", (q) => q.eq("tagId", tag._id))
+          .collect();
+        return {
+          ...tag,
+          bepCount: bepTags.length,
+        };
+      })
+    );
+
+    return tagsWithCounts.sort((a, b) => a.name.localeCompare(b.name));
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TAG MUTATIONS
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const create = mutation({
+  args: {
+    name: v.string(),
+    description: v.optional(v.string()),
+    color: v.string(),
+    requesterId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const requester = await ctx.db.get(args.requesterId);
+    if (!requester) {
+      throw new Error("User not found");
+    }
+
+    if (!hasTeamPermissions(requester.role)) {
+      throw new Error("Unauthorized: Only team members and BDFL can manage tags");
+    }
+
+    // Check if tag with same name already exists
+    const existing = await ctx.db
+      .query("tags")
+      .withIndex("by_name", (q) => q.eq("name", args.name))
+      .unique();
+
+    if (existing) {
+      throw new Error("A tag with this name already exists");
+    }
+
+    const now = Date.now();
+    const tagId = await ctx.db.insert("tags", {
+      name: args.name,
+      description: args.description,
+      color: args.color,
+      createdBy: args.requesterId,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return tagId;
+  },
+});
+
+export const update = mutation({
+  args: {
+    id: v.id("tags"),
+    name: v.optional(v.string()),
+    description: v.optional(v.string()),
+    color: v.optional(v.string()),
+    requesterId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const requester = await ctx.db.get(args.requesterId);
+    if (!requester) {
+      throw new Error("User not found");
+    }
+
+    if (!hasTeamPermissions(requester.role)) {
+      throw new Error("Unauthorized: Only team members and BDFL can manage tags");
+    }
+
+    const tag = await ctx.db.get(args.id);
+    if (!tag) {
+      throw new Error("Tag not found");
+    }
+
+    // If name is being changed, check for duplicates
+    if (args.name && args.name !== tag.name) {
+      const newName = args.name;
+      const existing = await ctx.db
+        .query("tags")
+        .withIndex("by_name", (q) => q.eq("name", newName))
+        .unique();
+
+      if (existing) {
+        throw new Error("A tag with this name already exists");
+      }
+    }
+
+    const updates: Record<string, unknown> = { updatedAt: Date.now() };
+    if (args.name !== undefined) updates.name = args.name;
+    if (args.description !== undefined) updates.description = args.description;
+    if (args.color !== undefined) updates.color = args.color;
+
+    await ctx.db.patch(args.id, updates);
+  },
+});
+
+export const remove = mutation({
+  args: {
+    id: v.id("tags"),
+    requesterId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const requester = await ctx.db.get(args.requesterId);
+    if (!requester) {
+      throw new Error("User not found");
+    }
+
+    if (!hasTeamPermissions(requester.role)) {
+      throw new Error("Unauthorized: Only team members and BDFL can manage tags");
+    }
+
+    const tag = await ctx.db.get(args.id);
+    if (!tag) {
+      throw new Error("Tag not found");
+    }
+
+    // Delete all bepTags associations first
+    const bepTags = await ctx.db
+      .query("bepTags")
+      .withIndex("by_tag", (q) => q.eq("tagId", args.id))
+      .collect();
+
+    for (const bt of bepTags) {
+      await ctx.db.delete(bt._id);
+    }
+
+    // Delete the tag
+    await ctx.db.delete(args.id);
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BEP TAG MUTATIONS
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const addTagToBep = mutation({
+  args: {
+    bepId: v.id("beps"),
+    tagId: v.id("tags"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    // Check if association already exists
+    const existing = await ctx.db
+      .query("bepTags")
+      .withIndex("by_bep_tag", (q) => q.eq("bepId", args.bepId).eq("tagId", args.tagId))
+      .unique();
+
+    if (existing) {
+      return existing._id;
+    }
+
+    const bepTagId = await ctx.db.insert("bepTags", {
+      bepId: args.bepId,
+      tagId: args.tagId,
+      addedBy: args.userId,
+      addedAt: Date.now(),
+    });
+
+    return bepTagId;
+  },
+});
+
+export const removeTagFromBep = mutation({
+  args: {
+    bepId: v.id("beps"),
+    tagId: v.id("tags"),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("bepTags")
+      .withIndex("by_bep_tag", (q) => q.eq("bepId", args.bepId).eq("tagId", args.tagId))
+      .unique();
+
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    }
+  },
+});
+
+// Set all tags for a BEP (replaces existing tags)
+export const setTagsForBep = mutation({
+  args: {
+    bepId: v.id("beps"),
+    tagIds: v.array(v.id("tags")),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    // Get existing tags for this BEP
+    const existingBepTags = await ctx.db
+      .query("bepTags")
+      .withIndex("by_bep", (q) => q.eq("bepId", args.bepId))
+      .collect();
+
+    const existingTagIds = new Set(existingBepTags.map((bt) => bt.tagId));
+    const newTagIds = new Set(args.tagIds);
+
+    // Remove tags that are no longer in the list
+    for (const bepTag of existingBepTags) {
+      if (!newTagIds.has(bepTag.tagId)) {
+        await ctx.db.delete(bepTag._id);
+      }
+    }
+
+    // Add new tags
+    const now = Date.now();
+    for (const tagId of args.tagIds) {
+      if (!existingTagIds.has(tagId)) {
+        await ctx.db.insert("bepTags", {
+          bepId: args.bepId,
+          tagId,
+          addedBy: args.userId,
+          addedAt: now,
+        });
+      }
+    }
+  },
+});

--- a/typescript/apps/beps/src/app/page.tsx
+++ b/typescript/apps/beps/src/app/page.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, User, Users, ChevronDown } from "lucide-react";
+import { LogOut, User, Users, Tags, ChevronDown } from "lucide-react";
 
 export default function Home() {
   const { user, userId, isLoading, logout, hasManagementPermissions } = useUser();
@@ -84,10 +84,16 @@ export default function Home() {
                   Your Profile
                 </DropdownMenuItem>
                 {hasManagementPermissions && (
-                  <DropdownMenuItem onClick={() => router.push("/users")}>
-                    <Users className="h-4 w-4 mr-2" />
-                    Manage Users
-                  </DropdownMenuItem>
+                  <>
+                    <DropdownMenuItem onClick={() => router.push("/users")}>
+                      <Users className="h-4 w-4 mr-2" />
+                      Manage Users
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => router.push("/tags")}>
+                      <Tags className="h-4 w-4 mr-2" />
+                      Manage Tags
+                    </DropdownMenuItem>
+                  </>
                 )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleLogout}>

--- a/typescript/apps/beps/src/app/tags/page.tsx
+++ b/typescript/apps/beps/src/app/tags/page.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { Id } from "../../../convex/_generated/dataModel";
+import { useUser } from "@/components/providers/user-provider";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { ArrowLeft, Tags, Plus, Pencil, Trash2 } from "lucide-react";
+
+const TAG_COLORS = [
+  { name: "Gray", value: "bg-gray-500" },
+  { name: "Red", value: "bg-red-500" },
+  { name: "Orange", value: "bg-orange-500" },
+  { name: "Amber", value: "bg-amber-500" },
+  { name: "Yellow", value: "bg-yellow-500" },
+  { name: "Lime", value: "bg-lime-500" },
+  { name: "Green", value: "bg-green-500" },
+  { name: "Emerald", value: "bg-emerald-500" },
+  { name: "Teal", value: "bg-teal-500" },
+  { name: "Cyan", value: "bg-cyan-500" },
+  { name: "Sky", value: "bg-sky-500" },
+  { name: "Blue", value: "bg-blue-500" },
+  { name: "Indigo", value: "bg-indigo-500" },
+  { name: "Violet", value: "bg-violet-500" },
+  { name: "Purple", value: "bg-purple-500" },
+  { name: "Fuchsia", value: "bg-fuchsia-500" },
+  { name: "Pink", value: "bg-pink-500" },
+  { name: "Rose", value: "bg-rose-500" },
+];
+
+interface TagRecord {
+  _id: Id<"tags">;
+  name: string;
+  description?: string;
+  color: string;
+  bepCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+function TagBadge({ name, color }: { name: string; color: string }) {
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium text-white ${color}`}
+    >
+      {name}
+    </span>
+  );
+}
+
+function ColorPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (color: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-6 gap-2">
+      {TAG_COLORS.map((color) => (
+        <button
+          key={color.value}
+          type="button"
+          className={`w-8 h-8 rounded-full ${color.value} ${
+            value === color.value
+              ? "ring-2 ring-offset-2 ring-primary"
+              : "hover:ring-2 hover:ring-offset-2 hover:ring-gray-300"
+          }`}
+          onClick={() => onChange(color.value)}
+          title={color.name}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CreateTagDialog({
+  userId,
+  onSuccess,
+}: {
+  userId: Id<"users">;
+  onSuccess?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [color, setColor] = useState("bg-blue-500");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createTag = useMutation(api.tags.create);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await createTag({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        color,
+        requesterId: userId,
+      });
+      setOpen(false);
+      setName("");
+      setDescription("");
+      setColor("bg-blue-500");
+      onSuccess?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create tag");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Create Tag
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create New Tag</DialogTitle>
+            <DialogDescription>
+              Create a new tag to categorize BEPs
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g., standard-library, core"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="description">Description (optional)</Label>
+              <Textarea
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Brief description of when to use this tag"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Color</Label>
+              <div className="flex items-center gap-4">
+                <TagBadge name={name || "Preview"} color={color} />
+              </div>
+              <ColorPicker value={color} onChange={setColor} />
+            </div>
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Creating..." : "Create Tag"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditTagDialog({
+  tag,
+  userId,
+  onSuccess,
+}: {
+  tag: TagRecord;
+  userId: Id<"users">;
+  onSuccess?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(tag.name);
+  const [description, setDescription] = useState(tag.description || "");
+  const [color, setColor] = useState(tag.color);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateTag = useMutation(api.tags.update);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await updateTag({
+        id: tag._id,
+        name: name.trim(),
+        description: description.trim() || undefined,
+        color,
+        requesterId: userId,
+      });
+      setOpen(false);
+      onSuccess?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update tag");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm">
+          <Pencil className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Edit Tag</DialogTitle>
+            <DialogDescription>
+              Update tag details
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-name">Name</Label>
+              <Input
+                id="edit-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-description">Description (optional)</Label>
+              <Textarea
+                id="edit-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Color</Label>
+              <div className="flex items-center gap-4">
+                <TagBadge name={name || "Preview"} color={color} />
+              </div>
+              <ColorPicker value={color} onChange={setColor} />
+            </div>
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : "Save Changes"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteTagDialog({
+  tag,
+  userId,
+  onSuccess,
+}: {
+  tag: TagRecord;
+  userId: Id<"users">;
+  onSuccess?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const removeTag = useMutation(api.tags.remove);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await removeTag({
+        id: tag._id,
+        requesterId: userId,
+      });
+      setOpen(false);
+      onSuccess?.();
+    } catch (err) {
+      console.error("Failed to delete tag:", err);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive">
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Tag</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete the tag "{tag.name}"?
+            {tag.bepCount > 0 && (
+              <span className="block mt-2 text-amber-600">
+                This tag is currently applied to {tag.bepCount} BEP{tag.bepCount !== 1 ? "s" : ""}.
+                Deleting it will remove it from all BEPs.
+              </span>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={isDeleting}
+          >
+            {isDeleting ? "Deleting..." : "Delete Tag"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TagRow({
+  tag,
+  userId,
+}: {
+  tag: TagRecord;
+  userId: Id<"users">;
+}) {
+  return (
+    <div className="flex items-center justify-between p-4 border rounded-lg bg-card">
+      <div className="flex items-center gap-4">
+        <TagBadge name={tag.name} color={tag.color} />
+        <div>
+          {tag.description && (
+            <p className="text-sm text-muted-foreground">{tag.description}</p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Used in {tag.bepCount} BEP{tag.bepCount !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <EditTagDialog tag={tag} userId={userId} />
+        <DeleteTagDialog tag={tag} userId={userId} />
+      </div>
+    </div>
+  );
+}
+
+export default function TagsPage() {
+  const { user, userId, isLoading: userLoading, hasManagementPermissions } = useUser();
+  const router = useRouter();
+
+  const tags = useQuery(
+    api.tags.listWithCounts,
+    userId && hasManagementPermissions ? {} : "skip"
+  );
+
+  useEffect(() => {
+    if (!userLoading && !userId) {
+      router.push("/login");
+      return;
+    }
+
+    if (!userLoading && userId && !hasManagementPermissions) {
+      router.push("/");
+    }
+  }, [userLoading, userId, hasManagementPermissions, router]);
+
+  if (userLoading || !hasManagementPermissions) {
+    return (
+      <div className="min-h-screen bg-background p-8">
+        <div className="max-w-4xl mx-auto space-y-4">
+          <Skeleton className="h-12 w-64" />
+          <Skeleton className="h-8 w-96" />
+          <div className="space-y-3">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user || !userId) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b">
+        <div className="max-w-4xl mx-auto px-4 py-4 flex items-center gap-4">
+          <Button variant="ghost" size="sm" onClick={() => router.push("/")}>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back
+          </Button>
+          <div className="flex items-center gap-2">
+            <Tags className="h-5 w-5" />
+            <h1 className="text-xl font-bold">Tag Management</h1>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 py-8">
+        <Card className="mb-8">
+          <CardHeader>
+            <CardTitle>About Tags</CardTitle>
+            <CardDescription>
+              Tags help categorize BEPs for easier navigation and filtering
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Create tags like "standard-library", "core", "tooling", "breaking-change", etc.
+              to help users find related BEPs quickly. Tags can be applied to any BEP and
+              users can filter the BEP list by tags on the home page.
+            </p>
+          </CardContent>
+        </Card>
+
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-lg font-semibold">All Tags</h2>
+          <CreateTagDialog userId={userId} />
+        </div>
+
+        {tags === undefined ? (
+          <div className="space-y-3">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+          </div>
+        ) : tags.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground border rounded-lg">
+            <Tags className="h-12 w-12 mx-auto mb-4 opacity-50" />
+            <p>No tags created yet.</p>
+            <p className="text-sm">Create your first tag to start categorizing BEPs.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {tags.map((tag) => (
+              <TagRow
+                key={tag._id}
+                tag={tag as TagRecord}
+                userId={userId}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/typescript/apps/beps/src/components/bep/bep-card.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-card.tsx
@@ -4,7 +4,9 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BepStatusBadge } from "./bep-status";
+import { BepTagList } from "./bep-tag-badge";
 import { MessageSquare, AlertCircle } from "lucide-react";
+import { Id } from "../../../convex/_generated/dataModel";
 
 type BepStatus =
   | "draft"
@@ -15,6 +17,12 @@ type BepStatus =
   | "rejected"
   | "superseded";
 
+interface Tag {
+  _id: Id<"tags">;
+  name: string;
+  color: string;
+}
+
 interface BepCardProps {
   number: number;
   title: string;
@@ -23,6 +31,7 @@ interface BepCardProps {
   commentCount: number;
   openIssueCount: number;
   updatedAt: number;
+  tags?: Tag[];
 }
 
 function formatRelativeTime(timestamp: number, now: number): string {
@@ -46,6 +55,7 @@ export function BepCard({
   commentCount,
   openIssueCount,
   updatedAt,
+  tags,
 }: BepCardProps) {
   // Use state with effect to avoid hydration mismatch
   const [relativeTime, setRelativeTime] = useState<string>("");
@@ -59,12 +69,19 @@ export function BepCard({
       <Card className="hover:bg-accent/50 transition-colors cursor-pointer">
         <CardHeader className="pb-2">
           <div className="flex items-start justify-between gap-4">
-            <CardTitle className="text-lg">
-              <span className="text-muted-foreground font-mono">
-                BEP-{String(number).padStart(3, "0")}
-              </span>{" "}
-              {title}
-            </CardTitle>
+            <div className="flex-1">
+              <CardTitle className="text-lg">
+                <span className="text-muted-foreground font-mono">
+                  BEP-{String(number).padStart(3, "0")}
+                </span>{" "}
+                {title}
+              </CardTitle>
+              {tags && tags.length > 0 && (
+                <div className="mt-2">
+                  <BepTagList tags={tags} size="sm" maxDisplay={3} />
+                </div>
+              )}
+            </div>
             <BepStatusBadge status={status} />
           </div>
         </CardHeader>

--- a/typescript/apps/beps/src/components/bep/bep-kanban-card.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-kanban-card.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
+import { BepTagList } from "./bep-tag-badge";
 import { MessageSquare, AlertCircle } from "lucide-react";
+import { Id } from "../../../convex/_generated/dataModel";
 
 type BepStatus =
   | "draft"
@@ -14,6 +16,12 @@ type BepStatus =
   | "rejected"
   | "superseded";
 
+interface Tag {
+  _id: Id<"tags">;
+  name: string;
+  color: string;
+}
+
 interface BepKanbanCardProps {
   number: number;
   title: string;
@@ -22,6 +30,7 @@ interface BepKanbanCardProps {
   commentCount: number;
   openIssueCount: number;
   updatedAt: number;
+  tags?: Tag[];
 }
 
 function formatRelativeTime(timestamp: number, now: number): string {
@@ -44,6 +53,7 @@ export function BepKanbanCard({
   commentCount,
   openIssueCount,
   updatedAt,
+  tags,
 }: BepKanbanCardProps) {
   const [relativeTime, setRelativeTime] = useState<string>("");
 
@@ -64,6 +74,9 @@ export function BepKanbanCard({
                 {title}
               </h4>
             </div>
+            {tags && tags.length > 0 && (
+              <BepTagList tags={tags} size="sm" maxDisplay={2} />
+            )}
             {shepherdNames.length > 0 && (
               <p className="text-xs text-muted-foreground truncate">
                 {shepherdNames.join(", ")}

--- a/typescript/apps/beps/src/components/bep/bep-list.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-list.tsx
@@ -3,13 +3,22 @@
 import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
+import { Id } from "../../../convex/_generated/dataModel";
 import { BepCard } from "./bep-card";
 import { BepKanbanCard } from "./bep-kanban-card";
+import { BepTagBadge } from "./bep-tag-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowUpDown, Search, LayoutList, Columns3 } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ArrowUpDown, Search, LayoutList, Columns3, X } from "lucide-react";
 
 type BepStatus =
   | "draft"
@@ -45,12 +54,17 @@ const KANBAN_COLUMNS: { status: BepStatus; label: string; color: string }[] = [
 
 export function BepList() {
   const [statusFilter, setStatusFilter] = useState<BepStatus | "all">("all");
+  const [tagFilter, setTagFilter] = useState<Id<"tags"> | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [showOldestFirst, setShowOldestFirst] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("kanban");
 
+  const allTags = useQuery(api.tags.list);
+  const selectedTag = allTags?.find((t) => t._id === tagFilter);
+
   const beps = useQuery(api.beps.list, {
     status: viewMode === "kanban" ? undefined : statusFilter === "all" ? undefined : statusFilter,
+    tagId: tagFilter ?? undefined,
   });
 
   const filteredBeps = beps
@@ -60,7 +74,8 @@ export function BepList() {
       return (
         bep.title.toLowerCase().includes(query) ||
         `bep-${bep.number}`.includes(query) ||
-        bep.shepherdNames.some((name) => name.toLowerCase().includes(query))
+        bep.shepherdNames.some((name) => name.toLowerCase().includes(query)) ||
+        bep.tags?.some((tag) => tag.name.toLowerCase().includes(query))
       );
     })
     .sort((a, b) =>
@@ -69,6 +84,10 @@ export function BepList() {
 
   const getBepsByStatus = (status: BepStatus) => {
     return filteredBeps?.filter((bep) => bep.status === status) || [];
+  };
+
+  const handleClearTagFilter = () => {
+    setTagFilter(null);
   };
 
   return (
@@ -90,7 +109,7 @@ export function BepList() {
               ))}
             </div>
           )}
-          <div className={`flex w-full ${viewMode === "kanban" ? "" : "sm:w-auto"} items-center gap-2`}>
+          <div className={`flex w-full ${viewMode === "kanban" ? "" : "sm:w-auto"} items-center gap-2 flex-wrap`}>
             <div className="relative flex-1 sm:flex-none sm:w-64">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
@@ -100,6 +119,27 @@ export function BepList() {
                 className="pl-9"
               />
             </div>
+            {allTags && allTags.length > 0 && (
+              <Select
+                value={tagFilter ?? "all"}
+                onValueChange={(value) => setTagFilter(value === "all" ? null : value as Id<"tags">)}
+              >
+                <SelectTrigger className="w-40">
+                  <SelectValue placeholder="Filter by tag" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All tags</SelectItem>
+                  {allTags.map((tag) => (
+                    <SelectItem key={tag._id} value={tag._id}>
+                      <div className="flex items-center gap-2">
+                        <div className={`w-2 h-2 rounded-full ${tag.color}`} />
+                        {tag.name}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
             {viewMode === "list" && (
               <Button
                 type="button"
@@ -134,6 +174,17 @@ export function BepList() {
             </div>
           </div>
         </div>
+        {selectedTag && (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Filtering by:</span>
+            <BepTagBadge
+              tag={selectedTag}
+              size="sm"
+              removable
+              onRemove={handleClearTagFilter}
+            />
+          </div>
+        )}
       </div>
 
       {/* Content */}
@@ -168,6 +219,7 @@ export function BepList() {
                         commentCount={bep.commentCount}
                         openIssueCount={bep.openIssueCount}
                         updatedAt={bep.updatedAt}
+                        tags={bep.tags}
                       />
                     ))
                   ) : (
@@ -192,6 +244,7 @@ export function BepList() {
                 commentCount={bep.commentCount}
                 openIssueCount={bep.openIssueCount}
                 updatedAt={bep.updatedAt}
+                tags={bep.tags}
               />
             </div>
           ))}

--- a/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
@@ -19,6 +19,7 @@ import { BepTableOfContents } from "@/components/bep/bep-table-of-contents";
 import { BepStatusSelect } from "@/components/bep/bep-status-select";
 import { BepUserStance } from "@/components/bep/bep-user-stance";
 import { BepGoodReferenceToggle } from "@/components/bep/bep-good-reference-toggle";
+import { BepTagSelect, BepTagDisplay } from "@/components/bep/bep-tag-select";
 import { BepVersionSelect } from "@/components/bep/bep-version-select";
 import { BepExportDialog } from "@/components/bep/bep-export-dialog";
 import { BepImportDialog } from "@/components/bep/bep-import-dialog";
@@ -884,23 +885,34 @@ const [copied, setCopied] = useState(false);
               )}
             </div>
           </div>
-          <div className="flex items-center justify-between">
-            <p className="text-muted-foreground">
-              Shepherds: {bep.shepherdNames.join(", ") || "None assigned"}
-              {bep.status === "implemented" && bep.implementedByNames && bep.implementedByNames.length > 0 && (
-                <span className="ml-4">
-                  Implemented by: {bep.implementedByNames.join(", ")}
-                </span>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <p className="text-muted-foreground">
+                Shepherds: {bep.shepherdNames.join(", ") || "None assigned"}
+                {bep.status === "implemented" && bep.implementedByNames && bep.implementedByNames.length > 0 && (
+                  <span className="ml-4">
+                    Implemented by: {bep.implementedByNames.join(", ")}
+                  </span>
+                )}
+              </p>
+              {currentVersionId && (
+                <BepUserStance
+                  bepId={bep._id}
+                  versionId={currentVersionId}
+                  versionNumber={latestVersionNumber ?? 1}
+                  readOnly={isViewingHistorical}
+                />
               )}
-            </p>
-            {currentVersionId && (
-              <BepUserStance
+            </div>
+            {userId && !isViewingHistorical ? (
+              <BepTagSelect
                 bepId={bep._id}
-                versionId={currentVersionId}
-                versionNumber={latestVersionNumber ?? 1}
-                readOnly={isViewingHistorical}
+                currentTags={bep.tags ?? []}
+                userId={userId}
               />
-            )}
+            ) : bep.tags && bep.tags.length > 0 ? (
+              <BepTagDisplay tags={bep.tags} size="sm" />
+            ) : null}
           </div>
         </div>
 

--- a/typescript/apps/beps/src/components/bep/bep-tag-badge.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-tag-badge.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Id } from "../../../convex/_generated/dataModel";
+
+interface Tag {
+  _id: Id<"tags">;
+  name: string;
+  color: string;
+}
+
+interface BepTagBadgeProps {
+  tag: Tag;
+  size?: "sm" | "md";
+  onClick?: () => void;
+  removable?: boolean;
+  onRemove?: () => void;
+}
+
+export function BepTagBadge({
+  tag,
+  size = "md",
+  onClick,
+  removable,
+  onRemove,
+}: BepTagBadgeProps) {
+  const sizeClasses = size === "sm" 
+    ? "px-1.5 py-0.5 text-[10px]" 
+    : "px-2 py-0.5 text-xs";
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full font-medium text-white ${tag.color} ${sizeClasses} ${
+        onClick ? "cursor-pointer hover:opacity-80" : ""
+      }`}
+      onClick={onClick}
+    >
+      {tag.name}
+      {removable && onRemove && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="ml-0.5 hover:bg-white/20 rounded-full p-0.5"
+        >
+          <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M3 3L9 9M9 3L3 9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </button>
+      )}
+    </span>
+  );
+}
+
+interface BepTagListProps {
+  tags: Tag[];
+  size?: "sm" | "md";
+  maxDisplay?: number;
+  onTagClick?: (tag: Tag) => void;
+}
+
+export function BepTagList({
+  tags,
+  size = "md",
+  maxDisplay,
+  onTagClick,
+}: BepTagListProps) {
+  if (!tags || tags.length === 0) return null;
+
+  const displayTags = maxDisplay ? tags.slice(0, maxDisplay) : tags;
+  const remainingCount = maxDisplay ? Math.max(0, tags.length - maxDisplay) : 0;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {displayTags.map((tag) => (
+        <BepTagBadge
+          key={tag._id}
+          tag={tag}
+          size={size}
+          onClick={onTagClick ? () => onTagClick(tag) : undefined}
+        />
+      ))}
+      {remainingCount > 0 && (
+        <span className={`inline-flex items-center rounded-full bg-muted text-muted-foreground ${
+          size === "sm" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-xs"
+        }`}>
+          +{remainingCount}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/typescript/apps/beps/src/components/bep/bep-tag-select.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-tag-select.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { Id } from "../../../convex/_generated/dataModel";
+import { BepTagBadge, BepTagList } from "./bep-tag-badge";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Tags, ChevronDown } from "lucide-react";
+
+interface Tag {
+  _id: Id<"tags">;
+  name: string;
+  color: string;
+  description?: string;
+}
+
+interface BepTagSelectProps {
+  bepId: Id<"beps">;
+  currentTags: Tag[];
+  userId: Id<"users">;
+  readOnly?: boolean;
+}
+
+export function BepTagSelect({
+  bepId,
+  currentTags,
+  userId,
+  readOnly = false,
+}: BepTagSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const allTags = useQuery(api.tags.list);
+  const setTagsForBep = useMutation(api.tags.setTagsForBep);
+
+  const currentTagIds = new Set(currentTags.map((t) => t._id));
+
+  const handleToggleTag = async (tagId: Id<"tags">) => {
+    if (isUpdating) return;
+    setIsUpdating(true);
+
+    try {
+      const newTagIds = currentTagIds.has(tagId)
+        ? currentTags.filter((t) => t._id !== tagId).map((t) => t._id)
+        : [...currentTags.map((t) => t._id), tagId];
+
+      await setTagsForBep({
+        bepId,
+        tagIds: newTagIds,
+        userId,
+      });
+    } catch (err) {
+      console.error("Failed to update tags:", err);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  if (readOnly) {
+    if (currentTags.length === 0) return null;
+    return <BepTagList tags={currentTags} size="sm" />;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <BepTagList tags={currentTags} size="sm" />
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="ghost" size="sm" className="h-6 px-2 text-xs">
+            <Tags className="h-3 w-3 mr-1" />
+            {currentTags.length === 0 ? "Add tags" : "Edit"}
+            <ChevronDown className="h-3 w-3 ml-1" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 p-2" align="start">
+          <div className="space-y-1">
+            {!allTags ? (
+              <p className="text-sm text-muted-foreground p-2">Loading...</p>
+            ) : allTags.length === 0 ? (
+              <p className="text-sm text-muted-foreground p-2">
+                No tags available. Team members can create tags in the tag management page.
+              </p>
+            ) : (
+              allTags.map((tag) => (
+                <div
+                  key={tag._id}
+                  className="flex items-center gap-2 p-2 rounded hover:bg-muted cursor-pointer"
+                  onClick={() => handleToggleTag(tag._id)}
+                >
+                  <Checkbox
+                    checked={currentTagIds.has(tag._id)}
+                    disabled={isUpdating}
+                    className="pointer-events-none"
+                  />
+                  <BepTagBadge tag={tag} size="sm" />
+                  {tag.description && (
+                    <span className="text-xs text-muted-foreground truncate flex-1">
+                      {tag.description}
+                    </span>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+interface BepTagDisplayProps {
+  tags: Tag[];
+  size?: "sm" | "md";
+  maxDisplay?: number;
+}
+
+export function BepTagDisplay({ tags, size = "sm", maxDisplay }: BepTagDisplayProps) {
+  if (!tags || tags.length === 0) return null;
+  return <BepTagList tags={tags} size={size} maxDisplay={maxDisplay} />;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
- [ ] This PR adds a tag management feature as requested in Slack by @paulo

## Changes
This PR adds a comprehensive tag management system to the BEPs app that allows team members and BDFL members to create and manage tags for categorizing BEPs.

### Key Features:
1. **Tag Management Page** (`/tags`)
   - Create, edit, and delete tags with custom names, descriptions, and colors
   - Only accessible to team members and BDFL members
   - Shows usage counts for each tag

2. **BEP Tagging**
   - Add/remove tags from individual BEPs on the BEP detail page
   - Tags displayed as colored badges on BEP cards in both list and kanban views

3. **Tag Filtering**
   - Filter BEPs by tag on the home page
   - Tags included in search queries

### Technical Changes:
- Added `tags` and `bepTags` tables to Convex schema
- Created `tags.ts` with CRUD operations and permission checks
- Updated `beps.ts` to include tags in list and detail queries
- New components: `BepTagBadge`, `BepTagList`, `BepTagSelect`
- Updated `BepCard`, `BepKanbanCard`, and `BepList` components

## Testing
- [x] TypeScript type checking passes (`pnpm tsc --noEmit`)
- [ ] Manual testing with a Convex deployment (requires deployment)

## PR Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
After merging, the Convex deployment will need to run `npx convex dev` or `npx convex deploy` to generate the new schema and push the updated functions.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1778175254174739?thread_ts=1778175254.174739&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-dcfdaec4-2e96-586b-9ad6-6e043e1038b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcfdaec4-2e96-586b-9ad6-6e043e1038b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

