### PR TITLE
docs: fix BamlTimeoutError attributes in timeout handling examples

### DIFF
--- a/fern/01-guide/04-baml-basics/timeouts.mdx
+++ b/fern/01-guide/04-baml-basics/timeouts.mdx
@@ -165,9 +165,8 @@ try:
     result = await b.ExtractData(input)
 except BamlTimeoutError as e:
     # Handle timeout specifically
-    print(f"Request timed out: {e.message}")
-    print(f"Timeout type: {e.timeout_type}")
-    print(f"Configured: {e.configured_value_ms}ms, Elapsed: {e.elapsed_ms}ms")
+    # Available attributes: client_name, message
+    print(f"Request timed out on client '{e.client_name}': {e.message}")
 except BamlClientError as e:
     # Handle other client errors
     print(f"Client error: {e.message}")
@@ -182,9 +181,8 @@ try {
 } catch (e) {
   if (e instanceof BamlTimeoutError) {
     // Handle timeout specifically
-    console.log(`Request timed out: ${e.message}`)
-    console.log(`Timeout type: ${e.timeout_type}`)
-    console.log(`Configured: ${e.configured_value_ms}ms, Elapsed: ${e.elapsed_ms}ms`)
+    // Available attributes: client_name, message
+    console.log(`Request timed out on client '${e.client_name}': ${e.message}`)
   } else {
     // Handle other errors
     console.log(`Error: ${e}`)
@@ -198,8 +196,6 @@ begin
 rescue Baml::TimeoutError => e
   # Handle timeout specifically
   puts "Request timed out: #{e.message}"
-  puts "Timeout type: #{e.timeout_type}"
-  puts "Configured: #{e.configured_value_ms}ms, Elapsed: #{e.elapsed_ms}ms"
 rescue Baml::ClientError => e
   # Handle other client errors
   puts "Client error: #{e.message}"


### PR DESCRIPTION
## Summary

Fixes #3465

The `Handling Timeout Errors` section in the timeouts guide showed `e.timeout_type`, `e.configured_value_ms`, and `e.elapsed_ms` as available attributes on `BamlTimeoutError`, but these fields do not exist on the exception class.

The actual available attributes are `client_name` and `message`, matching:
- `ExposedError::TimeoutError { client_name, message }` in `engine/baml-runtime/src/errors.rs`
- `BamlTimeoutError.__init__(client_name, message)` in `engine/language_client_python/python_src/baml_py/internal_monkeypatch.py`

### Changes
- Remove references to `timeout_type`, `configured_value_ms`, `elapsed_ms` from Python and TypeScript code examples
- Update examples to use the actual `client_name` attribute
- Remove the non-existent attributes from the Ruby example
- Add comments indicating the available attributes

## Test plan
- [ ] Verify the code examples now correctly reference only `client_name` and `message`
- [ ] Check that catching `BamlTimeoutError` and accessing `e.client_name` works in Python

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated timeout error handling examples in the BAML guide to focus on essential error attributes for better clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3516)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->