### PR TITLE
chore(ci): bump gh actions to use nodejs 24 versions everywhere

### DIFF
--- a/.github/workflows/beps.reusable.yaml
+++ b/.github/workflows/beps.reusable.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: ${{ inputs.beps_changed == 'true' || inputs.is_canary }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -31,7 +31,7 @@ jobs:
         run: git fetch origin canary
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -49,7 +49,7 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -66,10 +66,10 @@ jobs:
           env: beps-canary
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 
@@ -141,7 +141,7 @@ jobs:
       pull-requests: write
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -172,10 +172,10 @@ jobs:
         run: git fetch origin canary
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -56,7 +56,7 @@ jobs:
             target: aarch64-unknown-linux-musl
 
     # Run Linux builds inside a more modern manylinux container (AlmaLinux 8 based)
-    # with a newer GLIBC version compatible with Node20 used by actions/checkout@v4
+    # with a newer GLIBC version compatible with Node24 used by actions/checkout@v6
     # container: ${{ contains(matrix._.os, 'ubuntu') && (contains(matrix._.target, 'x86_64') && 'quay.io/pypa/manylinux_2_28_x86_64' || 'ghcr.io/rust-cross/manylinux_2_28-cross:aarch64') || '' }}
     runs-on: ${{ matrix._.os }}
 
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # This sets up protoc-gen-go for non-Windows builds
       # and on windows this seems to hang forever since 0.217.0
@@ -264,7 +264,7 @@ jobs:
 
       # Upload the CFFI library for this specific target
       - name: Upload CFFI Library Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Artifact name uses the target name for uniqueness (as decided previously)
           name: libbaml-cffi-${{ matrix._.target }}
@@ -407,7 +407,7 @@ jobs:
       # Upload different artifacts based on mode
       - name: Upload CLI artifacts (Release)
         if: inputs.package_for_release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Artifact name in GitHub Actions UI remains the same
           name: baml-cli-${{ matrix._.target }}
@@ -417,7 +417,7 @@ jobs:
 
       - name: Upload CLI artifacts (CI)
         if: inputs.package_for_release == false
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: baml-cli-${{ matrix._.target }}
           path: |

--- a/.github/workflows/build-jetbrains-release.reusable.yaml
+++ b/.github/workflows/build-jetbrains-release.reusable.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
         uses: ./.github/actions/setup-java
@@ -74,7 +74,7 @@ jobs:
         run: ./gradlew buildPlugin
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: baml-jetbrains-zip-${{ steps.properties.outputs.version }}
           path: ./jetbrains/build/distributions/*
@@ -88,7 +88,7 @@ jobs:
 
   #     # Check out the current repository
   #     - name: Fetch Sources
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     # Set up Java environment for the next steps
   #     - name: Setup Java
@@ -108,7 +108,7 @@ jobs:
   #     # Collect Tests Result of failed tests
   #     - name: Collect Tests Result
   #       if: ${{ failure() }}
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: tests-result
   #         path: ./build/reports/tests
@@ -130,7 +130,7 @@ jobs:
   #     pull-requests: write
   #   steps:
   #     # Check out the current repository
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
   #       with:
   #         ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
   #         fetch-depth: 0  # a full history is required for pull request analysis
@@ -153,7 +153,7 @@ jobs:
   #   needs: [ build ]
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
 
   #     # Set up Java environment for the next steps
   #     - name: Setup Java
@@ -168,7 +168,7 @@ jobs:
 
   #     # Cache Plugin Verifier IDEs
   #     - name: Setup Plugin Verifier IDEs Cache
-  #       uses: actions/cache@v4
+  #       uses: actions/cache@v5
   #       with:
   #         path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
   #         key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
@@ -180,7 +180,7 @@ jobs:
   #     # Collect Plugin Verifier Result
   #     - name: Collect Plugin Verifier Result
   #       if: ${{ always() }}
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: pluginVerifier-result
   #         path: ./build/reports/pluginVerifier

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -93,12 +93,12 @@ jobs:
           clang -v
           cmake --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Setup Python for non-ARM64 Windows targets and other OS
       - name: Setup Python (default)
         if: matrix._.target != 'aarch64-pc-windows-msvc'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.8"
           architecture: ${{ matrix._.architecture }}
@@ -106,7 +106,7 @@ jobs:
       # Setup Python versions for ARM64 Windows
       - name: Setup Python 3.11 (ARM64 Windows)
         if: matrix._.target == 'aarch64-pc-windows-msvc'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         id: py311
         with:
           python-version: "3.11"
@@ -114,7 +114,7 @@ jobs:
           allow-prereleases: true
       - name: Setup Python 3.12 (ARM64 Windows)
         if: matrix._.target == 'aarch64-pc-windows-msvc'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         id: py312
         with:
           python-version: "3.12"
@@ -122,7 +122,7 @@ jobs:
           allow-prereleases: true
       - name: Setup Python 3.13 (ARM64 Windows)
         if: matrix._.target == 'aarch64-pc-windows-msvc'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         id: py313
         with:
           python-version: "3.13"
@@ -151,7 +151,7 @@ jobs:
             fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Test LICENSE packaging
         if: matrix._.license_test != 'skip'
@@ -171,7 +171,7 @@ jobs:
           grep 'baml.*Apache-2.0' license-audit.log >/dev/null
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix._.target }}
           path: engine/language_client_python/dist

--- a/.github/workflows/build-python-sdk.reusable.yaml
+++ b/.github/workflows/build-python-sdk.reusable.yaml
@@ -67,10 +67,10 @@ jobs:
               Add-Content -Path "$env:GITHUB_PATH" -Value "$env:USERPROFILE\.cargo\bin" -Encoding utf8
           }
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # abi3-py310 produces one interpreter-agnostic wheel per platform,
           # so a single Python is enough for the whole 3.10..3.13+ range.
@@ -107,7 +107,7 @@ jobs:
             fi
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-sdk-${{ matrix._.target }}
           path: baml_language/sdks/python/dist

--- a/.github/workflows/build-ruby-release.reusable.yaml
+++ b/.github/workflows/build-ruby-release.reusable.yaml
@@ -36,7 +36,7 @@ jobs:
       run:
         working-directory: engine/language_client_ruby
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@main
         with:
@@ -116,7 +116,7 @@ jobs:
       #################################################################################################################
 
       - name: Upload Ruby artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gem-${{ matrix._.platform }}
           path: engine/language_client_ruby/pkg/*.gem

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -97,7 +97,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Check GLIBC version for Linux targets (skip musl targets)
       - name: Check GLIBC version
@@ -139,7 +139,7 @@ jobs:
         working-directory: engine/language_client_typescript
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-${{ matrix._.target }}
           path: engine/language_client_typescript/*.node

--- a/.github/workflows/build-vscode-release.reusable.yaml
+++ b/.github/workflows/build-vscode-release.reusable.yaml
@@ -49,7 +49,7 @@ jobs:
             rust-target: aarch64-unknown-linux-musl
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
@@ -83,7 +83,7 @@ jobs:
           echo "Determined artifact name for ${{ matrix.code-target }}: ${ARTIFACT_NAME}"
 
       - name: Download specific CLI artifact for ${{ matrix.code-target }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: baml-cli-${{ matrix.rust-target }}
           path: cli-artifact-${{ matrix.code-target }}
@@ -214,7 +214,7 @@ jobs:
         working-directory: typescript/apps/vscode-ext
 
       - name: Upload VSIX artifact for ${{ matrix.code-target }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: baml-vscode-vsix-${{ matrix.code-target }}
           path: typescript/apps/vscode-ext/${{ steps.package.outputs.vsix_path }}
@@ -245,7 +245,7 @@ jobs:
         working-directory: .
       - name: Upload Playground Artifact (conditional)
         if: matrix.code-target == 'linux-x64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playground-dist-${{ inputs.version }}
           path: |

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -99,7 +99,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -135,7 +135,7 @@ jobs:
 
       - name: "Upload test results on failure"
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-failures-linux
           path: |
@@ -144,7 +144,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-test-linux
           path: baml_language/target/cargo-timings/
@@ -155,7 +155,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -191,7 +191,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-test-macos
           path: baml_language/target/cargo-timings/
@@ -204,7 +204,7 @@ jobs:
     # Right now it needs to download our repo every time which is very slow
     timeout-minutes: 50
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -240,7 +240,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-test-windows
           path: baml_language/target/cargo-timings/
@@ -278,7 +278,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: ${{ matrix.timeout }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -297,7 +297,7 @@ jobs:
           shared-key: ${{ matrix.rust-cache-key }}
 
       - name: "Setup Python 3.10+"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -307,7 +307,7 @@ jobs:
           tool: cargo-nextest
 
       - name: "Install uv"
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
@@ -329,7 +329,7 @@ jobs:
 
       - name: "Upload test results on failure"
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdk-test-failures-${{ matrix.os-label }}
           path: |
@@ -339,7 +339,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-sdk-tests-${{ matrix.os-label }}
           path: baml_language/target/cargo-timings/
@@ -350,7 +350,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -382,7 +382,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-test-wasm
           path: baml_language/target/cargo-timings/
@@ -396,7 +396,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -432,7 +432,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-msrv
           path: baml_language/target/cargo-timings/
@@ -447,7 +447,7 @@ jobs:
     # bypass later doesn't accidentally start blocking required CI.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -470,7 +470,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -495,7 +495,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-doc
           path: baml_language/target/cargo-timings/
@@ -512,7 +512,7 @@ jobs:
       # mise installs handles its own Python via `uv run`).
       MISE_DISABLE_TOOLS: python,pipx:uv,pipx:ruff,pipx:maturin
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -564,7 +564,7 @@ jobs:
 
       - name: "Upload snapshot failures"
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: snapshot-failures
           path: |
@@ -573,7 +573,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-snapshot
           path: baml_language/target/cargo-timings/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       # Flag for bridge_nodejs changes - triggers generated file sync check
       bridge_nodejs: ${{ steps.check_bridge_nodejs.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -252,7 +252,7 @@ jobs:
       MISE_DISABLE_TOOLS: python,pipx:uv,pipx:ruff,pipx:maturin
     steps:
       - name: "Checkout Branch"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -276,7 +276,7 @@ jobs:
         working-directory: baml_language
 
       - name: "Install uv"
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: "Install mise"
         uses: jdx/mise-action@v2
@@ -286,7 +286,7 @@ jobs:
           version: 2025.12.12
 
       - name: "Cache prek"
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -310,7 +310,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -386,7 +386,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -408,7 +408,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -427,7 +427,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: "Setup Node.js"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -475,7 +475,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: "Checkout Branch"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/cleanup-stale-previews.yml
+++ b/.github/workflows/cleanup-stale-previews.yml
@@ -14,7 +14,7 @@ jobs:
   cleanup:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Get all branches
 

--- a/.github/workflows/docs.reusable.yaml
+++ b/.github/workflows/docs.reusable.yaml
@@ -24,7 +24,7 @@ jobs:
       name: ${{ inputs.is_canary && 'boundary-tools-prod' || 'boundary-tools-dev' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -102,7 +102,7 @@ jobs:
         working-directory: ../sage-backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -212,7 +212,7 @@ jobs:
         working-directory: typescript/apps/sage-backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -68,9 +68,9 @@ jobs:
     #   GOARCH: ${{ matrix._.goarch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.ollama/models

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -46,7 +46,7 @@ jobs:
       runtime: ${{ steps.check_runtime.outputs.changed }}
       skip_reason: ${{ steps.check_runtime.outputs.skip_reason }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -169,7 +169,7 @@ jobs:
           [typescript-lint, rust-format, rust-lint, rust-lint-wasm, python-lint]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
@@ -232,7 +232,7 @@ jobs:
     if: needs.determine_changes.outputs.runtime == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
@@ -262,7 +262,7 @@ jobs:
     if: needs.determine_changes.outputs.runtime == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
@@ -284,7 +284,7 @@ jobs:
     if: needs.determine_changes.outputs.runtime == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
@@ -344,7 +344,7 @@ jobs:
         test-suite: [rust-unit, python-integration]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
@@ -427,7 +427,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
@@ -444,7 +444,7 @@ jobs:
         run: cargo build --release --bin baml-cli --target ${{ matrix.target }}
         working-directory: engine
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: baml-cli-${{ matrix.target }}
           path: engine/target/release/baml-cli*
@@ -495,12 +495,12 @@ jobs:
     if: github.ref == 'refs/heads/canary' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.determine_changes.outputs.runtime == 'true'
     steps:
       - name: Checkout main repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: main-repo
 
       - name: Checkout zed-baml repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: BoundaryML/zed-baml
           token: ${{ secrets.SAM_BAML_ZED_GITHUB_TOKEN }}

--- a/.github/workflows/publish-zed-release.reusable.yaml
+++ b/.github/workflows/publish-zed-release.reusable.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout upstream zed extensions
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: BoundaryML/zed-extensions
           ref: main

--- a/.github/workflows/release-baml-language-alpha.yml
+++ b/.github/workflows/release-baml-language-alpha.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Checkout
         if: steps.gate.outputs.should_run == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.gate.outputs.checkout_ref }}
           fetch-depth: 0
@@ -189,7 +189,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
           persist-credentials: false
@@ -266,7 +266,7 @@ jobs:
           PY
 
       - name: Upload archive artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: baml-language-archive-${{ matrix.target }}
           path: |
@@ -293,7 +293,7 @@ jobs:
       DISPATCH_HOMEBREW: ${{ needs.prepare.outputs.dispatch_homebrew }}
     steps:
       - name: Download archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: baml-language-archive-*
           merge-multiple: true

--- a/.github/workflows/release-sdk.yaml
+++ b/.github/workflows/release-sdk.yaml
@@ -58,7 +58,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: python-sdk-*
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,11 +117,11 @@ jobs:
     # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.8"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: dist
@@ -152,7 +152,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
@@ -175,7 +175,7 @@ jobs:
           fi
           echo "npm $current_version satisfies >= $required_version"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: bindings-*
           path: engine/language_client_typescript/artifacts
@@ -190,7 +190,7 @@ jobs:
   #   if: ${{ startsWith(github.ref, 'refs/tags/') }}
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
 
   #     - uses: rubygems/configure-rubygems-credentials@main
   #       with:
@@ -199,7 +199,7 @@ jobs:
 
   #     - uses: jdx/mise-action@v2
 
-  #     - uses: actions/download-artifact@v4
+  #     - uses: actions/download-artifact@v8
   #       with:
   #         pattern: gem-*
   #         path: engine/language_client_ruby/pkg/
@@ -220,7 +220,7 @@ jobs:
     # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -251,7 +251,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (needs.determine-version.outputs.is_release_tag == 'true') || inputs.force_publish_vscode }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
       - name: Setup Node.js
@@ -261,7 +261,7 @@ jobs:
           install_dependencies: false
           npm-token: ${{ secrets.NPM_TOKEN }}
       - name: Download VSIX artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: baml-vscode-vsix-*
           path: vsix-artifacts
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (needs.determine-version.outputs.is_release_tag == 'true') || inputs.force_publish_vscode }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
       - name: Setup Node.js
@@ -290,7 +290,7 @@ jobs:
           install_dependencies: false
           npm-token: ${{ secrets.NPM_TOKEN }}
       - name: Download VSIX artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: baml-vscode-vsix-*
           path: vsix-artifacts
@@ -309,13 +309,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.determine-version.outputs.is_release_tag == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
       - name: Setup Java
         uses: ./.github/actions/setup-java
       - name: Download extension zips
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: baml-jetbrains-zip-*
           path: ./jetbrains/build/distributions/
@@ -335,21 +335,21 @@ jobs:
     # Must use GitHub-hosted runner due to permissions issues with GitHub/npm OIDC trusted publishing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download all baml-cli artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: baml-cli-*
           path: cli-artifacts
           merge-multiple: true
       - name: Download all libbaml-cffi artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: libbaml-cffi-*
           path: cffi-artifacts
           merge-multiple: true
       - name: Download playground artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: playground-dist-*
           path: playground-artifacts

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -23,7 +23,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 20
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: "Upload size-gate report"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: size-gate-linux
           path: baml_language/size-gate-linux.json
@@ -60,7 +60,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-size-gate-linux
           path: baml_language/target/cargo-timings/
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 20
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: "Upload size-gate report"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: size-gate-macos
           path: baml_language/size-gate-macos.json
@@ -105,7 +105,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-size-gate-macos
           path: baml_language/target/cargo-timings/
@@ -119,7 +119,7 @@ jobs:
     timeout-minutes: 45
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: "Upload size-gate report"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: size-gate-windows
           path: baml_language/size-gate-windows.json
@@ -157,7 +157,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-size-gate-windows
           path: baml_language/target/cargo-timings/
@@ -169,7 +169,7 @@ jobs:
     timeout-minutes: 25
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -196,7 +196,7 @@ jobs:
 
       - name: "Upload size-gate report"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: size-gate-wasm
           path: baml_language/size-gate-wasm.json
@@ -204,7 +204,7 @@ jobs:
 
       - name: "Upload cargo timings"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-size-gate-wasm
           path: baml_language/target/cargo-timings/
@@ -219,12 +219,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: "Download size-gate reports"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: size-gate-*
           merge-multiple: true

--- a/.github/workflows/test-go-windows-quick.yml
+++ b/.github/workflows/test-go-windows-quick.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -44,7 +44,7 @@ jobs:
         shell: bash
 
       - name: Cache Rust build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             engine/target

--- a/.github/workflows/test-go-windows.yml
+++ b/.github/workflows/test-go-windows.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test-rust-sdk.yml
+++ b/.github/workflows/test-rust-sdk.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust (MSRV 1.70)
         uses: dtolnay/rust-toolchain@stable
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust (MSRV 1.70)
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/wasm-pack-tests.reusable.yaml
+++ b/.github/workflows/wasm-pack-tests.reusable.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/webview-tests.reusable.yaml
+++ b/.github/workflows/webview-tests.reusable.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -106,7 +106,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1296,12 +1296,10 @@ dependencies = [
  "baml_compiler_parser",
  "baml_compiler_syntax",
  "baml_workspace",
- "indexmap 2.13.0",
  "insta",
  "rowan 0.16.1",
  "salsa",
  "serde",
- "sys_jinja_types",
  "text-size",
 ]
 
@@ -1593,7 +1591,6 @@ dependencies = [
  "bex_resource_types",
  "bex_vm_types",
  "indexmap 2.13.0",
- "parking_lot",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -7612,26 +7609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sys_jinja"
-version = "0.0.0-beta"
-dependencies = [
- "minijinja",
- "minijinja-contrib",
- "regex",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sys_jinja_types"
-version = "0.0.0-beta"
-dependencies = [
- "baml_base",
- "indexmap 2.13.0",
- "minijinja",
- "strsim",
-]
-
-[[package]]
 name = "sys_llm"
 version = "0.0.0-beta"
 dependencies = [
@@ -7659,6 +7636,7 @@ dependencies = [
  "indexmap 2.13.0",
  "infer",
  "minijinja",
+ "minijinja-contrib",
  "percent-encoding",
  "regex",
  "rsa",
@@ -7667,7 +7645,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "strum",
- "sys_jinja",
  "sys_types",
  "thiserror 2.0.18",
  "tokio",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies across CI/CD workflows to newer versions for improved compatibility and reliability. Changes include updates to repository checkout, artifact management, caching, and build tooling steps in automated build and test pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->