### PR TITLE
fix(sdk_tests): parallelize test execution

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -34,47 +34,21 @@ jobs:
           # Share cache across similar Linux jobs for better hit rates
           shared-key: "linux-cargo-32gb"
 
-      - name: "Setup Python 3.10+"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-
-      - name: "Install uv"
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
         working-directory: baml_language
 
       # Snapshot tests live in `baml_tests` and are exercised end-to-end by
-      # the dedicated `snapshot-tests` job; skip the package here so the
-      # per-platform jobs stay focused on cross-platform behavior.
+      # the dedicated `snapshot-tests` job. The `sdk_test_*` crates need uv
+      # and run in the dedicated `sdk-tests` matrix below. Skip both here.
       - name: "Run tests with nextest"
-        run: cargo nextest run --all-features -E 'not package(baml_tests)'
+        run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/)'
         working-directory: baml_language
-
-      - name: "Run language test suites"
-        run: |
-          found=0
-          for dir in baml_language/sdks/*/; do
-            lang=$(basename "$dir")
-            if [ -f "$dir/test.sh" ]; then
-              echo "==> Running $lang test suite"
-              bash "$dir/test.sh"
-              found=$((found + 1))
-            else
-              echo "::error::sdks/$lang/ exists but has no test.sh"
-              exit 1
-            fi
-          done
-          if [ "$found" -eq 0 ]; then
-            echo "::warning::No language test suites found in sdks/*/"
-          fi
 
       - name: "Upload test results on failure"
         if: failure()
@@ -98,7 +72,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -113,46 +87,21 @@ jobs:
           # Share cache across similar macOS jobs for better hit rates
           shared-key: "macos-cargo"
 
-      - name: "Setup Python 3.10+"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-
-      - name: "Install uv"
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
         working-directory: baml_language
 
       # Snapshot tests live in `baml_tests` and are covered by the dedicated
-      # `snapshot-tests` job; skip the package here.
+      # `snapshot-tests` job. The `sdk_test_*` crates need uv and run in the
+      # dedicated `sdk-tests` matrix below. Skip both here.
       - name: "Run tests"
-        run: cargo nextest run --all-features -E 'not package(baml_tests)'
+        run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/)'
         working-directory: baml_language
-
-      - name: "Run language test suites"
-        run: |
-          found=0
-          for dir in baml_language/sdks/*/; do
-            lang=$(basename "$dir")
-            if [ -f "$dir/test.sh" ]; then
-              echo "==> Running $lang test suite"
-              bash "$dir/test.sh"
-              found=$((found + 1))
-            else
-              echo "::error::sdks/$lang/ exists but has no test.sh"
-              exit 1
-            fi
-          done
-          if [ "$found" -eq 0 ]; then
-            echo "::warning::No language test suites found in sdks/*/"
-          fi
 
       - name: "Upload cargo timings"
         if: always()
@@ -169,7 +118,7 @@ jobs:
     # Right now it needs to download our repo every time which is very slow
     timeout-minutes: 50
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -184,6 +133,78 @@ jobs:
           # Share cache across similar Windows jobs for better hit rates
           shared-key: "windows-cargo"
 
