### PR TITLE
baml_language: ship baml-pack-host in release archives

### DIFF
--- a/.github/workflows/release-baml-language-alpha.yml
+++ b/.github/workflows/release-baml-language-alpha.yml
@@ -172,18 +172,22 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-14
             binary: baml-cli
+            pack_host: baml-pack-host
             archive_ext: tar.gz
           - target: x86_64-apple-darwin
             os: macos-15-intel
             binary: baml-cli
+            pack_host: baml-pack-host
             archive_ext: tar.gz
           - target: x86_64-unknown-linux-gnu
             os: blacksmith-4vcpu-ubuntu-2204
             binary: baml-cli
+            pack_host: baml-pack-host
             archive_ext: tar.gz
           - target: x86_64-pc-windows-msvc
             os: blacksmith-4vcpu-windows-2025
             binary: baml-cli.exe
+            pack_host: baml-pack-host.exe
             archive_ext: zip
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -210,6 +214,13 @@ jobs:
         run: cargo build --release --bin baml-cli --target "${TARGET}"
         working-directory: baml_language
 
+      - name: Build baml-pack-host
+        env:
+          BAML_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release -p baml_pack_host --bin baml-pack-host --target "${TARGET}"
+        working-directory: baml_language
+
       - name: Smoke test version
         env:
           EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
@@ -227,6 +238,7 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           TARGET: ${{ matrix.target }}
           BINARY: ${{ matrix.binary }}
+          PACK_HOST: ${{ matrix.pack_host }}
           ARCHIVE_EXT: ${{ matrix.archive_ext }}
         run: |
           set -euo pipefail
@@ -241,23 +253,27 @@ jobs:
           version = os.environ["VERSION"]
           target = os.environ["TARGET"]
           binary = os.environ["BINARY"]
+          pack_host = os.environ["PACK_HOST"]
           archive_ext = os.environ["ARCHIVE_EXT"]
 
           root = Path.cwd()
           staging = root / "dist" / target / "staging"
           staging.mkdir(parents=True, exist_ok=True)
-          shutil.copy2(root / "baml_language" / "target" / target / "release" / binary, staging / binary)
+          release_dir = root / "baml_language" / "target" / target / "release"
+          shutil.copy2(release_dir / binary, staging / binary)
+          shutil.copy2(release_dir / pack_host, staging / pack_host)
           shutil.copy2(root / "README.md", staging / "README.md")
           shutil.copy2(root / "LICENSE", staging / "LICENSE")
 
           archive = root / "dist" / target / f"baml-language-{version}-{target}.{archive_ext}"
+          contents = (binary, pack_host, "README.md", "LICENSE")
           if archive_ext == "zip":
               with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-                  for item in (binary, "README.md", "LICENSE"):
+                  for item in contents:
                       zf.write(staging / item, item)
           else:
               with tarfile.open(archive, "w:gz") as tf:
-                  for item in (binary, "README.md", "LICENSE"):
+                  for item in contents:
                       tf.add(staging / item, item)
 
           digest = hashlib.sha256(archive.read_bytes()).hexdigest()


### PR DESCRIPTION
## Summary
- `baml pack` downloads `baml-pack-host` from the published `baml-language-<version>-<target>` archive when no host is present next to `baml`, but the release workflow was only bundling `baml-cli`. This left `baml pack` unable to fetch a host on a clean install.
- Build `baml-pack-host` (`-p baml_pack_host`) for each release target and add it to every archive alongside `baml-cli`. Covers `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc` — the four targets `release_host_target_triple` whitelists.

## Test plan
- [ ] Manually trigger the workflow via `workflow_dispatch` (no publish) and confirm `baml-pack-host[.exe]` appears in each archive artifact.
- [ ] After the next canary alpha publish, run `baml pack` on a clean machine and confirm the host is downloaded successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `baml-pack-host` binary is now included alongside `baml-cli` in release packages for all supported platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->