### PR TITLE
GC Fixes

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1593,6 +1593,7 @@ dependencies = [
  "bex_resource_types",
  "bex_vm_types",
  "indexmap 2.13.0",
+ "parking_lot",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -367,7 +367,7 @@ impl BexEngine {
                         ),
                     });
                 }
-                self.globals[global_index]
+                self.globals.as_slice()[global_index]
             }
         })
     }

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -358,16 +358,24 @@ impl BexEngine {
                 Value::Object(holder.holder_mut().tlab_mut().alloc_rust_data(arc))
             }
             BexExternalValue::FunctionRef { global_index } => {
-                if global_index >= self.globals.len() {
+                // `convert_external_to_vm_value` runs while `holder`'s
+                // active heap permit is held, so we route through the
+                // permit-proof-gated `SharedGlobals` API. The slice's
+                // lifetime is tied to the proof, which is bounded by
+                // `holder.proof()`'s borrow of `holder` — both end at the
+                // close of this function call.
+                let proof = holder.proof();
+                let len = self.globals.len(proof);
+                let slice = self.globals.as_slice(proof);
+                if global_index >= len {
                     return Err(EngineError::TypeMismatch {
                         message: format!(
-                            "FunctionRef global_index {} out of bounds (globals len {})",
-                            global_index,
-                            self.globals.len()
+                            "FunctionRef global_index {global_index} out of \
+                             bounds (globals len {len})"
                         ),
                     });
                 }
-                self.globals.as_slice()[global_index]
+                slice[global_index]
             }
         })
     }

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -274,6 +274,36 @@ impl FutureManagerGuard<'_> {
     /// `debug_assert` below encodes that invariant: if `complete_pending` ever
     /// observes a non-`Pending` heap state, a caller has violated the
     /// removal/transition contract.