+      - name: "Install cargo nextest"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: "Build tests with --timings"
+        run: cargo test --no-run --all-features --timings
+        working-directory: baml_language
+
+      # Snapshot tests live in `baml_tests` and are covered by the dedicated
+      # `snapshot-tests` job. The `sdk_test_*` crates need uv and run in the
+      # dedicated `sdk-tests` matrix below. Skip both here.
+      - name: "Run tests"
+        run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/)'
+        working-directory: baml_language
+
+      - name: "Upload cargo timings"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-timings-test-windows
+          path: baml_language/target/cargo-timings/
+          if-no-files-found: ignore
+
+  # SDK tests (codegen end-to-end). The `sdk_test_*` crates each emit a
+  # generated Python project from `.baml` sources via build.rs and then
+  # run ruff / pyright / pytest against it through `uv sync` + `uv run`.
+  # They share a single editable install of `baml_core` (the local
+  # Python SDK) anchored at `baml_language/target/uv-cache`, so multiple
+  # tests racing on `uv sync` contend on uv's editable-build lock and
+  # — on Windows — on wheel-extraction file locks. We pre-warm by
+  # running the per-crate `sync_only` test serially (so the editable
+  # build of `baml_core` and the wheel cache populate exactly once),
+  # then fan out ruff/pyright/pytest in parallel against the warm
+  # cache.
+  sdk-tests:
+    name: "sdk tests (${{ matrix.os-label }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os-label: linux
+            runs-on: blacksmith-16vcpu-ubuntu-2404
+            rust-cache-key: linux-cargo-32gb
+            timeout: 30
+          - os-label: macos
+            runs-on: macos-latest
+            rust-cache-key: macos-cargo
+            timeout: 40
+          - os-label: windows
+            runs-on: blacksmith-4vcpu-windows-2025
+            rust-cache-key: windows-cargo
+            timeout: 60
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: ${{ matrix.timeout }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
+      - name: "Install Rust toolchain"
+        run: rustup show
+        working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Reuse the matching cargo-test-* shared-key so the Rust target/
+          # dir benefits from the cache populated by those jobs.
+          shared-key: ${{ matrix.rust-cache-key }}
+
       - name: "Setup Python 3.10+"
         uses: actions/setup-python@v5
         with:
@@ -195,42 +216,41 @@ jobs:
           tool: cargo-nextest
 
       - name: "Install uv"
-        run: irm https://astral.sh/uv/install.ps1 | iex
-        shell: powershell
+        uses: astral-sh/setup-uv@v5
 
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
         working-directory: baml_language
 
-      # Snapshot tests live in `baml_tests` and are covered by the dedicated
-      # `snapshot-tests` job; skip the package here.
-      - name: "Run tests"
-        run: cargo nextest run --all-features -E 'not package(baml_tests)'
+      # Pre-warm: run only the `sync_only` test from each sdk_test crate,
+      # serialized via `--test-threads=1`. The first sync builds the
+      # editable `baml_core` and extracts wheels into the shared
+      # `target/uv-cache`; subsequent syncs hardlink from cache into each
+      # crate's own `generated/.venv`. After this, the parallel test step
+      # below only does cheap cache reads + per-venv hardlinks.
+      - name: "Pre-warm uv cache (sync_only, serial)"
+        run: cargo nextest run --all-features --test-threads=1 -E 'package(/^sdk_test_/) and test(=sync_only)'
         working-directory: baml_language
 
-      - name: "Run language test suites"
-        run: |
-          found=0
-          for dir in baml_language/sdks/*/; do
-            lang=$(basename "$dir")
-            if [ -f "$dir/test.sh" ]; then
-              echo "==> Running $lang test suite"
-              bash "$dir/test.sh"
-              found=$((found + 1))
-            else
-              echo "::error::sdks/$lang/ exists but has no test.sh"
-              exit 1
-            fi
-          done
-          if [ "$found" -eq 0 ]; then
-            echo "::warning::No language test suites found in sdks/*/"
-          fi
+      - name: "Run sdk tests"
+        run: cargo nextest run --all-features -E 'package(/^sdk_test_/) and not test(=sync_only)'
+        working-directory: baml_language
+
+      - name: "Upload test results on failure"
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-test-failures-${{ matrix.os-label }}
+          path: |
+            baml_language/sdk_tests/crates/*/generated/
+            baml_language/target/nextest/
+          if-no-files-found: ignore
 
       - name: "Upload cargo timings"
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cargo-timings-test-windows
+          name: cargo-timings-sdk-tests-${{ matrix.os-label }}
           path: baml_language/target/cargo-timings/
           if-no-files-found: ignore
 
@@ -239,7 +259,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -282,7 +302,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -330,7 +350,7 @@ jobs:
     # bypass later doesn't accidentally start blocking required CI.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -353,7 +373,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -392,7 +412,7 @@ jobs:
       # mise installs handles its own Python via `uv run`).
       MISE_DISABLE_TOOLS: python,pipx:uv,pipx:ruff,pipx:maturin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -464,6 +484,7 @@ jobs:
       - cargo-test-linux
       - cargo-test-macos
       - cargo-test-windows
+      - sdk-tests
       - cargo-test-wasm
       - cargo-build-msrv
       - cargo-doc

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -6996,6 +6996,18 @@ dependencies = [
  "baml_project",
  "baml_workspace",
  "codegen_python",
+ "sdk_test_build",
+]
+
+[[package]]
+name = "sdk_test_build"
+version = "0.1.0"
+dependencies = [
+ "baml_codegen_types",
+ "baml_db",
+ "baml_project",
+ "baml_workspace",
+ "codegen_python",
 ]
 
 [[package]]
@@ -7007,6 +7019,7 @@ dependencies = [
  "baml_project",
  "baml_workspace",
  "codegen_python",
+ "sdk_test_build",
 ]
 
 [[package]]
@@ -7018,6 +7031,7 @@ dependencies = [
  "baml_project",
  "baml_workspace",
  "codegen_python",
+ "sdk_test_build",
 ]
 
 [[package]]
@@ -7029,6 +7043,7 @@ dependencies = [
  "baml_project",
  "baml_workspace",
  "codegen_python",
+ "sdk_test_build",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/*",
   "sdks/python/rust/*",
+  "sdk_tests/build",
   "sdk_tests/crates/*",
 ]
 exclude = [ "crates/bridge_go" ]

--- a/baml_language/sdk_tests/README.md
+++ b/baml_language/sdk_tests/README.md
@@ -1,4 +1,4 @@
-# BAML Codegen Test Rig
+# BAML Codegen SDK Tests
 
 E2E test crates for BAML code generation. Each crate drives codegen
 from real `.baml` source under `baml_src/` through the full
@@ -21,18 +21,18 @@ sdk_tests/
 └── crates/
     └── <fixture>/
         ├── Cargo.toml
-        ├── build.rs
-        ├── baml_src/        # real BAML source the crate exercises
-        ├── customizable/    # pytest assertions over the generated SDK
-        ├── src/lib.rs       # `cargo test` harness — shells out to
-        │                    # generated/test.sh
-        └── generated/       # build output (gitignored)
+        ├── build.rs           # hand-written codegen driver
+        ├── baml_src/          # real BAML source the crate exercises
+        ├── customizable/      # pytest assertions over the generated SDK
+        ├── src/lib.rs         # empty (doc comment only)
+        ├── tests/sdk_test.rs  # one-liner → sdk_test_build::sdk_test_suite!()
+        └── generated/         # build output (gitignored)
 ```
 
 Crates are hand-maintained. The reference template is
 `crates/llm_functions/`; new crates are added by copying its shape
-(build.rs, Cargo.toml, src/lib.rs, customizable/) and authoring a new
-`baml_src/`.
+(build.rs, Cargo.toml, src/lib.rs, tests/sdk_test.rs, customizable/)
+and authoring a new `baml_src/`.
 
 ## How It Works
 
@@ -45,18 +45,26 @@ Crates are hand-maintained. The reference template is
      `baml_codegen_python::to_source_code(&pool, &user_baml_files)`.
    - Writes the generated tree to `generated/baml_sdk/`.
    - Symlinks `customizable/*.py` into `generated/`.
-   - Writes `conftest.py`, `pyproject.toml`, and `test.sh` /
-     `test.ps1` shims into `generated/`.
-2. `src/lib.rs` runs `generated/test.sh` (or `test.ps1` on Windows).
-3. `test.sh` runs `py_compile`, `ruff`, and `pytest` over the
-   generated SDK plus the `customizable/` assertions.
+   - Writes `pyproject.toml` into `generated/`.
+2. `tests/sdk_test.rs` invokes `sdk_test_build::sdk_test_suite!()`,
+   which expands to four `#[test]` functions — `sync_only`, `ruff`,
+   `pyright`, `pytest`. The latter three each run `uv sync` then
+   `uv run <check>` inside `generated/` via
+   `sdk_test_build::run_test_cmd` (which splits the string and spawns
+   `Command::new(prog).args(rest)`). `sync_only` runs `uv sync` on its
+   own so CI can pre-warm the shared `target/uv-cache` (editable build
+   of `baml_core` + wheel extractions) by running it serially across
+   all sdk_test crates before fanning the rest of the suite out in
+   parallel — see the sdk-tests job in
+   `.github/workflows/cargo-tests.reusable.yaml`.
 
 ## Adding a New Fixture
 
 1. `cp -r crates/llm_functions crates/<name>` (or copy from any
-   existing rig crate).
-2. Adjust the `[package] name` in `Cargo.toml` and the
-   `pyproject.toml` `name = ...` in `build.rs` to match.
+   existing sdk-test crate).
+2. Adjust the `[package] name` in `Cargo.toml`. The generated
+   `pyproject.toml`'s `name` is auto-derived inside
+   `sdk_test_build::run` (strip `sdk_test_`, swap `_` → `-`).
 3. Replace `baml_src/` contents with the BAML source for the new
    fixture.
 4. Replace `customizable/test_main.py` with assertions over the

--- a/baml_language/sdk_tests/build/Cargo.toml
+++ b/baml_language/sdk_tests/build/Cargo.toml
@@ -1,0 +1,18 @@
+# Shared build-script logic for the `sdk_tests/crates/*` crates.
+# Each sdk-test crate's `build.rs` collapses to:
+#     fn main() { sdk_test_build::run(env!("CARGO_PKG_NAME")); }
+[package]
+name = "sdk_test_build"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+codegen_python = { workspace = true }
+baml_codegen_types = { workspace = true }
+baml_db = { workspace = true }
+baml_project = { workspace = true }
+baml_workspace = { workspace = true }
+
+[package.metadata.ci]
+wasm_support = false

--- a/baml_language/sdk_tests/build/src/lib.rs
+++ b/baml_language/sdk_tests/build/src/lib.rs
@@ -1,0 +1,319 @@
+//! Shared build- and test-side logic for the `sdk_tests/crates/*`
+//! crates. Each sdk-test crate's `tests/sdk_test.rs` collapses to:
+//!
+//! ```ignore
+//! sdk_test_build::sdk_test_suite!();
+//! ```
+//!
+//! `run` mirrors what `baml-cli generate` does end-to-end: discover
+//! `.baml` files → ProjectDatabase → diagnostics gate →
+//! `build_symbol_pool` → `codegen_python::to_source_code`. Then writes
+//! a `pyproject.toml` and symlinks `customizable/*.py` into
+//! `generated/`.
+//!
+//! `sdk_test_suite!` expands to four `#[test]` functions — `sync_only`,
+//! `ruff`, `pyright`, `pytest`. The latter three each run `uv sync`
+//! then `uv run <check>` inside `generated/` via
+//! `Command::new(...).args(...)`. `sync_only` runs `uv sync` on its
+//! own so CI can pre-warm the shared `target/uv-cache` (editable
+//! build of `baml_core` + wheel extractions) by running it serially
+//! across all sdk_test crates before the rest of the suite fans out
+//! in parallel. Within a single crate, libtest's parallel threads
+//! plus uv's own file locks make concurrent `uv sync` calls against
+//! the same venv safe; cross-crate contention on the shared cache is
+//! what the pre-warm exists to dodge.
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use baml_db::baml_compiler_diagnostics::Severity;
+use baml_project::ProjectDatabase;
+use codegen_python::UserBamlFile;
+
+/// Drive codegen for one sdk-test crate. `crate_name` is the rust
+/// crate's `CARGO_PKG_NAME` (e.g. `"sdk_test_llm_functions"`); the
+/// generated pyproject's `name` is derived by stripping the
+/// `sdk_test_` prefix and replacing underscores with hyphens — so
+/// `sdk_test_llm_functions` → `baml-test-llm-functions`.
+pub fn run(crate_name: &str) {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let baml_src = manifest_dir.join("baml_src");
+    let generated_dir = manifest_dir.join("generated");
+    let baml_sdk_dir = generated_dir.join("baml_sdk");
+
+    if generated_dir.exists() {
+        fs::remove_dir_all(&generated_dir).unwrap();
+    }
+    fs::create_dir_all(&baml_sdk_dir).unwrap();
+
+    // 1. Discover + load .baml files into the project DB.
+    let canonical = fs::canonicalize(&baml_src)
+        .unwrap_or_else(|_| panic!("baml_src not found at {}", baml_src.display()));
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(&canonical);
+    let baml_files = baml_workspace::discover_baml_files(&canonical);
+    assert!(
+        !baml_files.is_empty(),
+        "no .baml files discovered under {}",
+        canonical.display()
+    );
+    for file_path in &baml_files {
+        let content = fs::read_to_string(file_path)
+            .unwrap_or_else(|_| panic!("failed to read {}", file_path.display()));
+        db.add_or_update_file(file_path, &content);
+    }
+
+    // 2. Diagnostics gate — bail loudly on any compile error so a
+    //    broken `.baml` source doesn't masquerade as a codegen bug.
+    let project = db.get_project().expect("no project context");
+    let source_files = db.get_source_files();
+    let diagnostics = baml_project::collect_diagnostics(&db, project, &source_files);
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    if !errors.is_empty() {
+        let messages: Vec<String> = errors.iter().map(|d| format!("{d:?}")).collect();
+        panic!("baml_src has compile errors:\n{}", messages.join("\n"));
+    }
+
+    // 3. Build the codegen `SymbolPool` and the inlined-files list.
+    let pool = baml_project::build_symbol_pool(&db);
+    let user_baml_files: Vec<UserBamlFile> = source_files
+        .iter()
+        .map(|sf| {
+            let path = sf.path(&db);
+            let rel = path.strip_prefix(&canonical).unwrap_or(&path).to_path_buf();
+            (rel, sf.text(&db).to_string())
+        })
+        .collect();
+
+    // 4. Codegen.
+    let output = codegen_python::to_source_code(
+        &pool,
+        &user_baml_files,
+        codegen_python::NamingConvention::PreserveCase,
+    );
+    for (path, content) in output {
+        let file_path = baml_sdk_dir.join(&path);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&file_path, &content).unwrap();
+    }
+
+    // 5. Symlink customizable/ files into generated/. On Windows
+    //    `symlink_file` requires Developer Mode or admin, so fall back
+    //    to a plain copy on failure — the cost is that local edits to
+    //    `customizable/` won't be picked up without re-running
+    //    build.rs (which `cargo:rerun-if-changed=` below already
+    //    handles).
+    let customizable_dir = manifest_dir.join("customizable");
+    if customizable_dir.exists() {
+        for entry in fs::read_dir(&customizable_dir).unwrap() {
+            let entry = entry.unwrap();
+            let src = entry.path();
+            let file_name = entry.file_name();
+            let dst = generated_dir.join(&file_name);
+
+            if !src.is_file() {
+                continue;
+            }
+            if dst.exists() || dst.symlink_metadata().is_ok() {
+                let _ = fs::remove_file(&dst);
+            }
+            #[cfg(unix)]
+            let symlink_result = std::os::unix::fs::symlink(&src, &dst);
+            #[cfg(windows)]
+            let symlink_result = std::os::windows::fs::symlink_file(&src, &dst);
+            if symlink_result.is_err() {
+                fs::copy(&src, &dst).unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to symlink or copy {} from {}: {e}",
+                        file_name.to_string_lossy(),
+                        src.display()
+                    )
+                });
+            }
+        }
+    }
+
+    // 6. pyproject.toml. `uv sync` is invoked at test time by the
+    //    `sdk_test_suite!` macro (see `run_test_cmd` below), which
+    //    installs `baml_core` from the local source via
+    //    `[tool.uv.sources]`. uv drives the maturin build-backend
+    //    declared in `sdks/python/pyproject.toml`, so the PyO3
+    //    extension is compiled into the project venv as part of the
+    //    sync. `[tool.uv] package = false` keeps uv from trying to
+    //    install this directory as a wheel; the empty `dev` group
+    //    satisfies maturin's `uv pip install --group dev` step.
+    let short_name = crate_name.strip_prefix("sdk_test_").unwrap_or(crate_name);
+    let pyproject_name = format!("baml-test-{}", short_name.replace('_', "-"));
+    let pyproject_toml = r#"[project]
+name = "__PYPROJECT_NAME__"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "baml_core",
+    "pydantic>=2",
+    "typing-extensions",
+    "pytest>=7",
+    "ruff",
+    "pyright>=1.1",
+]
+
+[dependency-groups]
+dev = []
+
+[tool.uv]
+package = false
+
+[tool.uv.sources]
+baml_core = { path = "../../../../sdks/python", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-v"
+
+[tool.ruff]
+line-length = 120
+extend-exclude = ["*.pyi"]
+
+[tool.ruff.lint]
+ignore = ["F401", "F821", "E402"]
+"#
+    .replace("__PYPROJECT_NAME__", &pyproject_name);
+    fs::write(generated_dir.join("pyproject.toml"), pyproject_toml).unwrap();
+
+    // 7. rerun-if-changed for build.rs + every BAML and customizable
+    //    file.
+    println!("cargo:rerun-if-changed=build.rs");
+    watch_dir(&baml_src);
+    if customizable_dir.exists() {
+        watch_dir(&customizable_dir);
+    }
+}
+
+fn watch_dir(dir: &Path) {
+    for path in walk_files(dir) {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn walk_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                out.push(path);
+            } else if path.is_dir() {
+                out.extend(walk_files(&path));
+            }
+        }
+    }
+    out
+}
+
+/// Test-side helper used by the [`sdk_test_suite!`] macro. Splits `cmd`
+/// on whitespace and runs it as a single `Command::new(prog).args(rest)`
+/// from inside `<CARGO_MANIFEST_DIR>/generated/`, panicking on non-zero
+/// exit. Cargo sets `CARGO_MANIFEST_DIR` for the test binary at runtime,
+/// so the helper resolves the right sdk-test crate without the macro
+/// having to thread it through.
+///
+/// The uv cache is anchored at `<workspace>/target/uv-cache` so
+/// rust-analyzer and `cargo test` share it; uv's file locks make the
+/// concurrent `uv sync` calls (one per test) safe.
+pub fn run_test_cmd(cmd: &str) {
+    let manifest = PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set; run via `cargo test`"),
+    );
+    let dir = manifest.join("generated");
+    assert!(
+        dir.exists(),
+        "generated/ not found at {} — did build.rs run?",
+        dir.display()
+    );
+
+    // sdk-test crates always live at `<workspace>/sdk_tests/crates/<name>/`,
+    // so the workspace root is the 3rd ancestor of the manifest dir.
+    let workspace_root = manifest
+        .ancestors()
+        .nth(3)
+        .expect("sdk-test crate not at <workspace>/sdk_tests/crates/<name>/");
+    let uv_cache = workspace_root.join("target").join("uv-cache");
+
+    // Naive whitespace split — quoted args would silently break apart.
+    assert!(
+        !cmd.contains('"') && !cmd.contains('\''),
+        "run_test_cmd does not handle quoted args: `{cmd}`"
+    );
+    let mut words = cmd.split_whitespace();
+    let prog = words.next().unwrap_or_else(|| panic!("empty command"));
+    let args: Vec<&str> = words.collect();
+
+    let output = Command::new(prog)
+        .args(&args)
+        .current_dir(&dir)
+        .env("UV_CACHE_DIR", &uv_cache)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn `{cmd}`: {e}"));
+    assert!(
+        output.status.success(),
+        "`{cmd}` failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Expands to four `#[test]` functions — `sync_only`, `ruff`,
+/// `pyright`, `pytest`. The latter three each run `uv sync` then
+/// `uv run <check>` inside the sdk-test crate's `generated/`.
+/// `sync_only` runs `uv sync` on its own as a pre-warm hook so CI can
+/// populate the shared editable-build and wheel caches serially
+/// across all sdk_test crates (one process at a time) before fanning
+/// the rest out in parallel — see `nextest run -E
+/// 'test(=sync_only)' --test-threads=1` in the sdk-tests CI job. The
+/// `uv sync` calls in `ruff`/`pyright`/`pytest` are kept so each test
+/// remains runnable on its own (e.g. `cargo test -p sdk_test_X
+/// ruff`), and become near-no-ops once the cache is warm.
+///
+/// Invoke from `tests/sdk_test.rs` as:
+///
+/// ```ignore
+/// sdk_test_build::sdk_test_suite!();
+/// ```
+#[macro_export]
+macro_rules! sdk_test_suite {
+    () => {
+        #[test]
+        fn sync_only() {
+            $crate::run_test_cmd("uv sync");
+        }
+
+        #[test]
+        fn ruff() {
+            $crate::run_test_cmd("uv sync");
+            $crate::run_test_cmd("uv run ruff check --config pyproject.toml baml_sdk");
+        }
+
+        #[test]
+        fn pyright() {
+            $crate::run_test_cmd("uv sync");
+            $crate::run_test_cmd("uv run pyright baml_sdk");
+        }
+
+        #[test]
+        fn pytest() {
+            $crate::run_test_cmd("uv sync");
+            $crate::run_test_cmd("uv run pytest -v");
+        }
+    };
+}

--- a/baml_language/sdk_tests/crates/.gitignore
+++ b/baml_language/sdk_tests/crates/.gitignore
@@ -1,3 +1,3 @@
-# Generated content inside each test crate. Every rig's `generated/`
+# Generated content inside each sdk-test crate. The `generated/` tree
 # is build.rs output — never committed; regenerated on every build.
 **/generated/

--- a/baml_language/sdk_tests/crates/basic_type_shapes/Cargo.toml
+++ b/baml_language/sdk_tests/crates/basic_type_shapes/Cargo.toml
@@ -1,4 +1,4 @@
-# Rig crate for per-Ty-variant type-shape coverage. Each subnamespace
+# Sdk-test crate for per-Ty-variant type-shape coverage. Each subnamespace
 # under `baml_src/ns_*/` targets a specific family of BAML constructs
 # (literal types, map types, union types, etc.) and emits the
 # corresponding `baml_sdk.<ns>` Python package.
@@ -14,6 +14,9 @@ baml_codegen_types = { path = "../../../crates/baml_codegen_types" }
 baml_db = { path = "../../../crates/baml_db" }
 baml_project = { path = "../../../crates/baml_project" }
 baml_workspace = { path = "../../../crates/baml_workspace" }
+
+[dev-dependencies]
+sdk_test_build = { path = "../../build" }
 
 [package.metadata.ci]
 wasm_support = false

--- a/baml_language/sdk_tests/crates/basic_type_shapes/build.rs
+++ b/baml_language/sdk_tests/crates/basic_type_shapes/build.rs
@@ -113,13 +113,15 @@ fn main() {
         }
     }
 
