### PR TITLE
ci: include oncall config files in workflow trigger

### DIFF
--- a/.github/workflows/oncall.yml
+++ b/.github/workflows/oncall.yml
@@ -3,8 +3,11 @@ name: oncall
 on:
   pull_request:
     paths:
+      - '.github/workflows/oncall.yml'
       - 'tools/bctl'
       - 'tools/bctl_src/**'
+      - 'tools/pyproject.toml'
+      - 'tools/uv.lock'
   schedule:
     - cron: '0 17 * * 5'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- include the oncall workflow file in its own pull request trigger paths
- include the oncall tool dependency lock/config files in the same trigger

## Why

The `oncall` workflow runs `./tools/bctl oncall check` for pull requests that touch the oncall tooling. At the moment, the path filter only includes `tools/bctl` and `tools/bctl_src/**`, so changes to `.github/workflows/oncall.yml`, `tools/pyproject.toml`, or `tools/uv.lock` can skip the review job even though those files directly affect the workflow or its runtime environment.

## Tests

- Parsed `.github/workflows/oncall.yml` with PyYAML
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow trigger configuration to monitor additional tooling-related files for changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3511)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->