### PR TITLE
fix: sdk release shouldn't require environment=release

### DIFF
--- a/.github/workflows/release-sdk.yaml
+++ b/.github/workflows/release-sdk.yaml
@@ -50,7 +50,6 @@ jobs:
       - run: echo "::do-nothing::" >/dev/null
 
   publish-to-pypi:
-    environment: release
     needs: [all-builds]
     if: ${{ inputs.publish }}
     # Must use GitHub-hosted runner due to permissions issues with GitHub OIDC trusted publishing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized SDK release workflow configuration for improved automation efficiency. Updated internal release pipeline settings while maintaining existing package verification and PyPI publishing functionality. No impact on end-user product or released packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->