-    // 6. pyproject.toml + test.sh + test.ps1. Test runner does
-    //    `uv sync` then `maturin develop` against bridge_python's
-    //    Cargo.toml, installing the real `baml_core` (PyO3
-    //    extension) into the project venv. `[tool.uv] package =
-    //    false` keeps uv from trying to install this directory as
-    //    a wheel; the empty `dev` group satisfies maturin's
-    //    `uv pip install --group dev` step.
+    // 6. pyproject.toml. `uv sync` is invoked at test time by the
+    //    `sdk_test_suite!` macro from `tests/sdk_test.rs`, which
+    //    installs `baml_core` from the local source via
+    //    `[tool.uv.sources]`. uv drives the maturin build-backend
+    //    declared in `sdks/python/pyproject.toml`, so the PyO3
+    //    extension is compiled into the project venv as part of the
+    //    sync. `[tool.uv] package = false` keeps uv from trying to
+    //    install this directory as a wheel; the empty `dev` group
+    //    satisfies maturin's `uv pip install --group dev` step.
     let pyproject_toml = r#"[project]
 name = "baml-test-basic-type-shapes"
 version = "0.1.0"
@@ -157,62 +159,6 @@ extend-exclude = ["*.pyi"]
 ignore = ["F401", "F821", "E402"]
 "#;
     fs::write(generated_dir.join("pyproject.toml"), pyproject_toml).unwrap();
