### PR TITLE
feat: add graph diff rendering to TypeScript playground

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1329,6 +1329,7 @@ dependencies = [
  "anyhow",
  "axum",
  "baml_compiler2_visualization",
+ "baml_project",
  "baml_type",
  "base64",
  "bex_events",

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/diff.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/diff.rs
@@ -1,0 +1,1388 @@
+//! Graph diff engine for comparing two `ControlFlowGraph` snapshots.
+//!
+//! Uses a three-pass matching algorithm:
+//! 1. Exact `logFilterKey` match
+//! 2. `(nodeType, calleeName)` fallback for unmatched call nodes
+//! 3. Positional `(nodeType, label)` fallback within matched parents
+
+use std::collections::{HashMap, HashSet};
+
+use super::{ControlFlowGraph, Node, NodeId, NodeType, build_children_map};
+
+/// Result of comparing two control flow graphs.
+///
+/// Node IDs reference nodes in the original `base` and `head` graphs —
+/// the diff is a lightweight report, not a copy.
+pub struct GraphDiff {
+    /// Nodes present in `head` but not in `base`.
+    pub added: Vec<NodeId>,
+    /// Nodes present in `base` but not in `head`.
+    pub removed: Vec<NodeId>,
+    /// Matched node pairs where metadata differs: `(base_id, head_id)`.
+    pub modified: Vec<(NodeId, NodeId)>,
+    /// Matched node pairs where metadata is identical: `(base_id, head_id)`.
+    pub unchanged: Vec<(NodeId, NodeId)>,
+}
+
+/// Compare two nodes on semantically meaningful metadata.
+///
+/// Excludes: `id` (unstable sequential), `parent_node_id` (changes on reparent),
+/// `log_filter_key` (breaks on 6 of 12 scenarios), `source_expr` (arena index),
+/// `source_span` (file positions).
+fn nodes_metadata_equal(base: &Node, head: &Node) -> bool {
+    base.label == head.label
+        && base.node_type == head.node_type
+        && base.llm_client == head.llm_client
+        && base.callee_name == head.callee_name
+        && base.is_container == head.is_container
+}
+
+/// Compare two control flow graph snapshots and classify every node.
+pub fn compute_graph_diff(base: &ControlFlowGraph, head: &ControlFlowGraph) -> GraphDiff {
+    let mut matched_base: HashSet<NodeId> = HashSet::new();
+    let mut matched_head: HashSet<NodeId> = HashSet::new();
+    let mut modified: Vec<(NodeId, NodeId)> = Vec::new();
+    let mut unchanged: Vec<(NodeId, NodeId)> = Vec::new();
+
+    // Build lookup: logFilterKey → NodeId for base graph
+    let base_by_key: HashMap<&str, NodeId> = base
+        .nodes
+        .iter()
+        .map(|(&id, node)| (node.log_filter_key.as_str(), id))
+        .collect();
+
+    // Track which base nodes were matched to which head nodes, for use in
+    // pass 2's parent-preference logic
+    let mut base_to_head_parent: HashMap<NodeId, NodeId> = HashMap::new();
+
+    // --- Pass 1: Exact logFilterKey match ---
+    for (&head_id, head_node) in &head.nodes {
+        if let Some(&base_id) = base_by_key.get(head_node.log_filter_key.as_str()) {
+            if matched_base.contains(&base_id) {
+                continue; // Already matched (duplicate key edge case)
+            }
+            matched_base.insert(base_id);
+            matched_head.insert(head_id);
+            base_to_head_parent.insert(base_id, head_id);
+
+            let base_node = &base.nodes[&base_id];
+            if nodes_metadata_equal(base_node, head_node) {
+                unchanged.push((base_id, head_id));
+            } else {
+                modified.push((base_id, head_id));
+            }
+        }
+    }
+
+    // --- Pass 2: (nodeType, calleeName) fallback for unmatched call nodes ---
+    // Build index of unmatched base nodes by (nodeType, calleeName)
+    let mut base_by_callee: HashMap<(&NodeType, &str), Vec<NodeId>> = HashMap::new();
+    for (&base_id, base_node) in &base.nodes {
+        if matched_base.contains(&base_id) {
+            continue;
+        }
+        if let Some(ref callee) = base_node.callee_name {
+            base_by_callee
+                .entry((&base_node.node_type, callee.as_str()))
+                .or_default()
+                .push(base_id);
+        }
+    }
+
+    for (&head_id, head_node) in &head.nodes {
+        if matched_head.contains(&head_id) {
+            continue;
+        }
+        if let Some(ref callee) = head_node.callee_name {
+            let key = (&head_node.node_type, callee.as_str());
+            if let Some(candidates) = base_by_callee.get_mut(&key) {
+                if candidates.is_empty() {
+                    continue;
+                }
+                // Prefer candidate whose parent was already matched to this
+                // node's parent (via pass 1), otherwise take the first
+                let chosen_idx = if candidates.len() > 1 {
+                    candidates
+                        .iter()
+                        .position(|&base_id| {
+                            let base_parent = base.nodes[&base_id].parent_node_id;
+                            let head_parent = head_node.parent_node_id;
+                            // Check if base_parent was matched to head_parent
+                            match (base_parent, head_parent) {
+                                (Some(bp), Some(hp)) => base_to_head_parent.get(&bp) == Some(&hp),
+                                (None, None) => true,
+                                _ => false,
+                            }
+                        })
+                        .unwrap_or(0)
+                } else {
+                    0
+                };
+                let base_id = candidates.remove(chosen_idx);
+                matched_base.insert(base_id);
+                matched_head.insert(head_id);
+                base_to_head_parent.insert(base_id, head_id);
+
+                // calleeName matched but other metadata may differ (label, reparenting, etc.)
+                let base_node = &base.nodes[&base_id];
+                if nodes_metadata_equal(base_node, head_node) {
+                    unchanged.push((base_id, head_id));
+                } else {
+                    modified.push((base_id, head_id));
+                }
+            }
+        }
+    }
+
+    // --- Pass 3: Positional (nodeType, label) fallback within matched parents ---
+    let base_children = build_children_map(&base.nodes);
+    let head_children = build_children_map(&head.nodes);
+
+    // Collect all matched pairs so far for parent-based child lookup
+    let matched_pairs: Vec<(NodeId, NodeId)> =
+        unchanged.iter().chain(modified.iter()).copied().collect();
+
+    // Include root-level matching (nodes with no parent)
+    let root_base: Vec<NodeId> = base
+        .nodes
+        .keys()
+        .filter(|id| base.nodes[*id].parent_node_id.is_none() && !matched_base.contains(id))
+        .copied()
+        .collect();
+    let root_head: Vec<NodeId> = head
+        .nodes
+        .keys()
+        .filter(|id| head.nodes[*id].parent_node_id.is_none() && !matched_head.contains(id))
+        .copied()
+        .collect();
+
+    positional_match_children(
+        &root_base,
+        &root_head,
+        base,
+        head,
+        &mut matched_base,
+        &mut matched_head,
+        &mut modified,
+        &mut unchanged,
+    );
+
+    for (base_parent, head_parent) in &matched_pairs {
+        let base_kids: Vec<NodeId> = base_children
+            .get(base_parent)
+            .map(|kids| {
+                kids.iter()
+                    .filter(|id| !matched_base.contains(id))
+                    .copied()
+                    .collect()
+            })
+            .unwrap_or_default();
+        let head_kids: Vec<NodeId> = head_children
+            .get(head_parent)
+            .map(|kids| {
+                kids.iter()
+                    .filter(|id| !matched_head.contains(id))
+                    .copied()
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        positional_match_children(
+            &base_kids,
+            &head_kids,
+            base,
+            head,
+            &mut matched_base,
+            &mut matched_head,
+            &mut modified,
+            &mut unchanged,
+        );
+    }
+
+    // --- Collect unmatched as added/removed ---
+    let removed: Vec<NodeId> = base
+        .nodes
+        .keys()
+        .filter(|id| !matched_base.contains(id))
+        .copied()
+        .collect();
+    let added: Vec<NodeId> = head
+        .nodes
+        .keys()
+        .filter(|id| !matched_head.contains(id))
+        .copied()
+        .collect();
+
+    GraphDiff {
+        added,
+        removed,
+        modified,
+        unchanged,
+    }
+}
+
+/// Match unmatched children by `(nodeType, label)` — used in pass 3.
+#[allow(clippy::too_many_arguments)]
+fn positional_match_children(
+    base_kids: &[NodeId],
+    head_kids: &[NodeId],
+    base: &ControlFlowGraph,
+    head: &ControlFlowGraph,
+    matched_base: &mut HashSet<NodeId>,
+    matched_head: &mut HashSet<NodeId>,
+    modified: &mut Vec<(NodeId, NodeId)>,
+    unchanged: &mut Vec<(NodeId, NodeId)>,
+) {
+    // Index base children by (nodeType, label)
+    let mut base_by_type_label: HashMap<(&NodeType, &str), Vec<NodeId>> = HashMap::new();
+    for &base_id in base_kids {
+        let node = &base.nodes[&base_id];
+        base_by_type_label
+            .entry((&node.node_type, node.label.as_str()))
+            .or_default()
+            .push(base_id);
+    }
+
+    for &head_id in head_kids {
+        if matched_head.contains(&head_id) {
+            continue;
+        }
+        let head_node = &head.nodes[&head_id];
+        let key = (&head_node.node_type, head_node.label.as_str());
+        if let Some(candidates) = base_by_type_label.get_mut(&key) {
+            if let Some(pos) = candidates.iter().position(|id| !matched_base.contains(id)) {
+                let base_id = candidates[pos];
+                matched_base.insert(base_id);
+                matched_head.insert(head_id);
+
+                let base_node = &base.nodes[&base_id];
+                if nodes_metadata_equal(base_node, head_node) {
+                    unchanged.push((base_id, head_id));
+                } else {
+                    modified.push((base_id, head_id));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control_flow::{Edge, NodeType};
+
+    /// Construct a non-call node.
+    fn make_node(
+        id: u32,
+        parent: Option<u32>,
+        label: &str,
+        node_type: NodeType,
+        key: &str,
+    ) -> Node {
+        Node {
+            id: NodeId::new(id),
+            parent_node_id: parent.map(NodeId::new),
+            log_filter_key: key.to_string(),
+            label: label.to_string(),
+            source_expr: None,
+            node_type,
+            llm_client: None,
+            callee_name: None,
+            source_span: None,
+            is_container: false,
+        }
+    }
+
+    /// Construct a call-site `OtherScope` node with `callee_name`.
+    fn make_call_node(id: u32, parent: Option<u32>, label: &str, callee: &str, key: &str) -> Node {
+        let mut node = make_node(id, parent, label, NodeType::OtherScope, key);
+        node.callee_name = Some(callee.to_string());
+        node
+    }
+
+    /// Build a `ControlFlowGraph` from nodes and edge pairs.
+    fn build_graph(nodes: Vec<Node>, edges: Vec<(u32, u32)>) -> ControlFlowGraph {
+        let mut graph = ControlFlowGraph::default();
+        for node in nodes {
+            graph.nodes.insert(node.id, node);
+        }
+        for (src, dst) in edges {
+            graph
+                .edges_by_src
+                .entry(NodeId::new(src))
+                .or_default()
+                .push(Edge {
+                    src: NodeId::new(src),
+                    dst: NodeId::new(dst),
+                    label: None,
+                });
+        }
+        graph
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 1: Add a function call
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_1_add_function_call() {
+        // Base: Pipeline -> Summarize(text)
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Summarize(text)",
+                    "Summarize",
+                    "Pipeline|root:0|scope:summarize-text:0",
+                ),
+            ],
+            vec![(0, 1)],
+        );
+
+        // Head: Pipeline -> Summarize(text) -> EditSummary(summary)
+        let head = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Summarize(text)",
+                    "Summarize",
+                    "Pipeline|root:0|scope:summarize-text:0",
+                ),
+                make_call_node(
+                    2,
+                    Some(0),
+                    "EditSummary(summary)",
+                    "EditSummary",
+                    "Pipeline|root:0|scope:editsummary-summary:1",
+                ),
+            ],
+            vec![(0, 1), (1, 2)],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.added.len(), 1, "one node added");
+        assert_eq!(diff.removed.len(), 0, "no nodes removed");
+        assert_eq!(diff.modified.len(), 0, "no nodes modified");
+        assert_eq!(diff.unchanged.len(), 2, "root + Summarize unchanged");
+
+        let added_node = &head.nodes[&diff.added[0]];
+        assert_eq!(added_node.callee_name.as_deref(), Some("EditSummary"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 2: Remove a function call
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_2_remove_function_call() {
+        // Base: Pipeline -> StepA -> StepB -> StepC
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "StepA(text)",
+                    "StepA",
+                    "Pipeline|root:0|scope:stepa-text:0",
+                ),
+                make_call_node(
+                    2,
+                    Some(0),
+                    "StepB(a)",
+                    "StepB",
+                    "Pipeline|root:0|scope:stepb-a:1",
+                ),
+                make_call_node(
+                    3,
+                    Some(0),
+                    "StepC(b)",
+                    "StepC",
+                    "Pipeline|root:0|scope:stepc-b:2",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (2, 3)],
+        );
+
+        // Head: Pipeline -> StepA -> StepC(a) -- StepB removed, StepC label changed
+        let head = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "StepA(text)",
+                    "StepA",
+                    "Pipeline|root:0|scope:stepa-text:0",
+                ),
+                // StepC's ordinal shifted and label changed (arg changed from b to a)
+                make_call_node(
+                    2,
+                    Some(0),
+                    "StepC(a)",
+                    "StepC",
+                    "Pipeline|root:0|scope:stepc-a:1",
+                ),
+            ],
+            vec![(0, 1), (1, 2)],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.removed.len(), 1, "StepB removed");
+        assert_eq!(diff.added.len(), 0, "no nodes added");
+
+        let removed_node = &base.nodes[&diff.removed[0]];
+        assert_eq!(removed_node.callee_name.as_deref(), Some("StepB"));
+
+        // StepC matched via calleeName fallback (pass 2) -- label changed so it's modified
+        assert_eq!(diff.modified.len(), 1, "StepC modified (label changed)");
+        let (base_id, head_id) = diff.modified[0];
+        assert_eq!(base.nodes[&base_id].callee_name.as_deref(), Some("StepC"));
+        assert_eq!(head.nodes[&head_id].label, "StepC(a)");
+
+        // Root + StepA unchanged
+        assert_eq!(diff.unchanged.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 3: Rename a variable (cosmetic change)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_3_rename_variable() {
+        // Base: Summarize(text)
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Summarize(text)",
+                    "Summarize",
+                    "Pipeline|root:0|scope:summarize-text:0",
+                ),
+            ],
+            vec![(0, 1)],
+        );
+
+        // Head: Summarize(input) -- label changed, calleeName stable, logFilterKey changed
+        let head = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Summarize(input)",
+                    "Summarize",
+                    "Pipeline|root:0|scope:summarize-input:0",
+                ),
+            ],
+            vec![(0, 1)],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.added.len(), 0);
+        assert_eq!(diff.removed.len(), 0);
+        // Summarize matched via calleeName (pass 2, since logFilterKey changed)
+        assert_eq!(diff.modified.len(), 1, "Summarize modified (label changed)");
+        assert_eq!(diff.unchanged.len(), 1, "root unchanged");
+
+        let (base_id, _) = diff.modified[0];
+        assert_eq!(
+            base.nodes[&base_id].callee_name.as_deref(),
+            Some("Summarize")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 4: Add a branch (if/else)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_4_add_branch() {
+        // Base: Route -> Process(text)
+        let base = build_graph(
+            vec![
+                make_node(0, None, "Route", NodeType::FunctionRoot, "Route|root:0"),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Process(text)",
+                    "Process",
+                    "Route|root:0|scope:process-text:0",
+                ),
+            ],
+            vec![(0, 1)],
+        );
+
+        // Head: Route -> OtherScope wrapper -> BranchGroup -> BranchArm(if) -> QuickProcess
+        //                                                  -> BranchArm(else) -> Process(text)
+        let head = build_graph(
+            vec![
+                make_node(0, None, "Route", NodeType::FunctionRoot, "Route|root:0"),
+                make_node(
+                    1,
+                    Some(0),
+                    "let result = ...",
+                    NodeType::OtherScope,
+                    "Route|root:0|scope:let-result:0",
+                ),
+                make_node(
+                    2,
+                    Some(1),
+                    "if (fast)",
+                    NodeType::BranchGroup,
+                    "Route|root:0|scope:let-result:0|bg:if-fast:0",
+                ),
+                make_node(
+                    3,
+                    Some(2),
+                    "if (fast)",
+                    NodeType::BranchArm,
+                    "Route|root:0|scope:let-result:0|bg:if-fast:0|arm:if-fast:0",
+                ),
+                make_call_node(
+                    4,
+                    Some(3),
+                    "QuickProcess(text)",
+                    "QuickProcess",
+                    "Route|root:0|scope:let-result:0|bg:if-fast:0|arm:if-fast:0|scope:quickprocess-text:0",
+                ),
+                make_node(
+                    5,
+                    Some(2),
+                    "else",
+                    NodeType::BranchArm,
+                    "Route|root:0|scope:let-result:0|bg:if-fast:0|arm:else:1",
+                ),
+                // Process(text) reparented under else arm -- logFilterKey changed entirely
+                make_call_node(
+                    6,
+                    Some(5),
+                    "Process(text)",
+                    "Process",
+                    "Route|root:0|scope:let-result:0|bg:if-fast:0|arm:else:1|scope:process-text:0",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (2, 3), (3, 4), (2, 5), (5, 6)],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+
+        // Process(text) matched via calleeName fallback -- label same but reparented
+        // so it's "unchanged" by metadata (label, nodeType, calleeName all match)
+        let process_in_unchanged = diff.unchanged.iter().any(|(base_id, head_id)| {
+            base.nodes[base_id].callee_name.as_deref() == Some("Process")
+                && head.nodes[head_id].callee_name.as_deref() == Some("Process")
+        });
+        assert!(
+            process_in_unchanged,
+            "Process should be matched (unchanged metadata)"
+        );
+
+        // Root matched via logFilterKey (unchanged)
+        assert!(
+            diff.unchanged
+                .iter()
+                .any(|(base_id, _)| { base.nodes[base_id].node_type == NodeType::FunctionRoot }),
+            "FunctionRoot should be unchanged"
+        );
+
+        // 5 new nodes: wrapper OtherScope, BranchGroup, 2 BranchArms, QuickProcess
+        assert_eq!(diff.added.len(), 5, "5 structural nodes added");
+        assert_eq!(diff.removed.len(), 0, "no nodes removed");
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 5: Add a branch arm (else-if)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_5_add_branch_arm() {
+        // Base: BranchGroup with 2 arms (if + else)
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Classify",
+                    NodeType::FunctionRoot,
+                    "Classify|root:0",
+                ),
+                make_node(
+                    1,
+                    Some(0),
+                    "let result = ...",
+                    NodeType::OtherScope,
+                    "Classify|root:0|scope:let-result:0",
+                ),
+                make_node(
+                    2,
+                    Some(1),
+                    "if (is_short(text))",
+                    NodeType::BranchGroup,
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0",
+                ),
+                make_node(
+                    3,
+                    Some(2),
+                    "if (is_short(text))",
+                    NodeType::BranchArm,
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:if-is-short-text:0",
+                ),
+                make_call_node(
+                    4,
+                    Some(3),
+                    "ShortSummary(text)",
+                    "ShortSummary",
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:if-is-short-text:0|scope:shortsummary-text:0",
+                ),
+                make_node(
+                    5,
+                    Some(2),
+                    "else",
+                    NodeType::BranchArm,
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:else:1",
+                ),
+                make_call_node(
+                    6,
+                    Some(5),
+                    "LongSummary(text)",
+                    "LongSummary",
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:else:1|scope:longsummary-text:0",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (2, 3), (3, 4), (2, 5), (5, 6)],
+        );
+
+        // Head: Same + new else-if arm inserted between if and else
+        let head = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Classify",
+                    NodeType::FunctionRoot,
+                    "Classify|root:0",
+                ),
+                make_node(
+                    1,
+                    Some(0),
+                    "let result = ...",
+                    NodeType::OtherScope,
+                    "Classify|root:0|scope:let-result:0",
+                ),
+                make_node(
+                    2,
+                    Some(1),
+                    "if (is_short(text))",
+                    NodeType::BranchGroup,
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0",
+                ),
+                make_node(
+                    3,
+                    Some(2),
+                    "if (is_short(text))",
+                    NodeType::BranchArm,
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:if-is-short-text:0",
+                ),
+                make_call_node(
+                    4,
+                    Some(3),
+                    "ShortSummary(text)",
+                    "ShortSummary",
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:if-is-short-text:0|scope:shortsummary-text:0",
+                ),
+                // New else-if arm
+                make_node(
+                    7,
+                    Some(2),
+                    "else if (is_medium(text))",
+                    NodeType::BranchArm,
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:else-if-is-medium-text:1",
+                ),
+                make_call_node(
+                    8,
+                    Some(7),
+                    "MediumSummary(text)",
+                    "MediumSummary",
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:else-if-is-medium-text:1|scope:mediumsummary-text:0",
+                ),
+                // else arm ordinal shifted from :1 to :2
+                make_node(
+                    5,
+                    Some(2),
+                    "else",
+                    NodeType::BranchArm,
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:else:2",
+                ),
+                make_call_node(
+                    6,
+                    Some(5),
+                    "LongSummary(text)",
+                    "LongSummary",
+                    "Classify|root:0|scope:let-result:0|bg:if-is-short-text:0|arm:else:2|scope:longsummary-text:0",
+                ),
+            ],
+            vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+                (2, 7),
+                (7, 8),
+                (2, 5),
+                (5, 6),
+            ],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.added.len(), 2, "new arm + MediumSummary added");
+        assert_eq!(diff.removed.len(), 0, "no nodes removed");
+
+        // Existing arms + calls should be matched (some may be modified due to ordinal shift in logFilterKey)
+        let total_matched = diff.unchanged.len() + diff.modified.len();
+        assert_eq!(total_matched, 7, "all 7 base nodes matched");
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 6: Reorder sibling calls
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_6_reorder_siblings() {
+        // Base: Alpha -> Beta -> Gamma
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Alpha(text)",
+                    "Alpha",
+                    "Pipeline|root:0|scope:alpha-text:0",
+                ),
+                make_call_node(
+                    2,
+                    Some(0),
+                    "Beta(a)",
+                    "Beta",
+                    "Pipeline|root:0|scope:beta-a:1",
+                ),
+                make_call_node(
+                    3,
+                    Some(0),
+                    "Gamma(b)",
+                    "Gamma",
+                    "Pipeline|root:0|scope:gamma-b:2",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (2, 3)],
+        );
+
+        // Head: Beta -> Alpha -> Gamma (reordered, labels changed due to arg changes)
+        let head = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Beta(text)",
+                    "Beta",
+                    "Pipeline|root:0|scope:beta-text:0",
+                ),
+                make_call_node(
+                    2,
+                    Some(0),
+                    "Alpha(b)",
+                    "Alpha",
+                    "Pipeline|root:0|scope:alpha-b:1",
+                ),
+                make_call_node(
+                    3,
+                    Some(0),
+                    "Gamma(a)",
+                    "Gamma",
+                    "Pipeline|root:0|scope:gamma-a:2",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (2, 3)],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.added.len(), 0, "no nodes added");
+        assert_eq!(diff.removed.len(), 0, "no nodes removed");
+        // All three calls matched via calleeName (pass 2) -- labels all changed
+        assert_eq!(
+            diff.modified.len(),
+            3,
+            "all 3 calls modified (labels changed)"
+        );
+        assert_eq!(diff.unchanged.len(), 1, "root unchanged");
+
+        // Verify calleeName matching
+        for (base_id, head_id) in &diff.modified {
+            assert_eq!(
+                base.nodes[base_id].callee_name, head.nodes[head_id].callee_name,
+                "matched nodes should have same calleeName"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 7: Add header sections
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_7_add_header_section() {
+        // Base: Root -> Summarize -> GenerateDraft (flat)
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Summarize(text)",
+                    "Summarize",
+                    "Pipeline|root:0|scope:summarize-text:0",
+                ),
+                make_call_node(
+                    2,
+                    Some(0),
+                    "GenerateDraft(summary)",
+                    "GenerateDraft",
+                    "Pipeline|root:0|scope:generatedraft-summary:1",
+                ),
+            ],
+            vec![(0, 1), (1, 2)],
+        );
+
+        // Head: Root -> Header("Analysis") -> Summarize, Header("Generation") -> GenerateDraft
+        let head = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_node(
+                    1,
+                    Some(0),
+                    "Analysis",
+                    NodeType::HeaderContextEnter,
+                    "Pipeline|root:0|hdr:analysis:0",
+                ),
+                // Summarize reparented under header -- logFilterKey changed
+                make_call_node(
+                    2,
+                    Some(1),
+                    "Summarize(text)",
+                    "Summarize",
+                    "Pipeline|root:0|hdr:analysis:0|scope:summarize-text:0",
+                ),
+                make_node(
+                    3,
+                    Some(0),
+                    "Generation",
+                    NodeType::HeaderContextEnter,
+                    "Pipeline|root:0|hdr:generation:1",
+                ),
+                make_call_node(
+                    4,
+                    Some(3),
+                    "GenerateDraft(summary)",
+                    "GenerateDraft",
+                    "Pipeline|root:0|hdr:generation:1|scope:generatedraft-summary:0",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (0, 3), (3, 4)],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.added.len(), 2, "2 headers added");
+        assert_eq!(diff.removed.len(), 0, "no nodes removed");
+
+        // Both calls matched via calleeName (labels unchanged, metadata equal)
+        let summarize_matched = diff.unchanged.iter().any(|(b, h)| {
+            base.nodes[b].callee_name.as_deref() == Some("Summarize")
+                && head.nodes[h].callee_name.as_deref() == Some("Summarize")
+        });
+        let draft_matched = diff.unchanged.iter().any(|(b, h)| {
+            base.nodes[b].callee_name.as_deref() == Some("GenerateDraft")
+                && head.nodes[h].callee_name.as_deref() == Some("GenerateDraft")
+        });
+        assert!(summarize_matched, "Summarize matched via calleeName");
+        assert!(draft_matched, "GenerateDraft matched via calleeName");
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 8: Change LLM client
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_8_change_llm_client() {
+        // Base: LLM function with GPT4
+        let mut base_node = make_node(
+            0,
+            None,
+            "Summarize",
+            NodeType::LlmFunction,
+            "Summarize|root:0",
+        );
+        base_node.llm_client = Some("GPT4".to_string());
+        let base = build_graph(vec![base_node], vec![]);
+
+        // Head: Same function, different client
+        let mut head_node = make_node(
+            0,
+            None,
+            "Summarize",
+            NodeType::LlmFunction,
+            "Summarize|root:0",
+        );
+        head_node.llm_client = Some("Claude".to_string());
+        let head = build_graph(vec![head_node], vec![]);
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.added.len(), 0);
+        assert_eq!(diff.removed.len(), 0);
+        assert_eq!(diff.modified.len(), 1, "LLM client changed");
+        assert_eq!(diff.unchanged.len(), 0);
+
+        // Matched via exact logFilterKey (pass 1)
+        let (base_id, head_id) = diff.modified[0];
+        assert_eq!(base.nodes[&base_id].llm_client.as_deref(), Some("GPT4"));
+        assert_eq!(head.nodes[&head_id].llm_client.as_deref(), Some("Claude"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 9: Convert expression function to LLM function
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_9_convert_to_llm_function() {
+        // Base: expr function with Split -> Loop -> SummarizeChunk -> Combine
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Summarize",
+                    NodeType::FunctionRoot,
+                    "Summarize|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Split(text)",
+                    "Split",
+                    "Summarize|root:0|scope:split-text:0",
+                ),
+                make_node(
+                    2,
+                    Some(0),
+                    "for (let chunk in chunks)",
+                    NodeType::Loop,
+                    "Summarize|root:0|loop:for-let-chunk-in-chunks:0",
+                ),
+                make_call_node(
+                    3,
+                    Some(2),
+                    "SummarizeChunk(chunk)",
+                    "SummarizeChunk",
+                    "Summarize|root:0|loop:for-let-chunk-in-chunks:0|scope:summarizechunk-chunk:0",
+                ),
+                make_call_node(
+                    4,
+                    Some(0),
+                    "Combine(summaries)",
+                    "Combine",
+                    "Summarize|root:0|scope:combine-summaries:1",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (2, 3), (3, 4)],
+        );
+
+        // Head: single LlmFunction node (complete replacement)
+        let mut llm_node = make_node(
+            0,
+            None,
+            "Summarize",
+            NodeType::LlmFunction,
+            "Summarize|root:0",
+        );
+        llm_node.llm_client = Some("GPT4".to_string());
+        let head = build_graph(vec![llm_node], vec![]);
+
+        let diff = compute_graph_diff(&base, &head);
+        // FunctionRoot -> LlmFunction: logFilterKey matches but nodeType changed -> modified
+        // All other base nodes have no match -> removed
+        assert_eq!(
+            diff.removed.len(),
+            4,
+            "Split, Loop, SummarizeChunk, Combine removed"
+        );
+        assert_eq!(diff.added.len(), 0, "LlmFunction matched to FunctionRoot");
+        assert_eq!(diff.modified.len(), 1, "root matched but nodeType changed");
+        assert_eq!(diff.unchanged.len(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 10: Wrap a call in a loop
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_10_wrap_in_loop() {
+        // Base: Process -> Transform(items)
+        let base = build_graph(
+            vec![
+                make_node(0, None, "Process", NodeType::FunctionRoot, "Process|root:0"),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "Transform(items)",
+                    "Transform",
+                    "Process|root:0|scope:transform-items:0",
+                ),
+            ],
+            vec![(0, 1)],
+        );
+
+        // Head: Process -> Loop -> Transform(item) + Combine(results)
+        let head = build_graph(
+            vec![
+                make_node(0, None, "Process", NodeType::FunctionRoot, "Process|root:0"),
+                make_node(
+                    1,
+                    Some(0),
+                    "for (let item in items)",
+                    NodeType::Loop,
+                    "Process|root:0|loop:for-let-item-in-items:0",
+                ),
+                // Transform reparented under loop, label changed
+                make_call_node(
+                    2,
+                    Some(1),
+                    "Transform(item)",
+                    "Transform",
+                    "Process|root:0|loop:for-let-item-in-items:0|scope:transform-item:0",
+                ),
+                make_call_node(
+                    3,
+                    Some(0),
+                    "Combine(results)",
+                    "Combine",
+                    "Process|root:0|scope:combine-results:0",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (2, 3)],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.removed.len(), 0, "no nodes removed");
+        assert_eq!(diff.added.len(), 2, "Loop + Combine added");
+
+        // Transform matched via calleeName (pass 2) -- label changed
+        assert_eq!(
+            diff.modified.len(),
+            1,
+            "Transform modified (label + reparented)"
+        );
+        let (base_id, head_id) = diff.modified[0];
+        assert_eq!(
+            base.nodes[&base_id].callee_name.as_deref(),
+            Some("Transform")
+        );
+        assert_eq!(
+            head.nodes[&head_id].callee_name.as_deref(),
+            Some("Transform")
+        );
+
+        assert_eq!(diff.unchanged.len(), 1, "root unchanged");
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 11: Rename a called function
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_11_rename_called_function() {
+        // Base: Pipeline -> OldName(text)
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "OldName(text)",
+                    "OldName",
+                    "Pipeline|root:0|scope:oldname-text:0",
+                ),
+            ],
+            vec![(0, 1)],
+        );
+
+        // Head: Pipeline -> NewName(text) -- calleeName changed
+        let head = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "Pipeline",
+                    NodeType::FunctionRoot,
+                    "Pipeline|root:0",
+                ),
+                make_call_node(
+                    1,
+                    Some(0),
+                    "NewName(text)",
+                    "NewName",
+                    "Pipeline|root:0|scope:newname-text:0",
+                ),
+            ],
+            vec![(0, 1)],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+        // Both logFilterKey and calleeName changed -- only positional match possible
+        // Since both are OtherScope children of root, neither label nor calleeName matches
+        // -> removed + added (no reliable signal to pair them)
+        assert_eq!(diff.removed.len(), 1, "OldName removed");
+        assert_eq!(diff.added.len(), 1, "NewName added");
+        assert_eq!(diff.unchanged.len(), 1, "root unchanged");
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 12: Nested structural changes
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_scenario_12_nested_structural_changes() {
+        // Base: ContentPipeline with headers, GenerateDraft + EditDraft under "Generate"
+        let base = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "ContentPipeline",
+                    NodeType::FunctionRoot,
+                    "ContentPipeline|root:0",
+                ),
+                make_node(
+                    1,
+                    Some(0),
+                    "Analyze",
+                    NodeType::HeaderContextEnter,
+                    "ContentPipeline|root:0|hdr:analyze:0",
+                ),
+                make_call_node(
+                    2,
+                    Some(1),
+                    "Summarize(text)",
+                    "Summarize",
+                    "ContentPipeline|root:0|hdr:analyze:0|scope:summarize-text:0",
+                ),
+                make_node(
+                    3,
+                    Some(0),
+                    "Generate",
+                    NodeType::HeaderContextEnter,
+                    "ContentPipeline|root:0|hdr:generate:1",
+                ),
+                make_call_node(
+                    4,
+                    Some(3),
+                    "GenerateDraft(summary)",
+                    "GenerateDraft",
+                    "ContentPipeline|root:0|hdr:generate:1|scope:generatedraft-summary:0",
+                ),
+                make_call_node(
+                    5,
+                    Some(3),
+                    "EditDraft(draft)",
+                    "EditDraft",
+                    "ContentPipeline|root:0|hdr:generate:1|scope:editdraft-draft:1",
+                ),
+            ],
+            vec![(0, 1), (1, 2), (0, 3), (3, 4), (4, 5)],
+        );
+
+        // Head: EditDraft removed, GenerateDraft wrapped in conditional
+        let head = build_graph(
+            vec![
+                make_node(
+                    0,
+                    None,
+                    "ContentPipeline",
+                    NodeType::FunctionRoot,
+                    "ContentPipeline|root:0",
+                ),
+                make_node(
+                    1,
+                    Some(0),
+                    "Analyze",
+                    NodeType::HeaderContextEnter,
+                    "ContentPipeline|root:0|hdr:analyze:0",
+                ),
+                make_call_node(
+                    2,
+                    Some(1),
+                    "Summarize(text)",
+                    "Summarize",
+                    "ContentPipeline|root:0|hdr:analyze:0|scope:summarize-text:0",
+                ),
+                make_node(
+                    3,
+                    Some(0),
+                    "Generate",
+                    NodeType::HeaderContextEnter,
+                    "ContentPipeline|root:0|hdr:generate:1",
+                ),
+                make_node(
+                    6,
+                    Some(3),
+                    "let draft = ...",
+                    NodeType::OtherScope,
+                    "ContentPipeline|root:0|hdr:generate:1|scope:let-draft:0",
+                ),
+                make_node(
+                    7,
+                    Some(6),
+                    "if (is_long(summary))",
+                    NodeType::BranchGroup,
+                    "ContentPipeline|root:0|hdr:generate:1|scope:let-draft:0|bg:if-is-long-summary:0",
+                ),
+                make_node(
+                    8,
+                    Some(7),
+                    "if (is_long(summary))",
+                    NodeType::BranchArm,
+                    "ContentPipeline|root:0|hdr:generate:1|scope:let-draft:0|bg:if-is-long-summary:0|arm:if-is-long-summary:0",
+                ),
+                make_call_node(
+                    9,
+                    Some(8),
+                    "GenerateLongDraft(summary)",
+                    "GenerateLongDraft",
+                    "ContentPipeline|root:0|hdr:generate:1|scope:let-draft:0|bg:if-is-long-summary:0|arm:if-is-long-summary:0|scope:generatelongdraft-summary:0",
+                ),
+                make_node(
+                    10,
+                    Some(7),
+                    "else",
+                    NodeType::BranchArm,
+                    "ContentPipeline|root:0|hdr:generate:1|scope:let-draft:0|bg:if-is-long-summary:0|arm:else:1",
+                ),
+                // GenerateDraft reparented deeper
+                make_call_node(
+                    11,
+                    Some(10),
+                    "GenerateDraft(summary)",
+                    "GenerateDraft",
+                    "ContentPipeline|root:0|hdr:generate:1|scope:let-draft:0|bg:if-is-long-summary:0|arm:else:1|scope:generatedraft-summary:0",
+                ),
+            ],
+            vec![
+                (0, 1),
+                (1, 2),
+                (0, 3),
+                (3, 6),
+                (6, 7),
+                (7, 8),
+                (8, 9),
+                (7, 10),
+                (10, 11),
+            ],
+        );
+
+        let diff = compute_graph_diff(&base, &head);
+
+        // "Analyze" section entirely unchanged
+        let analyze_unchanged = diff
+            .unchanged
+            .iter()
+            .any(|(b, _)| base.nodes[b].label == "Analyze");
+        assert!(analyze_unchanged, "Analyze header should be unchanged");
+
+        let summarize_unchanged = diff
+            .unchanged
+            .iter()
+            .any(|(b, _)| base.nodes[b].callee_name.as_deref() == Some("Summarize"));
+        assert!(summarize_unchanged, "Summarize should be unchanged");
+
+        // EditDraft removed
+        assert!(
+            diff.removed
+                .iter()
+                .any(|id| { base.nodes[id].callee_name.as_deref() == Some("EditDraft") }),
+            "EditDraft should be removed"
+        );
+
+        // GenerateDraft matched via calleeName -- metadata unchanged
+        let gd_matched = diff.unchanged.iter().any(|(b, h)| {
+            base.nodes[b].callee_name.as_deref() == Some("GenerateDraft")
+                && head.nodes[h].callee_name.as_deref() == Some("GenerateDraft")
+        });
+        assert!(gd_matched, "GenerateDraft should be matched via calleeName");
+
+        // New structural nodes added
+        assert!(
+            diff.added.len() >= 4,
+            "at least wrapper, branch group, 2 arms, GenerateLongDraft added"
+        );
+    }
+}

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/diff.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/diff.rs
@@ -13,6 +13,8 @@ use super::{ControlFlowGraph, Node, NodeId, NodeType, build_children_map};
 ///
 /// Node IDs reference nodes in the original `base` and `head` graphs —
 /// the diff is a lightweight report, not a copy.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GraphDiff {
     /// Nodes present in `head` but not in `base`.
     pub added: Vec<NodeId>,

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/mod.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/mod.rs
@@ -3,11 +3,13 @@
 //! Graph types, builder infrastructure, the AST-based graph builder, the LLM
 //! graph builder, and the three-pass flattening pipeline.
 
