### PR TITLE
fix(oncall): notify if any of the recurring jobs fail

### DIFF
--- a/.github/workflows/oncall.yml
+++ b/.github/workflows/oncall.yml
@@ -14,6 +14,9 @@ on:
         options: [notify, fill-schedule]
         default: fill-schedule
 
+env:
+  UV_FROZEN: '1'
+
 jobs:
   review:
     if: github.event_name == 'pull_request'
@@ -23,10 +26,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: ./tools/bctl oncall check
 
       - name: Scope check - schedule-file-only PR?
@@ -62,8 +65,8 @@ jobs:
     env:
       SLACK_BOUNDARY_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
       - name: Validate schedule
         run: ./tools/bctl oncall check
       - name: Post weekly handoff
@@ -74,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: boundary-tools-prod
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: ./tools/bctl oncall fill-schedule
       - uses: peter-evans/create-pull-request@v6
         with:
@@ -84,3 +87,27 @@ jobs:
           title: "oncall: fill schedule horizon"
           commit-message: "fill schedule to 4mo horizon"
           body: "Automated: extending oncall schedule to 4-month horizon."
+
+  notify-failure:
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs: [review, notify, fill-schedule]
+    runs-on: ubuntu-latest
+    environment: boundary-tools-prod
+    env:
+      SLACK_BOUNDARY_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+      - name: Identify failed jobs
+        id: failed
+        run: |
+          failed=()
+          [ "${{ needs.review.result }}" = "failure" ] && failed+=("review")
+          [ "${{ needs.notify.result }}" = "failure" ] && failed+=("notify")
+          [ "${{ needs.fill-schedule.result }}" = "failure" ] && failed+=("fill-schedule")
+          echo "jobs=${failed[*]}" >> "$GITHUB_OUTPUT"
+      - name: Post failure to #oncall
+        run: |
+          ./tools/bctl oncall notify-failure \
+            --jobs "${{ steps.failed.outputs.jobs }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/tools/bctl_src/oncall/cli.py
+++ b/tools/bctl_src/oncall/cli.py
@@ -131,3 +131,76 @@ def notify(
             console.print(f"[bold]→ {channel}[/]")
             console.print(body)
             console.print()
+
+
+@app.command(name="notify-failure")
+def notify_failure(
+    jobs: str = typer.Option(..., "--jobs", help="Comma- or space-separated failed job names"),
+    run_url: str = typer.Option(..., "--run-url", help="URL of the failed workflow run"),
+    channel: str = typer.Option("", "--channel", help="Slack channel (default: schedule's notification_channel)"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print the message instead of posting"),
+) -> None:
+    """Post a workflow-failure alert to Slack, @-mentioning the current oncaller(s).
+
+    If no current shift covers today, posts to the channel without an @-mention.
+    """
+    from oncall.notify import _current_shift
+    from oncall.slack import client as slack_client
+    from oncall.slack import email_for, lookup_user_id
+    from oncall.slack import post as slack_post
+
+    job_list = ", ".join(j for j in jobs.replace(",", " ").split() if j)
+    if not job_list:
+        console.print("[red]error[/]: --jobs is empty")
+        raise typer.Exit(1)
+
+    path = _schedule_path()
+    # An unparseable schedule is a likely cause of `review` failing, so don't
+    # let it silence the alert — fall back to the channel default and skip the
+    # @-mention (we can't know the current oncaller without a valid schedule).
+    sched: ScheduleFile | None = None
+    parse_error: str | None = None
+    try:
+        sched = parse(path.read_text())
+    except (OSError, ValueError) as e:
+        parse_error = str(e)
+        console.print(f"[yellow]warn[/]: schedule unparseable ({e}); posting without @-mention")
+
+    target_channel = channel or (sched.slack_config.notification_channel if sched else "#oncall")
+
+    # `oncall-founders` is the escalation rotation — skip it for routine
+    # workflow-failure pings; only the primary oncaller(s) get notified.
+    escalation_rotations = {"oncall-founders"}
+
+    oncall_names: list[str] = []
+    if sched is not None:
+        current = _current_shift(sched, datetime.date.today())
+        if current is not None:
+            for rot in sched.roster.rotations_in_order():
+                if rot in escalation_rotations:
+                    continue
+                name = current.assignments.get(rot)
+                if name:
+                    oncall_names.append(name)
+
+    def _build(mentions: list[str]) -> str:
+        prefix = (" ".join(mentions) + " ") if mentions else ""
+        suffix = f" (schedule.oncall is unparseable: {parse_error})" if parse_error else ""
+        return f"{prefix}oncall workflow failed: {job_list} — needs a fix. <{run_url}|View run>{suffix}"
+
+    if dry_run:
+        text = _build([f"@{n}" for n in oncall_names])
+        console.print(f"[bold]→ {target_channel}[/]")
+        console.print(text)
+        return
+
+    wc = slack_client()
+    mentions: list[str] = []
+    for name in oncall_names:
+        try:
+            mentions.append(f"<@{lookup_user_id(wc, email_for(name))}>")
+        except Exception as e:
+            console.print(f"[yellow]warn[/]: failed to look up Slack user for {name}: {e}")
+
+    slack_post(wc, target_channel, _build(mentions))
+    console.print(f"[green]posted to {target_channel}[/]")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow failures now automatically post Slack notifications listing failed jobs and a link to the run.
  * New command to manually trigger failure notifications, with optional channel override and dry‑run preview.

* **Chores**
  * Improved on‑call workflow and notification handling for more reliable failure detection and clearer alerts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3504)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->