-
-    let test_sh = r#"#!/usr/bin/env bash
-set -e
-cd "$(dirname "$0")"
-export UV_CACHE_DIR="$(pwd)/.uv-cache"
-if ! command -v uv &> /dev/null; then
-    echo "Error: uv is not installed"
-    exit 1
-fi
-echo "==> uv sync (installs baml_core + deps, builds Rust extension if needed)"
-uv sync
-echo "==> ruff check"
-uv run ruff check --config pyproject.toml baml_sdk
-echo "==> pyright"
-uv run pyright baml_sdk
-echo "==> pytest"
-uv run pytest -v
-echo "==> All checks passed!"
-"#;
-    fs::write(generated_dir.join("test.sh"), test_sh).unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(generated_dir.join("test.sh"))
-            .unwrap()
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(generated_dir.join("test.sh"), perms).unwrap();
-    }
-
-    let test_ps1 = r#"$ErrorActionPreference = "Stop"
-Set-Location $PSScriptRoot
-$env:UV_CACHE_DIR = Join-Path $PSScriptRoot ".uv-cache"
-if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-    Write-Error "Error: uv is not installed"
-    exit 1
-}
-$BridgePythonDir = (Resolve-Path "../../../../sdks/python/rust/bridge_python").Path
-Write-Host "==> uv sync"
-uv sync
-Write-Host "==> maturin develop (builds bridge_python's PyO3 extension into .venv)"
-uv run maturin develop --manifest-path (Join-Path $BridgePythonDir "Cargo.toml")
-Write-Host "==> Running Python syntax check..."
-$pythonFiles = Get-ChildItem -Recurse -Include *.py,*.pyi | ForEach-Object { $_.FullName }
-if ($pythonFiles) {
-    foreach ($file in $pythonFiles) {
-        uv run python -m py_compile $file
-    }
-}
-Write-Host "==> Running ruff lint..."
-uv run ruff check --config pyproject.toml baml_sdk
-Write-Host "==> Running pytest..."
-uv run pytest -v
-Write-Host "==> All checks passed!"
-"#;
-    fs::write(generated_dir.join("test.ps1"), test_ps1).unwrap();
 
     // 7. rerun-if-changed for build.rs + every BAML and customizable
     //    file.

