### PR TITLE
Fix diagnostic spans for synthesized test expressions

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -1138,13 +1138,13 @@ fn synthesize_register_call(
     ctx: &mut lower_expr_body::InitTestContext,
     diags: &mut Vec<LoweringDiagnostic>,
 ) -> ExprId {
-    let span = text_size::TextRange::default();
     match reg {
         TestRegistrationItem::Test {
             name_element,
             body_node,
             runner_element,
         } => {
+            let span = name_element.text_range();
             // Lower the test block body into a fresh ExprBody (lambda body)
             let (lambda_body, lambda_source_map, lambda_diags) =
                 lower_expr_body::lower_block_node(body_node, &[Name::new("registry")]);
@@ -1196,6 +1196,7 @@ fn synthesize_register_call(
             body_node,
             runner_element,
         } => {
+            let span = name_element.text_range();
             // Lower the testset body into a collector lambda using the full testset lowering.
             let (collector_exprs, collector_source_map, collector_diags) =
                 lower_expr_body::lower_testset_block_node(

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -167,7 +167,11 @@ pub(crate) fn lower_runner_element(
 ) -> ExprId {
     let span = element.text_range();
     match element {
-        rowan::NodeOrToken::Node(node) => ctx.inner.lower_expr(node),
+        rowan::NodeOrToken::Node(node) => {
+            let expr_id = ctx.inner.lower_expr(node);
+            ctx.set_expr_span_if_default(expr_id, span);
+            expr_id
+        }
         rowan::NodeOrToken::Token(token) => {
             let expr = lower_bare_token_expr(token.kind(), token.text());
             ctx.inner.alloc_expr(expr, span)
@@ -214,6 +218,21 @@ impl InitTestContext {
 
     pub(crate) fn alloc_expr(&mut self, expr: Expr, span: text_size::TextRange) -> ExprId {
         self.inner.alloc_expr(expr, span)
+    }
+
+    fn set_expr_span_if_default(&mut self, id: ExprId, span: text_size::TextRange) {
+        let raw: u32 = id.into_raw().into_u32();
+        if let Some((_, current)) = self
+            .inner
+            .source_map
+            .expr_spans
+            .iter_mut()
+            .nth(raw as usize)
+            && current.is_empty()
+            && !span.is_empty()
+        {
+            *current = span;
+        }
     }
 
     pub(crate) fn alloc_stmt(

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -414,4 +414,26 @@ function demo() -> int throws string {
             ]
         );
     }
+
+    #[test]
+    fn check_file_places_function_body_diagnostic_on_expression() {
+        let test = CursorTest::new(
+            r#"function demo() -> int {
+  return missing_value
+}
+<[CURSOR]"#,
+        );
+
+        let diagnostics = check_file(&test.db, test.cursor.file);
+        let diag = diagnostics
+            .iter()
+            .find(|diag| diag.id == DiagnosticId::UnknownVariable)
+            .expect("unresolved name diagnostic");
+        let span = diag.primary_span().expect("primary span");
+        let text = test.cursor.file.text(&test.db);
+        let start: usize = span.range.start().into();
+        let end: usize = span.range.end().into();
+
+        assert_eq!(&text[start..end], "missing_value");
+    }
 }

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/diagnostic_span_regression.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/diagnostic_span_regression.baml
@@ -1,0 +1,31 @@
+// Regression: diagnostics inside expression functions should underline the
+// expression that caused the error, not the start of the file.
+
+function FunctionBodySpan() -> int {
+  return missing_value
+}
+
+function ReturnTypeSpan() -> string {
+  return 1
+}
+
+//----
+//- diagnostics
+// Error: unresolved name: missing_value
+//    ╭─[ expr_diagnostic_span_regression.baml:5:10 ]
+//    │
+//  5 │   return missing_value
+//    │          ──────┬──────  
+//    │                ╰──────── unresolved name: missing_value
+//    │ 
+//    │ Note: Error code: E0003
+// ───╯
+// Error: type mismatch: expected string, got 1
+//    ╭─[ expr_diagnostic_span_regression.baml:9:10 ]
+//    │
+//  9 │   return 1
+//    │          ┬  
+//    │          ╰── type mismatch: expected string, got 1
+//    │ 
+//    │ Note: Error code: E0001
+// ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/expr_full.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/expr_full.baml
@@ -99,14 +99,14 @@ test TestMakePoem() {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: unresolved name: functions
-//    ╭─[ expr_expr_full.baml:1:1 ]
-//    │
-//  1 │ function MakePoem(length: int) -> string {
-//    │ │ 
-//    │ ╰─ unresolved name: functions
-//    │ 
-//    │ Note: Error code: E0003
-// ───╯
+//     ╭─[ expr_expr_full.baml:44:6 ]
+//     │
+//  44 │ test TestPipeline() {
+//     │      ───────┬──────  
+//     │             ╰──────── unresolved name: functions
+//     │ 
+//     │ Note: Error code: E0003
+// ────╯
 // Error: unresolved name: TestPyramid
 //     ╭─[ expr_expr_full.baml:49:6 ]
 //     │
@@ -117,14 +117,14 @@ test TestMakePoem() {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: unresolved name: functions
-//    ╭─[ expr_expr_full.baml:1:1 ]
-//    │
-//  1 │ function MakePoem(length: int) -> string {
-//    │ │ 
-//    │ ╰─ unresolved name: functions
-//    │ 
-//    │ Note: Error code: E0003
-// ───╯
+//     ╭─[ expr_expr_full.baml:44:6 ]
+//     │
+//  44 │ test TestPipeline() {
+//     │      ───────┬──────  
+//     │             ╰──────── unresolved name: functions
+//     │ 
+//     │ Note: Error code: E0003
+// ────╯
 // Error: unresolved name: TestMakePoem
 //     ╭─[ expr_expr_full.baml:67:6 ]
 //     │
@@ -135,14 +135,14 @@ test TestMakePoem() {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: unresolved name: functions
-//    ╭─[ expr_expr_full.baml:1:1 ]
-//    │
-//  1 │ function MakePoem(length: int) -> string {
-//    │ │ 
-//    │ ╰─ unresolved name: functions
-//    │ 
-//    │ Note: Error code: E0003
-// ───╯
+//     ╭─[ expr_expr_full.baml:44:6 ]
+//     │
+//  44 │ test TestPipeline() {
+//     │      ───────┬──────  
+//     │             ╰──────── unresolved name: functions
+//     │ 
+//     │ Note: Error code: E0003
+// ────╯
 // Error: unresolved name: args
 //    ╭─[ expr_expr_full.baml:1:3 ]
 //    │
@@ -153,14 +153,14 @@ test TestMakePoem() {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: unresolved name: length
-//    ╭─[ expr_expr_full.baml:1:1 ]
-//    │
-//  1 │ function MakePoem(length: int) -> string {
-//    │ │ 
-//    │ ╰─ unresolved name: length
-//    │ 
-//    │ Note: Error code: E0003
-// ───╯
+//     ╭─[ expr_expr_full.baml:44:6 ]
+//     │
+//  44 │ test TestPipeline() {
+//     │      ───────┬──────  
+//     │             ╰──────── unresolved name: length
+//     │ 
+//     │ Note: Error code: E0003
+// ────╯
 // Error: unresolved name: functions
 //     ╭─[ expr_expr_full.baml:45:3 ]
 //     │

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__04_tir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 44394
 ---
 === TIR2 ===
 function user.$init_test_32(registry: testing.TestCollector) -> ? throws never {
@@ -26,7 +27,7 @@ function user.$init_test_32(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
   !! 106..108: type mismatch: expected string, got 42
-  !! 0..0: type mismatch: expected string, got int
+  !! 80..88: type mismatch: expected string, got int
 }
 lambda user.$init_test_32 {
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__05_diagnostics.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 38038
+assertion_line: 39003
 ---
 === COMPILER2 DIAGNOSTICS ===
   [type] Error: type mismatch: expected string, got int
-   ╭─[ main.baml:1:1 ]
+   ╭─[ main.baml:3:5 ]
    │
- 1 │ // Expression names — type errors: non-string expressions as test names.
-   │ │ 
-   │ ╰─ type mismatch: expected string, got int
+ 3 │ test "a" + 1 {
+   │     ────┬───  
+   │         ╰───── type mismatch: expected string, got int
    │ 
    │ Note: Error code: E0001
 ───╯


### PR DESCRIPTION
## Summary
- rebase onto fresh canary so the PR only contains the diagnostic-span fix
- use source spans for synthesized test/testset registration calls instead of default text ranges
- repair empty top-level spans when lowering runner/name nodes so diagnostics land on the expression
- add LSP fixture, unit regression, and updated diagnostics expectations showing the corrected spans

## Validation
- cargo fmt
- cargo test -p baml_lsp2_actions check::tests -- --nocapture
- cargo test --package baml_tests test_expr_name_type_error
- cargo test -p baml_lsp2_actions_tests syntax::test_expr_diagnostic_span_regression -- --nocapture
- PATH="/Users/aaron/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin:$PATH" cargo test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect source span propagation for synthesized test registration expressions and update/expand regression tests and snapshots to match the new diagnostic locations.
> 
> **Overview**
> Fixes diagnostic underlining for synthesized `test`/`testset` registration calls by using the CST name expression range (instead of `0..0`) as the span for the generated call/lambda metadata.
> 
> When lowering runner/name elements into `$init_test`, it now backfills empty/default expr spans with the element’s real `text_range`, so unresolved-name/type errors attach to the offending expression rather than the start of the file.
> 
> Adds a unit regression in `check_file`, a new LSP fixture for expression-body span placement, and updates expected diagnostics/snapshots to reflect the corrected spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269f7565042c75d07c2409adb75ec236166adcb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed diagnostic messages to correctly highlight the exact expression causing errors in function bodies, rather than pointing to incorrect file locations. Error messages now precisely identify the problematic code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->