### PR TITLE
ci: allow CodSpeed bench step to fail without failing CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -502,6 +502,7 @@ jobs:
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@v4
+        continue-on-error: true
         with:
           mode: walltime
           run: cd baml_language && cargo codspeed run


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the CodSpeed `Run benchmarks` step in `ci.yaml` so a bench flake doesn't fail the job.
- Job conclusion stays `success` → CI workflow conclusion stays `success` → `release-baml-language-alpha.yml`'s `workflow_run.conclusion == 'success'` gate is satisfied.
- Only the run step is exempted — toolchain install, bench build, and missing-token failures still fail the job. The step shows orange ("succeeded with errors") in the UI so the failure remains visible.

## Test plan
- [ ] CI runs on this PR; CodSpeed step result does not gate job conclusion.
- [ ] Confirm release-baml-language-alpha continues to fire on subsequent CI runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->