--- a/baml_language/sdk_tests/crates/basic_type_shapes/src/lib.rs
+++ b/baml_language/sdk_tests/crates/basic_type_shapes/src/lib.rs
@@ -1,44 +1,6 @@
-// Hand-written; same shape as the generated rig harnesses.
+//! Sdk-test crate. The harness — four `#[test]`s wrapping `uv sync`
+//! and `uv run {ruff,pyright,pytest}` — is generated below by
+//! `sdk_test_build::sdk_test_suite!`. See `sdk_tests/build/src/lib.rs`
+//! for what the macro expands to and why `sync_only` exists.
 #[cfg(test)]
-mod tests {
-    use std::{path::PathBuf, process::Command};
-
-    #[test]
-    fn test_generated_code() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("generated");
-
-        // Use appropriate test script based on platform
-        #[cfg(windows)]
-        let (script_name, command, arg) = ("test.ps1", "powershell", "-File");
-
-        #[cfg(not(windows))]
-        let (script_name, command, arg) = ("test.sh", "bash", "");
-
-        let test_script = dir.join(script_name);
-
-        assert!(
-            test_script.exists(),
-            "{} not found in generated directory",
-            script_name
-        );
-
-        // Run the test script
-        let mut cmd = Command::new(command);
-        if !arg.is_empty() {
-            cmd.arg(arg);
-        }
-        let output = cmd
-            .arg(&test_script)
-            .current_dir(&dir)
-            .output()
-            .unwrap_or_else(|_| panic!("Failed to run {}", script_name));
-
-        assert!(
-            output.status.success(),
-            "{} failed:\nstdout: {}\nstderr: {}",
-            script_name,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-}
+sdk_test_build::sdk_test_suite!();

--- a/baml_language/sdk_tests/crates/docstrings_etc/Cargo.toml
+++ b/baml_language/sdk_tests/crates/docstrings_etc/Cargo.toml
@@ -1,4 +1,4 @@
-# Rig crate covering BAML `///` doc-comment lowering. Each `ns_*/`
+# Sdk-test crate covering BAML `///` doc-comment lowering. Each `ns_*/`
 # subnamespace exercises a specific doc-comment shape and the Python
 # tests assert on the runtime `__doc__` of the generated symbols.
 [package]
@@ -13,6 +13,9 @@ baml_codegen_types = { path = "../../../crates/baml_codegen_types" }
 baml_db = { path = "../../../crates/baml_db" }
 baml_project = { path = "../../../crates/baml_project" }
 baml_workspace = { path = "../../../crates/baml_workspace" }
+
+[dev-dependencies]
+sdk_test_build = { path = "../../build" }
 
 [package.metadata.ci]
 wasm_support = false

--- a/baml_language/sdk_tests/crates/docstrings_etc/build.rs
+++ b/baml_language/sdk_tests/crates/docstrings_etc/build.rs
@@ -113,13 +113,15 @@ fn main() {
         }
     }
 
-    // 6. pyproject.toml + test.sh + test.ps1. Test runner does
-    //    `uv sync` then `maturin develop` against bridge_python's
-    //    Cargo.toml, installing the real `baml_core` (PyO3
-    //    extension) into the project venv. `[tool.uv] package =
-    //    false` keeps uv from trying to install this directory as
-    //    a wheel; the empty `dev` group satisfies maturin's
-    //    `uv pip install --group dev` step.
+    // 6. pyproject.toml. `uv sync` is invoked at test time by the
+    //    `sdk_test_suite!` macro from `tests/sdk_test.rs`, which
+    //    installs `baml_core` from the local source via
+    //    `[tool.uv.sources]`. uv drives the maturin build-backend
+    //    declared in `sdks/python/pyproject.toml`, so the PyO3
+    //    extension is compiled into the project venv as part of the
+    //    sync. `[tool.uv] package = false` keeps uv from trying to
+    //    install this directory as a wheel; the empty `dev` group
+    //    satisfies maturin's `uv pip install --group dev` step.
     let pyproject_toml = r#"[project]
 name = "baml-test-docstrings-etc"
 version = "0.1.0"
@@ -157,62 +159,6 @@ extend-exclude = ["*.pyi"]
 ignore = ["F401", "F821", "E402"]
 "#;
     fs::write(generated_dir.join("pyproject.toml"), pyproject_toml).unwrap();
