### PR TITLE
fix: stage playground webview into vscode ext dist during dev

### DIFF
--- a/typescript2/app-vscode-ext/tsup.config.ts
+++ b/typescript2/app-vscode-ext/tsup.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from 'tsup';
+import { cpSync, existsSync, mkdirSync } from 'fs';
+import { resolve } from 'path';
 
-export default defineConfig({
+function stagePlayground() {
+  const src = resolve(__dirname, '../app-vscode-webview/dist');
+  const dest = resolve(__dirname, 'dist/playground');
+  if (existsSync(src)) {
+    mkdirSync(dest, { recursive: true });
+    cpSync(src, dest, { recursive: true });
+  }
+}
+
+export default defineConfig((options) => ({
   entry: ['src/extension.ts'],
   outDir: 'dist',
   outExtension: () => ({ js: '.js' }),
@@ -10,8 +21,11 @@ export default defineConfig({
   bundle: true,
   noExternal: [/^(?!vscode$)/],
   sourcemap: true,
-  clean: true,
+  clean: !options.watch,
   platform: 'node',
   splitting: false,
   treeshake: true,
-});
+  onSuccess: async () => {
+    stagePlayground();
+  },
+}));

--- a/typescript2/package.json
+++ b/typescript2/package.json
@@ -8,7 +8,7 @@
     "dev:wasm": "BRIDGE_WASM_FORCE_RERUN=1 npx nodemon --watch ../baml_language --ignore '**/target/**' --ext rs,toml --exec \"pnpm build:wasm\"",
     "dev:webview": "pnpm --filter app-vscode-webview dev",
     "dev:cargo": "cargo watch -C ../baml_language  --ignore '**/target/**' --skip-local-deps --watch-when-idle -w crates -x 'build -p baml_cli'",
-    "dev:vscode": "turbo run dev --filter=app-vscode-ext --filter=app-vscode-webview --filter=@b/pkg-playground '//#dev:cargo'",
+    "dev:vscode": "turbo run build --filter=app-vscode-webview && turbo run dev --filter=app-vscode-ext --filter=app-vscode-webview --filter=@b/pkg-playground '//#dev:cargo'",
     "dev:promptfiddle": "turbo run dev --filter app-promptfiddle --filter @b/pkg-playground '//#dev:wasm'",
     "build": "turbo run build",
     "vscode:package": "pnpm run vscode:package:clean && pnpm run vscode:package:build && pnpm run vscode:package:stage && pnpm run vscode:package:vsix",


### PR DESCRIPTION
## Summary
- `pnpm dev:vscode` failed with `ENOENT: no such file or directory, open '.../app-vscode-ext/dist/playground/index.html'` because the webview build was never copied into the extension's dist during dev mode (only during `vscode:package:stage`)
- Build the webview before starting turbo dev, and copy it into `dist/playground/` via a tsup `onSuccess` hook
- Disable tsup `clean` in watch mode so the playground directory survives rebuilds

## Test plan
- [ ] Run `pnpm dev:vscode` and verify the playground opens without ENOENT errors
- [ ] Run `pnpm vscode:package` and verify packaging still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved VS Code extension build process with enhanced artifact staging and conditional cleanup behavior.
  * Updated development workflow to ensure webview components are built before launching the extension development environment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3515)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->