+mod diff;
 mod flatten;
 mod from_ast;
 
 use std::{collections::HashMap, fmt};
 
+pub use diff::{GraphDiff, compute_graph_diff};
 pub use flatten::{flatten_control_flow_graph, prepare_control_flow_graph_for_visualization};
 pub use from_ast::{STMT_SOURCE_EXPR_TAG, build_control_flow_graph_from_ast};
 use indexmap::IndexMap;
@@ -49,7 +51,7 @@ pub enum PathSegment {
 }
 
 /// The type of a visualization node.
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum NodeType {
     FunctionRoot,

--- a/baml_language/crates/baml_lsp_server/Cargo.toml
+++ b/baml_language/crates/baml_lsp_server/Cargo.toml
@@ -29,6 +29,7 @@ rustls = [ "aws-crypto" ]
 
 [dependencies]
 baml_compiler2_visualization = { workspace = true }
+baml_project = { workspace = true }
 baml_type = { workspace = true }
 bex_events = { workspace = true }
 bex_events_native = { workspace = true }

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -62,6 +62,161 @@ pub async fn pick_port(base_port: u16, max_attempts: u16) -> anyhow::Result<(Tcp
 }
 
 // ---------------------------------------------------------------------------
+// Git helpers for diff mode
+// ---------------------------------------------------------------------------
+
+/// Retrieve `.baml` file contents at a given git ref.
+///
+/// If `base_ref` is `None`, defaults to `merge-base HEAD main` (fallback to `master`).
+/// Otherwise resolves the ref directly (branch name, tag, commit hash, `HEAD~1`, etc).
+///
+/// Returns (relative_path -> content, workspace_root).
+fn get_git_base_files(
+    bex: &Arc<dyn bex_project::BexLsp>,
+    base_ref: Option<&str>,
+) -> (
+    std::collections::HashMap<String, String>,
+    Option<std::path::PathBuf>,
+) {
+    use std::process::Command;
+
+    let roots = bex.workspace_roots();
+    let workspace = match roots.first() {
+        Some(r) => r,
+        None => return (Default::default(), None),
+    };
+
+    // Special case: "__staged__" reads from the git index (staging area)
+    let is_staged = base_ref == Some("__staged__");
+
+    // Resolve the git ref to a commit-ish (unless reading staged)
+    let resolved_ref = if is_staged {
+        String::new() // not used — staged uses ":<file>" syntax
+    } else {
+        match base_ref {
+            Some(r) if !r.is_empty() => {
+                // Try to resolve the ref directly via rev-parse
+                let output = Command::new("git")
+                    .args(["rev-parse", "--verify", r])
+                    .current_dir(workspace)
+                    .output();
+                match output {
+                    Ok(out) if out.status.success() => {
+                        String::from_utf8_lossy(&out.stdout).trim().to_string()
+                    }
+                    _ => return (Default::default(), None),
+                }
+            }
+            _ => {
+                // Default: merge-base against main (fallback to master)
+                let try_main = Command::new("git")
+                    .args(["merge-base", "HEAD", "main"])
+                    .current_dir(workspace)
+                    .output();
+                match try_main {
+                    Ok(out) if out.status.success() => {
+                        String::from_utf8_lossy(&out.stdout).trim().to_string()
+                    }
+                    _ => {
+                        let try_master = Command::new("git")
+                            .args(["merge-base", "HEAD", "master"])
+                            .current_dir(workspace)
+                            .output();
+                        match try_master {
+                            Ok(out) if out.status.success() => {
+                                String::from_utf8_lossy(&out.stdout).trim().to_string()
+                            }
+                            _ => return (Default::default(), None),
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    // List tracked .baml files
+    let ls_output = Command::new("git")
+        .args(["ls-files", "*.baml"])
+        .current_dir(workspace)
+        .output();
+    let baml_files: Vec<String> = match ls_output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect(),
+        _ => return (Default::default(), None),
+    };
+
+    let mut base_files = std::collections::HashMap::new();
+    for file in &baml_files {
+        // For staged: "git show :<file>" reads from the index
+        // For commits: "git show <ref>:<file>" reads from that commit
+        let show_arg = if is_staged {
+            format!(":{file}")
+        } else {
+            format!("{resolved_ref}:{file}")
+        };
+        let show_output = Command::new("git")
+            .args(["show", &show_arg])
+            .current_dir(workspace)
+            .output();
+        if let Ok(out) = show_output
+            && out.status.success()
+            && let Ok(content) = String::from_utf8(out.stdout)
+        {
+            base_files.insert(file.clone(), content);
+        }
+    }
+
+    (base_files, Some(workspace.clone()))
+}
+
+/// List git branches and tags for the workspace.
+fn get_git_refs(bex: &Arc<dyn bex_project::BexLsp>) -> (Vec<String>, Vec<String>) {
+    use std::process::Command;
+
+    let roots = bex.workspace_roots();
+    let workspace = match roots.first() {
+        Some(r) => r,
+        None => return (vec![], vec![]),
+    };
+
+    let branches = Command::new("git")
+        .args(["branch", "--format=%(refname:short)"])
+        .current_dir(workspace)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| l.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let tags = Command::new("git")
+        .args(["tag", "--sort=-creatordate", "-l"])
+        .current_dir(workspace)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|l| !l.is_empty())
+                .take(20) // Limit to 20 most recent tags
+                .map(|l| l.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    (branches, tags)
+}
+
+// ---------------------------------------------------------------------------
 // Shared state for Axum handlers
 // ---------------------------------------------------------------------------
 
@@ -434,6 +589,101 @@ async fn handle_ws_in_message(
                 && sink.send(ws_msg).await.is_err()
             {
                 tracing::warn!("Failed to send control flow graph result");
+            }
+        }
+
+        WsInMessage::RequestControlFlowGraphDiff {
+            project: _,
+            function_name,
+            base_ref,
+        } => {
+            use baml_compiler2_visualization::control_flow::{
+                compute_graph_diff, prepare_control_flow_graph_for_visualization,
+            };
+
+            // Head graph: from current project state
+            let head_graph = state.bex.ast_control_flow_graph(&function_name);
+            let head_prepared =
+                head_graph.map(|g| prepare_control_flow_graph_for_visualization(&g));
+
+            // Base graph: retrieve base branch files via git, build a temporary project
+            let (base_files, _workspace_root) = get_git_base_files(&state.bex, base_ref.as_deref());
+            let base_graph = if base_files.is_empty() {
+                None
+            } else {
+                // Use a synthetic /tmp root to avoid filesystem canonicalization
+                // issues. The temp ProjectDatabase never touches disk — it only
+                // needs consistent paths between set_project_root and add_or_update_file.
+                let synthetic_root = std::path::Path::new("/tmp");
+                let mut base_db = baml_project::ProjectDatabase::new();
+                base_db.set_project_root(synthetic_root);
+                for (rel_path, content) in &base_files {
+                    // Strip leading directory to get just the filename under the synthetic root
+                    // e.g. "baml_src/resume.baml" → "/tmp/resume.baml"
+                    let file_name = std::path::Path::new(rel_path)
+                        .file_name()
+                        .unwrap_or_default();
+                    let abs_path = synthetic_root.join(file_name);
+                    base_db.add_or_update_file(&abs_path, content);
+                }
+                base_db.ast_control_flow_graph(&function_name)
+            };
+            let base_prepared =
+                base_graph.map(|g| prepare_control_flow_graph_for_visualization(&g));
+
+            let diff = match (&base_prepared, &head_prepared) {
+                (Some(base), Some(head)) => Some(compute_graph_diff(base, head)),
+                // New function (no base) — all head nodes are "added"
+                (None, Some(head)) => {
+                    let added = head.nodes.keys().copied().collect();
+                    Some(baml_compiler2_visualization::control_flow::GraphDiff {
+                        added,
+                        removed: vec![],
+                        modified: vec![],
+                        unchanged: vec![],
+                    })
+                }
+                // Removed function (no head) — all base nodes are "removed"
+                (Some(base), None) => {
+                    let removed = base.nodes.keys().copied().collect();
+                    Some(baml_compiler2_visualization::control_flow::GraphDiff {
+                        added: vec![],
+                        removed,
+                        modified: vec![],
+                        unchanged: vec![],
+                    })
+                }
+                (None, None) => None,
+            };
+
+            let base_json = base_prepared
+                .as_ref()
+                .and_then(|g| serde_json::to_value(g).ok());
+            let head_json = head_prepared
+                .as_ref()
+                .and_then(|g| serde_json::to_value(g).ok());
+            let diff_json = diff.as_ref().and_then(|d| serde_json::to_value(d).ok());
+
+            let msg = WsOutMessage::ControlFlowGraphDiffResult {
+                function_name,
+                base_graph: base_json,
+                head_graph: head_json,
+                diff: diff_json,
+            };
+            if let Some(ws_msg) = to_ws_text(&msg)
+                && sink.send(ws_msg).await.is_err()
+            {
+                tracing::warn!("Failed to send control flow graph diff result");
+            }
+        }
+
+        WsInMessage::RequestGitRefs => {
+            let (branches, tags) = get_git_refs(&state.bex);
+            let msg = WsOutMessage::GitRefs { branches, tags };
+            if let Some(ws_msg) = to_ws_text(&msg)
+                && sink.send(ws_msg).await.is_err()
+            {
+                tracing::warn!("Failed to send git refs");
             }
         }
 

--- a/baml_language/crates/baml_lsp_server/src/playground_ws.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_ws.rs
@@ -61,6 +61,18 @@ pub enum WsInMessage {
         #[serde(rename = "functionName")]
         function_name: String,
     },
+    #[serde(rename = "requestControlFlowGraphDiff")]
+    RequestControlFlowGraphDiff {
+        project: String,
+        #[serde(rename = "functionName")]
+        function_name: String,
+        /// Git ref to diff against (branch, tag, commit, "HEAD~1", etc).
+        /// If absent, defaults to merge-base against main/master.
+        #[serde(rename = "baseRef", default)]
+        base_ref: Option<String>,
+    },
+    #[serde(rename = "requestGitRefs")]
+    RequestGitRefs,
     #[serde(rename = "cursorPosition")]
     CursorPosition {
         file: String,
@@ -161,6 +173,21 @@ pub enum WsOutMessage {
         #[serde(rename = "functionName")]
         function_name: String,
         graph: Option<serde_json::Value>,
+    },
+    #[serde(rename = "controlFlowGraphDiffResult")]
+    ControlFlowGraphDiffResult {
+        #[serde(rename = "functionName")]
+        function_name: String,
+        #[serde(rename = "baseGraph")]
+        base_graph: Option<serde_json::Value>,
+        #[serde(rename = "headGraph")]
+        head_graph: Option<serde_json::Value>,
+        diff: Option<serde_json::Value>,
+    },
+    #[serde(rename = "gitRefs")]
+    GitRefs {
+        branches: Vec<String>,
+        tags: Vec<String>,
     },
     #[serde(rename = "cursorContext")]
     CursorContext { context: serde_json::Value },

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -1609,4 +1609,68 @@ function ContentPipeline(text: string) -> string {
             });
         assert!(summarize_matched, "Summarize should still be matched");
     }
+
+    /// Test that a temp `ProjectDatabase` built from multiple raw file contents
+    /// (simulating the diff handler's base-branch loading) can resolve functions.
+    #[test]
+    fn test_temp_db_from_raw_file_contents() {
+        // Simulate what the diff handler does: create a temp DB from
+        // raw file contents using a synthetic root path.
+        let files: Vec<(&str, &str)> = vec![
+            (
+                "clients.baml",
+                r#"
+client<llm> GPT4 {
+    provider openai
+    options {
+        model "gpt-4"
+    }
+}
+"#,
+            ),
+            (
+                "functions.baml",
+                r##"
+function Summarize(input: string) -> string {
+    client GPT4
+    prompt #"Summarize {{ input }}"#
+}
+
+function Pipeline(input: string) -> string {
+    let result = Summarize(input);
+    result
+}
+"##,
+            ),
+        ];
+
+        let synthetic_root = std::path::Path::new("/tmp");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(synthetic_root);
+        for (filename, content) in &files {
+            let abs_path = synthetic_root.join(filename);
+            db.add_or_update_file(&abs_path, content);
+        }
+
+        // LLM function should be found
+        let llm_graph = db.ast_control_flow_graph("Summarize");
+        assert!(
+            llm_graph.is_some(),
+            "should find LLM function Summarize in temp DB"
+        );
+
+        // Workflow function that calls the LLM function should also be found
+        let pipeline_graph = db.ast_control_flow_graph("Pipeline");
+        assert!(
+            pipeline_graph.is_some(),
+            "should find workflow function Pipeline in temp DB"
+        );
+
+        // Non-existent function should not be found
+        let missing = db.ast_control_flow_graph("DoesNotExist");
+        assert!(
+            missing.is_none(),
+            "non-existent function should return None"
+        );
+    }
 }

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -1439,4 +1439,174 @@ function Summarize(input: string) -> string {
 
         assert!(db.get_project().is_some());
     }
+
+    #[test]
+    fn test_graph_diff_add_call_integration() {
+        use baml_compiler2_visualization::control_flow::compute_graph_diff;
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        let path = std::path::Path::new("/tmp/test.baml");
+
+        // Before: single call
+        db.add_or_update_file(
+            path,
+            r#"
+function Pipeline(text: string) -> string {
+    let summary = Summarize(text);
+    summary
+}
+"#,
+        );
+        let base = db.ast_control_flow_graph("Pipeline").unwrap();
+
+        // After: add a second call
+        db.add_or_update_file(
+            path,
+            r#"
+function Pipeline(text: string) -> string {
+    let summary = Summarize(text);
+    let edited = EditSummary(summary);
+    edited
+}
+"#,
+        );
+        let head = db.ast_control_flow_graph("Pipeline").unwrap();
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.added.len(), 1, "EditSummary node added");
+        assert_eq!(diff.removed.len(), 0, "no nodes removed");
+
+        let added_node = &head.nodes[&diff.added[0]];
+        assert_eq!(added_node.callee_name.as_deref(), Some("EditSummary"));
+    }
+
+    #[test]
+    fn test_graph_diff_add_branch_integration() {
+        use baml_compiler2_visualization::control_flow::compute_graph_diff;
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        let path = std::path::Path::new("/tmp/test.baml");
+
+        // Before: flat call
+        db.add_or_update_file(
+            path,
+            r#"
+function Route(text: string) -> string {
+    let result = Process(text);
+    result
+}
+"#,
+        );
+        let base = db.ast_control_flow_graph("Route").unwrap();
+
+        // After: wrapped in conditional
+        db.add_or_update_file(
+            path,
+            r#"
+function Route(text: string, fast: bool) -> string {
+    let result = if (fast) {
+        QuickProcess(text)
+    } else {
+        Process(text)
+    };
+    result
+}
+"#,
+        );
+        let head = db.ast_control_flow_graph("Route").unwrap();
+
+        let diff = compute_graph_diff(&base, &head);
+        assert_eq!(diff.removed.len(), 0, "no nodes removed");
+        // Process should be matched via calleeName despite reparenting
+        let process_matched = diff
+            .unchanged
+            .iter()
+            .chain(diff.modified.iter())
+            .any(|(_, h)| head.nodes[h].callee_name.as_deref() == Some("Process"));
+        assert!(process_matched, "Process should be matched via calleeName");
+        assert!(
+            diff.added.len() >= 3,
+            "at least wrapper + branch structure + QuickProcess added"
+        );
+    }
+
+    #[test]
+    fn test_graph_diff_nested_changes_integration() {
+        use baml_compiler2_visualization::control_flow::compute_graph_diff;
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        let path = std::path::Path::new("/tmp/test.baml");
+
+        // Before: two headers with calls
+        db.add_or_update_file(
+            path,
+            r#"
+function ContentPipeline(text: string) -> string {
+    //# Analyze
+    let summary = Summarize(text);
+
+    //# Generate
+    let draft = GenerateDraft(summary);
+    let edited = EditDraft(draft);
+    edited
+}
+"#,
+        );
+        let base = db.ast_control_flow_graph("ContentPipeline").unwrap();
+
+        // After: EditDraft removed, conditional added in Generate section
+        db.add_or_update_file(
+            path,
+            r#"
+function ContentPipeline(text: string) -> string {
+    //# Analyze
+    let summary = Summarize(text);
+
+    //# Generate
+    let draft = if (is_long(summary)) {
+        GenerateLongDraft(summary)
+    } else {
+        GenerateDraft(summary)
+    };
+    draft
+}
+"#,
+        );
+        let head = db.ast_control_flow_graph("ContentPipeline").unwrap();
+
+        let diff = compute_graph_diff(&base, &head);
+
+        // EditDraft should be removed
+        assert!(
+            diff.removed
+                .iter()
+                .any(|id| { base.nodes[id].callee_name.as_deref() == Some("EditDraft") }),
+            "EditDraft should be removed"
+        );
+
+        // GenerateDraft should be matched via calleeName
+        let gd_matched = diff
+            .unchanged
+            .iter()
+            .chain(diff.modified.iter())
+            .any(|(b, h)| {
+                base.nodes[b].callee_name.as_deref() == Some("GenerateDraft")
+                    && head.nodes[h].callee_name.as_deref() == Some("GenerateDraft")
+            });
+        assert!(gd_matched, "GenerateDraft matched via calleeName");
+
+        // Summarize should be unchanged
+        let summarize_matched = diff
+            .unchanged
+            .iter()
+            .chain(diff.modified.iter())
+            .any(|(b, h)| {
+                base.nodes[b].callee_name.as_deref() == Some("Summarize")
+                    && head.nodes[h].callee_name.as_deref() == Some("Summarize")
+            });
+        assert!(summarize_matched, "Summarize should still be matched");
+    }
 }

--- a/baml_language/crates/bex_project/src/bex_lsp/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/mod.rs
@@ -145,6 +145,13 @@ pub enum PlaygroundNotification {
         graph: Option<serde_json::Value>,
     },
     #[serde(rename_all = "camelCase")]
+    ControlFlowGraphDiffResult {
+        function_name: String,
+        base_graph: Option<serde_json::Value>,
+        head_graph: Option<serde_json::Value>,
+        diff: Option<serde_json::Value>,
+    },
+    #[serde(rename_all = "camelCase")]
     CursorContext { context: serde_json::Value },
     #[serde(rename_all = "camelCase")]
     TestCollectionResult {
@@ -202,6 +209,16 @@ pub trait BexLsp: Send + Sync + notification::BexLspNotification + request::BexL
     /// callback as a `PlaygroundNotification::ControlFlowGraphResult`.
     fn request_control_flow_graph(&self, function_name: &str);
 
+    /// Request a diff of the control flow graph between base files and current state.
+    ///
+    /// Builds a temporary project from `base_files`, computes both graphs,
+    /// diffs them, and sends the result via `ControlFlowGraphDiffResult`.
+    fn request_control_flow_graph_diff(
+        &self,
+        function_name: &str,
+        base_files: std::collections::HashMap<String, String>,
+    );
+
     /// Get cursor context for playground navigation.
     ///
     /// Given a file path and position, returns context about what entity
@@ -243,6 +260,9 @@ pub trait BexLsp: Send + Sync + notification::BexLspNotification + request::BexL
     /// Used by the playground to navigate to source locations when clicking on
     /// log events. Returns the file path if the ID is valid, or None if not found.
     fn resolve_file_id(&self, file_id: u32) -> Option<String>;
+
+    /// Return the workspace root directories known to this LSP session.
+    fn workspace_roots(&self) -> Vec<std::path::PathBuf>;
 }
 
 use ::std::sync::Arc;

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
@@ -1025,6 +1025,53 @@ impl super::BexLsp for BexMulitProject {
         );
     }
 
+    fn request_control_flow_graph_diff(
+        &self,
+        function_name: &str,
+        base_files: std::collections::HashMap<String, String>,
+    ) {
+        use baml_compiler2_visualization::control_flow::{
+            compute_graph_diff, prepare_control_flow_graph_for_visualization,
+        };
+
+        // Head graph: from current project state (same as request_control_flow_graph)
+        let head_graph = self.ast_control_flow_graph(function_name);
+        let head_prepared = head_graph.map(|g| prepare_control_flow_graph_for_visualization(&g));
+
+        // Base graph: build a temporary ProjectDatabase from base files
+        let base_graph = {
+            let mut base_db = baml_project::ProjectDatabase::new();
+            for (path, content) in &base_files {
+                base_db.add_or_update_file(std::path::Path::new(path), content);
+            }
+            base_db.ast_control_flow_graph(function_name)
+        };
+        let base_prepared = base_graph.map(|g| prepare_control_flow_graph_for_visualization(&g));
+
+        // Compute diff if both graphs exist
+        let diff = match (&base_prepared, &head_prepared) {
+            (Some(base), Some(head)) => Some(compute_graph_diff(base, head)),
+            _ => None,
+        };
+
+        let base_json = base_prepared
+            .as_ref()
+            .and_then(|g| serde_json::to_value(g).ok());
+        let head_json = head_prepared
+            .as_ref()
+            .and_then(|g| serde_json::to_value(g).ok());
+        let diff_json = diff.as_ref().and_then(|d| serde_json::to_value(d).ok());
+
+        self.playground_sender.send_playground_notification(
+            crate::bex_lsp::PlaygroundNotification::ControlFlowGraphDiffResult {
+                function_name: function_name.to_string(),
+                base_graph: base_json,
+                head_graph: head_json,
+                diff: diff_json,
+            },
+        );
+    }
+
     fn playground_cursor_context(
         &self,
         file_path: &str,
@@ -1109,6 +1156,14 @@ impl super::BexLsp for BexMulitProject {
             }
         }
         None
+    }
+
+    fn workspace_roots(&self) -> Vec<std::path::PathBuf> {
+        let roots = self.workspace_roots.lock().unwrap();
+        roots
+            .iter()
+            .map(|vfs_path| std::path::PathBuf::from(vfs_path.as_str()))
+            .collect()
     }
 }
 

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -363,6 +363,23 @@ impl BamlWasmRuntime {
         self.bex.request_control_flow_graph(function_name);
     }
 