-
-    let test_sh = r#"#!/usr/bin/env bash
-set -e
-cd "$(dirname "$0")"
-export UV_CACHE_DIR="$(pwd)/.uv-cache"
-if ! command -v uv &> /dev/null; then
-    echo "Error: uv is not installed"
-    exit 1
-fi
-echo "==> uv sync (installs baml_core + deps, builds Rust extension if needed)"
-uv sync
-echo "==> ruff check"
-uv run ruff check --config pyproject.toml baml_sdk
-echo "==> pyright"
-uv run pyright baml_sdk
-echo "==> pytest"
-uv run pytest -v
-echo "==> All checks passed!"
-"#;
-    fs::write(generated_dir.join("test.sh"), test_sh).unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(generated_dir.join("test.sh"))
-            .unwrap()
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(generated_dir.join("test.sh"), perms).unwrap();
-    }
-
-    let test_ps1 = r#"$ErrorActionPreference = "Stop"
-Set-Location $PSScriptRoot
-$env:UV_CACHE_DIR = Join-Path $PSScriptRoot ".uv-cache"
-if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-    Write-Error "Error: uv is not installed"
-    exit 1
-}
-$BridgePythonDir = (Resolve-Path "../../../../sdks/python/rust/bridge_python").Path
-Write-Host "==> uv sync"
-uv sync
-Write-Host "==> maturin develop (builds bridge_python's PyO3 extension into .venv)"
-uv run maturin develop --manifest-path (Join-Path $BridgePythonDir "Cargo.toml")
-Write-Host "==> Running Python syntax check..."
-$pythonFiles = Get-ChildItem -Recurse -Include *.py,*.pyi | ForEach-Object { $_.FullName }
-if ($pythonFiles) {
-    foreach ($file in $pythonFiles) {
-        uv run python -m py_compile $file
-    }
-}
-Write-Host "==> Running ruff lint..."
-uv run ruff check --config pyproject.toml baml_sdk
-Write-Host "==> Running pytest..."
-uv run pytest -v
-Write-Host "==> All checks passed!"
-"#;
-    fs::write(generated_dir.join("test.ps1"), test_ps1).unwrap();
 
     // 7. rerun-if-changed for build.rs + every BAML and customizable
     //    file.

--- a/baml_language/sdk_tests/crates/docstrings_etc/src/lib.rs
+++ b/baml_language/sdk_tests/crates/docstrings_etc/src/lib.rs
@@ -1,44 +1,6 @@
-// Hand-written; same shape as the generated rig harnesses.
+//! Sdk-test crate. The harness — four `#[test]`s wrapping `uv sync`
+//! and `uv run {ruff,pyright,pytest}` — is generated below by
+//! `sdk_test_build::sdk_test_suite!`. See `sdk_tests/build/src/lib.rs`
+//! for what the macro expands to and why `sync_only` exists.
 #[cfg(test)]
-mod tests {
-    use std::{path::PathBuf, process::Command};
-
-    #[test]
-    fn test_generated_code() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("generated");
-
-        // Use appropriate test script based on platform
-        #[cfg(windows)]
-        let (script_name, command, arg) = ("test.ps1", "powershell", "-File");
-
-        #[cfg(not(windows))]
-        let (script_name, command, arg) = ("test.sh", "bash", "");
-
-        let test_script = dir.join(script_name);
-
-        assert!(
-            test_script.exists(),
-            "{} not found in generated directory",
-            script_name
-        );
-
-        // Run the test script
-        let mut cmd = Command::new(command);
-        if !arg.is_empty() {
-            cmd.arg(arg);
-        }
-        let output = cmd
-            .arg(&test_script)
-            .current_dir(&dir)
-            .output()
-            .unwrap_or_else(|_| panic!("Failed to run {}", script_name));
-
-        assert!(
-            output.status.success(),
-            "{} failed:\nstdout: {}\nstderr: {}",
-            script_name,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-}
+sdk_test_build::sdk_test_suite!();

--- a/baml_language/sdk_tests/crates/llm_functions/Cargo.toml
+++ b/baml_language/sdk_tests/crates/llm_functions/Cargo.toml
@@ -1,4 +1,4 @@
-# Hand-written rig crate; drives codegen from real `.baml` source
+# Hand-written sdk-test crate; drives codegen from real `.baml` source
 # under `baml_src/` through the full `baml_project::build_symbol_pool`
 # pipeline (parse → HIR → TIR → `SymbolPool` → emitter), mirroring the
 # path `baml-cli generate` takes end-to-end.
@@ -21,6 +21,9 @@ baml_codegen_types = { path = "../../../crates/baml_codegen_types" }
 baml_db = { path = "../../../crates/baml_db" }
 baml_project = { path = "../../../crates/baml_project" }
 baml_workspace = { path = "../../../crates/baml_workspace" }
+
+[dev-dependencies]
+sdk_test_build = { path = "../../build" }
 
 [package.metadata.ci]
 wasm_support = false

--- a/baml_language/sdk_tests/crates/llm_functions/baml_src/ns_lorem/functions.baml
+++ b/baml_language/sdk_tests/crates/llm_functions/baml_src/ns_lorem/functions.baml
@@ -27,7 +27,7 @@ function ExtractResume(text: string) -> Resume {
 
 // Paired with `StreamingDoc` to exercise the always-different
 // `$stream` companion branch (previously covered by the standalone
-// `python_llm_functions` rig crate).
+// `python_llm_functions` crate).
 function StreamingExtract(text: string) -> StreamingDoc {
   client Stub
   prompt #"

--- a/baml_language/sdk_tests/crates/llm_functions/build.rs
+++ b/baml_language/sdk_tests/crates/llm_functions/build.rs
@@ -2,7 +2,7 @@
 // in-memory `SymbolPool`. Mirrors the pipeline `baml-cli generate`
 // uses: discover files → ProjectDatabase → diagnostics gate →
 // `build_symbol_pool` → `to_source_code`. Reference template for the
-// other rig crates' build.rs / conftest.py / pyproject.toml shape.
+// other sdk-test crates' build.rs / conftest.py / pyproject.toml shape.
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -114,13 +114,15 @@ fn main() {
         }
     }
 
-    // 6. pyproject.toml + test.sh + test.ps1. Test runner does
-    //    `uv sync` then `maturin develop` against bridge_python's
-    //    Cargo.toml, installing the real `baml_core` (PyO3
-    //    extension) into the project venv. `[tool.uv] package =
-    //    false` keeps uv from trying to install this directory as
-    //    a wheel; the empty `dev` group satisfies maturin's
-    //    `uv pip install --group dev` step.
+    // 6. pyproject.toml. `uv sync` is invoked at test time by the
+    //    `sdk_test_suite!` macro from `tests/sdk_test.rs`, which
+    //    installs `baml_core` from the local source via
+    //    `[tool.uv.sources]`. uv drives the maturin build-backend
+    //    declared in `sdks/python/pyproject.toml`, so the PyO3
+    //    extension is compiled into the project venv as part of the
+    //    sync. `[tool.uv] package = false` keeps uv from trying to
+    //    install this directory as a wheel; the empty `dev` group
+    //    satisfies maturin's `uv pip install --group dev` step.
     let pyproject_toml = r#"[project]
 name = "baml-test-llm-functions"
 version = "0.1.0"
@@ -158,62 +160,6 @@ extend-exclude = ["*.pyi"]
 ignore = ["F401", "F821", "E402"]
 "#;
     fs::write(generated_dir.join("pyproject.toml"), pyproject_toml).unwrap();
-
-    let test_sh = r#"#!/usr/bin/env bash
-set -e
-cd "$(dirname "$0")"
-export UV_CACHE_DIR="$(pwd)/.uv-cache"
-if ! command -v uv &> /dev/null; then
-    echo "Error: uv is not installed"
-    exit 1
-fi
-echo "==> uv sync (installs baml_core + deps, builds Rust extension if needed)"
-uv sync
-echo "==> ruff check"
-uv run ruff check --config pyproject.toml baml_sdk
-echo "==> pyright"
-uv run pyright baml_sdk
-echo "==> pytest"
-uv run pytest -v
-echo "==> All checks passed!"
-"#;
-    fs::write(generated_dir.join("test.sh"), test_sh).unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(generated_dir.join("test.sh"))
-            .unwrap()
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(generated_dir.join("test.sh"), perms).unwrap();
-    }
-
-    let test_ps1 = r#"$ErrorActionPreference = "Stop"
-Set-Location $PSScriptRoot
-$env:UV_CACHE_DIR = Join-Path $PSScriptRoot ".uv-cache"
-if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-    Write-Error "Error: uv is not installed"
-    exit 1
-}
-$BridgePythonDir = (Resolve-Path "../../../../sdks/python/rust/bridge_python").Path
-Write-Host "==> uv sync"
-uv sync
-Write-Host "==> maturin develop (builds bridge_python's PyO3 extension into .venv)"
-uv run maturin develop --manifest-path (Join-Path $BridgePythonDir "Cargo.toml")
-Write-Host "==> Running Python syntax check..."
-$pythonFiles = Get-ChildItem -Recurse -Include *.py,*.pyi | ForEach-Object { $_.FullName }
-if ($pythonFiles) {
-    foreach ($file in $pythonFiles) {
-        uv run python -m py_compile $file
-    }
-}
-Write-Host "==> Running ruff lint..."
-uv run ruff check --config pyproject.toml baml_sdk
-Write-Host "==> Running pytest..."
-uv run pytest -v
-Write-Host "==> All checks passed!"
-"#;
-    fs::write(generated_dir.join("test.ps1"), test_ps1).unwrap();
 
     // 7. rerun-if-changed for build.rs + every BAML and customizable
     //    file. baml_src/ rebuilds when contents change.

