### PR TITLE
chore: Skip PR creation in fill-schedule workflow when no changes exist

### DIFF
--- a/.github/workflows/oncall.yml
+++ b/.github/workflows/oncall.yml
@@ -80,7 +80,16 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.1.0
       - run: ./tools/bctl oncall fill-schedule
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: peter-evans/create-pull-request@v6
+        if: steps.check_changes.outputs.has_changes == 'true'
         with:
           token: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE }}
           branch: oncall/fill-schedule


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Modified the `fill-schedule` GitHub workflow to skip the PR creation step when the `fill-schedule` command results in no changes.

## Changes

- Added a "Check for changes" step that uses `git diff --quiet` to detect if there are any uncommitted changes
- Added a conditional `if` statement to the `peter-evans/create-pull-request` step that only runs when changes are detected
- This prevents unnecessary empty PRs from being created when the schedule is already up to date

## Testing

The workflow will now:
- ✅ Create a PR when `./tools/bctl oncall fill-schedule` makes changes to the schedule
- ✅ Skip PR creation when `./tools/bctl oncall fill-schedule` makes no changes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1778869463095439?thread_ts=1778869463.095439&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-8332f25f-f83e-5e97-87e1-af4ee4acd4cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8332f25f-f83e-5e97-87e1-af4ee4acd4cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the schedule synchronization workflow to skip creating pull requests when no changes are detected, reducing unnecessary notifications and pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3531)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->