+    /// Request a diff of the control flow graph for a function against base files.
+    ///
+    /// `base_files_json` is a JSON string of `Record<string, string>` mapping
+    /// file paths to their base-branch content.
+    #[wasm_bindgen(js_name = requestControlFlowGraphDiff)]
+    pub fn request_control_flow_graph_diff(
+        &self,
+        _project: String,
+        function_name: &str,
+        base_files_json: &str,
+    ) {
+        let base_files: std::collections::HashMap<String, String> =
+            serde_json::from_str(base_files_json).unwrap_or_default();
+        self.bex
+            .request_control_flow_graph_diff(function_name, base_files);
+    }
+
     /// Handle a cursor position change from the editor.
     ///
     /// Computes cursor context (which function/workflow the cursor is in) and

--- a/baml_language/crates/bridge_wasm/src/wasm_playground.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_playground.rs
@@ -83,6 +83,13 @@ pub enum PlaygroundNotification {
         graph: Option<serde_json::Value>,
     },
     #[serde(rename_all = "camelCase")]
+    ControlFlowGraphDiffResult {
+        function_name: String,
+        base_graph: Option<serde_json::Value>,
+        head_graph: Option<serde_json::Value>,
+        diff: Option<serde_json::Value>,
+    },
+    #[serde(rename_all = "camelCase")]
     CursorContext { context: serde_json::Value },
     #[serde(rename_all = "camelCase")]
     TestCollectionResult {
@@ -167,6 +174,17 @@ impl From<bex_project::PlaygroundNotification> for PlaygroundNotification {
             } => PlaygroundNotification::ControlFlowGraphResult {
                 function_name,
                 graph,
+            },
+            bex_project::PlaygroundNotification::ControlFlowGraphDiffResult {
+                function_name,
+                base_graph,
+                head_graph,
+                diff,
+            } => PlaygroundNotification::ControlFlowGraphDiffResult {
+                function_name,
+                base_graph,
+                head_graph,
+                diff,
             },
             bex_project::PlaygroundNotification::CursorContext { context } => {
                 PlaygroundNotification::CursorContext { context }

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -419,6 +419,15 @@ function onPlaygroundNotification(notification: PlaygroundNotification): void {
         graph: notification.graph ?? null,
       });
       break;
+    case "controlFlowGraphDiffResult":
+      postOut({
+        type: "controlFlowGraphDiffResult",
+        functionName: notification.functionName,
+        baseGraph: notification.baseGraph ?? null,
+        headGraph: notification.headGraph ?? null,
+        diff: notification.diff ?? null,
+      });
+      break;
     case "cursorContext":
       postOut({
         type: "cursorContext",
@@ -825,6 +834,12 @@ self.onmessage = async (event: MessageEvent) => {
 
     case "requestControlFlowGraph":
       runtime?.requestControlFlowGraph(msg.project, msg.functionName);
+      return;
+
+    case "requestControlFlowGraphDiff":
+    case "requestGitRefs":
+      // WASM path: diff/git not supported (no git access)
+      // The WebSocket path handles this server-side via git
       return;
 
     case "cursorPosition":

--- a/typescript2/app-vscode-ext/src/panels/WebviewPanel.ts
+++ b/typescript2/app-vscode-ext/src/panels/WebviewPanel.ts
@@ -148,6 +148,7 @@ export class WebviewPanel {
     void this._panel.webview.postMessage({ type: 'cursorPosition', position });
   }
 
+
   public dispose() {
     WebviewPanel.currentPanel = undefined;
     this._panel.dispose();

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -44,6 +44,8 @@ import { ResultDisplay } from './ResultDisplay';
 import { registerBuiltinResultRenderers } from './renderers/registerBuiltins';
 import { HttpRequestCurlRenderer, isHttpRequest } from './renderers/HttpRequestCurl';
 import { GraphView } from './graph/GraphView';
+import { DiffGraphView } from './graph/DiffGraphView';
+import type { GraphDiffResult } from './worker-protocol';
 import { FunctionSidebar } from './FunctionSidebar';
 import { EventValueDisplay } from './EventValueDisplay';
 import { findImageMedia, mediaToSrc } from './shared/media-values';
@@ -366,6 +368,15 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   const [highlightedNodeId, setHighlightedNodeId] = useState<number | null>(null);
   const [cursorOffset, setCursorOffset] = useState<number | null>(null);
 
+  // Diff mode state
+  const [diffMode, setDiffMode] = useState(false);
+  const [diffResult, setDiffResult] = useState<{
+    baseGraph: ControlFlowGraph | null;
+    headGraph: ControlFlowGraph | null;
+    diff: GraphDiffResult;
+  } | null>(null);
+  const [diffBaseRef, setDiffBaseRef] = useState<string>('');  // empty = merge-base main
+  const [gitRefs, setGitRefs] = useState<{ branches: string[]; tags: string[] } | null>(null);
   // Workflow context: when a function belongs to multiple workflows,
   // this tracks which workflow is being viewed and the alternatives.
   const [workflowContext, setWorkflowContext] = useState<{
@@ -851,6 +862,23 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
           if (data.graph) setControlFlowGraph(data.graph);
           break;
 
+        case "controlFlowGraphDiffResult": {
+          if (data.diff && (data.baseGraph || data.headGraph)) {
+            setDiffResult({
+              baseGraph: data.baseGraph,
+              headGraph: data.headGraph,
+              diff: data.diff,
+            });
+          } else {
+            setDiffResult(null);
+          }
+          break;
+        }
+
+        case "gitRefs":
+          setGitRefs({ branches: data.branches, tags: data.tags });
+          break;
+
         case "cursorContext":
           handleCursorContext(data.context);
           break;
@@ -901,6 +929,27 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     if (!selectedFn || !selectedProject) return;
     port.postMessage({ type: 'requestControlFlowGraph', project: selectedProject, functionName: selectedFn });
   }, [port, selectedFn, selectedProject, projectUpdateVersion]);
+
+  // Send diff request when diff mode is active
+  useEffect(() => {
+    if (diffMode && selectedFn && selectedProject) {
+      port.postMessage({
+        type: 'requestControlFlowGraphDiff',
+        project: selectedProject,
+        functionName: selectedFn,
+        ...(diffBaseRef ? { baseRef: diffBaseRef } : {}),
+      });
+    }
+  }, [diffMode, selectedFn, selectedProject, port, diffBaseRef]);
+
+  // Fetch git refs when diff mode is toggled on
+  useEffect(() => {
+    if (diffMode && !gitRefs) {
+      port.postMessage({ type: 'requestGitRefs' });
+    }
+  }, [diffMode, gitRefs, port]);
+
+
 
   // Clear preview results when selected function changes
   useEffect(() => {
@@ -1314,6 +1363,64 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
           <div className="flex-1" />
 
+          {selectedFn && !viewingCollection && !viewingTestRun && activeTab === 'graph' && (
+            <>
+              <ToggleGroup
+                value={diffMode ? 'diff' : 'current'}
+                onValueChange={(v) => {
+                  const isDiff = v === 'diff';
+                  setDiffMode(isDiff);
+                  if (!isDiff) {
+                    setDiffResult(null);
+                  }
+                }}
+                options={[
+                  { value: 'current', label: 'Current' },
+                  { value: 'diff', label: 'Diff' },
+                ]}
+                size="sm"
+              />
+              {diffMode && (
+                <select
+                  value={diffBaseRef}
+                  onChange={(e) => {
+                    setDiffBaseRef(e.target.value);
+                    setDiffResult(null);
+                  }}
+                  style={{
+                    height: 24,
+                    fontSize: 10,
+                    padding: '1px 4px',
+                    borderRadius: 4,
+                    border: '1px solid rgba(255,255,255,0.2)',
+                    background: '#1e1e1e',
+                    color: '#ccc',
+                    minWidth: 80,
+                    outline: 'none',
+                    appearance: 'auto',
+                  }}
+                >
+                  <option value="">vs main</option>
+                  <option value="__staged__">vs staged</option>
+                  <option value="HEAD">vs HEAD</option>
+                  <option value="HEAD~1">vs HEAD~1</option>
+                  <option value="HEAD~2">vs HEAD~2</option>
+                  <option value="HEAD~3">vs HEAD~3</option>
+                  {gitRefs?.branches.map((b) => (
+                    <option key={`branch:${b}`} value={b}>
+                      vs {b}
+                    </option>
+                  ))}
+                  {gitRefs?.tags.map((t) => (
+                    <option key={`tag:${t}`} value={t}>
+                      vs tag:{t}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </>
+          )}
+
           {projectRoots.length > 1 && (
             <ToggleGroup
               value={selectedProject ?? projectRoots[0]}
@@ -1719,7 +1826,20 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                     ))}
                   </div>
                 )}
-                {controlFlowGraph ? (
+                {diffMode && diffResult ? (
+                  <DiffGraphView
+                    baseGraph={diffResult.baseGraph}
+                    headGraph={diffResult.headGraph}
+                    diff={diffResult.diff}
+                    selectedNodeId={highlightedNodeId}
+                    onNodeClick={handleGraphNodeClick}
+                    baseLabel={diffBaseRef === '__staged__' ? 'Staged' : diffBaseRef ? `Base (${diffBaseRef})` : 'Base (main)'}
+                  />
+                ) : diffMode ? (
+                  <div className="flex-1 flex items-center justify-center text-vsc-text-faint text-xs bg-vsc-bg h-full">
+                    Computing diff...
+                  </div>
+                ) : controlFlowGraph ? (
                   <GraphView
                     graph={controlFlowGraph}
                     runtimeEvents={latestGraphRun?.runtimeEvents}

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -243,7 +243,6 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
           const isSelected = selectedFn === fn.name;
           const isInternal = fn.origin !== 'userDefined';
           const Icon = fn.kind === 'llm' ? Bot : FunctionSquare;
-
           return (
             <button
               type="button"

--- a/typescript2/pkg-playground/src/graph/DiffGraphView.tsx
+++ b/typescript2/pkg-playground/src/graph/DiffGraphView.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useRef, useState, type FC, type MouseEvent } from 'react';
+import type { ControlFlowGraph, GraphDiffResult } from '../worker-protocol';
+import type { Viewport } from '@xyflow/react';
+import { GraphView } from './GraphView';
+
+interface DiffGraphViewProps {
+  baseGraph: ControlFlowGraph | null;
+  headGraph: ControlFlowGraph | null;
+  diff: GraphDiffResult;
+  selectedNodeId: number | null;
+  onNodeClick: (nodeId: number) => void;
+  baseLabel?: string;
+}
+
+const EmptyPane: FC<{ label: string }> = ({ label }) => (
+  <div style={{
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    color: '#6b7280',
+    fontSize: 12,
+  }}>
+    {label}
+  </div>
+);
+
+export const DiffGraphView: FC<DiffGraphViewProps> = ({
+  baseGraph,
+  headGraph,
+  diff,
+  selectedNodeId,
+  onNodeClick,
+  baseLabel = 'Base (main)',
+}) => {
+  const [splitRatio, setSplitRatio] = useState(0.5);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Viewport sync: when one pane pans/zooms, mirror to the other
+  const baseViewportRef = useRef<((v: Viewport) => void) | null>(null);
+  const headViewportRef = useRef<((v: Viewport) => void) | null>(null);
+  const syncingRef = useRef(false); // prevent infinite loops
+
+  const onBaseViewportChange = useCallback((viewport: Viewport) => {
+    if (syncingRef.current) return;
+    syncingRef.current = true;
+    headViewportRef.current?.(viewport);
+    syncingRef.current = false;
+  }, []);
+
+  const onHeadViewportChange = useCallback((viewport: Viewport) => {
+    if (syncingRef.current) return;
+    syncingRef.current = true;
+    baseViewportRef.current?.(viewport);
+    syncingRef.current = false;
+  }, []);
+
+  const onSplitterMouseDown = useCallback((e: MouseEvent) => {
+    e.preventDefault();
+    const container = containerRef.current;
+    if (!container) return;
+
+    const onMouseMove = (ev: globalThis.MouseEvent) => {
+      const rect = container.getBoundingClientRect();
+      const ratio = (ev.clientX - rect.left) / rect.width;
+      setSplitRatio(Math.max(0.2, Math.min(0.8, ratio)));
+    };
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%' }}
+    >
+      {/* Pane labels */}
+      <div style={{ display: 'flex', flexShrink: 0 }}>
+        <div
+          style={{
+            flex: splitRatio,
+            minWidth: 0,
+            padding: '3px 8px',
+            fontSize: 10,
+            color: '#9ca3af',
+            borderBottom: '1px solid var(--vsc-border, rgba(255,255,255,0.08))',
+            background: 'var(--vsc-bg-secondary, rgba(24,24,27,0.5))',
+          }}
+        >
+          {baseLabel}
+        </div>
+        <div style={{ width: 4, flexShrink: 0 }} />
+        <div
+          style={{
+            flex: 1 - splitRatio,
+            minWidth: 0,
+            padding: '3px 8px',
+            fontSize: 10,
+            color: '#9ca3af',
+            borderBottom: '1px solid var(--vsc-border, rgba(255,255,255,0.08))',
+            background: 'var(--vsc-bg-secondary, rgba(24,24,27,0.5))',
+          }}
+        >
+          Current
+        </div>
+      </div>
+
+      {/* Graph panes */}
+      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+        {/* Base (left) */}
+        <div style={{ flex: splitRatio, minWidth: 0, position: 'relative' }}>
+          {baseGraph ? (
+            <GraphView
+              graph={baseGraph}
+              selectedNodeId={selectedNodeId}
+              onNodeClick={onNodeClick}
+              onViewportChange={onBaseViewportChange}
+              viewportRef={baseViewportRef}
+              diffAnnotations={{ diff, side: 'base' }}
+            />
+          ) : (
+            <EmptyPane label="Function does not exist on base branch" />
+          )}
+        </div>
+
+        {/* Draggable splitter */}
+        <div
+          onMouseDown={onSplitterMouseDown}
+          style={{
+            width: 4,
+            flexShrink: 0,
+            cursor: 'col-resize',
+            background: 'rgba(255,255,255,0.06)',
+            transition: 'background 120ms',
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(59,130,246,0.3)'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = 'rgba(255,255,255,0.06)'; }}
+        />
+
+        {/* Head (right) */}
+        <div style={{ flex: 1 - splitRatio, minWidth: 0, position: 'relative' }}>
+          {headGraph ? (
+            <GraphView
+              graph={headGraph}
+              selectedNodeId={selectedNodeId}
+              onNodeClick={onNodeClick}
+              onViewportChange={onHeadViewportChange}
+              viewportRef={headViewportRef}
+              diffAnnotations={{ diff, side: 'head' }}
+            />
+          ) : (
+            <EmptyPane label="Function was removed" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/typescript2/pkg-playground/src/graph/GraphView.tsx
+++ b/typescript2/pkg-playground/src/graph/GraphView.tsx
@@ -10,12 +10,13 @@ import {
   Background,
   BackgroundVariant,
   type NodeMouseHandler,
+  type Viewport,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
-import type { ControlFlowGraph, DeserializedRuntimeEvent, RunEntry } from '../worker-protocol';
+import type { ControlFlowGraph, DeserializedRuntimeEvent, RunEntry, GraphDiffResult } from '../worker-protocol';
 import type { ResultRendererProps } from '../result-renderers';
-import { cfgToGraphNodes, graphToReactflow } from './convert';
+import { cfgToGraphNodes, graphToReactflow, decorateNodesWithDiff } from './convert';
 import { collectGraphNodeRuntime } from './runtime-output';
 import { layoutGraph } from './layout';
 import { kNodeTypes } from './nodes';
@@ -31,6 +32,12 @@ interface GraphViewProps {
   customRenderers?: Record<string, FC<ResultRendererProps>>;
   selectedNodeId: number | null;
   onNodeClick: (nodeId: number) => void;
+  /** Called when the user pans or zooms. Used to sync viewports in diff mode. */
+  onViewportChange?: (viewport: Viewport) => void;
+  /** Ref populated with a setViewport function for external viewport control. */
+  viewportRef?: React.MutableRefObject<((v: Viewport) => void) | null>;
+  /** When present, annotates nodes with diff status colors (added/removed/modified/unchanged). */
+  diffAnnotations?: { diff: GraphDiffResult; side: 'base' | 'head' };
 }
 
 const EMPTY_RUNTIME_EVENTS: DeserializedRuntimeEvent[] = [];
@@ -44,6 +51,9 @@ function GraphViewInner({
   customRenderers,
   selectedNodeId,
   onNodeClick,
+  onViewportChange,
+  viewportRef,
+  diffAnnotations,
 }: GraphViewProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState<WorkflowNode>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<WorkflowEdge>([]);
@@ -56,9 +66,12 @@ function GraphViewInner({
 
   const graphModel = useMemo(() => {
     const { nodes: graphNodes, edges: graphEdges } = cfgToGraphNodes(graph);
-    const { nodes: rfNodes, edges: rfEdges } = graphToReactflow(graphNodes, graphEdges);
+    let { nodes: rfNodes, edges: rfEdges } = graphToReactflow(graphNodes, graphEdges);
+    if (diffAnnotations) {
+      rfNodes = decorateNodesWithDiff(rfNodes, diffAnnotations.diff, diffAnnotations.side);
+    }
     return { graphNodes, rfNodes, rfEdges };
-  }, [graph]);
+  }, [graph, diffAnnotations]);
 
   const runtimeInputsRef = useRef({
     runtimeEvents,
@@ -183,8 +196,16 @@ function GraphViewInner({
   }, [selectedNodeId, setNodes]);
 
   // Auto-pan viewport to center the selected node — only when it's off-screen
-  const { setCenter, getNode, getViewport } = useReactFlow();
+  const { setCenter, getNode, getViewport, setViewport } = useReactFlow();
   const containerWidth = useStore((s) => s.width);
+
+  // Expose setViewport to parent via ref (for syncing viewports in diff mode)
+  useEffect(() => {
+    if (viewportRef) {
+      viewportRef.current = (v: Viewport) => setViewport(v, { duration: 0 });
+    }
+    return () => { if (viewportRef) viewportRef.current = null; };
+  }, [viewportRef, setViewport]);
   const containerHeight = useStore((s) => s.height);
   const prevGraphRef = useRef(graph);
   useEffect(() => {
@@ -310,6 +331,7 @@ function GraphViewInner({
         panOnScroll
         fitView
         fitViewOptions={{ minZoom: 0.3, maxZoom: 0.85, padding: 0.2 }}
+        onViewportChange={onViewportChange}
         proOptions={{ hideAttribution: true }}
         colorMode="dark"
       >

--- a/typescript2/pkg-playground/src/graph/constants.ts
+++ b/typescript2/pkg-playground/src/graph/constants.ts
@@ -1,3 +1,5 @@
+import type { DiffStatus } from './types';
+
 /**
  * Shared state colors & visual tokens for the graph.
  *
@@ -118,6 +120,27 @@ export function nodeBackground(s: NodeStateStyle): string {
     `linear-gradient(rgba(255,255,255,0.04), rgba(255,255,255,0) 28%)`,
     `linear-gradient(180deg, ${s.bgTop} 0%, ${s.bgBottom} 100%)`,
   ].join(', ');
+}
+
+export const diffColors: Record<DiffStatus, {
+  border: string;
+  glow: string;
+  bg: string;
+  opacity: number;
+  borderStyle?: string;
+  borderWidth?: string;
+}> = {
+  added:     { border: '#4ade80',               glow: 'rgba(74,222,128,0.35)',  bg: 'rgba(74,222,128,0.12)',  opacity: 1, borderWidth: '2px' },
+  removed:   { border: '#f87171',               glow: 'rgba(248,113,113,0.30)', bg: 'rgba(248,113,113,0.10)', opacity: 0.7, borderStyle: 'dashed', borderWidth: '2px' },
+  modified:  { border: '#fbbf24',               glow: 'rgba(251,191,36,0.35)',  bg: 'rgba(251,191,36,0.10)',  opacity: 1, borderWidth: '2px' },
+  unchanged: { border: 'rgba(255,255,255,0.08)', glow: 'transparent',           bg: 'transparent',           opacity: 0.25 },
+};
+
+/** Build a diff-aware box-shadow with a colored halo. */
+export function diffNodeShadow(diffStatus: DiffStatus): string {
+  const dc = diffColors[diffStatus];
+  if (dc.glow === 'transparent') return '0 1px 2px rgba(0,0,0,0.30), 0 4px 12px rgba(0,0,0,0.20)';
+  return `0 0 0 2px ${dc.glow}, 0 0 12px ${dc.glow}, 0 1px 2px rgba(0,0,0,0.30)`;
 }
 
 /**

--- a/typescript2/pkg-playground/src/graph/convert.ts
+++ b/typescript2/pkg-playground/src/graph/convert.ts
@@ -1,5 +1,5 @@
-import type { ControlFlowGraph, CfgNodeType } from '../worker-protocol';
-import type { GraphNode, GraphEdge, GraphNodeType, WorkflowNode, WorkflowEdge } from './types';
+import type { ControlFlowGraph, CfgNodeType, GraphDiffResult } from '../worker-protocol';
+import type { GraphNode, GraphEdge, GraphNodeType, WorkflowNode, WorkflowEdge, DiffStatus } from './types';
 import { getMarkerColors } from './edges/Marker';
 
 // Stage 1: ControlFlowGraph JSON -> GraphNode[] / GraphEdge[]
@@ -155,4 +155,50 @@ function graphTypeToReactflowType(gt: GraphNodeType): string {
     case 'scope': return 'base';
     case 'header': return 'base';
   }
+}
+
+/**
+ * Annotate ReactFlow nodes with diff status.
+ *
+ * @param side - 'base' or 'head' determines which node IDs from the diff apply:
+ *   - base side: removed (red), modified (amber), unchanged (dimmed)
+ *   - head side: added (green), modified (amber), unchanged (dimmed)
+ */
+export function decorateNodesWithDiff(
+  nodes: WorkflowNode[],
+  diff: GraphDiffResult,
+  side: 'base' | 'head',
+): WorkflowNode[] {
+  const statusByNodeId = new Map<string, DiffStatus>();
+
+  if (side === 'base') {
+    for (const id of diff.removed) {
+      statusByNodeId.set(String(id), 'removed');
+    }
+    for (const [baseId] of diff.modified) {
+      statusByNodeId.set(String(baseId), 'modified');
+    }
+    for (const [baseId] of diff.unchanged) {
+      statusByNodeId.set(String(baseId), 'unchanged');
+    }
+  } else {
+    for (const id of diff.added) {
+      statusByNodeId.set(String(id), 'added');
+    }
+    for (const [, headId] of diff.modified) {
+      statusByNodeId.set(String(headId), 'modified');
+    }
+    for (const [, headId] of diff.unchanged) {
+      statusByNodeId.set(String(headId), 'unchanged');
+    }
+  }
+
+  return nodes.map((node) => {
+    const diffStatus = statusByNodeId.get(node.id);
+    if (!diffStatus) return node;
+    return {
+      ...node,
+      data: { ...node.data, diffStatus },
+    };
+  });
 }

--- a/typescript2/pkg-playground/src/graph/edges/Marker.tsx
+++ b/typescript2/pkg-playground/src/graph/edges/Marker.tsx
@@ -19,6 +19,10 @@ export const kAllMarkerColors = [
   kNoMarkerColorDark,
   ...kBaseMarkerColorsLight,
   ...kBaseMarkerColorsDark,
+  // Diff status edge markers
+  '#4ade80',  // green-400 (added)
+  '#f87171',  // red-400 (removed)
+  '#fbbf24',  // amber-400 (modified)
 ];
 
 export const getMarkerColors = () => {

--- a/typescript2/pkg-playground/src/graph/nodes/BaseNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/BaseNode.tsx
@@ -1,6 +1,6 @@
 import { type NodeProps } from '@xyflow/react';
 import { type ComponentType, memo } from 'react';
-import { nodeBackground, nodeShadow, selectionRing, stateColors } from '../constants';
+import { nodeBackground, nodeShadow, selectionRing, stateColors, diffColors, diffNodeShadow } from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 import { NodeOutputPreview } from './NodeOutputPreview';
@@ -67,9 +67,18 @@ export const BaseNode: ComponentType<NodeProps> = memo(({ data }) => {
           gap: 6,
           padding: '7px 11px 7px 9px',
           borderRadius: 8,
-          background: nodeBackground(colors),
-          border: `1px solid ${isHighlighted ? selectionRing.color : colors.border}`,
-          boxShadow: nodeShadow(colors, !!isHighlighted),
+          background: d.diffStatus
+            ? `${diffColors[d.diffStatus].bg}, ${nodeBackground(colors)}`
+            : nodeBackground(colors),
+          border: `${d.diffStatus ? (diffColors[d.diffStatus].borderWidth ?? '1px') : '1px'} ${d.diffStatus === 'removed' ? 'dashed' : 'solid'} ${
+            d.diffStatus && !isHighlighted
+              ? diffColors[d.diffStatus].border
+              : isHighlighted ? selectionRing.color : colors.border
+          }`,
+          boxShadow: d.diffStatus
+            ? diffNodeShadow(d.diffStatus)
+            : nodeShadow(colors, !!isHighlighted),
+          opacity: d.diffStatus ? diffColors[d.diffStatus].opacity : undefined,
           width: '100%',
           height: '100%',
           boxSizing: 'border-box',

--- a/typescript2/pkg-playground/src/graph/nodes/DiamondNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/DiamondNode.tsx
@@ -1,7 +1,7 @@
 import { type NodeProps } from '@xyflow/react';
 import { GitBranch } from 'lucide-react';
 import { type ComponentType, memo } from 'react';
-import { nodeBackground, nodeShadow, selectionRing, stateColors } from '../constants';
+import { nodeBackground, nodeShadow, selectionRing, stateColors, diffColors, diffNodeShadow } from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 
@@ -26,9 +26,18 @@ export const DiamondNode: ComponentType<NodeProps> = memo(({ data }) => {
           gap: 8,
           padding: '7px 11px 7px 9px',
           borderRadius: 8,
-          background: nodeBackground(colors),
-          border: `1px solid ${colors.border}`,
-          boxShadow: nodeShadow(colors, !!isHighlighted),
+          background: d.diffStatus
+            ? `${diffColors[d.diffStatus].bg}, ${nodeBackground(colors)}`
+            : nodeBackground(colors),
+          border: `${d.diffStatus ? (diffColors[d.diffStatus].borderWidth ?? '1px') : '1px'} ${d.diffStatus === 'removed' ? 'dashed' : 'solid'} ${
+            d.diffStatus && !isHighlighted
+              ? diffColors[d.diffStatus].border
+              : colors.border
+          }`,
+          boxShadow: d.diffStatus
+            ? diffNodeShadow(d.diffStatus)
+            : nodeShadow(colors, !!isHighlighted),
+          opacity: d.diffStatus ? diffColors[d.diffStatus].opacity : undefined,
           width: '100%',
           height: '100%',
           boxSizing: 'border-box',

--- a/typescript2/pkg-playground/src/graph/nodes/GroupNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/GroupNode.tsx
@@ -1,7 +1,7 @@
 import { type NodeProps } from '@xyflow/react';
 import { Repeat } from 'lucide-react';
 import { type ComponentType, memo } from 'react';
-import { selectionRing, stateColors } from '../constants';
+import { selectionRing, stateColors, diffColors } from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 
@@ -23,9 +23,11 @@ export const GroupNode: ComponentType<NodeProps> = memo(({ data, id }) => {
 
   const borderColor = isHighlighted
     ? selectionRing.color
-    : isStateful
-      ? stateStyle.border
-      : 'rgba(255,255,255,0.10)';
+    : d.diffStatus
+      ? diffColors[d.diffStatus].border
+      : isStateful
+        ? stateStyle.border
+        : 'rgba(255,255,255,0.10)';
 
   return (
     <div
@@ -37,11 +39,14 @@ export const GroupNode: ComponentType<NodeProps> = memo(({ data, id }) => {
         borderRadius: 12,
         // Frame-only: no fill, so the canvas reads through. Nested groups
         // never stack into a darker patch — they just compose hairline frames.
-        background: 'transparent',
-        border: `1px solid ${borderColor}`,
+        background: d.diffStatus ? diffColors[d.diffStatus].bg : 'transparent',
+        border: `${d.diffStatus ? (diffColors[d.diffStatus].borderWidth ?? '1px') : '1px'} ${d.diffStatus === 'removed' ? 'dashed' : 'solid'} ${borderColor}`,
+        opacity: d.diffStatus ? diffColors[d.diffStatus].opacity : undefined,
         boxShadow: isHighlighted
           ? `0 0 0 1px ${selectionRing.glow}`
-          : undefined,
+          : d.diffStatus && diffColors[d.diffStatus].glow !== 'transparent'
+            ? `0 0 8px ${diffColors[d.diffStatus].glow}`
+            : undefined,
         transition: 'border-color 150ms ease, box-shadow 150ms ease',
       }}
     >

--- a/typescript2/pkg-playground/src/graph/nodes/HexagonNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/HexagonNode.tsx
@@ -1,7 +1,7 @@
 import { type NodeProps } from '@xyflow/react';
 import { Repeat } from 'lucide-react';
 import { type ComponentType, memo } from 'react';
-import { nodeBackground, nodeShadow, selectionRing, stateColors } from '../constants';
+import { nodeBackground, nodeShadow, selectionRing, stateColors, diffColors, diffNodeShadow } from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 
@@ -26,9 +26,18 @@ export const HexagonNode: ComponentType<NodeProps> = memo(({ data }) => {
           gap: 8,
           padding: '7px 11px 7px 9px',
           borderRadius: 8,
-          background: nodeBackground(colors),
-          border: `1px solid ${colors.border}`,
-          boxShadow: nodeShadow(colors, !!isHighlighted),
+          background: d.diffStatus
+            ? `${diffColors[d.diffStatus].bg}, ${nodeBackground(colors)}`
+            : nodeBackground(colors),
+          border: `${d.diffStatus ? (diffColors[d.diffStatus].borderWidth ?? '1px') : '1px'} ${d.diffStatus === 'removed' ? 'dashed' : 'solid'} ${
+            d.diffStatus && !isHighlighted
+              ? diffColors[d.diffStatus].border
+              : colors.border
+          }`,
+          boxShadow: d.diffStatus
+            ? diffNodeShadow(d.diffStatus)
+            : nodeShadow(colors, !!isHighlighted),
+          opacity: d.diffStatus ? diffColors[d.diffStatus].opacity : undefined,
           width: '100%',
           height: '100%',
           boxSizing: 'border-box',

--- a/typescript2/pkg-playground/src/graph/nodes/LLMNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/LLMNode.tsx
@@ -1,7 +1,7 @@
 import { type NodeProps } from '@xyflow/react';
 import { Sparkles } from 'lucide-react';
 import { type ComponentType, memo } from 'react';
-import { nodeBackground, nodeShadow, selectionRing, stateColors } from '../constants';
+import { nodeBackground, nodeShadow, selectionRing, stateColors, diffColors, diffNodeShadow } from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 import { NodeOutputPreview } from './NodeOutputPreview';
@@ -29,9 +29,18 @@ export const LLMNode: ComponentType<NodeProps> = memo(({ data }) => {
           gap: 4,
           padding: '7px 11px 8px 9px',
           borderRadius: 8,
-          background: nodeBackground(colors),
-          border: `1px solid ${colors.border}`,
-          boxShadow: nodeShadow(colors, !!isHighlighted),
+          background: d.diffStatus
+            ? `${diffColors[d.diffStatus].bg}, ${nodeBackground(colors)}`
+            : nodeBackground(colors),
+          border: `${d.diffStatus ? (diffColors[d.diffStatus].borderWidth ?? '1px') : '1px'} ${d.diffStatus === 'removed' ? 'dashed' : 'solid'} ${
+            d.diffStatus && !isHighlighted
+              ? diffColors[d.diffStatus].border
+              : colors.border
+          }`,
+          boxShadow: d.diffStatus
+            ? diffNodeShadow(d.diffStatus)
+            : nodeShadow(colors, !!isHighlighted),
+          opacity: d.diffStatus ? diffColors[d.diffStatus].opacity : undefined,
           width: '100%',
           height: '100%',
           boxSizing: 'border-box',

--- a/typescript2/pkg-playground/src/graph/types.ts
+++ b/typescript2/pkg-playground/src/graph/types.ts
@@ -45,6 +45,8 @@ export type NodeExecutionState =
   | 'skipped'
   | 'cached';
 
+export type DiffStatus = 'added' | 'removed' | 'modified' | 'unchanged';
+
 // ReactFlow node data
 export interface WorkflowNodeData {
   label: string;
@@ -59,6 +61,7 @@ export interface WorkflowNodeData {
   imageOutputs?: BamlJsMedia[];
   errorMessage?: string | null;
   customRenderers?: Record<string, FC<ResultRendererProps>>;
+  diffStatus?: DiffStatus;
   [key: string]: unknown;
 }
 

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -33,6 +33,8 @@ type WsOutMessage =
   | { type: 'fetchLogNew'; callId: number; id: number; method: string; url: string; requestHeaders: Record<string, string>; requestBody: string }
   | { type: 'fetchLogUpdate'; callId: number; logId: number; status?: number; durationMs?: number; responseBody?: string; error?: string; responseHeaders?: Record<string, string> }
   | { type: 'controlFlowGraphResult'; functionName: string; graph: unknown | null }
+  | { type: 'controlFlowGraphDiffResult'; functionName: string; baseGraph: unknown | null; headGraph: unknown | null; diff: unknown | null }
+  | { type: 'gitRefs'; branches: string[]; tags: string[] }
   | { type: 'cursorContext'; context: unknown }
   | { type: 'runtimeEvent'; data: string; callId: number };
 
@@ -49,6 +51,8 @@ type WsInMessage =
   | { type: 'requestState' }
   | { type: 'requestCollectTests'; project: string }
   | { type: 'requestControlFlowGraph'; project: string; functionName: string }
+  | { type: 'requestControlFlowGraphDiff'; project: string; functionName: string; baseRef?: string }
+  | { type: 'requestGitRefs' }
   | { type: 'cursorPosition'; file: string; line: number; column: number };
 
 const MAX_RECONNECT_DELAY = 5000;
@@ -213,6 +217,15 @@ export class WebSocketRuntimePort implements RuntimePort {
           project: msg.project,
           functionName: msg.functionName,
         };
+      case 'requestControlFlowGraphDiff':
+        return {
+          type: 'requestControlFlowGraphDiff',
+          project: msg.project,
+          functionName: msg.functionName,
+          ...(msg.baseRef ? { baseRef: msg.baseRef } : {}),
+        };
+      case 'requestGitRefs':
+        return { type: 'requestGitRefs' };
       case 'cursorPosition':
         return {
           type: 'cursorPosition',
@@ -329,6 +342,20 @@ export class WebSocketRuntimePort implements RuntimePort {
           type: 'controlFlowGraphResult',
           functionName: raw.functionName,
           graph: (raw.graph ?? null) as import('../worker-protocol').ControlFlowGraph | null,
+        };
+      case 'controlFlowGraphDiffResult':
+        return {
+          type: 'controlFlowGraphDiffResult',
+          functionName: raw.functionName,
+          baseGraph: (raw.baseGraph ?? null) as import('../worker-protocol').ControlFlowGraph | null,
+          headGraph: (raw.headGraph ?? null) as import('../worker-protocol').ControlFlowGraph | null,
+          diff: (raw.diff ?? null) as import('../worker-protocol').GraphDiffResult | null,
+        };
+      case 'gitRefs':
+        return {
+          type: 'gitRefs',
+          branches: raw.branches as string[],
+          tags: raw.tags as string[],
         };
       case 'cursorContext':
         return {

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -102,6 +102,8 @@ export type PlaygroundNotification =
   | { type: 'updateProject'; project: string; update: ProjectUpdate }
   | { type: 'openPlayground'; project: string; functionName?: string }
   | { type: 'controlFlowGraphResult'; functionName: string; graph: ControlFlowGraph | null }
+  | { type: 'controlFlowGraphDiffResult'; functionName: string; baseGraph: ControlFlowGraph | null; headGraph: ControlFlowGraph | null; diff: GraphDiffResult | null }
+  | { type: 'gitRefs'; branches: string[]; tags: string[] }
   | { type: 'cursorContext'; context: CursorContext }
   | { type: 'testCollectionResult'; project: string; generation: number; callId: number; data: number[]; expandError?: { testsetName: string; message: string } }
   | { type: 'runtimeEvent'; data: number[]; callId?: number };
@@ -143,6 +145,13 @@ export interface ControlFlowGraph {
   nodes: Record<string, CfgNode>;
   /** IndexMap<NodeId, Vec<Edge>> serializes as an object with numeric string keys. */
   edgesBySrc: Record<string, CfgEdge[]>;
+}
+
+export interface GraphDiffResult {
+  added: number[]
+  removed: number[]
+  modified: [number, number][]
+  unchanged: [number, number][]
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +237,8 @@ export type WorkerOutMessage =
   | { type: 'vfsFileDeleted'; path: string }
   | { type: 'buildTime'; value: string }
   | { type: 'controlFlowGraphResult'; functionName: string; graph: ControlFlowGraph | null }
+  | { type: 'controlFlowGraphDiffResult'; functionName: string; baseGraph: ControlFlowGraph | null; headGraph: ControlFlowGraph | null; diff: GraphDiffResult | null }
+  | { type: 'gitRefs'; branches: string[]; tags: string[] }
   | { type: 'cursorContext'; context: CursorContext }
   | { type: 'logDecorations'; decorations: LogDecoration[] }
   | { type: 'clearLogDecorations' }
@@ -248,6 +259,8 @@ export type WorkerInMessage =
   | { type: 'selectProject'; root: string }
   | { type: 'requestState' }
   | { type: 'requestControlFlowGraph'; project: string; functionName: string }
+  | { type: 'requestControlFlowGraphDiff'; project: string; functionName: string; baseRef?: string }
+  | { type: 'requestGitRefs' }
   | { type: 'cursorPosition'; file: string; line: number; column: number }
   | { type: 'requestCollectTests'; project: string }
   | { type: 'callTestFunction'; id: number; project: string; generation: number; testName: string }


### PR DESCRIPTION
[Ticket](https://cloud.codelayer.cloud/artifacts/019e1fe9-e127-73b4-b124-9cb82eed3cb6) | [Artifacts](https://cloud.codelayer.cloud/tasks/019e1fe9-df17-76fd-acf7-d5f3f77ef4e2/artifacts) | [Task](https://cloud.codelayer.cloud/deep/tasks/019e1fe9-df17-76fd-acf7-d5f3f77ef4e2)

## What problems was I solving

The BAML playground had no way to visualize structural differences between versions of a function's control flow graph. When reviewing code changes on a branch, developers had to mentally reconstruct how control flow changed by reading source diffs. This PR adds a side-by-side diff view to the playground's Graph tab that compares the current working tree against any git ref (branch, commit, tag, or staged), highlighting added/removed/modified/unchanged nodes with color-coded styling.

## What user-facing changes did I ship

- **Diff toggle**: "Current / Diff" toggle in the Graph tab header switches between single graph and side-by-side diff view
- **Git ref selector**: Dropdown to choose what to diff against — merge-base (main), staged, HEAD, HEAD~1/2/3, any local branch, or recent tags
- **Side-by-side graphs**: Draggable splitter between base (left) and current (right) panes with synchronized panning/zooming
- **Diff coloring**: Nodes colored by diff status — green (added), red dashed (removed), amber (modified), dimmed (unchanged) — with background tints and glowing halos
- **Edge cases**: New functions show "Function does not exist on base branch" on left pane; removed functions show the reverse

## How I implemented it

### Rust — Diff Algorithm & Serialization
- [`diff.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-diff.rs) — Three-pass graph diff engine (`compute_graph_diff`) with 12 scenario tests. Added serde derives to `GraphDiff` for cross-bridge serialization.
- [`mod.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-mod.rs) — Re-exports `GraphDiff`, added `Eq`/`Hash` to `NodeType` for diff matching.

### Rust — Bridge Plumbing
- [`bex_lsp/mod.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-mod.rs) — `ControlFlowGraphDiffResult` notification variant, `request_control_flow_graph_diff` and `workspace_roots` trait methods on `BexLsp`.
- [`multi_project/mod.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-mod.rs) — Implementation of diff request (builds temp project, computes diff) and `workspace_roots()`.
- [`bridge_wasm/lib.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-lib.rs) + [`wasm_playground.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-wasm_playground.rs) — WASM bindings for diff request and notification.

### Rust — LSP Server Git Integration
- [`playground_server.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-playground_server.rs) — `get_git_base_files()` resolves any git ref via `git rev-parse`, fetches `.baml` files via `git show`, supports `__staged__` pseudo-ref for index content. `get_git_refs()` lists branches and tags. Handler builds temp `ProjectDatabase` with synthetic `/tmp` root, synthesizes all-added/all-removed diffs for new/deleted functions.
- [`playground_ws.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-playground_ws.rs) — `RequestControlFlowGraphDiff` (with optional `base_ref`), `RequestGitRefs`, `ControlFlowGraphDiffResult`, `GitRefs` message types.

### Rust — Tests
- [`db.rs`](https://github.com/BoundaryML/baml/pull/3522/files#diff-db.rs) — Integration tests for graph diff through `ProjectDatabase`, plus `test_temp_db_from_raw_file_contents` validating the temp project pattern used by the diff handler.

### TypeScript — Protocol & Ports
- [`worker-protocol.ts`](https://github.com/BoundaryML/baml/pull/3522/files#diff-worker-protocol.ts) — `GraphDiffResult` type, `controlFlowGraphDiffResult`/`gitRefs` notification types, `requestControlFlowGraphDiff`/`requestGitRefs` request types.
- [`WebSocketRuntimePort.ts`](https://github.com/BoundaryML/baml/pull/3522/files#diff-WebSocketRuntimePort.ts) — `toServer()`/`fromServer()` handlers for all new message types.
- [`baml-lsp-worker.ts`](https://github.com/BoundaryML/baml/pull/3522/files#diff-baml-lsp-worker.ts) — WASM worker stubs (diff/git not supported in WASM).

### TypeScript — UI Components
- [`DiffGraphView.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-DiffGraphView.tsx) — New component: side-by-side container with draggable splitter, viewport sync between panes, dynamic base label, empty pane fallbacks.
- [`ExecutionPanel.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-ExecutionPanel.tsx) — Diff mode state (`diffMode`, `diffResult`, `diffBaseRef`, `gitRefs`), Current/Diff toggle, git ref dropdown, conditional rendering of `DiffGraphView` vs `GraphView`, message handlers.
- [`GraphView.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-GraphView.tsx) — `diffAnnotations`, `onViewportChange`, `viewportRef` props. Applies `decorateNodesWithDiff` in `graphModel` useMemo. Exposes `setViewport` via ref for external sync.

### TypeScript — Diff Color System
- [`constants.ts`](https://github.com/BoundaryML/baml/pull/3522/files#diff-constants.ts) — `diffColors` palette with `border`, `glow`, `bg`, `opacity`, `borderWidth` per status. `diffNodeShadow()` helper.
- [`types.ts`](https://github.com/BoundaryML/baml/pull/3522/files#diff-types.ts) — `DiffStatus` type, `diffStatus` field on `WorkflowNodeData`.
- [`convert.ts`](https://github.com/BoundaryML/baml/pull/3522/files#diff-convert.ts) — `decorateNodesWithDiff()` maps diff result node IDs to status annotations.
- [`BaseNode.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-BaseNode.tsx), [`DiamondNode.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-DiamondNode.tsx), [`HexagonNode.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-HexagonNode.tsx), [`LLMNode.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-LLMNode.tsx), [`GroupNode.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-GroupNode.tsx) — All 5 node components apply diff styling: colored borders (2px), background tints, glow halos, opacity.
- [`Marker.tsx`](https://github.com/BoundaryML/baml/pull/3522/files#diff-Marker.tsx) — Diff marker colors added for edge styling.

## Deviations from the plan

### Implemented as planned
- Phase 1: GraphDiff serde derives, PlaygroundNotification variant, WASM bindings, WebSocket message types
- Phase 2: TypeScript protocol types, worker handlers, WebSocket port handlers
- Phase 4: DiffStatus type, diffColors palette, all 5 node components, decorateNodesWithDiff, GraphView diffAnnotations prop, edge markers

### Deviations/surprises
- **Git integration moved server-side**: The plan had the VS Code extension host run git commands and pass base files to the client. Instead, git integration was moved entirely into the Rust LSP server (`get_git_base_files`), which is cleaner — uses the existing WebSocket channel, avoids `acquireVsCodeApi` issues, and works without VS Code-specific code.
- **`base_files` replaced by `base_ref`**: Instead of the client sending a `HashMap<String, String>` of file contents, the request sends an optional git ref string and the server resolves it. This enabled the git ref dropdown feature.
- **diffColors enhanced**: Added `bg` (background tint) and `borderWidth` fields beyond the planned `border`/`glow`/`opacity`. Unchanged opacity tightened from 0.4 to 0.25. Borders use full-opacity solid colors at 2px instead of 1px rgba.
- **DiffGraphView handles null graphs**: Props accept `ControlFlowGraph | null` with empty pane fallbacks, not required non-null as planned.

### Additions not in plan
- **Git ref dropdown** — Diff against any branch, tag, commit, HEAD~N, or staged
- **`get_git_refs()` / `RequestGitRefs` / `GitRefs`** — Server-side branch/tag listing
- **Viewport sync** — Synchronized panning/zooming between diff panes via `onViewportChange`/`viewportRef`
- **New/removed function synthesis** — Server generates all-added or all-removed diffs when function only exists on one side
- **`test_temp_db_from_raw_file_contents`** — Integration test for the temp ProjectDatabase pattern
- **Loading state** — "Computing diff..." placeholder while request is in-flight

### Items planned but not implemented
- **Phase 5 (sidebar diff dots)** — Implemented then reverted. The per-function dots added visual noise without enough value since diff status was only computed lazily (on function click).
- **WASM diff support** — Intentionally stubbed as no-op (no git access in WASM/promptfiddle).

## How to verify it

### Setup
```bash
git fetch
git checkout graph-diff-scenarios-for-code-review
```

### Manual Testing
- [ ] Open VS Code with a BAML project on a feature branch
- [ ] Open the BAML Playground, select a function, switch to Graph tab
- [ ] Click "Diff" toggle — side-by-side view appears with "Computing diff..." then graphs
- [ ] Verify diff coloring: green = added, red/dashed = removed, amber = modified, dimmed = unchanged
- [ ] Use the git ref dropdown to switch between "vs main", "vs staged", "vs HEAD~1", branch names
- [ ] Drag the splitter to resize panes
- [ ] Pan/zoom one pane — the other follows
- [ ] Select a new function (e.g., one that doesn't exist on base) — left pane shows "Function does not exist on base branch"
- [ ] Toggle back to "Current" — normal single graph view returns

### Automated Tests
```bash
cargo test -p baml_compiler2_visualization  # 50 tests (12 diff scenarios)
cargo test -p baml_project                  # 28 tests (4 new integration tests)
cd typescript2/pkg-playground && npx tsc --noEmit
```

## Description for the changelog

Add side-by-side graph diff view to the BAML Playground that compares control flow graphs across git refs with color-coded node highlighting (added/removed/modified/unchanged).