--- a/baml_language/sdk_tests/crates/llm_functions/customizable/test_main.py
+++ b/baml_language/sdk_tests/crates/llm_functions/customizable/test_main.py
@@ -8,7 +8,7 @@ Scope (subset of 09a-codegen-example-scenario.md):
 - user.lorem.Resume + ExtractResume (with auto-generated companions)
 - user.lorem.StreamingDoc + StreamingExtract (pins the always-different
   `$stream` companion branch; folded in from the former
-  `python_llm_functions` rig crate)
+  `python_llm_functions` crate)
 - user.ipsum.Sentiment (enum) + ClassifySentiment
 - stream_types/lorem leaf presence
 """
@@ -128,15 +128,21 @@ def test_classify_sentiment_factory_bindings():
 def test_inlinedbaml_files_present():
     # baml/_inlinedbaml.py captures the user .baml source; the runtime
     # uses it to bootstrap without re-reading from disk.
+    from pathlib import Path
     from baml_sdk.baml import _inlinedbaml
 
     assert "FILES" in dir(_inlinedbaml)
-    paths = set(_inlinedbaml.FILES.keys())
-    # Paths are relative to baml_src/.
-    assert "ns_lorem/types.baml" in paths
-    assert "ns_lorem/functions.baml" in paths
-    assert "ns_ipsum/types.baml" in paths
-    assert "ns_ipsum/functions.baml" in paths
+    # Paths are relative to baml_src/. Compare via pathlib.Path so the
+    # native separator on Windows (`ns_lorem\\types.baml`) matches the
+    # forward-slash form we write here.
+    actual_paths = {Path(p) for p in _inlinedbaml.FILES.keys()}
+    expected_paths = {
+        Path("ns_lorem/types.baml"),
+        Path("ns_lorem/functions.baml"),
+        Path("ns_ipsum/types.baml"),
+        Path("ns_ipsum/functions.baml"),
+    }
+    assert actual_paths == expected_paths
 
 
 def test_runtime_init_called_at_import():

--- a/baml_language/sdk_tests/crates/llm_functions/src/lib.rs
+++ b/baml_language/sdk_tests/crates/llm_functions/src/lib.rs
@@ -1,42 +1,6 @@
-// Hand-written; same shape as the generated rig harnesses.
+//! Sdk-test crate. The harness — four `#[test]`s wrapping `uv sync`
+//! and `uv run {ruff,pyright,pytest}` — is generated below by
+//! `sdk_test_build::sdk_test_suite!`. See `sdk_tests/build/src/lib.rs`
+//! for what the macro expands to and why `sync_only` exists.
 #[cfg(test)]
-mod tests {
-    use std::{path::PathBuf, process::Command};
-
-    #[test]
-    fn test_generated_code() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("generated");
-
-        #[cfg(windows)]
-        let (script_name, command, arg) = ("test.ps1", "powershell", "-File");
-
-        #[cfg(not(windows))]
-        let (script_name, command, arg) = ("test.sh", "bash", "");
-
-        let test_script = dir.join(script_name);
-
-        assert!(
-            test_script.exists(),
-            "{} not found in generated directory",
-            script_name
-        );
-
-        let mut cmd = Command::new(command);
-        if !arg.is_empty() {
-            cmd.arg(arg);
-        }
-        let output = cmd
-            .arg(&test_script)
-            .current_dir(&dir)
-            .output()
-            .unwrap_or_else(|_| panic!("Failed to run {}", script_name));
-
-        assert!(
-            output.status.success(),
-            "{} failed:\nstdout: {}\nstderr: {}",
-            script_name,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-}
+sdk_test_build::sdk_test_suite!();

--- a/baml_language/sdk_tests/crates/type_shapes/Cargo.toml
+++ b/baml_language/sdk_tests/crates/type_shapes/Cargo.toml
@@ -1,4 +1,4 @@
-# Rig crate covering BEP-030 Ty exhaustiveness: every type variant and
+# Sdk-test crate covering BEP-030 Ty exhaustiveness: every type variant and
 # every name-routing case from `bridge-python/18a-type-exhaustiveness.md`.
 # The generated `baml_sdk/` is checked into version control so reviewers
 # can diff codegen output directly without running the build.
@@ -14,6 +14,9 @@ baml_codegen_types = { path = "../../../crates/baml_codegen_types" }
 baml_db = { path = "../../../crates/baml_db" }
 baml_project = { path = "../../../crates/baml_project" }
 baml_workspace = { path = "../../../crates/baml_workspace" }
+
+[dev-dependencies]
+sdk_test_build = { path = "../../build" }
 
 [package.metadata.ci]
 wasm_support = false

--- a/baml_language/sdk_tests/crates/type_shapes/build.rs
+++ b/baml_language/sdk_tests/crates/type_shapes/build.rs
@@ -113,16 +113,15 @@ fn main() {
         }
     }
 
-    // 6. pyproject.toml + test.sh + test.ps1. Test runner does
-    //    `uv sync`, which installs `baml_core` from the local source
-    //    via `[tool.uv.sources]` — uv invokes the maturin build-backend
+    // 6. pyproject.toml. `uv sync` is invoked at test time by the
+    //    `sdk_test_suite!` macro from `tests/sdk_test.rs`, which
+    //    installs `baml_core` from the local source via
+    //    `[tool.uv.sources]`. uv drives the maturin build-backend
     //    declared in `sdks/python/pyproject.toml`, so the PyO3
     //    extension is compiled into the project venv as part of the
-    //    sync. No separate `maturin develop` step is needed (and adding
-    //    one would re-skew `test.sh` vs `test.ps1`). `[tool.uv]
-    //    package = false` keeps uv from trying to install this
-    //    directory as a wheel; the empty `dev` group satisfies
-    //    maturin's `uv pip install --group dev` step.
+    //    sync. `[tool.uv] package = false` keeps uv from trying to
+    //    install this directory as a wheel; the empty `dev` group
+    //    satisfies maturin's `uv pip install --group dev` step.
     let pyproject_toml = r#"[project]
 name = "baml-test-type-shapes"
 version = "0.1.0"
@@ -160,54 +159,6 @@ extend-exclude = ["*.pyi"]
 ignore = ["F401", "F821", "E402"]
 "#;
     fs::write(generated_dir.join("pyproject.toml"), pyproject_toml).unwrap();
-
-    let test_sh = r#"#!/usr/bin/env bash
-set -e
-cd "$(dirname "$0")"
-export UV_CACHE_DIR="$(pwd)/.uv-cache"
-if ! command -v uv &> /dev/null; then
-    echo "Error: uv is not installed"
-    exit 1
-fi
-echo "==> uv sync (installs baml_core + deps; maturin builds the PyO3 extension)"
-uv sync
-echo "==> ruff check"
-uv run ruff check --config pyproject.toml baml_sdk
-echo "==> pyright"
-uv run pyright baml_sdk
-echo "==> pytest"
-uv run pytest -v
-echo "==> All checks passed!"
-"#;
-    fs::write(generated_dir.join("test.sh"), test_sh).unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(generated_dir.join("test.sh"))
-            .unwrap()
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(generated_dir.join("test.sh"), perms).unwrap();
-    }
-
-    let test_ps1 = r#"$ErrorActionPreference = "Stop"
-Set-Location $PSScriptRoot
-$env:UV_CACHE_DIR = Join-Path $PSScriptRoot ".uv-cache"
-if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-    Write-Error "Error: uv is not installed"
-    exit 1
-}
-Write-Host "==> uv sync (installs baml_core + deps; maturin builds the PyO3 extension)"
-uv sync
-Write-Host "==> ruff check"
-uv run ruff check --config pyproject.toml baml_sdk
-Write-Host "==> pyright"
-uv run pyright baml_sdk
-Write-Host "==> pytest"
-uv run pytest -v
-Write-Host "==> All checks passed!"
-"#;
-    fs::write(generated_dir.join("test.ps1"), test_ps1).unwrap();
 
     // 7. rerun-if-changed for build.rs + every BAML and customizable
     //    file.

--- a/baml_language/sdk_tests/crates/type_shapes/customizable/test_main.py
+++ b/baml_language/sdk_tests/crates/type_shapes/customizable/test_main.py
@@ -1,8 +1,9 @@
-"""Smoke tests for the type_shapes rig crate.
+"""Smoke tests for the type_shapes sdk-test crate.
 
 The actual type-shape verification happens in `pyright baml_sdk` (run by
-test.sh). These pytest cases just confirm each generated namespace
-imports cleanly and that the symbols listed in 18a are reachable.
+the `pyright` test in `tests/sdk_test.rs`). These pytest cases just
+confirm each generated namespace imports cleanly and that the symbols
+listed in 18a are reachable.
 """
 
 

