### PR TITLE
baml_language: add duplicate parameter error

### DIFF
--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -246,6 +246,24 @@ impl<'db> SemanticIndexBuilder<'db> {
         }
     }
 
+    /// Emit a `DuplicateDefinition` diagnostic for any parameter name that
+    /// appears more than once in a function or lambda signature. Applies
+    /// uniformly to positional and defaulted parameters — both share the
+    /// same `params` vector, and any name collision among them would make
+    /// later references to the name ambiguous within the body.
+    fn emit_duplicate_param_diagnostics(&mut self, params: &[ast::Param]) {
+        let mut seen: FxHashMap<Name, Vec<MemberSite>> = FxHashMap::default();
+        for param in params {
+            seen.entry(param.name.clone())
+                .or_default()
+                .push(MemberSite {
+                    range: param.name_span,
+                    kind: DefinitionKind::Parameter,
+                });
+        }
+        self.emit_duplicate_diagnostics(seen);
+    }
+
     /// Emit `DuplicateDefinition` diagnostics for any name with more than one site.
     fn emit_duplicate_diagnostics(&mut self, seen: FxHashMap<Name, Vec<MemberSite>>) {
         let scope = self.current_scope_path();
@@ -798,6 +816,7 @@ impl<'db> SemanticIndexBuilder<'db> {
                 .params
                 .push((param.name.clone(), idx));
         }
+        self.emit_duplicate_param_diagnostics(&func_def.params);
         self.lambda_stack.push(scope_id);
         for param in &func_def.params {
             if let Some(default) = param.default {
@@ -955,6 +974,7 @@ impl<'db> SemanticIndexBuilder<'db> {
                 .params
                 .push((param.name.clone(), idx));
         }
+        self.emit_duplicate_param_diagnostics(&f.params);
         for param in &f.params {
             if let Some(default) = param.default {
                 self.walk_expr(

--- a/baml_language/crates/baml_tests/src/compiler2_hir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_hir.rs
@@ -542,6 +542,77 @@ mod tests {
         assert!(sites.iter().all(|s| s.kind == DefinitionKind::Variant));
     }
 
+    /// Duplicate parameter names within a function signature — across any
+    /// combination of positional and defaulted parameters — produce a
+    /// `DuplicateDefinition` diagnostic.
+    #[test]
+    fn duplicate_function_param_produces_diagnostic() {
+        use baml_compiler2_hir::{contributions::DefinitionKind, diagnostic::Hir2Diagnostic};
+
+        let cases: &[(&str, &str, &str)] = &[
+            (
+                "positional/positional",
+                "dup_param_pos_pos.baml",
+                "function Foo(x: int, x: string) -> string { x }",
+            ),
+            (
+                "positional/defaulted",
+                "dup_param_pos_opt.baml",
+                "function Foo(x: int, x: string = \"hi\") -> string { x }",
+            ),
+            (
+                "defaulted/defaulted",
+                "dup_param_opt_opt.baml",
+                "function Foo(x: int = 0, x: string = \"hi\") -> string { x }",
+            ),
+        ];
+
+        for (label, file_name, source) in cases {
+            let mut db = make_db();
+            let file = db.add_file(file_name, source);
+            let index = file_semantic_index(&db, file);
+            let diags = index.diagnostics();
+            let dups: Vec<_> = diags
+                .iter()
+                .filter(|d| matches!(d, Hir2Diagnostic::DuplicateDefinition { name, .. } if name == &Name::new("x")))
+                .collect();
+            assert_eq!(
+                dups.len(),
+                1,
+                "{label}: expected 1 duplicate diagnostic for 'x'"
+            );
+            let Hir2Diagnostic::DuplicateDefinition { scope, sites, .. } = dups[0] else {
+                panic!("{label}: expected DuplicateDefinition diagnostic");
+            };
+            assert_eq!(scope.as_ref().unwrap(), &Name::new("Foo"), "{label}");
+            assert_eq!(sites.len(), 2, "{label}");
+            assert!(
+                sites.iter().all(|s| s.kind == DefinitionKind::Parameter),
+                "{label}: all sites should be Parameter kind"
+            );
+        }
+    }
+
+    /// Distinct parameter names in a function signature do not produce a
+    /// duplicate diagnostic — regression guard against over-firing.
+    #[test]
+    fn distinct_function_params_have_no_duplicate_diagnostic() {
+        use baml_compiler2_hir::diagnostic::Hir2Diagnostic;
+
+        let mut db = make_db();
+        let file = db.add_file(
+            "distinct_params.baml",
+            "function Foo(x: int, y: string = \"hi\") -> string { y }",
+        );
+        let index = file_semantic_index(&db, file);
+        let diags = index.diagnostics();
+        assert!(
+            !diags
+                .iter()
+                .any(|d| matches!(d, Hir2Diagnostic::DuplicateDefinition { .. }))
+        );
+    }
+
     /// Same-scope let shadowing is legal and does not produce duplicate diagnostics.
     #[test]
     fn same_scope_let_shadowing_has_no_duplicate_diagnostic() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compiler now detects and reports duplicate parameter names in both functions and lambda expressions. This improved validation catches parameter naming conflicts early, preventing potential runtime issues.

* **Tests**
  * Added comprehensive test coverage for duplicate parameter detection to ensure the validation works correctly for both duplicate and distinct parameter names.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3518)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->