### PR TITLE
Port feb-17-studio baml-rpc UI types forward to canary

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -96,7 +96,7 @@ itertools = "0.14.0"
 jsonish = { path = "baml-lib/jsonish" }
 log = "0.4.20"
 # TODO: disable imports, etc
-minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "value-cmp", default-features = false, features = [
+minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "value-cmp2", default-features = false, features = [
   "macros",
   "builtins",
   "debug",
@@ -113,7 +113,7 @@ minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "val
   # loader
   #
 ] }
-minijinja-contrib = { git = "https://github.com/boundaryml/minijinja.git", branch = "value-cmp", features = ["pycompat"] }
+minijinja-contrib = { git = "https://github.com/boundaryml/minijinja.git", branch = "value-cmp2", features = ["pycompat"] }
 once_cell = "1"
 pathdiff = "0.2.2"
 pest = "2.8.1"

--- a/engine/baml-rpc/src/ui/ui_traces.rs
+++ b/engine/baml-rpc/src/ui/ui_traces.rs
@@ -28,27 +28,14 @@ pub struct UsageEstimateAggregate {
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct NodeDetails {
-    // Aggregate info for performance - calculated server-side
+    // Aggregate info - computed by build_trace_children_hierarchy in getTraceChildren
     #[ts(type = "number")]
     pub children_functions: u32,
     #[ts(type = "number")]
-    pub total_descendants: u32, // Total count including nested children
-    #[ts(type = "number")]
-    pub max_depth: u32, // Maximum nesting depth
+    pub total_descendants: u32,
     #[ts(optional)]
     pub usage_estimate_aggregate: Option<UsageEstimateAggregate>,
-
-    // Lazy loading metadata
     pub has_children: bool,
-    pub children_loaded: bool, // Whether children are included in this response
-    #[ts(type = "number", optional)]
-    pub children_limit: Option<u32>, // How many children were requested/returned
-    #[ts(type = "number", optional)]
-    pub children_offset: Option<u32>, // Pagination offset for children
-
-    // Match highlighting - IDs of descendants that matched filters
-    #[ts(optional)]
-    pub matched_descendant_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -90,19 +77,6 @@ pub struct ListTracesRequest {
     #[ts(optional)]
     pub ending_before: Option<String>,
 
-    // Lazy loading controls
-    /// Whether to include direct children in the response. Defaults to false.
-    #[ts(optional)]
-    pub include_children: Option<bool>,
-    /// Maximum depth of children to load. Defaults to 1 if include_children is true.
-    #[ts(optional)]
-    pub max_depth: Option<u32>,
-    /// Limit for children per trace. Defaults to 50.
-    #[ts(optional)]
-    pub children_limit: Option<u32>,
-    /// Offset for children pagination within each trace.
-    #[ts(optional)]
-    pub children_offset: Option<u32>,
     /// Whether to calculate usage estimates. Defaults to true.
     #[ts(optional)]
     pub include_usage_estimates: Option<bool>,
@@ -131,12 +105,12 @@ pub struct ListTracesRequest {
     /// Search term to filter across function_call_id, function_name, tags, error, input (args), and output
     #[ts(optional)]
     pub search: Option<String>,
+    /// When true, also search LLM request/response text (full-text search). Defaults to false.
+    #[ts(optional)]
+    pub full_text_search: Option<bool>,
     /// Filter to only show LLM function calls (function_type = 'baml_llm')
     #[ts(optional)]
     pub llm_only: Option<FilterExpression<bool>>,
-    /// Whether to include matched_descendant_ids in the response for match highlighting. Defaults to false.
-    #[ts(optional)]
-    pub include_match_highlights: Option<bool>,
 }
 
 impl Default for ListTracesRequest {
@@ -150,10 +124,6 @@ impl Default for ListTracesRequest {
             limit: Some(100),
             starting_after: None,
             ending_before: None,
-            include_children: Some(false),
-            max_depth: Some(1),
-            children_limit: Some(50),
-            children_offset: Some(0),
             include_usage_estimates: Some(true),
             function_call_id: None,
             function_id: None,
@@ -166,8 +136,8 @@ impl Default for ListTracesRequest {
             streamed: None,
             relative_time: None,
             search: None,
+            full_text_search: None,
             llm_only: None,
-            include_match_highlights: Some(false),
         }
     }
 }
@@ -190,6 +160,26 @@ pub struct GetTraceChildrenRequest {
     /// Whether to calculate usage estimates. Defaults to true.
     #[ts(optional)]
     pub include_usage_estimates: Option<bool>,
+
+    // Filter fields for children match highlighting
+    /// Search term to highlight matching children
+    #[ts(optional)]
+    pub search: Option<String>,
+    /// When true, also search LLM request/response text (full-text search). Defaults to false.
+    #[ts(optional)]
+    pub full_text_search: Option<bool>,
+    /// Status filter for matching children
+    #[ts(optional)]
+    pub status: Option<FilterExpression<FunctionCallStatus>>,
+    /// Tag filters for matching children
+    #[ts(optional)]
+    pub tag_filters: Option<Vec<TagFilter>>,
+    /// Error filters for matching children
+    #[ts(optional)]
+    pub error_filters: Option<Vec<TagFilter>>,
+    /// LLM-only filter for matching children
+    #[ts(optional)]
+    pub llm_only: Option<FilterExpression<bool>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -197,14 +187,15 @@ pub struct GetTraceChildrenRequest {
 pub struct GetTraceChildrenResponse {
     // The function_call_id of the parent function call
     pub function_call_id: String,
-    // The function_call details of the parent function call
-    pub function_call: ui_types::UiFunctionCall,
     // The children of the parent function call
     pub children: Vec<TraceCall>,
     // Breadcrumb trail
     #[ts(type = "number")]
     pub total_children: u32, // For pagination
     pub has_more: bool, // Whether there are more children to load
+    /// IDs of children that matched the given filters (for highlight)
+    #[ts(optional)]
+    pub matched_children_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -251,18 +242,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_list_traces_lazy_loading() {
+    fn test_list_traces_request_deserialization() {
         let json_str = r#"{
             "projectId": "proj_01jvb3fnp1f09ta2a6g016t4kz",
-            "includeChildren": true,
-            "maxDepth": 2,
-            "childrenLimit": 25
+            "includeUsageEstimates": true
         }"#;
 
         let request: ListTracesRequest = serde_json::from_str(json_str).unwrap();
-        assert_eq!(request.include_children, Some(true));
-        assert_eq!(request.max_depth, Some(2));
-        assert_eq!(request.children_limit, Some(25));
+        assert_eq!(request.include_usage_estimates, Some(true));
     }
 
     #[test]
@@ -321,6 +308,9 @@ pub struct ListTraceFunctionSummariesRequest {
     pub error_filters: Option<Vec<TagFilter>>,
     #[ts(optional)]
     pub search: Option<String>,
+    /// When true, also search LLM request/response text (full-text search). Defaults to false.
+    #[ts(optional)]
+    pub full_text_search: Option<bool>,
 }
 
 impl Default for ListTraceFunctionSummariesRequest {
@@ -339,6 +329,7 @@ impl Default for ListTraceFunctionSummariesRequest {
             tag_filters: None,
             error_filters: None,
             search: None,
+            full_text_search: None,
         }
     }
 }
@@ -395,4 +386,50 @@ impl ApiEndpoint for ListTraceFunctionSummaries {
     type Response<'a> = ListTraceFunctionSummariesResponse;
 
     const PATH: &'static str = "/v1/traces/function-summaries";
+}
+
+/// Batch request to compute costs for a set of root trace function_call_ids.
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct GetTraceCostsRequest {
+    #[ts(type = "string")]
+    pub project_id: ProjectId,
+    /// Root function_call_ids to compute costs for.
+    pub function_call_ids: Vec<String>,
+    /// Optional relative time to scope the cost query.
+    #[ts(optional)]
+    pub relative_time: Option<super::ui_function_calls::RelativeTime>,
+    /// Optional function name to narrow the cost query.
+    #[ts(optional)]
+    pub function_name: Option<String>,
+}
+
+/// Cost entry for a single root trace.
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct TraceCostEntry {
+    pub function_call_id: String,
+    #[ts(type = "number", optional)]
+    pub input_cost: Option<f64>,
+    #[ts(type = "number", optional)]
+    pub output_cost: Option<f64>,
+    #[ts(type = "number", optional)]
+    pub total_cost: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct GetTraceCostsResponse {
+    pub costs: Vec<TraceCostEntry>,
+}
+
+pub struct GetTraceCosts;
+
+impl ApiEndpoint for GetTraceCosts {
+    type Request<'a> = GetTraceCostsRequest;
+    type Response<'a> = GetTraceCostsResponse;
+
+    const PATH: &'static str = "/v1/traces/costs";
 }

--- a/engine/baml-rpc/src/ui/ui_types.rs
+++ b/engine/baml-rpc/src/ui/ui_types.rs
@@ -112,6 +112,9 @@ pub struct UiFunctionCall {
     #[ts(type = "unknown")]
     pub baml_options: serde_json::Value,
     pub inputs: Vec<UiFunctionInput>,
+    /// True when the inputs were too large and were truncated by the query
+    #[serde(default)]
+    pub inputs_truncated: bool,
     #[ts(as = "Option<BamlValue>")]
     pub output: serde_json::Value,
     pub error: Option<UiBamlFunctionCallError>,


### PR DESCRIPTION
## Summary

Unify minijinja `value-cmp` with current upstream `main` so studio2 builds against canary baml.

studio2 depends on baml-types (which uses minijinja's `value_cmp` from the `value-cmp` branch) AND directly on minijinja AST types (from `main`). When `value-cmp` and `main` resolve to different commits, cargo compiles two copies of `minijinja` and the AST type from one half doesn't match the other half, breaking `rust-src/usage/jinja2clickhouse.rs` (which constructs `boundary_udf::HashByPtr<minijinja::ast::Expr>` from one version against a function expecting the other).

This was previously masked because studio2's CI clones the `feb-17-studio` branch of baml, where the `value-cmp` branch happened to resolve to the same commit as `main`. Local builds against a current baml checkout (and any work against `canary`) hit the divergence.

## The fix — three coordinated PRs

**BoundaryML/minijinja — `value-cmp2`** ([PR](https://github.com/BoundaryML/minijinja/pull/new/value-cmp2))
- Cherry-picks the single `value-cmp` commit (`add value_cmp on top of custom_cmp`, 188 lines on `value/{mod,object}.rs` + a test) onto current upstream `main` (2.18.0). Auto-merges cleanly.
- Becomes the new shared branch both consumers point at.

**BoundaryML/baml — `port-feb17-rpc-to-canary` → `canary`** ([PR](https://github.com/BoundaryML/baml/pull/new/port-feb17-rpc-to-canary))
- Ports the feb-17-studio-only baml-rpc UI surface that studio2 references but canary lacks. Cumulative diff of 5 feb-17-studio commits (`add costs api`, `full text search param`, `traces model`, `update types`, `remove redundant object`):
  - `GetTraceCosts` / `GetTraceCostsRequest` / `GetTraceCostsResponse` / `TraceCostEntry` (new `/v1/traces/costs` endpoint)
  - `full_text_search: Option<bool>` on `ListTracesRequest`, `ListTraceFunctionSummariesRequest`, `GetTraceChildrenRequest`
  - Filter fields on `GetTraceChildrenRequest`: `search`, `status`, `tag_filters`, `error_filters`, `llm_only`
  - `matched_children_ids: Option<Vec<String>>` on `GetTraceChildrenResponse`
  - Slimmer `NodeDetails` (drops lazy-loading fields: `max_depth`, `children_loaded`, `children_limit`, `children_offset`, `matched_descendant_ids`)
  - `inputs_truncated: bool` on `UiFunctionCall`
- Switches `engine/Cargo.toml` minijinja + minijinja-contrib to `branch = "value-cmp2"`.
- Skips the `publisher.rs` revert (canary has the better lazy-init publisher) and the README/whitespace commits from feb-17-studio.

**BoundaryML/boundary-studio-2** (this PR)
- Switches root `Cargo.toml` minijinja from `branch = "main"` to `branch = "value-cmp2"` so the engine and studio2 resolve to one minijinja source.
- Updates `.github/workflows/build-project.yml` to clone the `port-feb17-rpc-to-canary` baml branch instead of `feb-17-studio` (since the RPC surface and minijinja branch now live there). Flip back to `canary` after the baml PR merges.

## Verification

With all three branches in place, `cargo build` in studio2 against canary baml compiles cleanly — exit 0, no errors (warnings only, pre-existing). CI on this PR exercises the same cargo build with the workflow pointing at the baml PR branch.

## Test plan

- [ ] `cargo build` succeeds locally
- [ ] studio2 CI build-and-test job passes
- [ ] All three PRs merged in order: minijinja → baml → studio2
- [ ] After baml PR merges, update studio2 workflow to clone `canary` instead of the PR branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trace cost analysis API endpoint for computing and retrieving trace costs.
  * Enhanced trace search with full-text search capability.
  * Improved trace filtering with richer search options including status, tags, and error-based filters.

* **Bug Fixes**
  * Added indicator for truncated function inputs in trace details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3512)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->