### PR TITLE
promptfiddle2: add vercel build script

### DIFF
--- a/typescript2/app-promptfiddle/vercel-build.sh
+++ b/typescript2/app-promptfiddle/vercel-build.sh
@@ -53,7 +53,9 @@ echo "wasm-pack version: $(wasm-pack --version)"
 export OPENSSL_NO_VENDOR=1
 
 echo "Installing pnpm workspace..."
-pnpm install --frozen-lockfile
+# Vercel sets NODE_ENV=production, which makes pnpm skip devDependencies
+# (buf, typescript, etc.). Force-install them since we need them to build.
+pnpm install --frozen-lockfile --prod=false
 
 echo "Generating proto types..."
 pnpm --filter @b/pkg-proto run generate

--- a/typescript2/app-promptfiddle/vercel-build.sh
+++ b/typescript2/app-promptfiddle/vercel-build.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Vercel build script for app-promptfiddle (typescript2 workspace).
+#
+# Modeled on typescript/apps/fiddle-web-app/vercel-build.sh, but simpler:
+#   - No Go toolchain (pkg-proto uses the `buf` npm package, not protoc-gen-go)
+#   - Single Rust crate to build: baml_language/crates/bridge_wasm
+#
+# Expected environment: Amazon Linux 2023 (Vercel build environment).
+# Run from Vercel Root Directory = typescript2/app-promptfiddle.
+
+set -x
+set -e
+
+export LC_ALL=C
+export LANG=C
+
+# Move up to the typescript2 workspace root.
+cd ..
+
+# --- System deps for Rust/WASM compilation -----------------------------------
+echo "Installing system dependencies..."
+dnf install -y gcc make readline-devel zlib-devel openssl-devel libyaml-devel
+dnf install -y llvm clang
+dnf install -y git wget tar gzip bzip2 xz
+
+if ! command -v curl &> /dev/null; then
+    echo "Error: curl is not available"
+    exit 1
+fi
+
+# --- Rust toolchain ----------------------------------------------------------
+echo "Installing Rust..."
+if ! command -v rustc &> /dev/null; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+    source "$HOME/.cargo/env"
+fi
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# rustup shims may exist without a default toolchain set
+rustup default stable
+rustup target add wasm32-unknown-unknown
+
+echo "Installing wasm-pack..."
+cargo install wasm-pack --version 0.14.0 || true
+
+# --- Verify --------------------------------------------------------------------
+echo "Rust version: $(rustc --version)"
+echo "Node version: $(node --version)"
+echo "pnpm version: $(pnpm --version)"
+echo "wasm-pack version: $(wasm-pack --version)"
+
+# --- Install workspace deps + build dependencies -----------------------------
+export OPENSSL_NO_VENDOR=1
+
+echo "Installing pnpm workspace..."
+pnpm install --frozen-lockfile
+
+echo "Generating proto types..."
+pnpm --filter @b/pkg-proto run generate
+
+echo "Building bridge_wasm..."
+pnpm --filter @b/pkg-playground run build:wasm
+
+# --- Build the Next.js app ---------------------------------------------------
+echo "Building app-promptfiddle..."
+pnpm --filter app-promptfiddle run build
+
+ls -l app-promptfiddle/.next-build || true


### PR DESCRIPTION
## Summary
- Adds `typescript2/app-promptfiddle/vercel-build.sh` so Vercel can build the new promptfiddle on its AL2023 image
- Installs Rust + wasm-pack, generates pkg-proto types via buf, builds the `bridge_wasm` crate, then runs `next build`
- Modeled on `typescript/apps/fiddle-web-app/vercel-build.sh` but without the Go toolchain (pkg-proto uses the buf npm package, not protoc-gen-go)

This is the only repo-side change needed; PR previews come from the Vercel GitHub app once the `baml/promptfiddle2` project is connected.

## Test plan
- [ ] Vercel preview build for this PR succeeds
- [ ] Preview URL loads the promptfiddle UI
- [ ] Monaco editor + wasm bridge initialize without console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Vercel build orchestration that prepares the build environment, ensures required toolchains and tooling are available, installs workspace dependencies, generates types, builds the Rust/WASM bridge and the Next.js application, and verifies build outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3530)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->