### PR TITLE
ci: bump benchmarks-instrumented timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -472,7 +472,7 @@ jobs:
         github.ref == 'refs/heads/canary' ||
         contains(github.event.pull_request.body, 'RUN_CODSPEED=1')
       )
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout duration for benchmark job in the CI pipeline to allow more time for execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->