--- a/baml_language/sdk_tests/crates/type_shapes/src/lib.rs
+++ b/baml_language/sdk_tests/crates/type_shapes/src/lib.rs
@@ -1,44 +1,6 @@
-// Hand-written; same shape as the generated rig harnesses.
+//! Sdk-test crate. The harness — four `#[test]`s wrapping `uv sync`
+//! and `uv run {ruff,pyright,pytest}` — is generated below by
+//! `sdk_test_build::sdk_test_suite!`. See `sdk_tests/build/src/lib.rs`
+//! for what the macro expands to and why `sync_only` exists.
 #[cfg(test)]
-mod tests {
-    use std::{path::PathBuf, process::Command};
-
-    #[test]
-    fn test_generated_code() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("generated");
-
-        // Use appropriate test script based on platform
-        #[cfg(windows)]
-        let (script_name, command, arg) = ("test.ps1", "powershell", "-File");
-
-        #[cfg(not(windows))]
-        let (script_name, command, arg) = ("test.sh", "bash", "");
-
-        let test_script = dir.join(script_name);
-
-        assert!(
-            test_script.exists(),
-            "{} not found in generated directory",
-            script_name
-        );
-
-        // Run the test script
-        let mut cmd = Command::new(command);
-        if !arg.is_empty() {
-            cmd.arg(arg);
-        }
-        let output = cmd
-            .arg(&test_script)
-            .current_dir(&dir)
-            .output()
-            .unwrap_or_else(|_| panic!("Failed to run {}", script_name));
-
-        assert!(
-            output.status.success(),
-            "{} failed:\nstdout: {}\nstderr: {}",
-            script_name,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-}
+sdk_test_build::sdk_test_suite!();

--- a/baml_language/stow.toml
+++ b/baml_language/stow.toml
@@ -38,7 +38,7 @@
 # ===========================================================================
 
 # Ignore crates that don't follow the namespace convention
-# - sdk_test_*: SDK test rig crates
+# - sdk_test_*: SDK test crates
 ignore_crates = ["sdk_test_*"]
 
 # Graph visualization settings


### PR DESCRIPTION
Each rig crate's build.rs (~250 lines) collapses to a one-liner that calls sdk_test_build::run("<crate_name>"). pyproject name is derived from the rust crate name. uv cache is anchored at
<workspace>/target/uv-cache so the four rig crates share wheels — uv uses file locks, so concurrent sync is safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a shared build helper to standardize SDK test execution across fixtures.
  * Refactored test system to use unified Rust macros instead of platform-specific scripts.
  * Updated CI/CD pipelines to use cargo-nextest for consistent, parallel testing across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->