+    ///
+    /// ## Why the Phase 1 `debug_assert` cannot trip for `Async` futures
+    ///
+    /// Concretely: there is exactly one writer per `future_id`, the writer
+    /// always observes `Pending` first, and no other code path can race a
+    /// non-Pending transition between the writer's observation and its own
+    /// terminal-state write. Trace:
+    ///
+    /// 1. **All `cancel_future` call sites** are at
+    ///    `crates/bex_engine/src/lib.rs:1508`, `:1528`, and `:1811`. The
+    ///    first two live inside the engine event loop, on the same VM that
+    ///    just allocated the future. Site `:1528` is inside the
+    ///    `SysOpResult::Ready` arm and so is unreachable for the
+    ///    `SysOpResult::Async` (`run_future`) path. Site `:1811` is inside
+    ///    `run_future` itself, of which there is exactly one task per
+    ///    `future_id`.
+    /// 2. **After the VM yields a permit at `Await` (`lib.rs:1594`)** and
+    ///    parks at `future.await`, the engine event loop is **not running**
+    ///    for that VM, so site `:1508` cannot fire either.
+    /// 3. **External `cancel_function_call`** (`lib.rs:1073`) only fires
+    ///    the cancel `CancellationToken` — it does **not** call
+    ///    `cancel_future`. Cancellation reaches the future only via
+    ///    `run_future`'s own `tokio::select!`, which then routes through
+    ///    site `:1811`.
+    ///
+    /// Conclusion: for `Async` futures, only the single `run_future` task
+    /// can transition `Pending` → terminal. Any future code change that
+    /// adds a fourth `cancel_future` call site (or that lets the engine
+    /// loop run for a parked VM) breaks this invariant — the
+    /// `debug_assert` below will catch it immediately.
     fn complete_pending(
         &mut self,
         id: FutureId,

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -153,10 +153,15 @@ impl FutureManagerGuard<'_> {
         (id, ptr)
     }
     pub fn fulfill_future(&mut self, id: FutureId, value: Value) -> Result<(), EngineError> {
-        self.complete_pending(id, |fut| {
+        // Snapshot the heap `Arc` before the borrow on `self` is taken by
+        // `complete_pending`; the closure needs it to fire the write barrier.
+        let heap = ::std::sync::Arc::clone(self.tlab().heap());
+        self.complete_pending(id, |fut, self_ptr| {
             // SAFETY: complete_pending guarantees we hold the `future_permit`
             // (single-writer invariant) and that `fut` is currently Pending.
-            unsafe { fut.set_ready(value) };
+            // `self_ptr` is the heap location of `fut`, so the write barrier
+            // marks the right card if `value` is a young heap pointer.
+            unsafe { fut.set_ready(heap.as_ref(), self_ptr, value) };
         })?;
         Ok(())
     }
@@ -172,15 +177,18 @@ impl FutureManagerGuard<'_> {
     /// (write here → variant in the heap object → throw in `Await`) so
     /// that wiring it up later is a one-call-site change.
     pub fn err_future(&mut self, id: FutureId, err: Value) -> Result<(), EngineError> {
-        self.complete_pending(id, |fut| {
+        let heap = ::std::sync::Arc::clone(self.tlab().heap());
+        self.complete_pending(id, |fut, self_ptr| {
             // SAFETY: see `fulfill_future`.
-            unsafe { fut.set_error(err) };
+            unsafe { fut.set_error(heap.as_ref(), self_ptr, err) };
         })?;
         Ok(())
     }
     pub fn cancel_future(&mut self, id: FutureId) -> Result<(), EngineError> {
-        let entry = self.complete_pending(id, |fut| {
-            // SAFETY: see `fulfill_future`.
+        let entry = self.complete_pending(id, |fut, _self_ptr| {
+            // SAFETY: see `fulfill_future`. `set_cancelled` writes only the
+            // discriminant tag, no `Value` payload, so no write barrier
+            // needed.
             unsafe { fut.set_cancelled() };
         })?;
         // The token is still cloned by the spawned sys-op task; firing it
@@ -269,7 +277,7 @@ impl FutureManagerGuard<'_> {
     fn complete_pending(
         &mut self,
         id: FutureId,
-        transition: impl FnOnce(&bex_vm_types::Future),
+        transition: impl FnOnce(&bex_vm_types::Future, HeapPtr),
     ) -> Result<FutureState, EngineError> {
         // Phase 1: pre-check the state without removing. A non-Pending
         // heap state means the caller has already routed this id through
@@ -311,7 +319,7 @@ impl FutureManagerGuard<'_> {
         // SAFETY: the entry is still rooting the heap object via local
         // ownership; the `FutureManager` Mutex enforces single-writer.
         let fut = unsafe { entry.future_ref() }?;
-        transition(fut);
+        transition(fut, entry.future);
         let set = entry.ready.set(Ok(()));
         debug_assert!(
             set.is_ok(),

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -91,7 +91,8 @@ pub use bex_heap::GcStats;
 pub use bex_heap::{ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapPermit};
 use bex_vm::{BexVm, SpanNotification, VmExecState};
 use bex_vm_types::{
-    FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SysOp, Value, VmGlobals,
+    FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SharedGlobals, SysOp, Value,
+    VmGlobals,
 };
 pub use conversion::test_arg_to_external;
 // Re-export CancellationToken for callers.
@@ -389,7 +390,19 @@ pub struct BexEngine {
     /// Populated once during `$init` and immutable thereafter; cloning is a
     /// cheap refcount bump (see `VmGlobals::Shared`). The VM rejects any
     /// `StoreGlobal` against this view as a `VmInternalError`.
-    globals: Arc<[Value]>,
+    ///
+    /// Stored as a [`SharedGlobals`] (rather than a plain `Arc<[Value]>`)
+    /// so the GC can trace + forward `Value::Object(HeapPtr)` entries: the
+    /// engine registers a clone of this `SharedGlobals` as a [`RootHaver`]
+    /// permit holder during `BexEngine::new`. Without that registration any
+    /// runtime heap object stored in a top-level `let` global was invisible
+    /// to GC and could be reclaimed mid-call.
+    globals: SharedGlobals,
+    /// Permit holder that keeps `globals` registered with the
+    /// `HeapPermitManager`. The engine never `acquire()`s this — it exists
+    /// purely so the GC's `collect_roots`/`forward_roots` walks reach the
+    /// frozen globals pool.
+    _globals_permit: bex_heap::InactiveHeapPermit<SharedGlobals>,
     /// Resolved function/class/enum names for lookup
     resolved_function_names: HashMap<String, (HeapPtr, bex_vm_types::FunctionKind)>,
     /// Resolved class names for instance allocation (`IndexMap` preserves definition order)
@@ -618,11 +631,13 @@ impl BexEngine {
             }
         }
 
-        // Freeze the now-populated globals into a shared `Arc<[Value]>`. Every
-        // post-`$init` VM cloned into a `call_function` invocation reads from
-        // this exact `Arc`. `StoreGlobal` against this shared view is rejected
-        // by the VM as `VmInternalError::StoreGlobalAfterInit`.
-        let globals: Arc<[Value]> = Arc::from(globals_pool.0);
+        // Freeze the now-populated globals into a `SharedGlobals` so the GC
+        // can trace + forward `Value::Object(HeapPtr)` entries. Every
+        // post-`$init` VM cloned into a `call_function` invocation reads
+        // from this shared instance via `VmGlobals::Shared(globals.clone())`.
+        // `StoreGlobal` against the shared view is rejected by the VM as
+        // `VmInternalError::StoreGlobalAfterInit`.
+        let globals = SharedGlobals::from_vec(globals_pool.0);
 
         // Build SysOpContext by pre-extracting LLM function metadata from the heap.
         // This avoids passing raw HeapPtrs to sys_ops.
@@ -647,6 +662,16 @@ impl BexEngine {
                 .new_permit(FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap)))),
         );
 
+        // Register the frozen globals pool as its own permit holder so the
+        // GC traces and forwards `Value::Object(HeapPtr)` entries (e.g.
+        // top-level `let g = [1, 2, 3]` populated during `$init`). The
+        // permit is never `acquire()`d — its sole job is to participate in
+        // `HeapGuard::collect_roots` / `forward_roots` walks. The
+        // `SharedGlobals` is `Clone` (Arc bump), so the holder and the
+        // engine's own field point at the same `UnsafeCell<Box<[Value]>>`.
+        let globals_permit =
+            futures::executor::block_on(heap_permit_manager.new_permit(globals.clone()));
+
         // Build a default RuntimeIo from the SysOps table with an empty context.
         // This is replaced per-call in execute_sys_op with a live context that
         // carries the correct cancellation token and spawner.
@@ -670,6 +695,7 @@ impl BexEngine {
         Ok(Self {
             heap,
             globals,
+            _globals_permit: globals_permit,
             resolved_function_names,
             resolved_class_names,
             resolved_enum_names,
@@ -980,7 +1006,7 @@ impl BexEngine {
         // Globals are shared as a frozen `Arc<[Value]>` — cloning is a refcount bump.
         let vm = BexVm::new(
             Arc::clone(&self.heap),
-            VmGlobals::Shared(Arc::clone(&self.globals)),
+            VmGlobals::Shared(self.globals.clone()),
             self.resolved_class_names
                 .iter()
                 .chain(self.resolved_enum_names.iter())

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -930,10 +930,44 @@ impl BexEngine {
         // Run GC — always returns the forwarding map so we can update parked VM stacks.
         let (stats, _remapped_roots, forwarding) =
             unsafe { self.heap.collect_garbage_generational(&all_roots, level) };
+
+        // Bug H, check 1 (heap_debug only): every pointer the GC was told
+        // about (`all_roots`) must end up in the forwarding map. If a
+        // holder's `collect_roots` produces a pointer the GC's BFS does
+        // not reach, the subsequent `forward_roots` will leave a stale
+        // reference behind. This assertion turns that silent class of
+        // bug into an immediate panic during stress tests.
+        #[cfg(feature = "heap_debug")]
+        for &ptr in &all_roots {
+            assert!(
+                forwarding.contains_key(&ptr),
+                "heap_debug: post-GC integrity sweep — root {ptr:?} was not \
+                 reached by the GC BFS (collect_roots produced it but it is \
+                 not in the forwarding map)"
+            );
+        }
+
         // Update all parked VM stacks with forwarding pointers and invalidate TLABs
         // SAFETY: VMs are still parked (gc_complete not yet notified), we have
         // exclusive access via the parked_vms lock we're still holding
         heap_guard.forward_roots(&forwarding);
+
+        // Bug H, check 3 (heap_debug only): after `forward_roots`, no
+        // holder root should still point into the inactive (former
+        // active) space. If any does, `forward_roots` missed it — the
+        // stale pointer would dereference into freed/poisoned memory.
+        #[cfg(feature = "heap_debug")]
+        {
+            let mut roots_after = self.heap.collect_handle_roots();
+            heap_guard.collect_roots(&mut roots_after);
+            for &ptr in &roots_after {
+                assert!(
+                    !self.heap.debug_ptr_in_inactive(ptr),
+                    "heap_debug: post-forward_roots — root {ptr:?} still points \
+                     into the inactive space (forward_roots missed it)"
+                );
+            }
+        }
 
         self.heap.verify_quick();
 

--- a/baml_language/crates/bex_engine/tests/gc_during_future_op.rs
+++ b/baml_language/crates/bex_engine/tests/gc_during_future_op.rs
@@ -34,7 +34,6 @@ fn make_engine(source: &str) -> Arc<BexEngine> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "temporarily disabled: flaky GC/future interaction panics in chunked_vec"]
 async fn no_deadlock_between_gc_and_concurrent_schedule_future() {
     // Pre-fix this hung once a VM started a `ScheduleFuture` critical section
     // and another VM concurrently entered `request_park`: GC's
@@ -106,7 +105,6 @@ async fn no_deadlock_between_gc_and_concurrent_schedule_future() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "temporarily disabled: flaky GC/future interaction panics in chunked_vec"]
 async fn gc_during_await_completes_promptly() {
     // Single call that schedules a future and awaits it; concurrent GC
     // requests must not block that progress. This isolates the `Await`

--- a/baml_language/crates/bex_heap/Cargo.toml
+++ b/baml_language/crates/bex_heap/Cargo.toml
@@ -13,6 +13,7 @@ bex_external_types = { workspace = true }
 bex_resource_types = { workspace = true }
 bex_vm_types = { workspace = true }
 indexmap = { workspace = true }
+parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [ "sync" ] }
 

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -6,9 +6,9 @@
 
 use baml_type::Ty;
 use bex_external_types::{BexExternalAdt, BexExternalValue, WeakHeapRef};
-use bex_vm_types::{HeapPtr, Object, Value};
+use bex_vm_types::{HeapPtr, Object, PermitProof, Value};
 
-use crate::{BexHeap, heap_guard::PermitProof};
+use crate::BexHeap;
 
 #[derive(Debug, PartialEq, thiserror::Error, Clone)]
 pub enum AccessError {

--- a/baml_language/crates/bex_heap/src/chunked_vec.rs
+++ b/baml_language/crates/bex_heap/src/chunked_vec.rs
@@ -917,25 +917,39 @@ mod tests {
     fn test_set_concurrent_with_resize_does_not_uaf() {
         use std::{sync::Arc, thread};
 
+        const NUM_SETTERS: usize = 4;
+        const SLOTS_PER_SETTER: usize = 2;
         // Chunk size of 2 so each `resize_to(N)` adds chunks, exercising
         // the outer-Vec growth path frequently.
         let vec: Arc<ChunkedVec<i32, 2>> = Arc::new(ChunkedVec::new());
-        // Pre-populate slots that the setters will hammer.
-        vec.resize_to(2);
+        // Pre-allocate one dedicated slot range per setter so the
+        // concurrent `set()` calls write **disjoint** indices — that's
+        // `set`'s actual safety contract. Multiple writers to the same
+        // index would be UB even on top of the `chunks_lock` RwLock fix.
+        vec.resize_to(NUM_SETTERS * SLOTS_PER_SETTER);
 
-        let setters: Vec<_> = (0..4)
+        let setters: Vec<_> = (0..NUM_SETTERS)
             .map(|tid| {
                 let vec = Arc::clone(&vec);
                 thread::spawn(move || {
+                    let base = tid * SLOTS_PER_SETTER;
                     for i in 0..200 {
-                        // SAFETY: Different `tid` values write the same
-                        // index but the test does not assert on the
-                        // intermediate value — we only care that no UAF
-                        // occurs. Final-value semantics are race-resolved
-                        // by the last writer.
+                        // SAFETY: each thread owns the slot range
+                        // `[tid*SLOTS_PER_SETTER, (tid+1)*SLOTS_PER_SETTER)`
+                        // exclusively, so the concurrent `set`s observe
+                        // `set`'s "different indices only" contract.
+                        // What we *are* racing is the outer-Vec buffer
+                        // pointer read inside `set`/`element_ptr` against
+                        // the grower thread's `resize_with` + `Vec::push`.
                         unsafe {
-                            vec.set(0, tid * 1000 + i);
-                            vec.set(1, tid * 1000 + i + 1);
+                            for slot in 0..SLOTS_PER_SETTER {
+                                #[expect(
+                                    clippy::cast_possible_wrap,
+                                    reason = "test data, values stay small"
+                                )]
+                                let value = (tid * 1_000 + i) as i32 + slot as i32;
+                                vec.set(base + slot, value);
+                            }
                         }
                     }
                 })
@@ -947,7 +961,8 @@ mod tests {
             // Grow past several outer-Vec capacity-doubling boundaries
             // (4 → 8 → 16 → 32 …): with chunk_size=2, every other
             // resize_to bump triggers another outer-Vec push.
-            for n in (2..400).step_by(2) {
+            let start = NUM_SETTERS * SLOTS_PER_SETTER;
+            for n in (start..400).step_by(2) {
                 grower_vec.resize_to(n);
             }
         });
@@ -957,10 +972,11 @@ mod tests {
         }
         grower.join().expect("grower panicked");
 
-        // Best-effort sanity: the slots are still readable; the vec did not
-        // wedge or panic with `len=0`.
-        assert!(*vec.get(0) >= 0);
-        assert!(*vec.get(1) >= 0);
-        assert!(vec.len() >= 2);
+        // Best-effort sanity: every slot the setters owned is still
+        // readable and the vec didn't wedge with `len=0`.
+        for idx in 0..NUM_SETTERS * SLOTS_PER_SETTER {
+            assert!(*vec.get(idx) >= 0);
+        }
+        assert!(vec.len() >= NUM_SETTERS * SLOTS_PER_SETTER);
     }
 }

--- a/baml_language/crates/bex_heap/src/chunked_vec.rs
+++ b/baml_language/crates/bex_heap/src/chunked_vec.rs
@@ -33,15 +33,31 @@
 //! # Thread Safety
 //!
 //! `ChunkedVec` is designed for the following concurrent access pattern:
-//! - Multiple threads can call `set()` on different indices concurrently
-//! - One thread can call `resize_with()` while others call `set()` on existing indices
-//! - `resize_with()` must be externally synchronized (only one thread at a time)
+//! - Multiple threads can call `set()` on different indices concurrently.
+//! - `resize_with()` / `push_with()` may run concurrently with any number
+//!   of `set()` / `get_ptr()` / `get()` callers; they serialize internally.
+//! - Multiple threads may call `resize_with()` / `push_with()` concurrently;
+//!   they serialize internally on a write lock.
 //!
 //! This is achieved by:
-//! - Using `AtomicUsize` for the length
-//! - Using raw pointer operations to avoid `&mut` reborrows that conflict with Miri's
-//!   stacked borrows model
-//! - Using `UnsafeCell` for each element
+//! - Using `AtomicUsize` for the length so readers see monotonically
+//!   increasing valid ranges.
+//! - Holding an internal `parking_lot::RwLock<()>` (`chunks_lock`) around
+//!   any access to the **outer** `Vec<Box<[…]>>`'s `(ptr, len, cap)`
+//!   triple. Growth (`resize_with`/`push_with`) takes the write lock so a
+//!   `Vec::push` that reallocates the outer buffer cannot race a reader
+//!   reading the buffer pointer; readers (`element_ptr`, `num_chunks`,
+//!   etc.) take the read lock for the brief window in which they read
+//!   `(*chunks_ptr).as_ptr()`.
+//! - Using raw pointer operations to avoid `&mut Vec` reborrows that
+//!   conflict with Miri's stacked borrows model.
+//! - Using `UnsafeCell` for each element so per-slot writes are gated by
+//!   the caller's own exclusivity (typically per-TLAB region).
+//!
+//! Inner-chunk access is **not** lock-gated: each chunk is its own
+//! heap-allocated `Box<[UnsafeCell<T>]>` whose address is stable for the
+//! lifetime of the `ChunkedVec`. Once `element_ptr` has resolved a slot's
+//! address, that pointer remains valid after the read lock is dropped.
 //!
 //! # Future Optimization: Virtual Memory Approach
 //!
@@ -86,6 +102,8 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use parking_lot::RwLock;
+
 /// Default chunk size (number of elements per chunk).
 ///
 /// This MUST be a power of 2 for efficient index calculation (shift + AND
@@ -122,12 +140,33 @@ const _: () = assert!(
 pub struct ChunkedVec<T, const CHUNK_SIZE: usize = DEFAULT_CHUNK_SIZE> {
     /// Storage chunks. Each chunk is heap-allocated and never moves.
     /// This is wrapped in UnsafeCell for interior mutability during resize.
-    /// Access to this field must be synchronized externally for resize operations.
     ///
     /// IMPORTANT: To avoid data races detected by Miri's stacked borrows, we never
     /// create `&mut Vec<...>` references to this field. Instead, we use raw pointer
     /// operations throughout.
     chunks: UnsafeCell<Vec<Box<[UnsafeCell<T>]>>>,
+
+    /// Synchronizes access to the **outer** `chunks` `Vec`'s (ptr, len, cap)
+    /// triple — *not* to the inner chunks themselves (those are individually
+    /// heap-allocated `Box<[UnsafeCell<T>]>`s and never move once pushed).
+    ///
+    /// - `resize_with` / `push_with` / `clear` take the **write** lock around
+    ///   any read/mutation of the outer Vec.
+    /// - `element_ptr`, `num_chunks`, `chunk_start_ptr`, `capacity`, etc. take
+    ///   the **read** lock for the brief window in which they read
+    ///   `(*chunks_ptr).as_ptr()` (the outer Vec's heap buffer pointer).
+    ///   Once the read lock has handed back a stable inner-chunk pointer, the
+    ///   read lock is dropped — subsequent dereferences go through the
+    ///   never-moving inner chunk and need no synchronization beyond the
+    ///   `UnsafeCell` already gating per-element exclusivity.
+    ///
+    /// This closes a UB hole in the previous design where a concurrent
+    /// `Vec::push` (inside `resize_with`) reallocating the outer Vec's heap
+    /// buffer raced with `set` / `get_ptr` callers reading the same buffer
+    /// pointer non-atomically. The buffer pointer can no longer change while
+    /// any reader holds the read lock, so a freed buffer can never be
+    /// dereferenced.
+    chunks_lock: RwLock<()>,
 
     /// Number of elements in the vec (not capacity).
     /// Uses AtomicUsize for safe concurrent reads.
@@ -156,6 +195,7 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
 
         Self {
             chunks: UnsafeCell::new(Vec::new()),
+            chunks_lock: RwLock::new(()),
             len: AtomicUsize::new(0),
         }
     }
@@ -184,7 +224,9 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
     /// Get the total capacity (number of slots across all chunks).
     #[inline]
     pub fn capacity(&self) -> usize {
-        // SAFETY: We only read the length of the Vec via raw pointer
+        let _read = self.chunks_lock.read();
+        // SAFETY: read lock excludes concurrent resize; we only read the
+        // outer Vec's len.
         unsafe {
             let chunks_ptr = self.chunks.get();
             (*chunks_ptr).len() * CHUNK_SIZE
@@ -193,15 +235,13 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
 
     /// Get the number of allocated chunks.
     ///
-    /// # Safety
-    ///
-    /// Reads the chunks `Vec`'s non-atomic length through an `UnsafeCell`.
-    /// The caller must ensure the underlying chunks `Vec` is not being grown
-    /// concurrently — i.e., call at a GC safepoint or while holding exclusive
-    /// access to this `ChunkedVec`.
+    /// Internally takes the read side of `chunks_lock`, so this is safe to
+    /// call concurrently with `set`/`get_ptr` and is excluded only by an
+    /// in-flight `resize_with`/`push_with`/`clear`.
     #[inline]
-    pub unsafe fn num_chunks(&self) -> usize {
-        // SAFETY: Caller upholds the no-concurrent-growth contract.
+    pub fn num_chunks(&self) -> usize {
+        let _read = self.chunks_lock.read();
+        // SAFETY: read lock excludes concurrent resize.
         unsafe { (*self.chunks.get()).len() }
     }
 
@@ -209,15 +249,22 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
     ///
     /// # Safety
     ///
-    /// - The caller must ensure the chunks `Vec` is not being grown concurrently
-    ///   (see [`num_chunks`](Self::num_chunks)).
     /// - `chunk_idx` must be `< num_chunks()`.
+    ///
+    /// The returned pointer remains valid as long as the chunk exists; the
+    /// chunk itself is heap-allocated and never moves (only the outer Vec's
+    /// buffer can move on growth, and that race is closed by taking the
+    /// read lock around the buffer-pointer dereference here).
     #[inline]
     pub unsafe fn chunk_start_ptr(&self, chunk_idx: usize) -> *const T {
-        // SAFETY: Caller upholds no-concurrent-growth and bounds preconditions.
+        let _read = self.chunks_lock.read();
+        // SAFETY: read lock excludes concurrent resize. Caller upholds the
+        // bounds precondition.
         unsafe {
-            let chunks = &*self.chunks.get();
-            chunks[chunk_idx].as_ptr() as *const T
+            let chunks_ptr = self.chunks.get();
+            let chunks_data_ptr = (*chunks_ptr).as_ptr();
+            let chunk_box_ptr = chunks_data_ptr.add(chunk_idx);
+            (*chunk_box_ptr).as_ptr() as *const T
         }
     }
 
@@ -234,23 +281,44 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
 
     /// Get a raw pointer to the element at (chunk_idx, offset) without creating references.
     ///
+    /// Acquires `chunks_lock` in **read** mode for the brief window in which
+    /// the outer Vec's buffer pointer is read. The returned pointer points
+    /// into a heap-allocated `Box<[UnsafeCell<T>]>` whose address never
+    /// changes, so it remains valid after the read lock is dropped.
+    ///
     /// # Safety
     ///
     /// - chunk_idx must be < number of chunks
     /// - offset must be < CHUNK_SIZE
     #[inline]
     unsafe fn element_ptr(&self, chunk_idx: usize, offset: usize) -> *mut T {
+        let _read = self.chunks_lock.read();
+        // SAFETY: the read lock excludes any concurrent `Vec::push` that
+        // could realloc the outer Vec's buffer. The inner chunk's `Box`
+        // address is itself stable across the lifetime of the chunk, so the
+        // returned `*mut T` remains valid after we drop `_read`.
+        unsafe { self.element_ptr_locked(chunk_idx, offset) }
+    }
+
+    /// Lock-free helper for [`Self::element_ptr`].
+    ///
+    /// # Safety
+    ///
+    /// In addition to the bounds preconditions of `element_ptr`, the caller
+    /// must already hold the `chunks_lock` (read or write). Used by
+    /// [`Self::push_with`] which holds the write lock and would deadlock if
+    /// `element_ptr` tried to take the read lock again (`parking_lot::RwLock`
+    /// is not reentrant).
+    #[inline]
+    unsafe fn element_ptr_locked(&self, chunk_idx: usize, offset: usize) -> *mut T {
+        // SAFETY: caller upholds the lock-held precondition; bounds are
+        // checked by the caller.
         unsafe {
             let chunks_ptr = self.chunks.get();
-            // Get pointer to the Vec's internal buffer
             let chunks_data_ptr = (*chunks_ptr).as_ptr();
-            // Get pointer to the specific chunk (Box<[UnsafeCell<T>]>)
             let chunk_box_ptr = chunks_data_ptr.add(chunk_idx);
-            // Dereference to get the Box, then get the slice pointer
             let chunk_slice_ptr = (*chunk_box_ptr).as_ptr();
-            // Get pointer to the specific element
             let element_cell_ptr = chunk_slice_ptr.add(offset);
-            // Get the inner pointer from UnsafeCell
             (*element_cell_ptr).get()
         }
     }
@@ -274,16 +342,17 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
     /// Ensure capacity for at least `min_len` elements, using a factory function.
     ///
     /// If the current capacity is insufficient, new chunks are allocated.
-    /// Existing chunks are never moved.
+    /// Existing chunks are never moved (each is its own heap-allocated
+    /// `Box<[UnsafeCell<T>]>`).
     ///
     /// This also sets len to min_len, filling new slots with values from the factory.
     ///
-    /// # Safety
-    ///
-    /// This method must be externally synchronized - only one thread can call
-    /// resize_with at a time. However, other threads can safely call `set()` or
-    /// `get()` on existing indices while this is running.
-    pub unsafe fn resize_with<F2: FnMut() -> T>(&self, min_len: usize, mut factory: F2) {
+    /// Internally takes the **write** side of `chunks_lock` so that any
+    /// `set` / `get_ptr` reader concurrently reading the outer Vec's buffer
+    /// pointer is excluded for the duration of the `Vec::push`. Without this
+    /// exclusion, the outer Vec's heap buffer can be reallocated underneath
+    /// a concurrent reader (use-after-free).
+    pub fn resize_with<F2: FnMut() -> T>(&self, min_len: usize, mut factory: F2) {
         let current_len = self.len.load(Ordering::Acquire);
         if min_len <= current_len {
             return;
@@ -292,13 +361,12 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
         // Calculate how many chunks we need
         let needed_chunks = min_len.div_ceil(CHUNK_SIZE);
 
-        // SAFETY: Caller ensures only one thread is resizing at a time.
-        // Other threads may be accessing existing chunks via set(), but we only
-        // append new chunks - we never touch existing ones.
-        //
-        // CRITICAL: We use raw pointer operations here to avoid creating a `&mut Vec`
-        // which would conflict with concurrent `&Vec` accesses in set() under Miri's
-        // stacked borrows model.
+        // Acquire the write lock so concurrent `element_ptr` callers cannot
+        // read a torn outer-Vec buffer pointer while we push & potentially
+        // realloc.
+        let _write = self.chunks_lock.write();
+
+        // SAFETY: write lock provides exclusive access to the outer Vec.
         unsafe {
             let chunks_ptr = self.chunks.get();
 
@@ -326,15 +394,17 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
     ///
     /// Returns the index of the pushed element.
     ///
-    /// # Safety
-    ///
-    /// This method must be externally synchronized - only one thread can push
-    /// at a time.
-    pub unsafe fn push_with<F2: FnMut() -> T>(&self, value: T, mut factory: F2) -> usize {
+    /// Internally takes the **write** side of `chunks_lock` so concurrent
+    /// `set` / `get_ptr` readers cannot observe a torn outer-Vec buffer
+    /// pointer while we may grow & realloc.
+    pub fn push_with<F2: FnMut() -> T>(&self, value: T, mut factory: F2) -> usize {
         let index = self.len.load(Ordering::Acquire);
 
-        // SAFETY: Caller ensures only one thread is pushing at a time.
-        // Use raw pointer operations to avoid &mut reborrow.
+        // Hold the write lock for the entire push-and-write so concurrent
+        // `element_ptr` readers cannot race the realloc.
+        let _write = self.chunks_lock.write();
+
+        // SAFETY: write lock provides exclusive access to the outer Vec.
         unsafe {
             let chunks_ptr = self.chunks.get();
             let current_chunk_count = (*chunks_ptr).len();
@@ -348,10 +418,12 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
                 (*chunks_ptr).push(chunk);
             }
 
-            // Write the value
+            // Write the value. Use the lock-free helper since we already
+            // hold the write lock — calling `element_ptr` here would
+            // deadlock on the non-reentrant parking_lot RwLock.
             let (chunk_idx, offset) = self.chunk_location(index);
-            // SAFETY: Index is within allocated range, we have exclusive push access
-            let elem_ptr = self.element_ptr(chunk_idx, offset);
+            // SAFETY: Index is within allocated range; we hold the write lock.
+            let elem_ptr = self.element_ptr_locked(chunk_idx, offset);
             // Drop the factory-created placeholder before writing the actual value
             std::ptr::drop_in_place(elem_ptr);
             std::ptr::write(elem_ptr, value);
@@ -482,22 +554,16 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
 impl<T: Default, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
     /// Ensure capacity for at least `min_len` elements.
     ///
-    /// # Safety
-    ///
-    /// See `resize_with`.
-    pub unsafe fn resize_to(&self, min_len: usize) {
-        // SAFETY: Caller ensures proper synchronization
-        unsafe { self.resize_with(min_len, T::default) }
+    /// See [`Self::resize_with`].
+    pub fn resize_to(&self, min_len: usize) {
+        self.resize_with(min_len, T::default);
     }
 
     /// Push an element, allocating a new chunk if needed.
     ///
-    /// # Safety
-    ///
-    /// See `push_with`.
-    pub unsafe fn push(&self, value: T) -> usize {
-        // SAFETY: Caller ensures proper synchronization
-        unsafe { self.push_with(value, T::default) }
+    /// See [`Self::push_with`].
+    pub fn push(&self, value: T) -> usize {
+        self.push_with(value, T::default)
     }
 }
 
@@ -576,15 +642,13 @@ mod tests {
     fn test_push_and_get() {
         let vec: ChunkedVec<i32, 4> = ChunkedVec::new();
 
-        unsafe {
-            let idx0 = vec.push(10);
-            let idx1 = vec.push(20);
-            let idx2 = vec.push(30);
+        let idx0 = vec.push(10);
+        let idx1 = vec.push(20);
+        let idx2 = vec.push(30);
 
-            assert_eq!(idx0, 0);
-            assert_eq!(idx1, 1);
-            assert_eq!(idx2, 2);
-        }
+        assert_eq!(idx0, 0);
+        assert_eq!(idx1, 1);
+        assert_eq!(idx2, 2);
         assert_eq!(vec.len(), 3);
 
         assert_eq!(*vec.get(0), 10);
@@ -596,11 +660,9 @@ mod tests {
     fn test_push_across_chunks() {
         let vec: ChunkedVec<i32, 2> = ChunkedVec::new();
 
-        unsafe {
-            // Push 5 elements (requires 3 chunks with chunk_size=2)
-            for i in 0..5 {
-                vec.push(i * 10);
-            }
+        // Push 5 elements (requires 3 chunks with chunk_size=2)
+        for i in 0..5 {
+            vec.push(i * 10);
         }
 
         assert_eq!(vec.len(), 5);
@@ -615,7 +677,7 @@ mod tests {
     fn test_resize_to() {
         let vec: ChunkedVec<i32, 4> = ChunkedVec::new();
 
-        unsafe { vec.resize_to(10) };
+        vec.resize_to(10);
 
         assert_eq!(vec.len(), 10);
         assert!(vec.capacity() >= 10);
@@ -629,8 +691,9 @@ mod tests {
     #[test]
     fn test_set() {
         let vec: ChunkedVec<i32, 4> = ChunkedVec::new();
-        unsafe { vec.resize_to(5) };
+        vec.resize_to(5);
 
+        // SAFETY: single-threaded test, no concurrent access to slot 2.
         unsafe {
             vec.set(2, 42);
         }
@@ -642,10 +705,8 @@ mod tests {
     fn test_clear() {
         let mut vec: ChunkedVec<i32, 4> = ChunkedVec::new();
 
-        unsafe {
-            for i in 0..10 {
-                vec.push(i);
-            }
+        for i in 0..10 {
+            vec.push(i);
         }
 
         assert_eq!(vec.len(), 10);
@@ -660,10 +721,8 @@ mod tests {
     fn test_get_mut() {
         let mut vec: ChunkedVec<i32, 4> = ChunkedVec::new();
 
-        unsafe {
-            vec.push(10);
-            vec.push(20);
-        }
+        vec.push(10);
+        vec.push(20);
 
         *vec.get_mut(1) = 99;
 
@@ -674,10 +733,8 @@ mod tests {
     fn test_iter() {
         let vec: ChunkedVec<i32, 2> = ChunkedVec::new();
 
-        unsafe {
-            for i in 0..5 {
-                vec.push(i * 10);
-            }
+        for i in 0..5 {
+            vec.push(i * 10);
         }
 
         let collected: Vec<i32> = vec.iter().copied().collect();
@@ -688,10 +745,8 @@ mod tests {
     fn test_iter_mut() {
         let mut vec: ChunkedVec<i32, 2> = ChunkedVec::new();
 
-        unsafe {
-            for i in 0..5 {
-                vec.push(i);
-            }
+        for i in 0..5 {
+            vec.push(i);
         }
 
         for elem in vec.iter_mut() {
@@ -706,19 +761,19 @@ mod tests {
     fn test_pointer_stability() {
         let vec: ChunkedVec<i32, 2> = ChunkedVec::new();
 
-        unsafe { vec.push(42) };
+        vec.push(42);
 
         // Get pointer to first element
         let ptr = vec.get_ptr(0);
 
         // Push more elements, causing chunk allocation
-        unsafe {
-            for i in 0..10 {
-                vec.push(i);
-            }
+        for i in 0..10 {
+            vec.push(i);
         }
 
         // Original pointer should still be valid
+        // SAFETY: chunks never move once allocated, so the original
+        // pointer remains valid even across concurrent growth.
         unsafe {
             assert_eq!(*ptr, 42);
         }
@@ -735,10 +790,8 @@ mod tests {
     fn test_large_allocation() {
         let vec: ChunkedVec<i32, 1024> = ChunkedVec::new();
 
-        unsafe {
-            for i in 0..10_000 {
-                vec.push(i);
-            }
+        for i in 0..10_000 {
+            vec.push(i);
         }
 
         assert_eq!(vec.len(), 10_000);
@@ -788,8 +841,9 @@ mod tests {
         let vec: Arc<ChunkedVec<i32, 2>> = Arc::new(ChunkedVec::new());
 
         // Pre-populate with initial data
+        vec.resize_to(2);
+        // SAFETY: single-threaded set-up; the slot is uniquely written here.
         unsafe {
-            vec.resize_to(2);
             vec.set(0, 42);
             vec.set(1, 43);
         }
@@ -822,9 +876,7 @@ mod tests {
         let writer = thread::spawn(move || {
             for i in 1..100 {
                 let new_len = 2 + (i * 2);
-                unsafe {
-                    vec_writer.resize_to(new_len);
-                }
+                vec_writer.resize_to(new_len);
             }
         });
 
@@ -834,9 +886,81 @@ mod tests {
         // Verify the original values are still accessible via the pointers
         let ptr0 = ptr0_addr as *const i32;
         let ptr1 = ptr1_addr as *const i32;
+        // SAFETY: chunks never move once allocated; the pointers remain valid.
         unsafe {
             assert_eq!(*ptr0, 42);
             assert_eq!(*ptr1, 43);
         }
+    }
+
+    /// Regression test for the outer-`Vec`-realloc / `set` race that motivated
+    /// the `chunks_lock` `RwLock<()>`.
+    ///
+    /// **Pre-fix behavior:** `set` (via `element_ptr`) read
+    /// `(*chunks.get()).as_ptr()` non-atomically. Concurrent `resize_with`
+    /// callers `Vec::push`-ed onto the outer `Vec`, which can reallocate the
+    /// outer buffer and free the old pointer. A `set` reader caught
+    /// mid-realloc would dereference freed memory — UAF / SIGSEGV.
+    ///
+    /// **Post-fix:** `resize_with` takes the outer-Vec write lock, and `set`
+    /// (via `element_ptr`) takes the outer-Vec read lock for the brief
+    /// window of the buffer-pointer read. `Vec::push` cannot run while a
+    /// reader holds the read lock; readers cannot start while a `Vec::push`
+    /// holds the write lock.
+    ///
+    /// This test launches one writer that grows the outer `Vec` past
+    /// multiple capacity-doubling boundaries while several writers race
+    /// `set` against the existing chunk's slots. Without the fix, Miri
+    /// (or sufficient real-world contention) catches the UAF; with the fix,
+    /// every iteration completes cleanly.
+    #[test]
+    fn test_set_concurrent_with_resize_does_not_uaf() {
+        use std::{sync::Arc, thread};
+
+        // Chunk size of 2 so each `resize_to(N)` adds chunks, exercising
+        // the outer-Vec growth path frequently.
+        let vec: Arc<ChunkedVec<i32, 2>> = Arc::new(ChunkedVec::new());
+        // Pre-populate slots that the setters will hammer.
+        vec.resize_to(2);
+
+        let setters: Vec<_> = (0..4)
+            .map(|tid| {
+                let vec = Arc::clone(&vec);
+                thread::spawn(move || {
+                    for i in 0..200 {
+                        // SAFETY: Different `tid` values write the same
+                        // index but the test does not assert on the
+                        // intermediate value — we only care that no UAF
+                        // occurs. Final-value semantics are race-resolved
+                        // by the last writer.
+                        unsafe {
+                            vec.set(0, tid * 1000 + i);
+                            vec.set(1, tid * 1000 + i + 1);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        let grower_vec = Arc::clone(&vec);
+        let grower = thread::spawn(move || {
+            // Grow past several outer-Vec capacity-doubling boundaries
+            // (4 → 8 → 16 → 32 …): with chunk_size=2, every other
+            // resize_to bump triggers another outer-Vec push.
+            for n in (2..400).step_by(2) {
+                grower_vec.resize_to(n);
+            }
+        });
+
+        for s in setters {
+            s.join().expect("setter panicked");
+        }
+        grower.join().expect("grower panicked");
+
+        // Best-effort sanity: the slots are still readable; the vec did not
+        // wedge or panic with `len=0`.
+        assert!(*vec.get(0) >= 0);
+        assert!(*vec.get(1) >= 0);
+        assert!(vec.len() >= 2);
     }
 }

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -1794,10 +1794,14 @@ mod tests {
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
         let result = tlab.alloc_string("result".to_string());
-        let future = Future::pending(FutureId::from_usize(0));
-        // SAFETY: single-writer; this Future is local and not yet visible.
-        unsafe { future.set_ready(Value::Object(result)) };
-        let future_ptr = tlab.alloc(Object::Future(future));
+        // Allocate the Future in `Pending` state first so we have a real
+        // `HeapPtr` to pass to `set_ready` for its write-barrier hook.
+        let future_ptr = tlab.alloc(Object::Future(Future::pending(FutureId::from_usize(0))));
+        let Object::Future(future) = (unsafe { future_ptr.get() }) else {
+            panic!("expected Object::Future");
+        };
+        // SAFETY: single-writer; the heap object was just allocated locally.
+        unsafe { future.set_ready(heap.as_ref(), future_ptr, Value::Object(result)) };
 
         let roots = vec![future_ptr];
         let (stats, new_roots, _) = unsafe { heap.collect_garbage(&roots) };
@@ -1822,10 +1826,14 @@ mod tests {
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
-        let future = Future::pending(FutureId::from_usize(0));
-        // SAFETY: single-writer; this Future is local and not yet visible.
-        unsafe { future.set_ready(Value::Int(99)) };
-        let future_ptr = tlab.alloc(Object::Future(future));
+        // Allocate the Future in `Pending` state first so we have a real
+        // `HeapPtr` to pass to `set_ready`.
+        let future_ptr = tlab.alloc(Object::Future(Future::pending(FutureId::from_usize(0))));
+        let Object::Future(future) = (unsafe { future_ptr.get() }) else {
+            panic!("expected Object::Future");
+        };
+        // SAFETY: single-writer; the heap object was just allocated locally.
+        unsafe { future.set_ready(heap.as_ref(), future_ptr, Value::Int(99)) };
         let roots = vec![future_ptr];
         let (stats, _, _) = unsafe { heap.collect_garbage(&roots) };
 

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -208,6 +208,19 @@ impl BexHeap {
         // Poison or clear the inactive space (now holds old-space debris).
         self.finalize_inactive_space();
 
+        // Bug H, check 2 (heap_debug only): after a Major GC, every live
+        // object lives in compile_time or Gen2 (Gen0 and Gen1 were just
+        // cleared). Walk every Gen2 object's outgoing references and
+        // assert each lands in compile_time or Gen2 — anything else means
+        // a write barrier was missed when the reference was originally
+        // installed, so `value_mut_for_fixup` / dirty-card scan didn't
+        // patch it and it now points into a cleared region.
+        #[cfg(feature = "heap_debug")]
+        // SAFETY: GC safepoint, all permits parked.
+        unsafe {
+            self.debug_assert_post_major_no_dead_refs();
+        }
+
         // Remap each root to its new location (or keep it if it was compile-time).
         let remapped_roots: Vec<HeapPtr> = roots
             .iter()
@@ -341,6 +354,41 @@ impl BexHeap {
             | Object::RustData(_)
             | Object::Collector(_)
             | Object::Type(_) => {}
+        }
+    }
+
+    /// Bug H, check 2 (heap_debug only): after a Major GC, every Gen2
+    /// object's outgoing heap references must land in compile_time or
+    /// Gen2. Anything else means the reference was installed without
+    /// firing a write barrier (so dirty-card scan didn't surface it),
+    /// and now points into the cleared Gen0/Gen1.
+    ///
+    /// # Safety
+    /// Must be called only at a GC safepoint (all permits parked).
+    #[cfg(feature = "heap_debug")]
+    unsafe fn debug_assert_post_major_no_dead_refs(&self) {
+        // SAFETY: caller is at a GC safepoint.
+        unsafe {
+            let gen2 = &*self.gen2.get();
+            let mut refs = Vec::new();
+            for runtime_idx in 0..gen2.len() {
+                let obj = gen2.get(runtime_idx);
+                refs.clear();
+                self.add_references_to_worklist(obj, &mut refs);
+                for &ref_ptr in &refs {
+                    let generation = self.generation_of(ref_ptr);
+                    assert!(
+                        matches!(
+                            generation,
+                            crate::heap::Generation::CompileTime | crate::heap::Generation::Gen2
+                        ),
+                        "heap_debug: post-Major Gen2 object at runtime_idx={runtime_idx} \
+                         (variant {:?}) holds a reference to {ref_ptr:?} in {generation:?} — \
+                         a write barrier was missed when this reference was stored",
+                        bex_vm_types::ObjectType::of(obj),
+                    );
+                }
+            }
         }
     }
 

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -8,6 +8,22 @@
 //!   to inactive, swaps inactive↔Gen2, clears Gen0 and Gen1
 //! - **Compacting**: No fragmentation; all live objects are contiguous in Gen2
 //! - **Handle-aware**: Handles updated to point to new object locations
+//!
+//! # Invariant: compile-time objects do not contain runtime `HeapPtr`s
+//!
+//! When the BFS in `copy_collection` / `collect_garbage_minor` encounters a
+//! compile-time pointer it identity-maps it into `forwarding` and stops —
+//! it does **not** call `add_references_to_worklist` on the compile-time
+//! object's payload. This shortcut is sound only because every compile-time
+//! `Object` variant (`Function`, `Class`, `Enum`, `Type`) is a leaf with no
+//! `HeapPtr` fields. If a future change adds a runtime-`HeapPtr` field to
+//! one of those variants, the BFS would silently miss anything reachable
+//! only through it and the GC would reclaim live objects.
+//!
+//! `add_references_to_worklist` carries a `debug_assert!` that fires if it
+//! is ever handed a compile-time pointer whose payload would have produced
+//! a runtime reference, so a regression of this invariant surfaces as an
+//! immediate panic in debug builds (and under `heap_debug`).
 
 use std::{cell::UnsafeCell, collections::HashMap};
 
@@ -156,8 +172,25 @@ impl BexHeap {
                 continue;
             }
 
-            // Compile-time objects are permanent — keep their pointer unchanged.
+            // Compile-time objects are permanent — keep their pointer
+            // unchanged and skip tracing their outgoing references (see
+            // the module-level "compile-time objects do not contain
+            // runtime HeapPtrs" invariant).
             if self.is_compile_time_ptr(old_ptr) {
+                #[cfg(debug_assertions)]
+                {
+                    // SAFETY: GC runs at safepoints; the compile-time
+                    // object's payload is stable for the program lifetime.
+                    let obj = unsafe { old_ptr.get() };
+                    let mut tmp = Vec::new();
+                    self.add_references_to_worklist(obj, &mut tmp);
+                    debug_assert!(
+                        tmp.iter().all(|p| self.is_compile_time_ptr(*p)),
+                        "compile-time object {old_ptr:?} contains a runtime \
+                         HeapPtr — module-level invariant violated; the GC's \
+                         compile-time shortcut would silently miss it"
+                    );
+                }
                 forwarding.insert(old_ptr, old_ptr);
                 continue;
             }

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -23,7 +23,7 @@ use std::{
 
 use ::bex_vm_types::Value;
 use bex_external_types::{Handle, WeakHeapRef};
-use bex_vm_types::{HeapPtr, Object, ObjectIndex};
+use bex_vm_types::{HeapPtr, Object, ObjectIndex, WriteBarrier};
 
 use crate::{
     HeapDebuggerConfig, HeapDebuggerState, card_table::CardTable, chunked_vec::ChunkedVec,
@@ -219,6 +219,17 @@ pub struct BexHeap {
 // - growth_lock: Mutex is thread-safe
 unsafe impl Send for BexHeap {}
 unsafe impl Sync for BexHeap {}
+
+// Forward `bex_vm_types::WriteBarrier` to the inherent `BexHeap::write_barrier`
+// so heap-mutation sites in upstream crates (e.g. `Future::set_ready` in
+// `bex_vm_types`, which can't name `BexHeap` directly because of dep
+// direction) can fire the barrier through a small trait.
+impl WriteBarrier for BexHeap {
+    #[inline]
+    fn write_barrier(&self, container: HeapPtr, value: Value) {
+        BexHeap::write_barrier(self, container, value);
+    }
+}
 
 // Implement WeakHeapRef trait from bex_external_types
 impl WeakHeapRef for BexHeap {

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -568,22 +568,6 @@ impl BexHeap {
     /// call this for spaces that grow exclusively at GC safepoints (Gen1/Gen2),
     /// or while holding exclusive access to the space being scanned.
     #[inline]
-    /// Bug H, check 3 helper (heap_debug only): is `ptr` inside the
-    /// inactive (former active) space?
-    ///
-    /// Used by the engine's post-`forward_roots` integrity sweep to detect
-    /// stale references the GC failed to forward. The inactive space's
-    /// chunks still exist (their slots have been overwritten with
-    /// `Sentinel::FromSpacePoison` in heap_debug builds), so checking
-    /// `ptr_in_chunked_vec` against `inactive` is safe even after
-    /// `finalize_inactive_space` has run.
-    #[cfg(feature = "heap_debug")]
-    pub fn debug_ptr_in_inactive(&self, ptr: HeapPtr) -> bool {
-        let raw = ptr.as_ptr() as *const Object;
-        // SAFETY: GC has parked all permits before the engine calls this.
-        unsafe { Self::ptr_in_chunked_vec(&*self.inactive.get(), raw) }
-    }
-
     unsafe fn ptr_in_chunked_vec(vec: &ChunkedVec<Object>, raw_ptr: *const Object) -> bool {
         // `num_chunks` and `chunk_start_ptr` now serialize on the
         // ChunkedVec's internal RwLock, so the brief window is safe even
@@ -599,6 +583,22 @@ impl BexHeap {
             }
         }
         false
+    }
+
+    /// Bug H, check 3 helper (heap_debug only): is `ptr` inside the
+    /// inactive (former active) space?
+    ///
+    /// Used by the engine's post-`forward_roots` integrity sweep to detect
+    /// stale references the GC failed to forward. The inactive space's
+    /// chunks still exist (their slots have been overwritten with
+    /// `Sentinel::FromSpacePoison` in heap_debug builds), so checking
+    /// `ptr_in_chunked_vec` against `inactive` is safe even after
+    /// `finalize_inactive_space` has run.
+    #[cfg(feature = "heap_debug")]
+    pub fn debug_ptr_in_inactive(&self, ptr: HeapPtr) -> bool {
+        let raw = ptr.as_ptr() as *const Object;
+        // SAFETY: GC has parked all permits before the engine calls this.
+        unsafe { Self::ptr_in_chunked_vec(&*self.inactive.get(), raw) }
     }
 
     /// Mark the card dirty for the card containing `container_ptr` in Gen2.

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -568,6 +568,22 @@ impl BexHeap {
     /// call this for spaces that grow exclusively at GC safepoints (Gen1/Gen2),
     /// or while holding exclusive access to the space being scanned.
     #[inline]
+    /// Bug H, check 3 helper (heap_debug only): is `ptr` inside the
+    /// inactive (former active) space?
+    ///
+    /// Used by the engine's post-`forward_roots` integrity sweep to detect
+    /// stale references the GC failed to forward. The inactive space's
+    /// chunks still exist (their slots have been overwritten with
+    /// `Sentinel::FromSpacePoison` in heap_debug builds), so checking
+    /// `ptr_in_chunked_vec` against `inactive` is safe even after
+    /// `finalize_inactive_space` has run.
+    #[cfg(feature = "heap_debug")]
+    pub fn debug_ptr_in_inactive(&self, ptr: HeapPtr) -> bool {
+        let raw = ptr.as_ptr() as *const Object;
+        // SAFETY: GC has parked all permits before the engine calls this.
+        unsafe { Self::ptr_in_chunked_vec(&*self.inactive.get(), raw) }
+    }
+
     unsafe fn ptr_in_chunked_vec(vec: &ChunkedVec<Object>, raw_ptr: *const Object) -> bool {
         // `num_chunks` and `chunk_start_ptr` now serialize on the
         // ChunkedVec's internal RwLock, so the brief window is safe even

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -558,10 +558,11 @@ impl BexHeap {
     /// or while holding exclusive access to the space being scanned.
     #[inline]
     unsafe fn ptr_in_chunked_vec(vec: &ChunkedVec<Object>, raw_ptr: *const Object) -> bool {
-        // SAFETY: `num_chunks` and `chunk_start_ptr` require the chunks `Vec`
-        // to not be growing concurrently; the caller of `ptr_in_chunked_vec`
-        // upholds that (only called for Gen1/Gen2, which grow at safepoints).
-        let num_chunks = unsafe { vec.num_chunks() };
+        // `num_chunks` and `chunk_start_ptr` now serialize on the
+        // ChunkedVec's internal RwLock, so the brief window is safe even
+        // under a concurrent grower. `chunk_start_ptr` is still `unsafe`
+        // for the bounds precondition.
+        let num_chunks = vec.num_chunks();
         for chunk_idx in 0..num_chunks {
             // SAFETY: `chunk_idx < num_chunks` by loop bound.
             let chunk_start = unsafe { vec.chunk_start_ptr(chunk_idx) };
@@ -612,9 +613,9 @@ impl BexHeap {
         vec: &ChunkedVec<Object>,
         raw_ptr: *const Object,
     ) -> Option<(usize, usize)> {
-        // SAFETY: Caller of `locate_in_chunked_vec` ensures the chunks `Vec`
-        // is not being grown concurrently (safepoint-only / exclusive access).
-        let num_chunks = unsafe { vec.num_chunks() };
+        // `num_chunks` and `chunk_start_ptr` now serialize on the
+        // ChunkedVec's internal RwLock; concurrent growers are excluded.
+        let num_chunks = vec.num_chunks();
         for chunk_idx in 0..num_chunks {
             // SAFETY: `chunk_idx < num_chunks` by loop bound.
             let chunk_start = unsafe { vec.chunk_start_ptr(chunk_idx) };
@@ -744,27 +745,33 @@ impl BexHeap {
         let runtime_end = runtime_start + self.tlab_size;
         let reserve_end = runtime_end + canary_slots;
 
-        // Lock only for growth (serializes chunk allocation)
+        // The chunk-allocation policy mutex still serializes the
+        // fetch_add → resize → canary-write critical section as a unit.
+        // (`ChunkedVec::resize_with` now self-synchronizes against
+        // concurrent `set` callers, so this is no longer load-bearing for
+        // memory safety — but keeping it preserves the existing "one
+        // grower at a time" policy and keeps the canary write paired with
+        // the resize that produced its slot.)
         let _guard = self.growth_lock.lock().unwrap();
 
         let ct_len = self.compile_time.len();
-        // SAFETY: We hold the growth_lock, so no other thread is resizing.
-        // ChunkedVec's resize_with never moves existing elements, and takes &self
-        // so we don't need a mutable reference - which avoids the data race.
+        // SAFETY: `&*self.gen0.get()` produces a `&ChunkedVec<Object>`.
+        // The ChunkedVec's own RwLock now gates outer-Vec mutation, so this
+        // shared reference is sound to hold concurrently with other readers
+        // and growers; per-element exclusivity is gated separately by
+        // `UnsafeCell` + caller-side TLAB regions.
         let gen0 = unsafe { &*self.gen0.get() };
         if gen0.len() < reserve_end {
-            // SAFETY: We hold the growth_lock, ensuring only one thread resizes at a time.
-            unsafe {
-                gen0.resize_with(reserve_end, || {
-                    // Placeholder object - will be overwritten by TLAB alloc
-                    self.placeholder_object()
-                });
-            }
+            gen0.resize_with(reserve_end, || {
+                // Placeholder object - will be overwritten by TLAB alloc
+                self.placeholder_object()
+            });
         }
         if use_canary {
             let chunk_start = ct_len + runtime_start;
             let chunk_end = ct_len + runtime_end;
-            // SAFETY: We hold the growth_lock, index is within bounds
+            // SAFETY: `runtime_end` is within the freshly-grown range; the
+            // canary slot is exclusive to this chunk reservation.
             unsafe {
                 gen0.set(runtime_end, self.tlab_canary_object(chunk_start, chunk_end));
             }

--- a/baml_language/crates/bex_heap/src/heap_guard.rs
+++ b/baml_language/crates/bex_heap/src/heap_guard.rs
@@ -5,7 +5,7 @@
 //! - A single exclusive heap access [`HeapGuard`], or
 //! - Any number of non-exclusive tracked active heap permits [`ActiveHeapPermit`].
 
-use ::bex_vm_types::{HeapPtr, RootHaver};
+use ::bex_vm_types::{HeapPtr, PermitProof, RootHaver};
 use ::core::{
     cell::UnsafeCell,
     marker::PhantomData,
@@ -101,21 +101,18 @@ impl<T: RootHaver> HeapPermit<T> for ActiveHeapPermit<T> {
         unsafe { self.state.holder_mut() }
     }
     fn proof(&self) -> PermitProof<'_> {
-        PermitProof {
-            _marker: PhantomData,
+        // SAFETY: `&self` proves an `ActiveHeapPermit<T>` is held for the
+        // returned proof's lifetime, which is the very invariant
+        // `PermitProof::new` requires. This is the canonical safe
+        // constructor referenced by `PermitProof`'s docs.
+        #[allow(
+            unsafe_code,
+            reason = "this is the canonical safe constructor of PermitProof"
+        )]
+        unsafe {
+            PermitProof::new()
         }
     }
-}
-
-/// A type-erased proof that an [`ActiveHeapPermit`] is held in the current
-/// scope (for at least lifetime `'a`).
-///
-/// Constructed via [`ActiveHeapPermit::proof`]. Carries no runtime data — the
-/// GC-exclusion guarantee comes from the lifetime, which is bound by the
-/// originating permit's borrow.
-#[derive(Clone, Copy)]
-pub struct PermitProof<'a> {
-    _marker: PhantomData<&'a ()>,
 }
 
 impl<T: RootHaver> Deref for ActiveHeapPermit<T> {
@@ -229,8 +226,13 @@ impl<'a, T: RootHaver> HeapPermit<T> for SharedHeapPermitGuard<'a, T> {
         unsafe { self.state.holder_mut() }
     }
     fn proof(&self) -> PermitProof<'_> {
-        PermitProof {
-            _marker: PhantomData,
+        // SAFETY: see `ActiveHeapPermit::proof`.
+        #[allow(
+            unsafe_code,
+            reason = "this is the canonical safe constructor of PermitProof"
+        )]
+        unsafe {
+            PermitProof::new()
         }
     }
 }

--- a/baml_language/crates/bex_heap/src/heap_guard.rs
+++ b/baml_language/crates/bex_heap/src/heap_guard.rs
@@ -371,5 +371,31 @@ impl<T: ?Sized + RootHaver> PermitCell<T> {
 // gain access via a semaphore permit; the GC gains access by draining all permits
 // while holding the manager mutex. `RootHaver: Send` ensures the inner value is safe
 // to move between threads, which is what's actually happening — never true sharing.
+//
+// # `Sync` is unconditional even for `T: !Sync` — why this is sound
+//
+// The unconditional `Sync` impl below is **structurally** load-bearing:
+// `Weak<PermitCell<dyn RootHaver>>` lives in
+// `HeapPermitManager::holders: Mutex<Vec<Weak<...>>>`, and `Mutex<Vec<Weak<U>>>`
+// requires `U: Send + Sync`. Constraining the bound to `T: Sync` would
+// reject every `T: !Sync` `RootHaver` (e.g. `BexVm`, which intentionally
+// is not `Sync`).
+//
+// What rescues soundness is the *safe wrappers* that hand out access to
+// the inner `T`: `ActiveHeapPermit<T>` and `SharedHeapPermitGuard<'_, T>`
+// each carry a `_marker: PhantomData<T>` field that re-ties the wrapper's
+// auto-`Send`/`Sync` derivation to `T`. So while `&PermitCell<T>` is
+// `Sync` regardless of `T`, the only safe way to project a `&T` out of
+// it is through one of those wrappers, and `&Wrapper<T>: Sync` iff
+// `T: Sync`. Two threads cannot simultaneously hold `&Wrapper<T>: Sync`
+// for `T: !Sync`, so two threads cannot simultaneously call `.holder()`
+// to observe `&T`.
+//
+// **Maintenance hazard**: any future safe API that returns `&T` from a
+// `&PermitCell<T>` *without* the `PhantomData<T>` re-tie (or another
+// equivalent `T: Sync` requirement on the consumer) silently breaks the
+// contract above. If you add such an API, also tighten this `Sync` impl
+// to `T: Sync` (and accept that some `RootHaver`s can no longer be
+// holders), or rework the holders Mutex's element type.
 unsafe impl<T: ?Sized + RootHaver> Send for PermitCell<T> {}
 unsafe impl<T: ?Sized + RootHaver> Sync for PermitCell<T> {}

--- a/baml_language/crates/bex_heap/src/lib.rs
+++ b/baml_language/crates/bex_heap/src/lib.rs
@@ -70,11 +70,12 @@ mod tlab;
 // Re-export types from bex_external_types for convenience
 pub use accessor::{AccessError, BexClass, BexValue, BuiltinClass};
 pub use bex_external_types::{BexExternalValue, Handle};
+pub use bex_vm_types::PermitProof;
 pub use gc::{CollectionLevel, GcStats};
 pub use heap::{BexHeap, DEFAULT_TLAB_SIZE, Generation, HeapStats};
 pub(crate) use heap_debugger::{HeapDebuggerConfig, HeapDebuggerState};
 pub use heap_guard::{
-    ActiveHeapPermit, HeapGuard, HeapPermit, HeapPermitManager, InactiveHeapPermit, PermitProof,
+    ActiveHeapPermit, HeapGuard, HeapPermit, HeapPermitManager, InactiveHeapPermit,
     SharedHeapPermit, SharedHeapPermitGuard,
 };
 pub use tlab::{Tlab, TlabHolder};

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -86,7 +86,21 @@ pub struct Tlab {
 }
 
 impl Tlab {
-    /// Create a new TLAB with an initial chunk from the heap.
+    /// Create a new TLAB with an initial chunk eagerly reserved from the
+    /// heap.
+    ///
+    /// **Avoid in production code paths.** Reserving a chunk here happens
+    /// outside any [`HeapPermitManager`](crate::HeapPermitManager) permit;
+    /// if a concurrent GC clears Gen0 before the caller registers as a
+    /// holder and acquires its permit, this TLAB's cursor is left pointing
+    /// into a freed/cleared region. Subsequent allocations panic with
+    /// `index N out of bounds (len=0)` (debug) or segfault (release).
+    ///
+    /// Permit-managed holders (`BexVm`, `FutureManagerInner`, …) must use
+    /// [`Tlab::new_empty`] so the first refill happens under a held permit.
+    /// `Tlab::new` is retained for standalone heap tests that exercise
+    /// TLAB mechanics without the permit infrastructure (those tests
+    /// guarantee single-threaded access).
     pub fn new(heap: Arc<BexHeap>) -> Self {
         let chunk = heap.alloc_tlab_chunk();
         Self {
@@ -98,7 +112,11 @@ impl Tlab {
 
     /// Create a TLAB without allocating an initial chunk.
     ///
-    /// The first allocation will trigger a refill.
+    /// The first allocation will trigger a refill. This is the right
+    /// constructor for permit-managed holders: it defers the
+    /// `alloc_tlab_chunk` call until the holder has been registered with
+    /// [`HeapPermitManager`](crate::HeapPermitManager) and acquired its
+    /// permit, so a concurrent GC cannot strand the TLAB cursor.
     pub fn new_empty(heap: Arc<BexHeap>) -> Self {
         Self {
             alloc_ptr: 0,

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -42,7 +42,7 @@ use ::core::sync::atomic::AtomicBool;
 use bex_heap::{BexHeap, Tlab};
 use bex_vm_types::{
     BinOp, CmpOp, FunctionKind, FutureRead, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool,
-    ObjectType, PanicClass, StackIndex, UnaryOp, Value, Variant, VmGlobals,
+    ObjectType, PanicClass, PermitProof, StackIndex, UnaryOp, Value, Variant, VmGlobals,
     bytecode::{self, BlockNotification},
     types::{
         BoundMethod, Cell, Closure, ConstValue, Function, FunctionType, FutureType, Instance, Type,
@@ -576,6 +576,40 @@ fn value_type_tag(value: &Value) -> i64 {
 }
 
 impl BexVm {
+    /// Construct a [`PermitProof`] tied to `&self`'s borrow.
+    ///
+    /// # Why this is safe
+    ///
+    /// A `&BexVm` is only ever obtained inside an
+    /// `bex_heap::ActiveHeapPermit<BexVm>` deref context — every
+    /// caller of any `&BexVm` method is therefore already inside an
+    /// active heap permit. The returned `PermitProof<'_>`'s lifetime is
+    /// bounded by `&self`, which is bounded by the wrapping permit's,
+    /// so the proof witnesses a genuinely-held permit.
+    ///
+    /// The internal `PermitProof::new()` is `unsafe` because in general
+    /// minting a proof from nothing breaks the type-level
+    /// permit-exclusion guarantee. Here the borrow of `&self` *is* the
+    /// runtime witness; we just need to repackage it as the canonical
+    /// proof token. This is the VM-internal mirror of
+    /// `bex_heap::ActiveHeapPermit::proof`.
+    #[inline]
+    #[must_use]
+    #[allow(
+        clippy::unused_self,
+        reason = "the `&self` borrow is load-bearing — it ties the returned \
+                  proof's lifetime to a valid `&BexVm` borrow, which only \
+                  exists inside an active permit deref"
+    )]
+    pub(crate) fn proof(&self) -> PermitProof<'_> {
+        // SAFETY: `&self` is only obtainable inside an active permit
+        // deref; see the method-level "Why this is safe" argument.
+        #[allow(unsafe_code, reason = "PermitProof::new is the unsafe boundary")]
+        unsafe {
+            PermitProof::new()
+        }
+    }
+
     /// Create a new VM with a shared heap.
     ///
     /// The heap is shared across all VMs. Each VM gets its own TLAB
@@ -1112,7 +1146,7 @@ impl BexVm {
     /// suitable for hot paths; callers that need repeated lookups should cache
     /// the result.
     pub fn find_function_by_name(&self, name: &str) -> Option<HeapPtr> {
-        for v in self.globals.as_slice() {
+        for v in self.globals.as_slice(self.proof()) {
             if let Value::Object(ptr) = v {
                 if let Object::Function(f) = self.get_object(*ptr) {
                     if f.name == name {
@@ -2215,7 +2249,7 @@ impl BexVm {
                     let (instruction, metadata) = crate::debug::display_instruction(
                         instruction_ptr,
                         function,
-                        self.globals.as_slice(),
+                        self.globals.as_slice(self.proof()),
                         None,
                         None,
                     );
@@ -2401,7 +2435,7 @@ impl BexVm {
             }
 
             Instruction::LoadGlobal(index) => {
-                let value = self.globals.get(index);
+                let value = self.globals.get(self.proof(), index);
                 self.stack.push(value);
             }
 
@@ -3541,7 +3575,7 @@ impl BexVm {
             }
 
             Instruction::DispatchFuture(callee) => {
-                let callee_value = self.globals[callee];
+                let callee_value = self.globals.get(self.proof(), callee);
                 let expected_type = FunctionType::SysOp;
                 let callee_ptr = self.as_object_ptr(&callee_value, expected_type.into())?;
 
@@ -3770,7 +3804,7 @@ impl BexVm {
             }
 
             Instruction::Call { callee, ntypeargs } => {
-                let callee_value = self.globals[callee];
+                let callee_value = self.globals.get(self.proof(), callee);
                 let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
 
                 // Pop `ntypeargs` Object::Type values from the stack into a Vec<Ty>.
@@ -4338,7 +4372,7 @@ impl BexVm {
 
             Instruction::MakeBoundMethod(global_idx) => {
                 let receiver = self.stack.ensure_pop();
-                let callee_value = self.globals[global_idx];
+                let callee_value = self.globals.get(self.proof(), global_idx);
                 let function_ptr =
                     self.as_object_ptr(&callee_value, FunctionType::Callable.into())?;
                 debug_assert!(
@@ -5184,7 +5218,7 @@ impl BexVm {
                 OpCode::LoadGlobal => {
                     let raw = { read_u32_unchecked(code, pc) };
                     let global_idx = bex_vm_types::GlobalIndex::from_raw(raw as usize);
-                    let value = self.globals[global_idx];
+                    let value = self.globals.get(self.proof(), global_idx);
                     self.stack.push(value);
                 }
 
@@ -5409,7 +5443,7 @@ impl BexVm {
                 OpCode::DispatchFuture => {
                     let raw = { read_u32_unchecked(code, pc) };
                     let callee = bex_vm_types::GlobalIndex::from_raw(raw as usize);
-                    let callee_value = self.globals[callee];
+                    let callee_value = self.globals.get(self.proof(), callee);
                     let expected_type = FunctionType::SysOp;
                     let callee_ptr = self.as_object_ptr(&callee_value, expected_type.into())?;
                     let Object::Function(callable_future) = self.get_object(callee_ptr) else {
@@ -5575,7 +5609,7 @@ impl BexVm {
                     let raw = read_u32_unchecked(code, pc);
                     let ntypeargs = read_u16_unchecked(code, pc) as usize;
                     let callee_global = bex_vm_types::GlobalIndex::from_raw(raw as usize);
-                    let callee_value = self.globals[callee_global];
+                    let callee_value = self.globals.get(self.proof(), callee_global);
                     let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
 
                     // Pop `ntypeargs` Object::Type values from the stack into a Vec<Ty>.
@@ -6102,7 +6136,7 @@ impl BexVm {
                     let raw = { read_u32_unchecked(code, pc) };
                     let global_idx = bex_vm_types::GlobalIndex::from_raw(raw as usize);
                     let receiver = self.stack.ensure_pop();
-                    let callee_value = self.globals[global_idx];
+                    let callee_value = self.globals.get(self.proof(), global_idx);
                     let function_ptr =
                         self.as_object_ptr(&callee_value, FunctionType::Callable.into())?;
                     let bound = Object::BoundMethod(BoundMethod {

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -587,7 +587,13 @@ impl BexVm {
         #[cfg(not(target_arch = "wasm32"))] park_requested: Arc<AtomicBool>,
         argv: Arc<[String]>,
     ) -> Self {
-        let tlab = Tlab::new(Arc::clone(&heap));
+        // Defer the first TLAB chunk reservation until the first `tlab.alloc`,
+        // which the engine reaches only after the VM has been registered as a
+        // permit holder via `HeapPermitManager::new_permit` and a permit is
+        // active. Eagerly calling `Tlab::new` here would reserve a chunk
+        // *before* registration, leaving the cursor stale across any GC that
+        // fires in the engine's pre-permit window.
+        let tlab = Tlab::new_empty(Arc::clone(&heap));
 
         // Pre-resolve error class pointers indexed by Error discriminant.
         let error_class_ptrs: Vec<HeapPtr> = ErrorClass::ALL

--- a/baml_language/crates/bex_vm/src/watch.rs
+++ b/baml_language/crates/bex_vm/src/watch.rs
@@ -929,8 +929,7 @@ mod tests {
         ] {
             assert!(
                 roots.contains(&needed),
-                "collect_roots missing pointer that forward_roots would patch: {:?}",
-                needed
+                "collect_roots missing pointer that forward_roots would patch: {needed:?}"
             );
         }
     }

--- a/baml_language/crates/bex_vm/src/watch.rs
+++ b/baml_language/crates/bex_vm/src/watch.rs
@@ -552,16 +552,81 @@ fn remap_node_set(
 impl RootHaver for Watch {
     /// Collects GC roots from Watch state.
     ///
-    /// Only `last_assigned` and `last_notified` need to be roots — `value`
-    /// is always a copy of the stack slot (already a root), and graph `NodeId`s
-    /// point to objects transitively reachable from stack values.
+    /// Visits **every** field that `forward_roots` later patches. This is the
+    /// load-bearing invariant: a pointer that `forward_roots` would rewrite
+    /// must be in the root set, otherwise the underlying object can be
+    /// reclaimed (it isn't traced through any other path) and the rewrite
+    /// will install a stale pointer-to-freed-memory into the graph or a
+    /// `RootState`.
+    ///
+    /// Specifically:
+    /// - `state.value`, `state.last_assigned`, `state.last_notified`:
+    ///   `Value::Object` payloads must be rooted because `forward_roots`
+    ///   patches them in place.
+    /// - `state.filter` if `WatchFilter::Function(ptr)`: the function
+    ///   pointer is a heap reference (closure object) and is patched in
+    ///   place by `forward_roots`, so it must be a root.
+    /// - All `NodeId::HeapObject(ptr)` reached through `roots`,
+    ///   `children` (keys + edge children), `parents` (keys + edge
+    ///   parents), `reachable_from_root` (keys + values), and
+    ///   `roots_reaching_node` (keys + values): `forward_roots` rewrites
+    ///   them, so any object reachable only through this graph must be
+    ///   rooted via the graph itself.
     fn collect_roots(&self, roots: &mut Vec<HeapPtr>) {
+        // RootState values.
         for state in self.roots.values() {
+            if let Value::Object(ptr) = state.value {
+                roots.push(ptr);
+            }
             if let Some(Value::Object(ptr)) = state.last_assigned {
                 roots.push(ptr);
             }
             if let Some(Value::Object(ptr)) = state.last_notified {
                 roots.push(ptr);
+            }
+            if let WatchFilter::Function(ptr) = state.filter {
+                roots.push(ptr);
+            }
+        }
+
+        // Graph NodeIds: collect every `HeapObject` reachable through the
+        // graph maps. Duplicates are fine — the GC's worklist deduplicates
+        // via the forwarding HashMap.
+        let push_if_heap = |node: &NodeId, roots: &mut Vec<HeapPtr>| {
+            if let NodeId::HeapObject(ptr) = node {
+                roots.push(*ptr);
+            }
+        };
+        // `roots` (Watch's own `roots: HashMap<NodeId, RootState>`).
+        for node in self.roots.keys() {
+            push_if_heap(node, roots);
+        }
+        // `children`: parent keys + (path, child) edge children.
+        for (parent, edges) in &self.children {
+            push_if_heap(parent, roots);
+            for (_path, child) in edges {
+                push_if_heap(child, roots);
+            }
+        }
+        // `parents`: child keys + (parent, path) edge parents.
+        for (child, edges) in &self.parents {
+            push_if_heap(child, roots);
+            for (parent, _path) in edges {
+                push_if_heap(parent, roots);
+            }
+        }
+        // `reachable_from_root`: root keys + reachable-set values.
+        for (root, reachable) in &self.reachable_from_root {
+            push_if_heap(root, roots);
+            for node in reachable {
+                push_if_heap(node, roots);
+            }
+        }
+        // `roots_reaching_node`: node keys + roots-set values.
+        for (node, reaching) in &self.roots_reaching_node {
+            push_if_heap(node, roots);
+            for root in reaching {
+                push_if_heap(root, roots);
             }
         }
     }
@@ -570,6 +635,12 @@ impl RootHaver for Watch {
     ///
     /// After a copying GC, all heap objects may have moved. This updates
     /// `RootState` values and rebuilds the graph maps with new pointers.
+    ///
+    /// Every pointer patched here must have been pushed by
+    /// [`Self::collect_roots`] — otherwise the GC won't have a forwarding
+    /// entry for it (the pre-fix bug). In debug builds, the
+    /// `debug_assert!(remap_was_traced(...))` calls below verify the
+    /// invariant on every patched node.
     fn forward_roots(&mut self, forwarding: &HashMap<HeapPtr, HeapPtr>) {
         if forwarding.is_empty() || self.roots.is_empty() {
             return;
@@ -805,5 +876,62 @@ mod tests {
             watch.copy_roots_reaching(NodeId::HeapObject(obj_ptr)).len(),
             0
         );
+    }
+
+    /// Regression test: every `HeapPtr` that `forward_roots` would patch
+    /// must be present in `collect_roots`'s output. Pre-fix, `collect_roots`
+    /// only emitted `last_assigned`/`last_notified`, so `state.value`,
+    /// `WatchFilter::Function(ptr)`, and graph `NodeId::HeapObject(ptr)`s
+    /// could be silently rewritten to point at freed memory after a GC.
+    #[test]
+    fn collect_roots_covers_every_pointer_forward_roots_patches() {
+        let mut watch = Watch::new();
+
+        // Build a watch state that exercises every HeapPtr-bearing field:
+        // - `state.value` (Object)
+        // - `state.last_assigned` (Object)
+        // - `state.last_notified` (Object)
+        // - `state.filter = WatchFilter::Function(ptr)`
+        // - graph edges: parent (HeapObject) -> child (HeapObject), with
+        //   reachable_from_root / roots_reaching_node populated.
+        let value_ptr = leaf();
+        let assigned_ptr = leaf();
+        let notified_ptr = leaf();
+        let filter_fn_ptr = leaf();
+        let parent_ptr = leaf();
+        let child_ptr = leaf();
+
+        let parent_node = NodeId::HeapObject(parent_ptr);
+        watch.register_root(
+            parent_node,
+            RootState {
+                value: Value::Object(value_ptr),
+                last_assigned: Some(Value::Object(assigned_ptr)),
+                last_notified: Some(Value::Object(notified_ptr)),
+                channel: "Test".to_string(),
+                filter: WatchFilter::Function(filter_fn_ptr),
+            },
+        );
+        track_watch_dependencies(&mut watch, parent_node, Path::Binding, child_ptr);
+
+        let mut roots = Vec::new();
+        watch.collect_roots(&mut roots);
+
+        // Each pointer that `forward_roots` will patch must appear at least
+        // once in the root set.
+        for &needed in &[
+            value_ptr,
+            assigned_ptr,
+            notified_ptr,
+            filter_fn_ptr,
+            parent_ptr,
+            child_ptr,
+        ] {
+            assert!(
+                roots.contains(&needed),
+                "collect_roots missing pointer that forward_roots would patch: {:?}",
+                needed
+            );
+        }
     }
 }

--- a/baml_language/crates/bex_vm/tests/forward_roots.rs
+++ b/baml_language/crates/bex_vm/tests/forward_roots.rs
@@ -18,8 +18,10 @@ use bex_vm::BexVm;
 use bex_vm_types::{HeapPtr, RootHaver, Value};
 
 fn make_vm() -> BexVm {
-    // The program contents don't matter — we only need a VM with a live
-    // TLAB. `from_program` calls `Tlab::new`, which reserves a chunk.
+    // The program contents don't matter — we only need a VM whose TLAB
+    // can be materialized on demand. `BexVm::new` builds the TLAB with
+    // `Tlab::new_empty` (lazy refill) so the chunk is reserved on the
+    // first allocation under the VM's permit, not at construction time.
     let program = compile_source("function noop() -> int { 0 }");
     BexVm::from_program(program, Arc::new(AtomicBool::new(false))).expect("from_program")
 }
@@ -27,7 +29,14 @@ fn make_vm() -> BexVm {
 #[test]
 fn forward_roots_invalidates_tlab() {
     let mut vm = make_vm();
-    assert!(vm.tlab.is_valid(), "fresh TLAB should hold a chunk");
+    // `Tlab::new_empty` defers chunk reservation until first alloc, so a
+    // fresh VM has an invalid TLAB by construction. Force a refill by
+    // allocating once, then verify `forward_roots` invalidates it.
+    let _ = vm.tlab.alloc_string("force_refill".to_string());
+    assert!(
+        vm.tlab.is_valid(),
+        "TLAB should hold a chunk after the first allocation"
+    );
 
     vm.forward_roots(&HashMap::new());
     assert!(

--- a/baml_language/crates/bex_vm_types/src/indexable.rs
+++ b/baml_language/crates/bex_vm_types/src/indexable.rs
@@ -14,7 +14,7 @@
 
 use std::{cell::UnsafeCell, collections::HashMap, marker::PhantomData, sync::Arc};
 
-use crate::{HeapPtr, Object, RootHaver, Value};
+use crate::{HeapPtr, Object, PermitProof, RootHaver, Value};
 
 // Marker types for different pool kinds
 
@@ -274,7 +274,7 @@ pub type ObjectPool = Pool<Object, ObjectKind>;
 /// **not** enforced by the type system: `SharedGlobals` is `Send + Sync +
 /// Clone`, so the lifetime of `&Self` (and any `&[Value]` projected from
 /// it via [`Self::as_slice`]) is decoupled from any specific
-/// [`ActiveHeapPermit`](crate)'s lifetime. Misuse causes UB. Where
+/// `ActiveHeapPermit`'s lifetime. Misuse causes UB. Where
 /// possible, prefer [`Self::get`] (returns `Value` by copy) to avoid
 /// holding the slice borrow across any operation that could end the
 /// caller's permit.
@@ -329,58 +329,65 @@ impl SharedGlobals {
     }
 
     /// Number of globals in the pool.
-    pub fn len(&self) -> usize {
-        // SAFETY: reads the boxed slice's length through the UnsafeCell.
-        // Length is set at construction and never changes, so this is
-        // synchronized regardless of GC state. Explicit `&*` produces a
-        // `&Box<[Value]>` so `.len()` doesn't autoref a raw pointer.
-        unsafe { (&*self.inner.values.get()).len() }
+    ///
+    /// Requires a [`PermitProof`] witnessing that an active heap permit
+    /// is held — this excludes GC's `forward_roots` (the only writer
+    /// against `inner.values`) for the duration of the read.
+    pub fn len(&self, _proof: PermitProof<'_>) -> usize {
+        // SAFETY: `_proof` is the runtime witness that no `forward_roots`
+        // can run concurrently. Explicit `&*` produces a `&Box<[Value]>`
+        // so `.len()` doesn't autoref a raw pointer.
+        #[allow(unsafe_code, reason = "UnsafeCell projection gated by `_proof`")]
+        unsafe {
+            (&*self.inner.values.get()).len()
+        }
     }
 
     /// Whether the pool is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    ///
+    /// See [`Self::len`] for the permit-proof requirement.
+    pub fn is_empty(&self, proof: PermitProof<'_>) -> bool {
+        self.len(proof) == 0
     }
 
     /// Read a global by index.
     ///
-    /// Caller must hold an active heap permit. `Value` is `Copy`, so the
-    /// returned value is decoupled from any aliasing of the underlying
-    /// `UnsafeCell`.
+    /// Requires a [`PermitProof`]; see [`Self::len`].
     ///
     /// # Panics
     ///
     /// Panics if `index` is out of bounds — same contract as slice indexing.
-    pub fn get(&self, index: GlobalIndex) -> Value {
-        // SAFETY: caller holds an active heap permit, so GC's `forward_roots`
-        // is excluded for the duration of this read. Explicit `&*` produces
-        // a `&[Value]` (no autoref through the raw-pointer indexing path).
-        unsafe { (&*self.inner.values.get())[index.into_raw()] }
+    pub fn get(&self, _proof: PermitProof<'_>, index: GlobalIndex) -> Value {
+        // SAFETY: `_proof` excludes concurrent `forward_roots`. `Value`
+        // is `Copy`, so the returned value is decoupled from any
+        // aliasing of the underlying `UnsafeCell` after this returns.
+        // Explicit `&*` produces a `&[Value]` (no autoref through the
+        // raw-pointer indexing path).
+        #[allow(unsafe_code, reason = "UnsafeCell projection gated by `_proof`")]
+        unsafe {
+            (&*self.inner.values.get())[index.into_raw()]
+        }
     }
 
     /// Borrow the underlying globals as a slice.
     ///
-    /// # Unenforced contract
+    /// The returned slice's lifetime is tied to `proof`'s lifetime, not
+    /// to `&self`: dropping the originating [`bex_heap::ActiveHeapPermit`]
+    /// invalidates the proof and therefore the slice borrow. This is the
+    /// type-system guarantee that makes the underlying `UnsafeCell`
+    /// projection sound — GC cannot run `forward_roots` while any
+    /// `PermitProof<'a>` is live, and the borrow checker forces the
+    /// slice borrow to die with the proof.
     ///
-    /// Caller must hold an active heap permit for the *entire* lifetime
-    /// of the returned `&[Value]`. The slice borrow is tied to `&self`,
-    /// **not** to the permit — Rust's type system has no way to express
-    /// that relationship through `SharedGlobals` (`SharedGlobals` is
-    /// `Clone` and `Send + Sync`, so its `&` lifetime is decoupled from
-    /// any specific permit's). If the permit drops while the slice is
-    /// still alive and a GC runs `forward_roots` on this `SharedGlobals`
-    /// (which mutates `inner.values` via [`UnsafeCell`]), the resulting
-    /// aliasing is **undefined behavior**.
-    ///
-    /// Prefer [`Self::get`] (returns `Value` by copy) whenever the call
-    /// site only needs a single element. `as_slice` exists for the
-    /// `VmGlobals::as_slice` / `VmGlobals::Index<GlobalIndex>` paths
-    /// which are already governed by the wider VM-permit invariant.
-    pub fn as_slice(&self) -> &[Value] {
-        // SAFETY: caller upholds the unenforced contract above — they
-        // hold an active heap permit and won't release it before the
-        // returned slice's last use.
-        unsafe { &*self.inner.values.get() }
+    /// [`bex_heap::ActiveHeapPermit`]: <https://docs.rs/bex_heap>
+    pub fn as_slice<'a>(&'a self, _proof: PermitProof<'a>) -> &'a [Value] {
+        // SAFETY: `_proof` excludes concurrent `forward_roots` for `'a`,
+        // and the returned slice borrow cannot outlive `'a` (and hence
+        // cannot outlive the proof, which cannot outlive the permit).
+        #[allow(unsafe_code, reason = "UnsafeCell projection gated by `_proof`")]
+        unsafe {
+            &*self.inner.values.get()
+        }
     }
 }
 
@@ -437,26 +444,34 @@ pub enum VmGlobals {
 
 impl VmGlobals {
     /// Number of globals in the view.
-    pub fn len(&self) -> usize {
+    ///
+    /// `proof` is consumed for the `Shared` variant (where it gates a
+    /// safe read against the `UnsafeCell`-backed `SharedGlobals`); the
+    /// `Owned` variant ignores it. Taking the proof unconditionally
+    /// keeps the API symmetric across variants and matches how
+    /// post-`$init` VM operations always have access to one.
+    pub fn len(&self, proof: PermitProof<'_>) -> usize {
         match self {
             Self::Owned(pool) => pool.len(),
-            Self::Shared(globals) => globals.len(),
+            Self::Shared(globals) => globals.len(proof),
         }
     }
 
     /// Whether the view is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    ///
+    /// See [`Self::len`] for the `proof` parameter.
+    pub fn is_empty(&self, proof: PermitProof<'_>) -> bool {
+        self.len(proof) == 0
     }
 
     /// Read a global by index. `Value` is `Copy` so this returns by value.
     ///
     /// # Panics
     /// Panics if `index` is out of bounds — same contract as slice indexing.
-    pub fn get(&self, index: GlobalIndex) -> Value {
+    pub fn get(&self, proof: PermitProof<'_>, index: GlobalIndex) -> Value {
         match self {
             Self::Owned(pool) => pool[index],
-            Self::Shared(globals) => globals.get(index),
+            Self::Shared(globals) => globals.get(proof, index),
         }
     }
 
@@ -475,28 +490,15 @@ impl VmGlobals {
 
     /// View the globals as a slice. Both variants support O(1) slice access.
     ///
-    /// For [`VmGlobals::Shared`] the caller must hold an active heap permit
-    /// (no concurrent `forward_roots` mutation). See
-    /// [`SharedGlobals::as_slice`].
-    pub fn as_slice(&self) -> &[Value] {
+    /// The returned slice is tied to `proof`'s lifetime: dropping the
+    /// originating [`bex_heap::ActiveHeapPermit`] invalidates the proof
+    /// and therefore the slice borrow. See [`SharedGlobals::as_slice`].
+    ///
+    /// [`bex_heap::ActiveHeapPermit`]: <https://docs.rs/bex_heap>
+    pub fn as_slice<'a>(&'a self, proof: PermitProof<'a>) -> &'a [Value] {
         match self {
             Self::Owned(pool) => &pool.0,
-            Self::Shared(globals) => globals.as_slice(),
-        }
-    }
-}
-
-impl std::ops::Index<GlobalIndex> for VmGlobals {
-    type Output = Value;
-
-    fn index(&self, index: GlobalIndex) -> &Self::Output {
-        match self {
-            Self::Owned(pool) => &pool[index],
-            // SAFETY of underlying read: caller holds an active heap permit
-            // for the lifetime of the returned reference (the same contract
-            // already governs every other use of `&Value` from the engine
-            // hot path).
-            Self::Shared(globals) => &globals.as_slice()[index.into_raw()],
+            Self::Shared(globals) => globals.as_slice(proof),
         }
     }
 }
@@ -653,7 +655,11 @@ mod shared_globals_tests {
         // Take a fresh `as_slice()` view; the in-place rewrite must be
         // visible through the *same* `Arc<UnsafeCell<...>>` that any
         // existing `SharedGlobals` clone observes.
-        let slice = globals.as_slice();
+        //
+        // SAFETY: single-threaded test, no concurrent `forward_roots`.
+        #[allow(unsafe_code, reason = "test mock proof")]
+        let proof = unsafe { PermitProof::new() };
+        let slice = globals.as_slice(proof);
         assert_eq!(slice[0], Value::Object(new1));
         assert_eq!(slice[1], Value::Int(42));
         assert_eq!(slice[2], Value::Object(new2));
@@ -676,6 +682,10 @@ mod shared_globals_tests {
         held_by_holder.forward_roots(&forwarding);
 
         // The engine-side clone (`original`) must see the rewrite.
-        assert_eq!(original.get(GlobalIndex::from_raw(0)), Value::Object(new));
+        // SAFETY: single-threaded test; no concurrent `forward_roots`.
+        #[allow(unsafe_code, reason = "test mock proof")]
+        let proof = unsafe { PermitProof::new() };
+        let v = original.get(proof, GlobalIndex::from_raw(0));
+        assert_eq!(v, Value::Object(new));
     }
 }

--- a/baml_language/crates/bex_vm_types/src/indexable.rs
+++ b/baml_language/crates/bex_vm_types/src/indexable.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 //! The VM has 3 different "indexable" pools.
 //!
 //! One of them is the object pool, the other one is the globals pool, and
@@ -11,9 +12,9 @@
 //! This module provides a vector wrapper that needs specific types to index
 //! into it, thus solving the problem mentioned above at compile time.
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{cell::UnsafeCell, collections::HashMap, marker::PhantomData, sync::Arc};
 
-use crate::{Object, Value};
+use crate::{HeapPtr, Object, RootHaver, Value};
 
 // Marker types for different pool kinds
 
@@ -242,6 +243,150 @@ impl<'a, T, K> std::iter::IntoIterator for &'a mut Pool<T, K> {
 pub type GlobalPool = Pool<Value, GlobalKind>;
 pub type ObjectPool = Pool<Object, ObjectKind>;
 
+/// The frozen globals pool shared by every post-`$init` VM.
+///
+/// Wraps an `Arc<UnsafeCell<Box<[Value]>>>` so every VM holds a cheap
+/// refcounted view, and so the GC can rewrite `Value::Object(HeapPtr)`
+/// entries in place after an object move (via `RootHaver::forward_roots`)
+/// without re-broadcasting a new `Arc` to every VM.
+///
+/// # Why this exists
+///
+/// Pre-fix, the engine stored `globals: Arc<[Value]>`. The frozen `Arc<[Value]>`
+/// was *not* registered with [`HeapPermitManager`](crate)
+/// (it isn't a `RootHaver`), so any `Value::Object(HeapPtr)` populated during
+/// `$init` (e.g. a top-level `let` bound to a heap-allocated literal) was
+/// invisible to GC — the object could be reclaimed and the stale pointer left
+/// in the globals pool. `SharedGlobals` fixes this: the engine wraps the
+/// frozen pool, registers a clone with the permit manager, and the GC
+/// traces / forwards the entries.
+///
+/// # Concurrency
+///
+/// - Reads ([`Self::get`], [`Self::as_slice`]) require the caller to hold an
+///   active heap permit. While any permit is active, GC cannot park, so
+///   `forward_roots` cannot be running.
+/// - [`RootHaver::collect_roots`] / [`RootHaver::forward_roots`] are only
+///   called by the GC while every permit is parked — so the `&mut` view they
+///   take through the [`UnsafeCell`] cannot alias any reader.
+pub struct SharedGlobals {
+    inner: Arc<SharedGlobalsInner>,
+}
+
+struct SharedGlobalsInner {
+    /// Heap-allocated `Box<[Value]>` whose contents are read concurrently
+    /// by VMs (under their permits) and rewritten by GC `forward_roots`
+    /// (with all permits parked). `UnsafeCell` is the right primitive
+    /// because the `Send`/`Sync` invariant is enforced by the permit
+    /// manager, not by the type system.
+    values: UnsafeCell<Box<[Value]>>,
+}
+
+// SAFETY: concurrent access to `values` is gated externally by the
+// `HeapPermitManager` semaphore + holders mutex. See module docs.
+unsafe impl Send for SharedGlobalsInner {}
+unsafe impl Sync for SharedGlobalsInner {}
+
+impl Clone for SharedGlobals {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl std::fmt::Debug for SharedGlobals {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // SAFETY: same as `Self::as_slice` — read-only access via UnsafeCell;
+        // the caller of `Debug::fmt` is expected to be holding a permit (or
+        // running outside the GC). In practice this is only used for
+        // diagnostics.
+        let slice = unsafe { &*self.inner.values.get() };
+        f.debug_struct("SharedGlobals")
+            .field("len", &slice.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl SharedGlobals {
+    /// Build a `SharedGlobals` from the freshly-frozen globals vector
+    /// produced by `$init`.
+    pub fn from_vec(values: Vec<Value>) -> Self {
+        Self {
+            inner: Arc::new(SharedGlobalsInner {
+                values: UnsafeCell::new(values.into_boxed_slice()),
+            }),
+        }
+    }
+
+    /// Number of globals in the pool.
+    pub fn len(&self) -> usize {
+        // SAFETY: reads the boxed slice's length through the UnsafeCell.
+        // Length is set at construction and never changes, so this is
+        // synchronized regardless of GC state. Explicit `&*` produces a
+        // `&Box<[Value]>` so `.len()` doesn't autoref a raw pointer.
+        unsafe { (&*self.inner.values.get()).len() }
+    }
+
+    /// Whether the pool is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Read a global by index.
+    ///
+    /// Caller must hold an active heap permit. `Value` is `Copy`, so the
+    /// returned value is decoupled from any aliasing of the underlying
+    /// `UnsafeCell`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds — same contract as slice indexing.
+    pub fn get(&self, index: GlobalIndex) -> Value {
+        // SAFETY: caller holds an active heap permit, so GC's `forward_roots`
+        // is excluded for the duration of this read. Explicit `&*` produces
+        // a `&[Value]` (no autoref through the raw-pointer indexing path).
+        unsafe { (&*self.inner.values.get())[index.into_raw()] }
+    }
+
+    /// Borrow the underlying globals as a slice.
+    ///
+    /// Caller must hold an active heap permit (excludes any concurrent
+    /// `forward_roots` mutation). The borrow must not outlive the
+    /// permit's active lifetime.
+    pub fn as_slice(&self) -> &[Value] {
+        // SAFETY: caller holds an active heap permit.
+        unsafe { &*self.inner.values.get() }
+    }
+}
+
+impl RootHaver for SharedGlobals {
+    fn collect_roots(&self, roots: &mut Vec<HeapPtr>) {
+        // SAFETY: GC parks every active permit before calling this, so no
+        // reader is observing the slice concurrently.
+        let slice = unsafe { &*self.inner.values.get() };
+        for value in slice {
+            if let Value::Object(ptr) = value {
+                roots.push(*ptr);
+            }
+        }
+    }
+
+    fn forward_roots(&mut self, roots: &HashMap<HeapPtr, HeapPtr>) {
+        // SAFETY: GC parks every active permit before calling this; `&mut self`
+        // additionally proves there is no concurrent reader of the
+        // `SharedGlobals` permit-cell value on this thread.
+        let slice = unsafe { &mut *self.inner.values.get() };
+        for value in slice.iter_mut() {
+            if let Value::Object(ptr) = value
+                && let Some(&new) = roots.get(ptr)
+            {
+                *ptr = new;
+            }
+        }
+    }
+}
+
 /// The view of globals available to a [`crate::Object`]-aware VM.
 ///
 /// **Invariant**: only `$init` functions emit [`crate::Instruction::StoreGlobal`].
@@ -253,14 +398,17 @@ pub type ObjectPool = Pool<Object, ObjectKind>;
 ///
 /// # Variants
 /// - [`VmGlobals::Owned`]: a mutable [`GlobalPool`] used during `$init` execution.
-/// - [`VmGlobals::Shared`]: a frozen `Arc<[Value]>` shared by every post-`$init` VM.
-///   Cloning is a refcount bump; reads are direct slice indexing.
+/// - [`VmGlobals::Shared`]: a frozen [`SharedGlobals`] shared by every
+///   post-`$init` VM. The underlying `Arc` clone is a refcount bump; reads
+///   require an active heap permit (which excludes the GC's `forward_roots`
+///   mutation pass).
 #[derive(Clone, Debug)]
 pub enum VmGlobals {
     /// Mutable globals pool, used during `$init`.
     Owned(GlobalPool),
-    /// Frozen globals shared across all post-`$init` VMs.
-    Shared(Arc<[Value]>),
+    /// Frozen globals shared across all post-`$init` VMs and rooted by the
+    /// engine's [`SharedGlobals`] permit holder.
+    Shared(SharedGlobals),
 }
 
 impl VmGlobals {
@@ -268,7 +416,7 @@ impl VmGlobals {
     pub fn len(&self) -> usize {
         match self {
             Self::Owned(pool) => pool.len(),
-            Self::Shared(slice) => slice.len(),
+            Self::Shared(globals) => globals.len(),
         }
     }
 
@@ -284,7 +432,7 @@ impl VmGlobals {
     pub fn get(&self, index: GlobalIndex) -> Value {
         match self {
             Self::Owned(pool) => pool[index],
-            Self::Shared(slice) => slice[index.into_raw()],
+            Self::Shared(globals) => globals.get(index),
         }
     }
 
@@ -301,21 +449,15 @@ impl VmGlobals {
         }
     }
 
-    /// Freeze this view into a shared `Arc<[Value]>`. For [`VmGlobals::Owned`],
-    /// this consumes the underlying `Vec`; for [`VmGlobals::Shared`], it clones
-    /// the existing `Arc`.
-    pub fn freeze(self) -> Arc<[Value]> {
-        match self {
-            Self::Owned(pool) => Arc::from(pool.0),
-            Self::Shared(slice) => slice,
-        }
-    }
-
     /// View the globals as a slice. Both variants support O(1) slice access.
+    ///
+    /// For [`VmGlobals::Shared`] the caller must hold an active heap permit
+    /// (no concurrent `forward_roots` mutation). See
+    /// [`SharedGlobals::as_slice`].
     pub fn as_slice(&self) -> &[Value] {
         match self {
             Self::Owned(pool) => &pool.0,
-            Self::Shared(slice) => slice,
+            Self::Shared(globals) => globals.as_slice(),
         }
     }
 }
@@ -326,7 +468,11 @@ impl std::ops::Index<GlobalIndex> for VmGlobals {
     fn index(&self, index: GlobalIndex) -> &Self::Output {
         match self {
             Self::Owned(pool) => &pool[index],
-            Self::Shared(slice) => &slice[index.into_raw()],
+            // SAFETY of underlying read: caller holds an active heap permit
+            // for the lifetime of the returned reference (the same contract
+            // already governs every other use of `&Value` from the engine
+            // hot path).
+            Self::Shared(globals) => &globals.as_slice()[index.into_raw()],
         }
     }
 }
@@ -416,5 +562,96 @@ impl Index<ObjectKind> {
 
     pub fn epoch(self) -> u32 {
         0
+    }
+}
+
+#[cfg(test)]
+mod shared_globals_tests {
+    use super::*;
+    use crate::HeapPtr;
+
+    fn fake_ptr(addr: usize) -> HeapPtr {
+        // SAFETY: tests never deref the pointer; we only inspect it as a
+        // raw `HeapPtr` through `RootHaver::collect_roots` /
+        // `forward_roots`. The address need not be a valid heap slot.
+        #[cfg(feature = "heap_debug")]
+        unsafe {
+            HeapPtr::from_ptr(addr as *mut crate::Object, 0)
+        }
+        #[cfg(not(feature = "heap_debug"))]
+        unsafe {
+            HeapPtr::from_ptr(addr as *mut crate::Object)
+        }
+    }
+
+    #[test]
+    fn collect_roots_returns_only_object_values() {
+        let p1 = fake_ptr(0x1000);
+        let p2 = fake_ptr(0x2000);
+        let globals = SharedGlobals::from_vec(vec![
+            Value::Int(1),
+            Value::Object(p1),
+            Value::Float(3.14),
+            Value::Object(p2),
+            Value::Null,
+        ]);
+
+        let mut roots = Vec::new();
+        globals.collect_roots(&mut roots);
+
+        assert_eq!(roots.len(), 2);
+        assert!(roots.contains(&p1));
+        assert!(roots.contains(&p2));
+    }
+
+    #[test]
+    fn forward_roots_rewrites_in_place_through_unsafecell() {
+        let old1 = fake_ptr(0x1000);
+        let new1 = fake_ptr(0x9000);
+        let old2 = fake_ptr(0x2000);
+        let new2 = fake_ptr(0xA000);
+        // Pointer NOT in the forwarding map should pass through unchanged
+        // (it represents a compile-time pointer or one that wasn't moved).
+        let stable = fake_ptr(0x3000);
+
+        let mut globals = SharedGlobals::from_vec(vec![
+            Value::Object(old1),
+            Value::Int(42),
+            Value::Object(old2),
+            Value::Object(stable),
+        ]);
+
+        let mut forwarding = HashMap::new();
+        forwarding.insert(old1, new1);
+        forwarding.insert(old2, new2);
+        globals.forward_roots(&forwarding);
+
+        // Take a fresh `as_slice()` view; the in-place rewrite must be
+        // visible through the *same* `Arc<UnsafeCell<...>>` that any
+        // existing `SharedGlobals` clone observes.
+        let slice = globals.as_slice();
+        assert_eq!(slice[0], Value::Object(new1));
+        assert_eq!(slice[1], Value::Int(42));
+        assert_eq!(slice[2], Value::Object(new2));
+        assert_eq!(slice[3], Value::Object(stable));
+    }
+
+    #[test]
+    fn clone_shares_underlying_storage_with_engine() {
+        // The engine wires this up so that `SharedGlobals` registered with
+        // the heap permit manager and `SharedGlobals` cloned into VMs
+        // share the same `Arc<UnsafeCell<Box<[Value]>>>`. Verify the clone
+        // observes a `forward_roots` mutation made through another clone.
+        let old = fake_ptr(0x1000);
+        let new = fake_ptr(0x9000);
+        let original = SharedGlobals::from_vec(vec![Value::Object(old)]);
+        let mut held_by_holder = original.clone();
+
+        let mut forwarding = HashMap::new();
+        forwarding.insert(old, new);
+        held_by_holder.forward_roots(&forwarding);
+
+        // The engine-side clone (`original`) must see the rewrite.
+        assert_eq!(original.get(GlobalIndex::from_raw(0)), Value::Object(new));
     }
 }

--- a/baml_language/crates/bex_vm_types/src/indexable.rs
+++ b/baml_language/crates/bex_vm_types/src/indexable.rs
@@ -591,7 +591,7 @@ mod shared_globals_tests {
         let globals = SharedGlobals::from_vec(vec![
             Value::Int(1),
             Value::Object(p1),
-            Value::Float(3.14),
+            Value::Float(1.234),
             Value::Object(p2),
             Value::Null,
         ]);

--- a/baml_language/crates/bex_vm_types/src/indexable.rs
+++ b/baml_language/crates/bex_vm_types/src/indexable.rs
@@ -269,6 +269,15 @@ pub type ObjectPool = Pool<Object, ObjectKind>;
 /// - [`RootHaver::collect_roots`] / [`RootHaver::forward_roots`] are only
 ///   called by the GC while every permit is parked — so the `&mut` view they
 ///   take through the [`UnsafeCell`] cannot alias any reader.
+///
+/// The "caller holds a permit for the slice's lifetime" obligation is
+/// **not** enforced by the type system: `SharedGlobals` is `Send + Sync +
+/// Clone`, so the lifetime of `&Self` (and any `&[Value]` projected from
+/// it via [`Self::as_slice`]) is decoupled from any specific
+/// [`ActiveHeapPermit`](crate)'s lifetime. Misuse causes UB. Where
+/// possible, prefer [`Self::get`] (returns `Value` by copy) to avoid
+/// holding the slice borrow across any operation that could end the
+/// caller's permit.
 pub struct SharedGlobals {
     inner: Arc<SharedGlobalsInner>,
 }
@@ -351,11 +360,26 @@ impl SharedGlobals {
 
     /// Borrow the underlying globals as a slice.
     ///
-    /// Caller must hold an active heap permit (excludes any concurrent
-    /// `forward_roots` mutation). The borrow must not outlive the
-    /// permit's active lifetime.
+    /// # Unenforced contract
+    ///
+    /// Caller must hold an active heap permit for the *entire* lifetime
+    /// of the returned `&[Value]`. The slice borrow is tied to `&self`,
+    /// **not** to the permit — Rust's type system has no way to express
+    /// that relationship through `SharedGlobals` (`SharedGlobals` is
+    /// `Clone` and `Send + Sync`, so its `&` lifetime is decoupled from
+    /// any specific permit's). If the permit drops while the slice is
+    /// still alive and a GC runs `forward_roots` on this `SharedGlobals`
+    /// (which mutates `inner.values` via [`UnsafeCell`]), the resulting
+    /// aliasing is **undefined behavior**.
+    ///
+    /// Prefer [`Self::get`] (returns `Value` by copy) whenever the call
+    /// site only needs a single element. `as_slice` exists for the
+    /// `VmGlobals::as_slice` / `VmGlobals::Index<GlobalIndex>` paths
+    /// which are already governed by the wider VM-permit invariant.
     pub fn as_slice(&self) -> &[Value] {
-        // SAFETY: caller holds an active heap permit.
+        // SAFETY: caller upholds the unenforced contract above — they
+        // hold an active heap permit and won't release it before the
+        // returned slice's last use.
         unsafe { &*self.inner.values.get() }
     }
 }

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -22,7 +22,7 @@ pub use bytecode::{
 };
 pub use heap_ptr::HeapPtr;
 pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex, VmGlobals};
-pub use roots::RootHaver;
+pub use roots::{RootHaver, WriteBarrier};
 pub use types::{
     Class, ClassField, ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum,
     EnumVariant, Function, FunctionKind, FunctionMeta, FunctionOrigin, Future, FutureRead,

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -21,7 +21,9 @@ pub use bytecode::{
     VizNodeMeta, VizNodeType,
 };
 pub use heap_ptr::HeapPtr;
-pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex, VmGlobals};
+pub use indexable::{
+    GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, SharedGlobals, StackIndex, VmGlobals,
+};
 pub use roots::{RootHaver, WriteBarrier};
 pub use types::{
     Class, ClassField, ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum,

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -24,7 +24,7 @@ pub use heap_ptr::HeapPtr;
 pub use indexable::{
     GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, SharedGlobals, StackIndex, VmGlobals,
 };
-pub use roots::{RootHaver, WriteBarrier};
+pub use roots::{PermitProof, RootHaver, WriteBarrier};
 pub use types::{
     Class, ClassField, ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum,
     EnumVariant, Function, FunctionKind, FunctionMeta, FunctionOrigin, Future, FutureRead,

--- a/baml_language/crates/bex_vm_types/src/roots.rs
+++ b/baml_language/crates/bex_vm_types/src/roots.rs
@@ -1,6 +1,6 @@
 use ::std::collections::HashMap;
 
-use crate::HeapPtr;
+use crate::{HeapPtr, Value};
 
 /// A trait for types that have heap roots.
 ///
@@ -19,4 +19,30 @@ pub trait RootHaver: Send {
 impl RootHaver for () {
     fn collect_roots(&self, _roots: &mut Vec<HeapPtr>) {}
     fn forward_roots(&mut self, _roots: &HashMap<HeapPtr, HeapPtr>) {}
+}
+
+/// Generational write-barrier hook for heap mutations that touch a [`Value`].
+///
+/// Implemented by [`bex_heap::BexHeap`] (`bex_heap` is downstream of this
+/// crate, so we can't name it here directly). Lives in `bex_vm_types` so
+/// types like [`crate::Future`] — which perform their own
+/// `UnsafeCell<MaybeUninit<Value>>` writes via `unsafe` setters — can
+/// require callers to fire the barrier through this trait without taking a
+/// dependency on the heap crate.
+///
+/// # Why this exists
+///
+/// The generational GC tracks cross-generation references via a card table.
+/// When an older-generation object is mutated to hold a younger-generation
+/// reference, the container's card must be marked dirty so a partial
+/// (Minor) GC can rediscover the reference. Heap-mutation sites in the VM
+/// (`vm.rs`) call `BexHeap::write_barrier` for this. The `Future` heap
+/// object is special: its terminal-state writes don't go through the VM —
+/// they go through the engine's spawned `run_future` writeback path. That
+/// path now must fire the barrier too, and `Future::set_ready` /
+/// `set_error` enforces it via this trait at compile time.
+pub trait WriteBarrier {
+    /// Mark a card dirty for `container` if `value` is a younger-gen
+    /// `Value::Object`. Called *before* the actual field write.
+    fn write_barrier(&self, container: HeapPtr, value: Value);
 }

--- a/baml_language/crates/bex_vm_types/src/roots.rs
+++ b/baml_language/crates/bex_vm_types/src/roots.rs
@@ -1,4 +1,4 @@
-use ::std::collections::HashMap;
+use ::std::{collections::HashMap, marker::PhantomData};
 
 use crate::{HeapPtr, Value};
 
@@ -23,7 +23,7 @@ impl RootHaver for () {
 
 /// Generational write-barrier hook for heap mutations that touch a [`Value`].
 ///
-/// Implemented by [`bex_heap::BexHeap`] (`bex_heap` is downstream of this
+/// Implemented by `bex_heap::BexHeap` (`bex_heap` is downstream of this
 /// crate, so we can't name it here directly). Lives in `bex_vm_types` so
 /// types like [`crate::Future`] — which perform their own
 /// `UnsafeCell<MaybeUninit<Value>>` writes via `unsafe` setters — can
@@ -45,4 +45,56 @@ pub trait WriteBarrier {
     /// Mark a card dirty for `container` if `value` is a younger-gen
     /// `Value::Object`. Called *before* the actual field write.
     fn write_barrier(&self, container: HeapPtr, value: Value);
+}
+
+/// A type-erased proof that an active heap permit is held in the current
+/// scope (for at least lifetime `'a`).
+///
+/// `PermitProof<'a>` is a zero-sized lifetime witness. It carries no
+/// runtime data — the GC-exclusion guarantee comes purely from the
+/// lifetime, which is bound by the originating permit's borrow.
+///
+/// # Where it lives
+///
+/// Defined here in `bex_vm_types` (rather than `bex_heap`, where the
+/// permit machinery lives) so that upstream types like
+/// [`crate::SharedGlobals`] — which themselves need to gate their
+/// `UnsafeCell`-backed reads on "an active permit is held" without taking
+/// a dependency on `bex_heap` — can accept the proof safely.
+/// `bex_heap::ActiveHeapPermit::proof` is the canonical safe constructor;
+/// it re-exports this type for backward compatibility.
+///
+/// # Why the constructor is `unsafe`
+///
+/// The whole point of `PermitProof` is that *holding* one is a runtime
+/// witness that a permit is active. Construction must therefore be
+/// gated: only callers who genuinely hold a permit may produce one. The
+/// only safe production caller is
+/// `bex_heap::ActiveHeapPermit::proof`, which calls
+/// [`Self::new`] inside an `unsafe` block whose safety argument is
+/// "`&self` proves an active permit is held for this borrow's lifetime."
+/// Test mocks may use [`Self::new`] directly with a documented safety
+/// argument.
+#[derive(Clone, Copy)]
+pub struct PermitProof<'a> {
+    _marker: PhantomData<&'a ()>,
+}
+
+impl PermitProof<'_> {
+    /// Construct a `PermitProof` tied to lifetime `'a`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must hold an active heap permit for at least lifetime `'a`.
+    /// The only intended production caller is
+    /// `bex_heap::ActiveHeapPermit::proof`, which justifies the
+    /// invariant via its `&self` borrow.
+    #[inline]
+    #[must_use]
+    #[allow(unsafe_code, reason = "construction is the unsafety boundary")]
+    pub const unsafe fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
 }

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -1088,13 +1088,29 @@ impl Future {
 
     /// Transition to `Ready`.
     ///
+    /// Fires the generational write barrier on `heap` for `self_ptr`
+    /// before the value write. This is required because a `Future` can
+    /// survive across GCs (rooted by `FutureManagerInner::active_futures`)
+    /// and may end up in Gen2; if `value` is a `Value::Object` referring
+    /// to a younger-generation heap object, the next Minor GC's
+    /// dirty-card scan must find this reference. Without the barrier the
+    /// young object would be reclaimed and the `Future`'s `value` left
+    /// dangling.
+    ///
     /// # Safety
     ///
     /// Caller must hold `future_permit` (single-writer invariant). The
     /// future must currently be in `Pending` state — overwriting `value`
     /// after a previous `set_ready`/`set_error` would race with
-    /// concurrent readers.
-    pub unsafe fn set_ready(&self, value: Value) {
+    /// concurrent readers. `self_ptr` must be the [`HeapPtr`] under which
+    /// `self` lives (so the write barrier marks the correct card).
+    pub unsafe fn set_ready(
+        &self,
+        heap: &impl crate::WriteBarrier,
+        self_ptr: HeapPtr,
+        value: Value,
+    ) {
+        heap.write_barrier(self_ptr, value);
         // SAFETY: single-writer invariant via `future_permit`.
         unsafe { (*self.value.get()).write(value) };
         self.state.store(FutureTag::Ready as u8, Ordering::Release);
@@ -1102,11 +1118,20 @@ impl Future {
 
     /// Transition to `Error`.
     ///
+    /// Fires the generational write barrier — see [`Self::set_ready`].
+    ///
     /// # Safety
     ///
-    /// See [`Self::set_ready`] — caller must hold `future_permit` and the
-    /// future must currently be `Pending`.
-    pub unsafe fn set_error(&self, value: Value) {
+    /// See [`Self::set_ready`] — caller must hold `future_permit`, the
+    /// future must currently be `Pending`, and `self_ptr` must point at
+    /// `self`'s heap slot.
+    pub unsafe fn set_error(
+        &self,
+        heap: &impl crate::WriteBarrier,
+        self_ptr: HeapPtr,
+        value: Value,
+    ) {
+        heap.write_barrier(self_ptr, value);
         // SAFETY: single-writer invariant via `future_permit`.
         unsafe { (*self.value.get()).write(value) };
         self.state.store(FutureTag::Error as u8, Ordering::Release);


### PR DESCRIPTION
- Fixes bug where TLAB could be allocated for new VMs even during GC
- Fixes bug where read operations that used ChunkedVec index (instead of specific TLAB/object pointer/references) could happen during GC or resize
- Fixes bug where write barrier was not set when resolving futures, meaning a potentially invalid card table state
- Fixes regression where globals were not a `RootHaver`
- Fixes bug where the `RootHaver` implementation for `Watch` did not include all held references
- Add debug assertions to validate heap/GC state to prevent future regressions
- Other cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger GC integrity checks to prevent dead references and invalid forwarding.
  * Fixed race conditions in concurrent heap operations to avoid use-after-free and stale pointers.

* **Improvements**
  * Safer concurrent heap APIs via internal locking and write-barrier-aware updates.
  * Frozen globals now use a guarded shared representation to ensure safe reads during GC.
  * TLAB initialization deferred to avoid stale allocation cursors.

* **Tests**
  * Previously skipped GC/future regression tests re-enabled and expanded.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3514)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->