### PR TITLE
Remove noisy 'unformatted' warning from `baml run`

### DIFF
--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -167,12 +167,6 @@ pub enum OutputFormat {
 // ============================================================================
 
 impl RunArgs {
-    fn emit_format_hint_if_needed(needs_format_hint: bool) {
-        if needs_format_hint {
-            eprintln!("{FORMAT_HINT}");
-        }
-    }
-
     /// Print a `[verbose]`-prefixed line when `--verbose` is set; no-op otherwise.
     fn vlog(&self, args: std::fmt::Arguments<'_>) {
         if self.verbose {
@@ -285,18 +279,16 @@ impl RunArgs {
 
         let argv = self.build_argv();
 
-        let (db, engine, needs_format_hint) =
-            if self.target.as_ref().is_some_and(|t| t.ends_with(".baml")) {
-                self.load_and_compile_standalone(
-                    self.target.as_ref().unwrap(),
-                    event_sink.clone(),
-                    argv,
-                )?
-            } else {
-                self.load_and_compile(event_sink.clone(), argv)?
-            };
+        let (db, engine) = if self.target.as_ref().is_some_and(|t| t.ends_with(".baml")) {
+            self.load_and_compile_standalone(
+                self.target.as_ref().unwrap(),
+                event_sink.clone(),
+                argv,
+            )?
+        } else {
+            self.load_and_compile(event_sink.clone(), argv)?
+        };
         let _ = db; // keep db alive for engine lifetime
-        Self::emit_format_hint_if_needed(needs_format_hint);
 
         let toml_content = std::fs::read_to_string(self.from.join("baml.toml")).unwrap_or_default();
         let scripts = Self::parse_scripts(&toml_content);
@@ -427,18 +419,13 @@ impl RunArgs {
         &self,
         event_sink: Option<Arc<dyn bex_events::EventSink>>,
         argv: Vec<String>,
-    ) -> Result<(ProjectDatabase, BexEngine, bool)> {
+    ) -> Result<(ProjectDatabase, BexEngine)> {
         let (db, from, baml_files) = load_project_from(&self.from)?;
         self.vlog(format_args!("Loading project from {}", from.display()));
         if baml_files.is_empty() {
             anyhow::bail!("No .baml files found in {}", from.display());
         }
         self.vlog(format_args!("Found {} .baml file(s)", baml_files.len()));
-        let needs_format_hint = baml_files.iter().any(|path| {
-            std::fs::read_to_string(path)
-                .map(|source| source_needs_format_hint(&source))
-                .unwrap_or(false)
-        });
 
         self.check_project_diagnostics(&db, "Cannot run: compilation errors found")?;
         self.vlog(format_args!("Compiling..."));
@@ -447,7 +434,7 @@ impl RunArgs {
             "Compiled {} user function(s)",
             engine.user_functions().len()
         ));
-        Ok((db, engine, needs_format_hint))
+        Ok((db, engine))
     }
 
     /// Load a single .baml file in hermetic standalone mode.
@@ -459,7 +446,7 @@ impl RunArgs {
         file_path: &str,
         event_sink: Option<Arc<dyn bex_events::EventSink>>,
         argv: Vec<String>,
-    ) -> Result<(ProjectDatabase, BexEngine, bool)> {
+    ) -> Result<(ProjectDatabase, BexEngine)> {
         let canonical = std::fs::canonicalize(Path::new(file_path))
             .with_context(|| format!("File not found: {file_path}"))?;
         self.vlog(format_args!(
@@ -469,7 +456,6 @@ impl RunArgs {
 
         let content = std::fs::read_to_string(&canonical)
             .with_context(|| format!("Failed to read {}", canonical.display()))?;
-        let needs_format_hint = source_needs_format_hint(&content);
 
         // Project root is the file's parent so relative imports resolve.
         let parent = canonical.parent().unwrap_or_else(|| Path::new("."));
@@ -487,7 +473,7 @@ impl RunArgs {
             "Compiled {} function(s) from standalone file",
             engine.user_functions().len()
         ));
-        Ok((db, engine, needs_format_hint))
+        Ok((db, engine))
     }
 
     // ========================================================================
@@ -1209,16 +1195,6 @@ impl RunArgs {
 // Reserved verbs & namespace helpers
 // ============================================================================
 
-const FORMAT_HINT: &str = "[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml fmt`.";
-
-fn source_needs_format_hint(source: &str) -> bool {
-    let options = baml_fmt::FormatOptions::default();
-    match baml_fmt::format(source, &options) {
-        Ok(formatted) => formatted != source,
-        Err(_) => false,
-    }
-}
-
 /// BEP-027 Appendix A: names that cannot be used as `[scripts]` keys.
 const RESERVED_VERBS: &[&str] = &[
     "run", "test", "repl", "init", "help", "version", "fmt", "lint", "check", "build", "generate",
@@ -1818,32 +1794,6 @@ mod tests {
         Ty::Bool {
             attr: Default::default(),
         }
-    }
-
-    #[test]
-    fn source_needs_format_hint_returns_false_for_formatted_source() {
-        let source = "function main() -> string {\n    \"ok\"\n}\n";
-        assert!(!source_needs_format_hint(source));
-    }
-
-    #[test]
-    fn source_needs_format_hint_returns_true_for_unformatted_source() {
-        let source = "function main()->string {\n\"ok\"\n}\n";
-        assert!(source_needs_format_hint(source));
-    }
-
-    #[test]
-    fn source_needs_format_hint_returns_false_on_formatter_error() {
-        let source = "function main( -> string {";
-        assert!(!source_needs_format_hint(source));
-    }
-
-    #[test]
-    fn format_hint_text_matches_ticket() {
-        assert_eq!(
-            FORMAT_HINT,
-            "[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml fmt`."
-        );
     }
 
     // Tests that touch the filesystem build paths under $TMPDIR. Appending
@@ -3641,7 +3591,7 @@ function AskDocs(query: string, max_results: int = 10, filter: string = "none") 
         args.from = project.to_path_buf();
         args.target = Some(s("eval"));
 
-        let (_db, engine, _needs_format_hint) = args
+        let (_db, engine) = args
             .load_and_compile(None, Vec::new())
             .expect("compile should succeed");
         match args.resolve_target(&engine, &no_scripts()).unwrap() {
@@ -3679,8 +3629,7 @@ backfill = "--function scripts.Backfill"
         let mut args_dev = run_args();
         args_dev.from = project.to_path_buf();
         args_dev.target = Some(s("dev"));
-        let (_db, engine, _needs_format_hint) =
-            args_dev.load_and_compile(None, Vec::new()).unwrap();
+        let (_db, engine) = args_dev.load_and_compile(None, Vec::new()).unwrap();
         let toml = std::fs::read_to_string(project.join("baml.toml")).unwrap();
         let scripts = RunArgs::parse_scripts(&toml);
         match args_dev.resolve_target(&engine, &scripts).unwrap() {
@@ -3695,7 +3644,7 @@ backfill = "--function scripts.Backfill"
         let mut args_bf = run_args();
         args_bf.from = project.to_path_buf();
         args_bf.target = Some(s("backfill"));
-        let (_db, engine, _needs_format_hint) = args_bf.load_and_compile(None, Vec::new()).unwrap();
+        let (_db, engine) = args_bf.load_and_compile(None, Vec::new()).unwrap();
         match args_bf.resolve_target(&engine, &scripts).unwrap() {
             ResolvedTarget::Script(expansion) => {
                 assert_eq!(expansion.function.as_deref(), Some("scripts.Backfill"));
@@ -3919,7 +3868,7 @@ hidden = "--function $init_test"
     }
 
     #[test]
-    fn expression_run_does_not_mutate_project_sources_for_format_hints() {
+    fn expression_run_does_not_mutate_project_sources() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("baml.toml"), "").unwrap();
         let src = tmp.path().join("baml_src");

--- a/baml_language/crates/baml_fmt/Cargo.toml
+++ b/baml_language/crates/baml_fmt/Cargo.toml
@@ -23,3 +23,4 @@ ouroboros = { workspace = true }
 rowan = { workspace = true }
 salsa = { workspace = true }
 thiserror = { workspace = true }
+

--- a/baml_language/crates/baml_fmt/src/ast/declarations.rs
+++ b/baml_language/crates/baml_fmt/src/ast/declarations.rs
@@ -82,9 +82,7 @@ impl Printable for TopLevelDeclaration {
             }
             TopLevelDeclaration::Generator(generator_decl) => generator_decl.print(shape, printer),
             TopLevelDeclaration::Unknown(range) => {
-                // May not be idempotent due to whitespace changes, but that's okay because we shouldn't
-                // have unknown stuff anyway.
-                printer.print_input_range(*range);
+                printer.print_input_range_trimmed_start(*range);
                 PrintInfo::default_multi_lined()
             }
         }

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -295,3 +295,207 @@ mod is_format_tests {
         assert_formats_to(source, source);
     }
 }
+
+#[cfg(test)]
+mod idempotency_tests {
+    use super::*;
+
+    fn assert_idempotent(source: &str) {
+        let options = FormatOptions::default();
+        let first = match format(source, &options) {
+            Ok(f) => f,
+            Err(_) => return,
+        };
+        let second = format(&first, &options).expect("second format pass should succeed");
+        assert_eq!(
+            first, second,
+            "formatter is not idempotent\n--- first pass ---\n{first}\n--- second pass ---\n{second}"
+        );
+    }
+
+    #[test]
+    fn trailing_newline() {
+        assert_idempotent("function main() -> int {\n    42\n}\n");
+    }
+
+    #[test]
+    fn no_trailing_newline() {
+        assert_idempotent("function main() -> int {\n    42\n}");
+    }
+
+    #[test]
+    fn multiple_trailing_newlines() {
+        assert_idempotent("function main() -> int {\n    42\n}\n\n\n");
+    }
+
+    #[test]
+    fn empty_source() {
+        assert_idempotent("");
+    }
+
+    #[test]
+    fn only_whitespace() {
+        assert_idempotent("   \n\n  \n");
+    }
+
+    #[test]
+    fn only_comment() {
+        assert_idempotent("// hello world\n");
+    }
+
+    #[test]
+    fn only_block_comment() {
+        assert_idempotent("/* hello world */\n");
+    }
+
+    #[test]
+    fn two_functions_no_blank_line() {
+        assert_idempotent("function a() -> int { 1 }\nfunction b() -> int { 2 }\n");
+    }
+
+    #[test]
+    fn two_functions_with_blank_line() {
+        assert_idempotent("function a() -> int {\n    1\n}\n\nfunction b() -> int {\n    2\n}\n");
+    }
+
+    #[test]
+    fn class_with_trailing_comma() {
+        assert_idempotent("class Foo {\n    x: int,\n    y: string,\n}\n");
+    }
+
+    #[test]
+    fn class_without_trailing_comma() {
+        assert_idempotent("class Foo {\n    x: int,\n    y: string\n}\n");
+    }
+
+    #[test]
+    fn enum_basic() {
+        assert_idempotent("enum Color {\n    Red,\n    Green,\n    Blue,\n}\n");
+    }
+
+    #[test]
+    fn function_unformatted_spacing() {
+        assert_idempotent("function main()->string {\n\"ok\"\n}\n");
+    }
+
+    #[test]
+    fn deeply_nested_blocks() {
+        assert_idempotent(
+            "function f(x: int) -> int {\n    if (x > 0) {\n        if (x > 10) {\n            100\n        } else {\n            x\n        }\n    } else {\n        0\n    }\n}\n",
+        );
+    }
+
+    #[test]
+    fn comment_between_declarations() {
+        assert_idempotent(
+            "function a() -> int {\n    1\n}\n\n// a comment\n\nfunction b() -> int {\n    2\n}\n",
+        );
+    }
+
+    #[test]
+    fn inline_comment() {
+        assert_idempotent("function f(x: int) -> int {\n    x + 1 // add one\n}\n");
+    }
+
+    #[test]
+    fn block_comment_inline() {
+        assert_idempotent("function f(x: int) -> int {\n    x /* inline */ + 1\n}\n");
+    }
+
+    #[test]
+    fn type_alias() {
+        assert_idempotent("type MyInt = int\n");
+    }
+
+    #[test]
+    fn complex_type_union() {
+        assert_idempotent("function f(x: int | string | bool) -> int {\n    0\n}\n");
+    }
+
+    #[test]
+    fn template_string_basic() {
+        assert_idempotent("template_string Greeting() #\"\n    Hello, World!\n\"#\n");
+    }
+
+    #[test]
+    fn multiple_blank_lines_between_decls() {
+        assert_idempotent(
+            "function a() -> int {\n    1\n}\n\n\n\nfunction b() -> int {\n    2\n}\n",
+        );
+    }
+
+    #[test]
+    fn let_binding() {
+        assert_idempotent("function f() -> int {\n    let x = 42;\n    x\n}\n");
+    }
+
+    #[test]
+    fn match_expression() {
+        assert_idempotent(
+            "function f(x: int | string) -> string {\n    match x {\n        i: int => \"int\",\n        s: string => s,\n    }\n}\n",
+        );
+    }
+
+    #[test]
+    fn client_block() {
+        assert_idempotent(
+            "client<llm> GPT4 {\n  provider openai\n  options {\n    model gpt-4o\n    api_key env.OPENAI_API_KEY\n  }\n}\n",
+        );
+    }
+
+    #[test]
+    fn retry_policy() {
+        assert_idempotent(
+            "retry_policy Bar {\n  max_retries 3\n  strategy {\n    type exponential_backoff\n  }\n}\n",
+        );
+    }
+
+    #[test]
+    fn function_with_prompt() {
+        assert_idempotent(
+            "function Foo(input: string) -> string {\n  client GPT4\n  prompt #\"\n    {{ _.role(\"user\") }}\n    {{ input }}\n  \"#\n}\n",
+        );
+    }
+
+    #[test]
+    fn test_block() {
+        assert_idempotent(
+            "test MyTest {\n  functions [Foo]\n  args {\n    input \"hello\"\n  }\n}\n",
+        );
+    }
+
+    #[test]
+    fn generator_block() {
+        assert_idempotent(
+            "generator lang_python {\n  output_type python/pydantic\n  output_dir \"../python\"\n  version \"0.64.0\"\n}\n",
+        );
+    }
+
+    #[test]
+    fn class_with_attributes() {
+        assert_idempotent(
+            "class Foo {\n    name string @alias(\"full_name\")\n    age int @description(\"The age\")\n}\n",
+        );
+    }
+
+    #[test]
+    fn enum_with_attributes() {
+        assert_idempotent(
+            "enum Color {\n    Red @alias(\"RED\")\n    Green\n    Blue @description(\"ocean\")\n}\n",
+        );
+    }
+
+    #[test]
+    fn template_string_multiline() {
+        assert_idempotent(
+            "template_string Greeting(name: string) #\"\n    Hello, {{ name }}!\n    Welcome aboard.\n\"#\n",
+        );
+    }
+
+    #[test]
+    fn mixed_file() {
+        assert_idempotent(
+            "class Input {\n    text: string,\n}\n\nfunction Classify(input: Input) -> string {\n    \"hello\"\n}\n\nenum Category {\n    A,\n    B,\n}\n",
+        );
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

## Issue Reference
- [x] Fixes noisy `[INFO] Your code is unformatted...` warning emitted on every `baml run` invocation (reported via Slack)
- [x] Fixes formatter idempotency issue for `TopLevelDeclaration::Unknown` nodes

## Changes

### 1. Remove noisy format hint from `baml run`

During `baml run`, the CLI was running the full formatter on every `.baml` source file to detect whether the code differed from its formatted form. If any file was "unformatted", it emitted an `[INFO]` warning to stderr on every single invocation:

```
[INFO] Your code is unformatted, but will continue to run. You can fix this whenever you'd like by running `baml fmt`.
```

This was problematic because:
- **Noisy during write-then-test loop** — the warning appeared on every `baml run`, adding noise to the development workflow
- **Could fire even after formatting** — if the formatter wasn't perfectly idempotent on certain source patterns, the warning persisted even after running `baml fmt`

Removed the entire format-hint path:
- Deleted `FORMAT_HINT` constant and `source_needs_format_hint()` function
- Deleted `emit_format_hint_if_needed()` method
- Simplified `load_and_compile` / `load_and_compile_standalone` return types from `(ProjectDatabase, BexEngine, bool)` to `(ProjectDatabase, BexEngine)`
- Removed four unit tests that only tested the deleted format-hint code

### 2. Fix formatter idempotency for Unknown nodes

`TopLevelDeclaration::Unknown` was using `print_input_range` (preserving verbatim whitespace) while `Statement::Unknown` and `Expression::Unknown` were already using `print_input_range_trimmed_start`. This inconsistency meant Unknown top-level nodes could have whitespace that shifts across formatting passes.

Fixed `TopLevelDeclaration::Unknown` to use `print_input_range_trimmed_start`, matching the other Unknown handlers.

### 3. Add idempotency regression tests

Added 32 idempotency regression tests in `baml_fmt` covering diverse BAML patterns: trailing newlines, empty sources, comments, multiple declarations, classes, enums, type aliases, template strings, match expressions, let bindings, client blocks, retry policies, generators, functions with prompts, test blocks, attributes, and mixed files. Each test formats twice and asserts `format(format(x)) == format(x)`.

The `baml fmt` command itself is completely unaffected — users can still format their code on demand.

## Testing

- [x] All 56 `baml_fmt` unit tests pass (including 32 new idempotency tests)
- [x] All 211 `baml_cli` unit tests pass (`cargo test --lib -p baml_cli`)
- [x] All 177 `baml_tests` formatter integration tests pass (each with idempotency check)
- [x] `cargo fmt` check passes

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1778619210722459?thread_ts=1778619210.722459&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-3ec21770-c8bc-4409-ba5b-e5319bbe6848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ec21770-c8bc-4409-ba5b-e5319bbe6848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

