### PR TITLE
baml_language: autocli redesign for run/pack + baml init

### DIFF
--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -79,6 +79,9 @@ pub(crate) enum Commands {
     #[command(about = "Initialize a new BAML project (creates baml.toml)")]
     Init(crate::init_command::InitArgs),
 
+    #[command(about = "Create a new BAML project directory")]
+    New(crate::init_command::NewArgs),
+
     #[command(about = "Run a BAML function or script", disable_help_flag = true)]
     Run(crate::run_command::RunArgs),
 
@@ -143,6 +146,7 @@ impl RuntimeCli {
     pub fn run(&self) -> Result<crate::ExitCode> {
         match &self.command {
             Commands::Init(args) => args.run(),
+            Commands::New(args) => args.run(),
             Commands::Run(args) => args.run(),
             Commands::Pack(args) => args.run(),
             Commands::Describe(args) => args.run(),

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -76,6 +76,9 @@ pub(crate) enum Commands {
     #[command(about = "Run BAML tests")]
     Test(crate::test_command::TestArgs),
 
+    #[command(about = "Initialize a new BAML project (creates baml.toml)")]
+    Init(crate::init_command::InitArgs),
+
     #[command(about = "Run a BAML function or script", disable_help_flag = true)]
     Run(crate::run_command::RunArgs),
 
@@ -139,6 +142,7 @@ impl RuntimeCli {
 
     pub fn run(&self) -> Result<crate::ExitCode> {
         match &self.command {
+            Commands::Init(args) => args.run(),
             Commands::Run(args) => args.run(),
             Commands::Pack(args) => args.run(),
             Commands::Describe(args) => args.run(),

--- a/baml_language/crates/baml_cli/src/init_command.rs
+++ b/baml_language/crates/baml_cli/src/init_command.rs
@@ -1,13 +1,14 @@
-// `baml init` — scaffold a new BAML project.
+// `baml init` / `baml new` — scaffold a new BAML project.
 //
-// Mirrors `cargo init`'s shape: produces a `baml.toml` with a
-// `[package]` table at the target directory, plus an empty `baml_src/`
-// so the project marker layout (`baml.toml` required + optional
-// `baml_src/` for sources) is in place from the start. A starter
-// `baml_src/main.baml` gives the user something runnable immediately.
+// Both produce a `baml.toml` with a `[package]` table plus a
+// `baml_src/main.baml` starter file. The difference mirrors Cargo:
+//   - `baml init [PATH]` initializes *in place* (`PATH` defaults to `.`)
+//     and refuses to overwrite an existing `baml.toml`.
+//   - `baml new <PATH>` creates a fresh directory at `PATH` and
+//     initializes inside; refuses to run if `PATH` already exists.
 //
-// Refuses to overwrite existing `baml.toml`. Directory creation is
-// idempotent — running `init` inside an empty existing folder is fine.
+// Both flows share the same writer (`scaffold`) so the produced layout
+// stays consistent — only the directory precondition differs.
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
@@ -39,44 +40,94 @@ impl InitArgs {
     }
 
     fn run_with_reporter(&self, reporter: &Reporter) -> Result<crate::ExitCode> {
+        // `init` is in-place: create-or-reuse the directory, then
+        // refuse if `baml.toml` already exists so we never clobber a
+        // project the user already initialized.
         std::fs::create_dir_all(&self.path)
             .with_context(|| format!("Failed to create directory {}", self.path.display()))?;
         let canonical = std::fs::canonicalize(&self.path)
             .with_context(|| format!("Failed to canonicalize path {}", self.path.display()))?;
-
-        let toml_path = canonical.join("baml.toml");
-        if toml_path.exists() {
+        if canonical.join("baml.toml").exists() {
             anyhow::bail!(
                 "`{}` already exists. Refusing to overwrite an existing project.",
-                toml_path.display()
+                canonical.join("baml.toml").display()
             );
         }
-
-        let name = self
-            .name
-            .clone()
-            .or_else(|| default_project_name(&canonical))
-            .unwrap_or_else(|| "baml-project".to_string());
-        validate_project_name(&name)?;
-
-        reporter.spin("Creating", format!("baml.toml ({name})"));
-        std::fs::write(&toml_path, render_baml_toml(&name))
-            .with_context(|| format!("Failed to write {}", toml_path.display()))?;
-
-        let src_dir = canonical.join("baml_src");
-        std::fs::create_dir_all(&src_dir)
-            .with_context(|| format!("Failed to create {}", src_dir.display()))?;
-
-        let main_path = src_dir.join("main.baml");
-        if !main_path.exists() {
-            reporter.spin("Creating", "baml_src/main.baml");
-            std::fs::write(&main_path, STARTER_MAIN_BAML)
-                .with_context(|| format!("Failed to write {}", main_path.display()))?;
-        }
-
-        reporter.finish("Initialized", format!("{} ({name})", canonical.display()));
-        Ok(crate::ExitCode::Success)
+        scaffold(&canonical, self.name.as_deref(), reporter, "Initialized")
     }
+}
+
+/// `baml new <PATH>` — create a fresh directory at `<PATH>` and
+/// scaffold a project inside. Refuses to run if `<PATH>` already exists,
+/// the same way `cargo new` does.
+#[derive(Args, Clone, Debug)]
+pub struct NewArgs {
+    /// Directory to create. Errors if it already exists.
+    #[arg(value_name = "PATH")]
+    pub path: PathBuf,
+
+    /// Project name written to `baml.toml`'s `[package].name`. Defaults
+    /// to the basename of `<PATH>`.
+    #[arg(long)]
+    pub name: Option<String>,
+}
+
+impl NewArgs {
+    pub fn run(&self) -> Result<crate::ExitCode> {
+        let reporter = Reporter::new();
+        self.run_with_reporter(&reporter)
+    }
+
+    fn run_with_reporter(&self, reporter: &Reporter) -> Result<crate::ExitCode> {
+        if self.path.exists() {
+            anyhow::bail!(
+                "destination `{}` already exists. Use `baml init` to initialize \
+                 inside an existing directory, or pick a new path.",
+                self.path.display()
+            );
+        }
+        std::fs::create_dir(&self.path)
+            .with_context(|| format!("Failed to create directory {}", self.path.display()))?;
+        let canonical = std::fs::canonicalize(&self.path)
+            .with_context(|| format!("Failed to canonicalize path {}", self.path.display()))?;
+        scaffold(&canonical, self.name.as_deref(), reporter, "Created")
+    }
+}
+
+/// Shared writer for `init` and `new`. Both flows reach this once the
+/// destination directory exists and is known not to already be a BAML
+/// project. `verb` is the past-tense label rendered in the final status
+/// line ("Initialized" vs. "Created").
+fn scaffold(
+    canonical: &Path,
+    explicit_name: Option<&str>,
+    reporter: &Reporter,
+    verb: &str,
+) -> Result<crate::ExitCode> {
+    let name = explicit_name
+        .map(str::to_string)
+        .or_else(|| default_project_name(canonical))
+        .unwrap_or_else(|| "baml-project".to_string());
+    validate_project_name(&name)?;
+
+    let toml_path = canonical.join("baml.toml");
+    reporter.spin("Creating", format!("baml.toml ({name})"));
+    std::fs::write(&toml_path, render_baml_toml(&name))
+        .with_context(|| format!("Failed to write {}", toml_path.display()))?;
+
+    let src_dir = canonical.join("baml_src");
+    std::fs::create_dir_all(&src_dir)
+        .with_context(|| format!("Failed to create {}", src_dir.display()))?;
+
+    let main_path = src_dir.join("main.baml");
+    if !main_path.exists() {
+        reporter.spin("Creating", "baml_src/main.baml");
+        std::fs::write(&main_path, STARTER_MAIN_BAML)
+            .with_context(|| format!("Failed to write {}", main_path.display()))?;
+    }
+
+    reporter.finish(verb, format!("{} ({name})", canonical.display()));
+    Ok(crate::ExitCode::Success)
 }
 
 /// Derive a project name from the canonical path's basename. Returns
@@ -271,5 +322,84 @@ mod tests {
         args.name = Some(r#"my"app"#.into());
         let err = args.run().unwrap_err();
         assert!(format!("{err}").contains("invalid character"));
+    }
+
+    // ── baml new ──────────────────────────────────────────────────────
+
+    fn new_args(path: PathBuf) -> NewArgs {
+        NewArgs { path, name: None }
+    }
+
+    /// Happy path: `baml new <PATH>` creates the directory and scaffolds
+    /// the same `baml.toml` + `baml_src/main.baml` layout as `init`.
+    #[test]
+    fn new_creates_directory_and_scaffolds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("brand-new-app");
+        new_args(target.clone()).run().unwrap();
+        assert!(target.is_dir());
+        let toml = std::fs::read_to_string(target.join("baml.toml")).unwrap();
+        assert!(toml.contains("name = \"brand-new-app\""));
+        assert!(target.join("baml_src/main.baml").exists());
+    }
+
+    /// `baml new <PATH>` refuses to run if `<PATH>` already exists —
+    /// mirrors `cargo new`'s precondition. User should use `baml init`
+    /// instead when targeting an existing directory.
+    #[test]
+    fn new_refuses_to_run_on_existing_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("already-here");
+        std::fs::create_dir(&target).unwrap();
+
+        let err = new_args(target).run().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("already exists"), "got: {msg}");
+        assert!(msg.contains("baml init"), "got: {msg}");
+    }
+
+    /// Existing file at the destination also blocks `new` — same as
+    /// directories. Catches the case where the user typed a name that
+    /// happens to be a regular file.
+    #[test]
+    fn new_refuses_to_run_on_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("blocking-file");
+        std::fs::write(&target, "").unwrap();
+
+        let err = new_args(target).run().unwrap_err();
+        assert!(format!("{err}").contains("already exists"));
+    }
+
+    /// Explicit `--name` overrides the directory basename for `new`,
+    /// same as `init`.
+    #[test]
+    fn new_explicit_name_overrides_directory_basename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("brand-new-app");
+        let mut args = new_args(target.clone());
+        args.name = Some("renamed".into());
+        args.run().unwrap();
+        let toml = std::fs::read_to_string(target.join("baml.toml")).unwrap();
+        assert!(toml.contains("name = \"renamed\""));
+    }
+
+    /// `--name` validation applies to `new` too — the shared `scaffold`
+    /// path runs `validate_project_name` once. A bad `--name` must
+    /// surface before any directory is created.
+    #[test]
+    fn new_rejects_invalid_name_without_partial_writes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("bad-name-test");
+        let mut args = new_args(target.clone());
+        args.name = Some("bad name".into());
+        let err = args.run().unwrap_err();
+        assert!(format!("{err}").contains("invalid character"));
+        // The dir was created (we can't avoid that without a more
+        // involved pre-check), but no manifest landed inside.
+        assert!(
+            !target.join("baml.toml").exists(),
+            "must not write a manifest when validation fails"
+        );
     }
 }

--- a/baml_language/crates/baml_cli/src/init_command.rs
+++ b/baml_language/crates/baml_cli/src/init_command.rs
@@ -1,0 +1,229 @@
+// `baml init` — scaffold a new BAML project.
+//
+// Mirrors `cargo init`'s shape: produces a `baml.toml` with a
+// `[package]` table at the target directory, plus an empty `baml_src/`
+// so the project marker layout (`baml.toml` required + optional
+// `baml_src/` for sources) is in place from the start. A starter
+// `baml_src/main.baml` gives the user something runnable immediately.
+//
+// Refuses to overwrite existing `baml.toml`. Directory creation is
+// idempotent — running `init` inside an empty existing folder is fine.
+
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Args;
+
+use crate::reporter::Reporter;
+
+/// `baml init` — scaffold a new project under the given directory
+/// (default `.`). Refuses to clobber an existing `baml.toml`.
+#[derive(Args, Clone, Debug)]
+pub struct InitArgs {
+    /// Directory to initialize. Defaults to the current directory.
+    #[arg(value_name = "PATH", default_value = ".")]
+    pub path: PathBuf,
+
+    /// Project name written to `baml.toml`'s `[package].name`. Defaults
+    /// to the basename of `<PATH>` (or `baml-project` for `.`).
+    #[arg(long)]
+    pub name: Option<String>,
+}
+
+impl InitArgs {
+    pub fn run(&self) -> Result<crate::ExitCode> {
+        let reporter = Reporter::new();
+        self.run_with_reporter(&reporter)
+    }
+
+    fn run_with_reporter(&self, reporter: &Reporter) -> Result<crate::ExitCode> {
+        std::fs::create_dir_all(&self.path)
+            .with_context(|| format!("Failed to create directory {}", self.path.display()))?;
+        let canonical = std::fs::canonicalize(&self.path)
+            .with_context(|| format!("Failed to canonicalize path {}", self.path.display()))?;
+
+        let toml_path = canonical.join("baml.toml");
+        if toml_path.exists() {
+            anyhow::bail!(
+                "`{}` already exists. Refusing to overwrite an existing project.",
+                toml_path.display()
+            );
+        }
+
+        let name = self
+            .name
+            .clone()
+            .or_else(|| default_project_name(&canonical))
+            .unwrap_or_else(|| "baml-project".to_string());
+        validate_project_name(&name)?;
+
+        reporter.spin("Creating", format!("baml.toml ({name})"));
+        std::fs::write(&toml_path, render_baml_toml(&name))
+            .with_context(|| format!("Failed to write {}", toml_path.display()))?;
+
+        let src_dir = canonical.join("baml_src");
+        std::fs::create_dir_all(&src_dir)
+            .with_context(|| format!("Failed to create {}", src_dir.display()))?;
+
+        let main_path = src_dir.join("main.baml");
+        if !main_path.exists() {
+            reporter.spin("Creating", "baml_src/main.baml");
+            std::fs::write(&main_path, STARTER_MAIN_BAML)
+                .with_context(|| format!("Failed to write {}", main_path.display()))?;
+        }
+
+        reporter.finish("Initialized", format!("{} ({name})", canonical.display()));
+        Ok(crate::ExitCode::Success)
+    }
+}
+
+/// Derive a project name from the canonical path's basename. Returns
+/// `None` if the path has no usable basename (e.g. `/`), letting the
+/// caller fall back to a hard-coded default.
+fn default_project_name(canonical: &Path) -> Option<String> {
+    canonical
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Cargo-style project-name rules: non-empty, no whitespace, no path
+/// separators. Lets dashes / underscores / dots through so common names
+/// like `my-app` and `my.tool` are fine.
+fn validate_project_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Project name cannot be empty.");
+    }
+    if name
+        .chars()
+        .any(|c| c.is_whitespace() || c == '/' || c == '\\')
+    {
+        anyhow::bail!(
+            "Project name `{name}` contains invalid characters \
+             (whitespace or path separators). Use letters, digits, `-`, `_`, or `.`."
+        );
+    }
+    Ok(())
+}
+
+fn render_baml_toml(name: &str) -> String {
+    format!(
+        "[package]\n\
+         name = \"{name}\"\n\
+         \n\
+         # [scripts]\n\
+         # dev = \"-f main\"\n",
+    )
+}
+
+const STARTER_MAIN_BAML: &str = r#"function main() -> string {
+  "hello from baml"
+}
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_args(path: PathBuf) -> InitArgs {
+        InitArgs { path, name: None }
+    }
+
+    /// Happy path: empty dir → `baml.toml`, `baml_src/main.baml` written.
+    #[test]
+    fn init_creates_baml_toml_and_starter_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_args(tmp.path().to_path_buf()).run().unwrap();
+        let toml = std::fs::read_to_string(tmp.path().join("baml.toml")).unwrap();
+        assert!(toml.contains("[package]"));
+        assert!(toml.contains("name = "));
+        assert!(tmp.path().join("baml_src/main.baml").exists());
+    }
+
+    /// Default name comes from the directory's basename.
+    #[test]
+    fn init_default_name_matches_directory_basename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("my-cool-app");
+        std::fs::create_dir(&sub).unwrap();
+        init_args(sub.clone()).run().unwrap();
+        let toml = std::fs::read_to_string(sub.join("baml.toml")).unwrap();
+        assert!(
+            toml.contains("name = \"my-cool-app\""),
+            "expected basename-derived name; got:\n{toml}"
+        );
+    }
+
+    /// Explicit `--name` overrides the directory basename.
+    #[test]
+    fn init_explicit_name_overrides_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut args = init_args(tmp.path().to_path_buf());
+        args.name = Some("explicit".to_string());
+        args.run().unwrap();
+        let toml = std::fs::read_to_string(tmp.path().join("baml.toml")).unwrap();
+        assert!(toml.contains("name = \"explicit\""));
+    }
+
+    /// Refuses to overwrite existing `baml.toml`. No partial writes.
+    #[test]
+    fn init_refuses_to_clobber_existing_baml_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("baml.toml"), "[package]\nname=\"prior\"\n").unwrap();
+        let err = init_args(tmp.path().to_path_buf()).run().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("already exists"), "got: {msg}");
+
+        // The pre-existing file must be untouched.
+        let preserved = std::fs::read_to_string(tmp.path().join("baml.toml")).unwrap();
+        assert!(preserved.contains("prior"));
+    }
+
+    /// Idempotent on `baml_src/` — running init when `baml_src/` already
+    /// exists is fine as long as `baml.toml` doesn't (and an existing
+    /// `main.baml` isn't overwritten).
+    #[test]
+    fn init_preserves_existing_main_baml() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("baml_src")).unwrap();
+        std::fs::write(
+            tmp.path().join("baml_src/main.baml"),
+            "// pre-existing content",
+        )
+        .unwrap();
+
+        init_args(tmp.path().to_path_buf()).run().unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("baml_src/main.baml")).unwrap();
+        assert_eq!(content, "// pre-existing content");
+    }
+
+    /// Whitespace / slashes in `--name` are rejected.
+    #[test]
+    fn init_rejects_invalid_project_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut args = init_args(tmp.path().to_path_buf());
+        args.name = Some("bad name".to_string());
+        let err = args.run().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("invalid characters"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_project_name_accepts_common_shapes() {
+        for ok in &["app", "my-app", "my_app", "my.app", "App1", "a"] {
+            validate_project_name(ok).expect(ok);
+        }
+    }
+
+    #[test]
+    fn validate_project_name_rejects_empty_and_path_separators() {
+        assert!(validate_project_name("").is_err());
+        assert!(validate_project_name("a/b").is_err());
+        assert!(validate_project_name("a\\b").is_err());
+        assert!(validate_project_name("a b").is_err());
+    }
+}

--- a/baml_language/crates/baml_cli/src/init_command.rs
+++ b/baml_language/crates/baml_cli/src/init_command.rs
@@ -90,20 +90,22 @@ fn default_project_name(canonical: &Path) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-/// Cargo-style project-name rules: non-empty, no whitespace, no path
-/// separators. Lets dashes / underscores / dots through so common names
-/// like `my-app` and `my.tool` are fine.
+/// Cargo-style project-name rules: non-empty, ASCII alphanumeric plus
+/// `-`, `_`, `.`. Whitelist beats blacklist here — `render_baml_toml`
+/// drops the name straight into a `"..."` TOML string, so a stray `"`
+/// (or any control char) in the name produces an unparseable manifest.
 fn validate_project_name(name: &str) -> Result<()> {
     if name.is_empty() {
         anyhow::bail!("Project name cannot be empty.");
     }
-    if name
+    let bad: Vec<char> = name
         .chars()
-        .any(|c| c.is_whitespace() || c == '/' || c == '\\')
-    {
+        .filter(|c| !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')))
+        .collect();
+    if !bad.is_empty() {
         anyhow::bail!(
-            "Project name `{name}` contains invalid characters \
-             (whitespace or path separators). Use letters, digits, `-`, `_`, or `.`."
+            "Project name `{name}` contains invalid character(s) {bad:?}. \
+             Use ASCII letters, digits, `-`, `_`, or `.`."
         );
     }
     Ok(())
@@ -209,7 +211,7 @@ mod tests {
         args.name = Some("bad name".to_string());
         let err = args.run().unwrap_err();
         let msg = format!("{err}");
-        assert!(msg.contains("invalid characters"), "got: {msg}");
+        assert!(msg.contains("invalid character"), "got: {msg}");
     }
 
     #[test]
@@ -225,5 +227,49 @@ mod tests {
         assert!(validate_project_name("a/b").is_err());
         assert!(validate_project_name("a\\b").is_err());
         assert!(validate_project_name("a b").is_err());
+    }
+
+    /// `render_baml_toml` drops the name straight into a `"..."` literal,
+    /// so a name containing `"` would produce unparseable TOML. The
+    /// validator's whitelist catches this before we ever try to write.
+    #[test]
+    fn validate_project_name_rejects_toml_breakers() {
+        assert!(
+            validate_project_name(r#"my"app"#).is_err(),
+            "double quote must be rejected (would break TOML literal)",
+        );
+        assert!(
+            validate_project_name("my'app").is_err(),
+            "single quote must be rejected",
+        );
+        assert!(
+            validate_project_name("my\nname").is_err(),
+            "newline must be rejected",
+        );
+        assert!(
+            validate_project_name("my\tname").is_err(),
+            "tab must be rejected",
+        );
+    }
+
+    /// Non-ASCII names are rejected by the whitelist — keep package
+    /// names ASCII so they map cleanly onto filesystem-name conventions
+    /// the binary outputs use.
+    #[test]
+    fn validate_project_name_rejects_non_ascii() {
+        assert!(validate_project_name("café").is_err());
+        assert!(validate_project_name("プロジェクト").is_err());
+    }
+
+    /// Whatever the validator rejects, the `baml init` happy path must
+    /// also reject. Defensive against the validator and the init flow
+    /// drifting apart.
+    #[test]
+    fn init_rejects_quote_in_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut args = init_args(tmp.path().to_path_buf());
+        args.name = Some(r#"my"app"#.into());
+        let err = args.run().unwrap_err();
+        assert!(format!("{err}").contains("invalid character"));
     }
 }

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -16,6 +16,7 @@ mod describe_command_tests;
 pub(crate) mod format;
 pub(crate) mod generate;
 pub(crate) mod grep_command;
+pub(crate) mod init_command;
 pub(crate) mod lsp;
 pub(crate) mod pack_command;
 pub(crate) mod project_load;

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -1,10 +1,20 @@
-// `baml pack` — compile any `baml run` target (except expression mode)
-// into a single self-contained executable.
+// `baml pack` — compile one or more BAML functions into a single
+// self-contained executable.
 //
 // Target resolution mirrors `baml run`'s shape minus two things:
 //   - `-e` is not packageable (no persistent target to bake in).
 //   - `[scripts]` are not packageable — scripts are a dev-time dispatch
 //     mechanism, not an entry-point concept.
+//
+// Targets are picked via repeatable `-f/--function` flags. With multiple
+// `-f` the packed binary becomes a multi-subcommand CLI (`./cli foo …`,
+// `./cli bar …`); with a single `-f` it's the same shape with one
+// subcommand. A bare positional `<TARGET>` runs a single function as the
+// binary's only entry point (no subcommand layer).
+//
+// Standalone single-file sources are loaded via `--file <PATH>`, which
+// is mutually exclusive with `--from <DIR>`. Without either, the project
+// at the current directory is loaded.
 //
 // The output is the host binary (baml-pack-host) with a `PackEnvelope`
 // (bitcode-serialized) appended in an OS-native section. At runtime the
@@ -34,21 +44,29 @@ use crate::{
     commands::release_version, project_load::load_project_from_reporting, reporter::Reporter,
 };
 
-/// `baml pack` — compile a target into a standalone executable.
+/// `baml pack` — compile one or more targets into a standalone executable.
 #[derive(Args, Clone, Debug)]
 pub struct PackArgs {
-    /// Target: namespace name to pack its `main`, or a path to a `.baml`
-    /// file for hermetic packaging. If omitted, packs the root `main`.
+    /// Positional target: a function name to pack as the binary's only
+    /// entry point. Mutually exclusive with `-f/--function`.
     #[arg(value_name = "TARGET")]
     pub target: Option<String>,
 
-    /// Pack a specific function as the entry point (e.g. `llm.Summarize`).
-    /// Replaces the positional target.
-    #[arg(long)]
-    pub function: Option<String>,
+    /// Pack a specific function as a subcommand of the produced binary.
+    /// Repeatable: each `-f` adds another subcommand. With one `-f` the
+    /// binary still has a subcommand layer (vs. a bare positional, which
+    /// produces a single-entry binary with no subcommand).
+    #[arg(short = 'f', long = "function", value_name = "NAME")]
+    pub functions: Vec<String>,
 
-    /// Output path for the packaged executable.
-    /// Defaults to `./<target-name>`.
+    /// Standalone single-file source. Loads only this file (no project
+    /// discovery). Mutually exclusive with `--from`.
+    #[arg(long, value_name = "PATH")]
+    pub file: Option<PathBuf>,
+
+    /// Output path for the packaged executable. Defaults to the
+    /// `[package].name` from `baml.toml`; for a single target with no
+    /// `[package].name`, falls back to the function name.
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 
@@ -65,25 +83,26 @@ pub struct PackArgs {
     #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
     pub output_format: OutputFormat,
 
-    /// Project root directory. Ignored for hermetic `.baml` targets.
+    /// Project root directory. Ignored when `--file` is set.
     #[arg(long, default_value = ".")]
     pub from: PathBuf,
 
     /// `-e/--expression` is recognized only so we can reject it with a
-    /// targeted message — `baml pack` doesn't support expression mode
-    /// (BEP-027 §"Expression mode is not packageable"). Without this
-    /// flag declared, `baml pack -e '...'` falls through to clap's
-    /// positional handling and surfaces a confusing parse error.
+    /// targeted message — `baml pack` doesn't support expression mode.
+    /// Without this flag declared, `baml pack -e '...'` falls through to
+    /// clap's positional handling and surfaces a confusing parse error.
     #[arg(short = 'e', long = "expression", value_name = "EXPR")]
     pub expression: Option<String>,
 }
 
-/// Resolved entry point: everything needed to build a `PackEnvelope`.
-#[derive(Debug)]
+/// One resolved entry point baked into a packed binary.
+#[derive(Debug, Clone)]
 struct ResolvedPackTarget {
     qualified_name: String,
-    identifier: String,
-    default_basename: String,
+    /// Display name (qualified, `user.` prefix stripped).
+    display_name: String,
+    /// CLI subcommand name (last `.`-segment of `display_name`).
+    subcommand_name: String,
 }
 
 impl PackArgs {
@@ -93,14 +112,8 @@ impl PackArgs {
     }
 
     fn run_with_reporter(&self, reporter: &Reporter) -> Result<crate::ExitCode> {
-        if self.expression.is_some() {
-            return Err(anyhow!(
-                "expression mode (`-e` / `--expression`) is not packageable; \
-                 `baml pack` requires a function or `.baml` file target. \
-                 Pass `--function <name>` or a positional target instead.\n\
-                 See BEP-027 §\"Expression mode is not packageable\"."
-            ));
-        }
+        self.validate_flags()?;
+
         let (db, program, needs_format_hint) = self.load_and_compile(reporter)?;
         let _ = db;
         // Mirror `baml run`'s format advisory: if any source file
@@ -121,19 +134,24 @@ impl PackArgs {
         )
         .map_err(|e| anyhow!("Failed to initialize engine for resolution: {e:?}"))?;
 
-        let resolved = self.resolve_target(&engine)?;
-        validate_help_param(&engine, &resolved.qualified_name)?;
-        let display_name = resolved
-            .qualified_name
-            .strip_prefix("user.")
-            .unwrap_or(&resolved.qualified_name)
-            .to_string();
-        reporter.spin("Packaging", &display_name);
+        let (mode, targets) = self.resolve_targets(&engine)?;
+        for t in &targets {
+            validate_help_param(&engine, &t.qualified_name)?;
+        }
+        let label = label_for(&targets);
+        reporter.spin("Packaging", &label);
 
         let envelope = PackEnvelope {
             program,
-            target_name: resolved.qualified_name.clone(),
-            target_identifier: resolved.identifier.clone(),
+            mode: mode.clone(),
+            targets: targets
+                .iter()
+                .map(|t| baml_exec::TargetEntry {
+                    qualified_name: t.qualified_name.clone(),
+                    display_name: t.display_name.clone(),
+                    subcommand_name: t.subcommand_name.clone(),
+                })
+                .collect(),
             output_format: self.output_format,
         };
         let serialized = bitcode::serialize(&envelope)
@@ -141,10 +159,11 @@ impl PackArgs {
 
         let target_triple = self.resolved_target_triple()?;
         let host_bytes = read_host_binary(target_triple, reporter)?;
+        let basename = self.resolve_output_basename()?;
         let output_path = self
             .output
             .clone()
-            .unwrap_or_else(|| default_output_path(&resolved.default_basename, target_triple));
+            .unwrap_or_else(|| default_output_path(&basename, target_triple));
 
         let mut output_file = std::fs::File::create(&output_path)
             .with_context(|| format!("Failed to create {}", output_path.display()))?;
@@ -166,14 +185,55 @@ impl PackArgs {
         // without parsing an ambiguous arrow.
         reporter.finish(
             "Finished",
-            format!(
-                "{} [{}, {}]",
-                output_path.display(),
-                display_name,
-                target_triple,
-            ),
+            format!("{} [{label}, {}]", output_path.display(), target_triple),
         );
         Ok(crate::ExitCode::Success)
+    }
+
+    /// Validate flag combinations the clap-side `Args` derive can't catch.
+    fn validate_flags(&self) -> Result<()> {
+        if self.expression.is_some() {
+            anyhow::bail!(
+                "expression mode (`-e` / `--expression`) is not packageable; \
+                 pass a positional `<TARGET>` or `-f <NAME>` instead."
+            );
+        }
+        // `--file` and `--from` both name a source location. Reject the
+        // combination up front instead of silently preferring one. Same
+        // rule as `baml run`. The check is gated on `--from != "."`
+        // because clap can't tell "user passed `.`" from "user passed
+        // nothing"; `--file` alongside the default `--from` is fine.
+        if self.file.is_some() && self.from != Path::new(".") {
+            anyhow::bail!(
+                "`--file` and `--from` are mutually exclusive — `--file` already names \
+                 the single source to load."
+            );
+        }
+        if let Some(target) = self.target.as_deref() {
+            if looks_like_path(target) {
+                anyhow::bail!(
+                    "positional `<TARGET>` is a function name, not a file path. \
+                     For a single-file source, use `--file {target}` and pass the \
+                     function via `-f <NAME>`. For example:\n\
+                     \n    baml pack --file {target} -f <NAME>\n",
+                );
+            }
+            if !self.functions.is_empty() {
+                anyhow::bail!(
+                    "positional `<TARGET>` and `-f/--function` are mutually exclusive — \
+                     use one or the other (positional packs a single-entry binary; \
+                     `-f` produces a subcommand binary)."
+                );
+            }
+        }
+        if self.target.is_none() && self.functions.is_empty() {
+            anyhow::bail!(
+                "no target specified. Pass a positional `<TARGET>` to pack one \
+                 function as the binary's only entry point, or one or more \
+                 `-f <NAME>` flags to pack a subcommand binary."
+            );
+        }
+        Ok(())
     }
 
     fn resolved_target_triple(&self) -> Result<&str> {
@@ -187,12 +247,12 @@ impl PackArgs {
         // Per-file `Loading <path>` lines come from
         // `load_project_from_reporting` (cargo-shaped per-unit
         // progress) — no aggregate `Loading <project>` needed.
-        let (db, needs_format_hint) = match self.target.as_deref() {
-            Some(t) if t.ends_with(".baml") => {
-                reporter.spin("Loading", t);
-                self.load_standalone(t)?
-            }
-            _ => self.load_project(reporter)?,
+        let (db, needs_format_hint) = if let Some(file) = self.file.as_deref() {
+            let display = file.display().to_string();
+            reporter.spin("Loading", &display);
+            self.load_standalone(file)?
+        } else {
+            self.load_project(reporter)?
         };
 
         // File count is the meaningful unit here — `self.from` is
@@ -232,9 +292,9 @@ impl PackArgs {
         Ok((db, needs_format_hint))
     }
 
-    fn load_standalone(&self, file_path: &str) -> Result<(ProjectDatabase, bool)> {
-        let canonical = std::fs::canonicalize(Path::new(file_path))
-            .with_context(|| format!("File not found: {file_path}"))?;
+    fn load_standalone(&self, file_path: &Path) -> Result<(ProjectDatabase, bool)> {
+        let canonical = std::fs::canonicalize(file_path)
+            .with_context(|| format!("File not found: {}", file_path.display()))?;
         let content = std::fs::read_to_string(&canonical)
             .with_context(|| format!("Failed to read {}", canonical.display()))?;
         let needs_format_hint = crate::run_command::source_needs_format_hint(&content);
@@ -245,100 +305,109 @@ impl PackArgs {
         Ok((db, needs_format_hint))
     }
 
-    /// Resolve the pack target to `(qualified_name, identifier, default_basename)`.
-    fn resolve_target(&self, engine: &BexEngine) -> Result<ResolvedPackTarget> {
-        if self.function.is_some() && self.target.is_some() {
-            anyhow::bail!("`--function` and a positional target are mutually exclusive.");
+    /// Resolve into `(mode, targets)`. Positional `<TARGET>` →
+    /// [`PackMode::Single`] with one entry; one-or-more `-f` →
+    /// [`PackMode::Subcommand`] (a single `-f` still gets the subcommand
+    /// layer per the spec).
+    fn resolve_targets(
+        &self,
+        engine: &BexEngine,
+    ) -> Result<(baml_exec::PackMode, Vec<ResolvedPackTarget>)> {
+        if let Some(target) = self.target.as_deref() {
+            let resolved = resolve_one(engine, target)?;
+            return Ok((baml_exec::PackMode::Single, vec![resolved]));
         }
 
-        if let Some(func) = &self.function {
-            if !engine.function_exists(func) {
-                let suggestions = function_suggestions(engine, func);
-                if suggestions.is_empty() {
-                    anyhow::bail!(
-                        "Function `{func}` not found. Use `baml run --list` to see \
-                         available targets."
-                    );
-                } else {
-                    anyhow::bail!(
-                        "Function `{func}` not found. Did you mean one of:\n{}",
-                        suggestions
-                            .iter()
-                            .map(|s| format!("  - {s}"))
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    );
-                }
-            }
-            // BEP-027 §"`baml.argv` in packaged binaries": `argv[1]` is
-            // the *qualified function name* — i.e. the display form, with
-            // the engine's `user.` prefix stripped. Use the canonical
-            // form so `--function user.llm.X` and `--function llm.X` both
-            // produce `argv[1] = "llm.X"`.
-            let qualified_name = canonicalize_function_name(engine, func);
-            let display = qualified_name
-                .strip_prefix("user.")
-                .unwrap_or(&qualified_name)
-                .to_string();
-            let basename = display.rsplit('.').next().unwrap_or(&display).to_string();
-            return Ok(ResolvedPackTarget {
-                qualified_name,
-                identifier: display,
-                default_basename: basename,
-            });
+        // Subcommand mode. Resolve each `-f` and reject duplicate subcommand names.
+        let mut resolved: Vec<ResolvedPackTarget> = Vec::with_capacity(self.functions.len());
+        for func in &self.functions {
+            resolved.push(resolve_one(engine, func)?);
         }
+        let mut seen: HashMap<&str, &str> = HashMap::new();
+        for r in &resolved {
+            if let Some(prev) = seen.insert(r.subcommand_name.as_str(), r.display_name.as_str()) {
+                anyhow::bail!(
+                    "two targets share subcommand name `{}` (`{}` and `{}`). \
+                     Subcommand names come from the last `.`-segment of the function name; \
+                     rename one of them so the binary's subcommands stay unambiguous.",
+                    r.subcommand_name,
+                    prev,
+                    r.display_name,
+                );
+            }
+        }
+        Ok((baml_exec::PackMode::Subcommand, resolved))
+    }
 
-        match self.target.as_deref() {
-            None => {
-                if !engine.function_exists("main") {
-                    anyhow::bail!(
-                        "No `main` function found in the root namespace. \
-                         Use `--function <name>` to pack a specific function."
-                    );
-                }
-                Ok(ResolvedPackTarget {
-                    qualified_name: canonicalize_function_name(engine, "main"),
-                    identifier: "main".to_string(),
-                    default_basename: "main".to_string(),
-                })
+    /// Pick the default output basename. With `[package].name` mandatory
+    /// in `baml.toml` (validated up front by `project_load`), project-mode
+    /// output naming has exactly one source of truth.
+    ///
+    /// - `--file <PATH>` single-file mode: file stem (e.g. `foo.baml` →
+    ///   `foo`). `baml.toml` isn't consulted — single-file packs are
+    ///   intentionally hermetic.
+    /// - Project mode: `[package].name` from `<from>/baml.toml`. Guaranteed
+    ///   present (manifest validation happened at load time).
+    fn resolve_output_basename(&self) -> Result<String> {
+        if let Some(file) = self.file.as_deref() {
+            if let Some(stem) = file.file_stem().and_then(|s| s.to_str()) {
+                return Ok(stem.to_string());
             }
-            Some(target) if target.ends_with(".baml") => {
-                if !engine.function_exists("main") {
-                    anyhow::bail!(
-                        "Standalone file `{target}` has no `main` function. \
-                         Use `--function <name>` to pack a specific function."
-                    );
-                }
-                let basename = Path::new(target)
-                    .file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| target.to_string());
-                let stem = Path::new(target)
-                    .file_stem()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| basename.clone());
-                Ok(ResolvedPackTarget {
-                    qualified_name: canonicalize_function_name(engine, "main"),
-                    identifier: basename,
-                    default_basename: stem,
-                })
-            }
-            Some(target) => {
-                let ns_main = format!("{target}.main");
-                if !engine.function_exists(&ns_main) {
-                    anyhow::bail!(
-                        "No namespace `{target}` with a `main` function. \
-                         `baml pack` does not support `[scripts]`; use the \
-                         resolved `--function` form directly."
-                    );
-                }
-                Ok(ResolvedPackTarget {
-                    qualified_name: canonicalize_function_name(engine, &ns_main),
-                    identifier: target.to_string(),
-                    default_basename: target.to_string(),
-                })
-            }
+            // Pathologically nameless file (e.g. `.baml`); fall through to
+            // the manifest lookup. In `--file` mode that may still fail
+            // (no project to consult); the user can always pass `-o`.
         }
+        crate::project_load::read_package_name(&self.from)
+    }
+}
+
+/// Resolve a single function-name string against the engine; returns
+/// canonical qualified/display/subcommand-name triple.
+fn resolve_one(engine: &BexEngine, func: &str) -> Result<ResolvedPackTarget> {
+    if !engine.function_exists(func) {
+        let suggestions = function_suggestions(engine, func);
+        if suggestions.is_empty() {
+            anyhow::bail!(
+                "Function `{func}` not found. Use `baml run --list` to see \
+                 available targets."
+            );
+        }
+        anyhow::bail!(
+            "Function `{func}` not found. Did you mean one of:\n{}",
+            suggestions
+                .iter()
+                .map(|s| format!("  - {s}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+    let qualified_name = canonicalize_function_name(engine, func);
+    let display_name = qualified_name
+        .strip_prefix("user.")
+        .unwrap_or(&qualified_name)
+        .to_string();
+    let subcommand_name = display_name
+        .rsplit('.')
+        .next()
+        .unwrap_or(&display_name)
+        .to_string();
+    Ok(ResolvedPackTarget {
+        qualified_name,
+        display_name,
+        subcommand_name,
+    })
+}
+
+/// Label for status output: `display_name` for single targets,
+/// `a,b,c` for subcommand packs.
+fn label_for(targets: &[ResolvedPackTarget]) -> String {
+    match targets {
+        [single] => single.display_name.clone(),
+        _ => targets
+            .iter()
+            .map(|t| t.subcommand_name.as_str())
+            .collect::<Vec<_>>()
+            .join(","),
     }
 }
 
@@ -584,6 +653,16 @@ const SUPPORTED_PACK_TARGETS: &[&str] = &[
     "x86_64-pc-windows-msvc",
 ];
 
+/// Heuristic: does this positional `<TARGET>` look like a filesystem
+/// path rather than a function name? Triggers when the user typed
+/// something like `baml_src/main.baml` and we want to redirect them to
+/// `--file`. Function names can't contain `/` or `\`, and the `.baml`
+/// suffix is the strong signal — namespaced functions like `llm.Foo`
+/// use `.` but never end in `.baml`.
+fn looks_like_path(target: &str) -> bool {
+    target.contains('/') || target.contains('\\') || target.ends_with(".baml")
+}
+
 fn default_output_path(default_basename: &str, target_triple: &str) -> PathBuf {
     let mut path = PathBuf::from(default_basename);
     if target_triple.ends_with("windows-msvc")
@@ -692,10 +771,25 @@ mod tests {
         .expect("BexEngine::new should succeed")
     }
 
+    /// Build an engine from a multi-file project so we can exercise
+    /// namespaced functions (`ns_<name>/foo.baml` → `<name>.foo`). Single
+    /// `engine_from_source` can't express folder-based namespaces.
+    fn engine_from_files(files: &[(&str, &str)]) -> BexEngine {
+        let snapshot = baml_project::testing::compile_multi_file(files);
+        BexEngine::new(
+            snapshot,
+            Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("BexEngine::new should succeed")
+    }
+
     fn pack_args() -> PackArgs {
         PackArgs {
             target: None,
-            function: None,
+            functions: Vec::new(),
+            file: None,
             output: None,
             target_triple: None,
             output_format: OutputFormat::Json,
@@ -704,26 +798,37 @@ mod tests {
         }
     }
 
-    // ── Target resolution — BEP-027 §"What `baml pack` inherits" ───
+    // ── Target resolution ─────────────────────────────────────────────
 
-    /// No target + root `main` exists → packs the root main with
-    /// `argv[1] == "main"` and the default basename `"main"`.
+    /// Positional `<TARGET>` → single-target pack with the function
+    /// name as both display and subcommand.
     #[test]
-    fn test_pack_resolve_no_target_packs_root_main() {
+    fn test_pack_positional_single_target() {
         let engine = engine_from_source("function main() -> int { 42 }");
-        let resolved = pack_args().resolve_target(&engine).unwrap();
-        assert_eq!(resolved.qualified_name, "user.main");
-        assert_eq!(resolved.identifier, "main");
-        assert_eq!(resolved.default_basename, "main");
+        let mut args = pack_args();
+        args.target = Some("main".to_string());
+        let (mode, targets) = args.resolve_targets(&engine).unwrap();
+        assert!(matches!(mode, baml_exec::PackMode::Single));
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].qualified_name, "user.main");
+        assert_eq!(targets[0].display_name, "main");
+        assert_eq!(targets[0].subcommand_name, "main");
     }
 
-    /// `baml pack -e '<expr>'` must surface a clean "expression mode is
-    /// not packageable" message (BEP-027 §"Expression mode is not
-    /// packageable") rather than a confusing clap parse error. The
-    /// `-e/--expression` flag exists on `PackArgs` solely so we can
-    /// intercept it and reject; otherwise the token falls through to
-    /// the positional `<TARGET>` slot and surfaces a misleading
-    /// "unexpected argument" error.
+    /// `--file` + `--from` rejected (both name a source).
+    #[test]
+    fn test_pack_rejects_file_plus_explicit_from() {
+        let mut args = pack_args();
+        args.functions = vec!["main".into()];
+        args.file = Some(PathBuf::from("a.baml"));
+        args.from = PathBuf::from("./project");
+        let err = args.validate_flags().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("mutually exclusive"), "got: {msg}");
+        assert!(msg.contains("--file"), "got: {msg}");
+    }
+
+    /// `-e` is rejected before any other validation runs.
     #[test]
     fn test_pack_rejects_expression_mode() {
         let mut args = pack_args();
@@ -738,26 +843,72 @@ mod tests {
             msg.contains("-e") || msg.contains("--expression"),
             "error should name the rejected flag; got: {msg}"
         );
+    }
+
+    /// No positional and no `-f` → user gets a clean "no target" error.
+    #[test]
+    fn test_pack_no_target_errors() {
+        let args = pack_args();
+        let err = args.validate_flags().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("no target"), "got: {msg}");
+        assert!(msg.contains("-f"), "got: {msg}");
+    }
+
+    /// Positional + `-f` is rejected.
+    #[test]
+    fn test_pack_positional_plus_function_errors() {
+        let mut args = pack_args();
+        args.target = Some("main".to_string());
+        args.functions = vec!["Summarize".to_string()];
+        let err = args.validate_flags().unwrap_err();
+        assert!(format!("{err}").contains("mutually exclusive"));
+    }
+
+    /// Path-shaped positional → redirect to `--file`, not the generic
+    /// "mutually exclusive" message. Covers the common confusion of
+    /// `baml pack baml_src/main.baml -f main`.
+    #[test]
+    fn test_pack_path_positional_suggests_file_flag() {
+        let mut args = pack_args();
+        args.target = Some("baml_src/main.baml".to_string());
+        args.functions = vec!["main".to_string()];
+        let err = args.validate_flags().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("--file"), "expected --file hint; got: {msg}");
         assert!(
-            msg.contains("--function") || msg.contains(".baml"),
-            "error should point at the supported alternatives; got: {msg}"
+            msg.contains("baml_src/main.baml"),
+            "expected the path echoed back; got: {msg}",
         );
     }
 
-    /// No target + no root `main` → error pointing at `--function`.
+    /// Same redirect when the path-shaped positional appears alone (no `-f`).
+    /// The hint should win over the generic "no target specified" path.
     #[test]
-    fn test_pack_resolve_no_target_no_main_errors() {
-        let engine = engine_from_source("function Other() -> int { 1 }");
-        let err = pack_args().resolve_target(&engine).unwrap_err();
+    fn test_pack_bare_path_positional_suggests_file_flag() {
+        let mut args = pack_args();
+        args.target = Some("./hello.baml".to_string());
+        let err = args.validate_flags().unwrap_err();
         let msg = format!("{err}");
-        assert!(msg.contains("No `main`"), "got: {msg}");
-        assert!(msg.contains("--function"), "got: {msg}");
+        assert!(msg.contains("--file"), "got: {msg}");
     }
 
-    /// `--function <name>` → direct function target. BEP: "`argv[1]` is
-    /// the fully qualified function name for `--function` packages".
     #[test]
-    fn test_pack_resolve_function_flag() {
+    fn test_looks_like_path_signal() {
+        assert!(looks_like_path("baml_src/main.baml"));
+        assert!(looks_like_path("hello.baml"));
+        assert!(looks_like_path("./x"));
+        assert!(looks_like_path(r"C:\foo"));
+        // Function names don't look like paths.
+        assert!(!looks_like_path("main"));
+        assert!(!looks_like_path("llm.Summarize"));
+        assert!(!looks_like_path("user.llm.Summarize"));
+    }
+
+    /// Single `-f` → subcommand mode with one entry (subcommand layer
+    /// retained, per the spec).
+    #[test]
+    fn test_pack_single_function_uses_subcommand_mode() {
         let engine = engine_from_source(
             r#"
                 function main() -> int { 1 }
@@ -765,95 +916,145 @@ mod tests {
             "#,
         );
         let mut args = pack_args();
-        args.function = Some("Summarize".to_string());
-        let resolved = args.resolve_target(&engine).unwrap();
-        assert_eq!(resolved.identifier, "Summarize");
-        assert_eq!(resolved.default_basename, "Summarize");
-        // Qualified name canonicalizes to whatever form the engine stores.
-        assert!(
-            resolved.qualified_name == "Summarize" || resolved.qualified_name == "user.Summarize"
-        );
+        args.functions = vec!["Summarize".to_string()];
+        let (mode, targets) = args.resolve_targets(&engine).unwrap();
+        assert!(matches!(mode, baml_exec::PackMode::Subcommand));
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].subcommand_name, "Summarize");
     }
 
-    /// BEP-027 §"`baml.argv` in packaged binaries": `argv[1]` is the
-    /// *qualified* function name — `user.` prefix stripped — regardless
-    /// of how the user spelled the `--function` argument.
+    /// Multiple `-f` → subcommand mode, one entry per `-f`.
     #[test]
-    fn test_pack_resolve_function_flag_canonicalizes_user_prefix() {
+    fn test_pack_multi_function_subcommand_mode() {
+        let engine = engine_from_source(
+            r#"
+                function Summarize(text: string) -> string { text }
+                function Categorize(text: string) -> string { text }
+            "#,
+        );
+        let mut args = pack_args();
+        args.functions = vec!["Summarize".to_string(), "Categorize".to_string()];
+        let (mode, targets) = args.resolve_targets(&engine).unwrap();
+        assert!(matches!(mode, baml_exec::PackMode::Subcommand));
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].subcommand_name, "Summarize");
+        assert_eq!(targets[1].subcommand_name, "Categorize");
+    }
+
+    /// Subcommand name canonicalizes to the last `.`-segment of the
+    /// display name regardless of how the user spelled the `-f` flag.
+    #[test]
+    fn test_pack_function_flag_strips_user_prefix() {
         let engine = engine_from_source("function Summarize(text: string) -> string { text }");
         let mut args = pack_args();
-        args.function = Some("user.Summarize".to_string());
-        let resolved = args.resolve_target(&engine).unwrap();
-        // identifier (becomes argv[1]) must drop the `user.` prefix.
-        assert_eq!(resolved.identifier, "Summarize");
-        // Default output basename uses the last `.`-segment of the
-        // display name, not the user's raw input.
-        assert_eq!(resolved.default_basename, "Summarize");
+        args.functions = vec!["user.Summarize".to_string()];
+        let (_mode, targets) = args.resolve_targets(&engine).unwrap();
+        assert_eq!(targets[0].display_name, "Summarize");
+        assert_eq!(targets[0].subcommand_name, "Summarize");
     }
 
-    /// `--function` with an unknown name → error.
+    /// Unknown function → error.
     #[test]
-    fn test_pack_resolve_function_flag_unknown_errors() {
+    fn test_pack_function_unknown_errors() {
         let engine = engine_from_source("function main() -> int { 1 }");
         let mut args = pack_args();
-        args.function = Some("DoesNotExist".to_string());
-        let err = args.resolve_target(&engine).unwrap_err();
+        args.functions = vec!["DoesNotExist".to_string()];
+        let err = args.resolve_targets(&engine).unwrap_err();
         assert!(format!("{err}").contains("not found"));
     }
 
-    /// `--function` + positional target → error. Dispatch modes are
-    /// mutually exclusive.
+    // ── Namespaced targets (folder-based, `ns_<name>/`) ──────────────
+
+    /// Positional `<TARGET>` resolves a namespaced function by display
+    /// name. The packed binary's `argv[1]` (identifier / subcommand
+    /// name) is the *last* `.`-segment — `llm.Summarize` → `Summarize`.
     #[test]
-    fn test_pack_resolve_function_and_positional_errors() {
-        let engine = engine_from_source("function main() -> int { 1 }");
+    fn test_pack_namespaced_positional() {
+        let engine = engine_from_files(&[(
+            "ns_llm/summarize.baml",
+            "function Summarize(text: string) -> string { text }",
+        )]);
         let mut args = pack_args();
-        args.function = Some("main".to_string());
-        args.target = Some("some_namespace".to_string());
-        let err = args.resolve_target(&engine).unwrap_err();
-        assert!(format!("{err}").contains("mutually exclusive"));
+        args.target = Some("llm.Summarize".to_string());
+        let (mode, targets) = args.resolve_targets(&engine).unwrap();
+        assert!(matches!(mode, baml_exec::PackMode::Single));
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].qualified_name, "user.llm.Summarize");
+        assert_eq!(targets[0].display_name, "llm.Summarize");
+        assert_eq!(targets[0].subcommand_name, "Summarize");
     }
 
-    /// `.baml` positional → hermetic mode; `argv[1]` is the file basename,
-    /// default output uses the file stem.
+    /// `-f` with namespaced names produces subcommand-mode targets keyed
+    /// on each function's last `.`-segment.
     #[test]
-    fn test_pack_resolve_baml_file_target() {
-        let engine = engine_from_source("function main() -> int { 1 }");
+    fn test_pack_namespaced_multi_function() {
+        let engine = engine_from_files(&[
+            (
+                "ns_llm/summarize.baml",
+                "function Summarize(text: string) -> string { text }",
+            ),
+            (
+                "ns_util/greet.baml",
+                "function Greet(name: string) -> string { name }",
+            ),
+        ]);
         let mut args = pack_args();
-        args.target = Some("scripts/hello.baml".to_string());
-        let resolved = args.resolve_target(&engine).unwrap();
-        assert_eq!(resolved.identifier, "hello.baml");
-        assert_eq!(resolved.default_basename, "hello");
+        args.functions = vec!["llm.Summarize".into(), "util.Greet".into()];
+        let (mode, targets) = args.resolve_targets(&engine).unwrap();
+        assert!(matches!(mode, baml_exec::PackMode::Subcommand));
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].display_name, "llm.Summarize");
+        assert_eq!(targets[0].subcommand_name, "Summarize");
+        assert_eq!(targets[1].display_name, "util.Greet");
+        assert_eq!(targets[1].subcommand_name, "Greet");
     }
 
-    /// `.baml` positional when the file has no `main` → error.
+    /// Two namespaces exporting the same leaf name → subcommand-name
+    /// collision is rejected with a clear message that names both
+    /// fully-qualified targets so the user can rename one.
     #[test]
-    fn test_pack_resolve_baml_file_without_main_errors() {
-        let engine = engine_from_source("function Other() -> int { 1 }");
+    fn test_pack_namespaced_subcommand_name_collision_errors() {
+        let engine = engine_from_files(&[
+            ("ns_llm/foo.baml", "function Foo() -> int { 1 }"),
+            ("ns_util/foo.baml", "function Foo() -> int { 2 }"),
+        ]);
         let mut args = pack_args();
-        args.target = Some("hello.baml".to_string());
-        let err = args.resolve_target(&engine).unwrap_err();
-        assert!(format!("{err}").contains("no `main`"));
-    }
-
-    // NOTE on namespace resolution: BAML namespaces are folder-based
-    // (`ns_eval/*.baml` or `ns_eval.baml`), not an inline syntax, so
-    // `compile_source` can't construct a multi-namespace engine in-process.
-    // The namespace branch of `resolve_target` is exercised end-to-end in
-    // the packaging smoke test in the `baml_pack_host` crate (TODO once a
-    // cargo-build harness exists); the only logic it contains beyond the
-    // "function exists?" check is string formatting (`{target}.main`).
-
-    /// Unknown positional → error that explicitly points out scripts
-    /// aren't packable.
-    #[test]
-    fn test_pack_resolve_unknown_target_errors() {
-        let engine = engine_from_source("function main() -> int { 1 }");
-        let mut args = pack_args();
-        args.target = Some("nonexistent".to_string());
-        let err = args.resolve_target(&engine).unwrap_err();
+        args.functions = vec!["llm.Foo".into(), "util.Foo".into()];
+        let err = args.resolve_targets(&engine).unwrap_err();
         let msg = format!("{err}");
-        assert!(msg.contains("nonexistent"), "got: {msg}");
-        assert!(msg.contains("[scripts]"), "got: {msg}");
+        assert!(msg.contains("share subcommand name `Foo`"), "got: {msg}");
+        assert!(msg.contains("llm.Foo"), "got: {msg}");
+        assert!(msg.contains("util.Foo"), "got: {msg}");
+    }
+
+    /// Bare-name lookup also resolves namespaced targets via the
+    /// shared resolver's suffix scan — `Summarize` finds `llm.Summarize`
+    /// when it's the unique match.
+    #[test]
+    fn test_pack_namespaced_resolves_via_bare_name() {
+        let engine = engine_from_files(&[(
+            "ns_llm/summarize.baml",
+            "function Summarize(text: string) -> string { text }",
+        )]);
+        let mut args = pack_args();
+        args.functions = vec!["Summarize".into()];
+        let (_, targets) = args.resolve_targets(&engine).unwrap();
+        assert_eq!(targets[0].qualified_name, "user.llm.Summarize");
+        assert_eq!(targets[0].subcommand_name, "Summarize");
+    }
+
+    /// Two `-f`s with the same trailing segment → error.
+    #[test]
+    fn test_pack_duplicate_subcommand_names_error() {
+        // Without namespaces in `compile_source` we can only exercise the
+        // duplicate path by repeating the same function. Engine accepts
+        // duplicates in the input list — `resolve_targets` is what rejects.
+        let engine = engine_from_source("function Foo() -> int { 1 }");
+        let mut args = pack_args();
+        args.functions = vec!["Foo".to_string(), "Foo".to_string()];
+        let err = args.resolve_targets(&engine).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("share subcommand name"), "got: {msg}");
     }
 
     // ── Reserved `help` parameter — BEP-027 §"Auto-CLI conventions" ───
@@ -914,6 +1115,84 @@ mod tests {
             parsed.args.target_triple.as_deref(),
             Some("x86_64-pc-windows-msvc")
         );
+    }
+
+    /// `-f` / `--function` are repeatable through the clap derive — same
+    /// regression coverage as `RunArgs`.
+    #[test]
+    fn test_pack_dash_f_is_repeatable() {
+        use clap::Parser;
+        #[derive(Parser)]
+        struct Wrapper {
+            #[command(flatten)]
+            args: PackArgs,
+        }
+        let parsed =
+            Wrapper::try_parse_from(["baml-pack", "-f", "a", "-f", "b", "--function", "c"])
+                .unwrap();
+        assert_eq!(parsed.args.functions, vec!["a", "b", "c"]);
+        assert!(parsed.args.target.is_none());
+    }
+
+    /// `--file` binds to the PathBuf field on `PackArgs`.
+    #[test]
+    fn test_pack_file_flag_parses() {
+        use clap::Parser;
+        #[derive(Parser)]
+        struct Wrapper {
+            #[command(flatten)]
+            args: PackArgs,
+        }
+        let parsed =
+            Wrapper::try_parse_from(["baml-pack", "-f", "foo", "--file", "x.baml"]).unwrap();
+        assert_eq!(parsed.args.functions, vec!["foo"]);
+        assert_eq!(parsed.args.file.as_deref(), Some(Path::new("x.baml")));
+    }
+
+    // ── Output basename resolution ────────────────────────────────────
+
+    /// Project mode (`baml.toml` with `[package].name`) → use that name
+    /// directly. No fallback to function name; manifest validation up
+    /// front guarantees the field is there.
+    #[test]
+    fn test_pack_resolve_basename_uses_package_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("baml.toml"),
+            "[package]\nname = \"my-app\"\n",
+        )
+        .unwrap();
+        let mut args = pack_args();
+        args.from = tmp.path().to_path_buf();
+        assert_eq!(args.resolve_output_basename().unwrap(), "my-app");
+    }
+
+    /// `--file foo.baml` → file stem.
+    #[test]
+    fn test_pack_file_mode_defaults_to_file_stem() {
+        let mut args = pack_args();
+        args.file = Some(PathBuf::from("scripts/foo.baml"));
+        assert_eq!(args.resolve_output_basename().unwrap(), "foo");
+    }
+
+    /// `--file` ignores adjacent `baml.toml` — single-file packs are
+    /// hermetic by intent.
+    #[test]
+    fn test_pack_file_mode_ignores_adjacent_baml_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let baml_file = tmp.path().join("hello.baml");
+        std::fs::write(&baml_file, "function describe() -> int { 1 }").unwrap();
+        std::fs::write(
+            tmp.path().join("baml.toml"),
+            "[package]\nname = \"unrelated\"\n",
+        )
+        .unwrap();
+
+        let mut args = pack_args();
+        args.file = Some(baml_file);
+        // `--from` defaults to `.`, but file mode short-circuits before
+        // touching it. Stem wins.
+        assert_eq!(args.resolve_output_basename().unwrap(), "hello");
     }
 
     // ── GitHub release fallback ───────────────────────────────────────
@@ -1065,14 +1344,20 @@ mod tests {
         let snapshot = baml_tests::engine::compile_source("function main() -> int { 1 }");
         let envelope = PackEnvelope {
             program: snapshot,
-            target_name: "user.main".to_string(),
-            target_identifier: "main".to_string(),
+            mode: baml_exec::PackMode::Single,
+            targets: vec![baml_exec::TargetEntry {
+                qualified_name: "user.main".to_string(),
+                display_name: "main".to_string(),
+                subcommand_name: "main".to_string(),
+            }],
             output_format: OutputFormat::Json,
         };
         let bytes = bitcode::serialize(&envelope).unwrap();
         let decoded: PackEnvelope = bitcode::deserialize(&bytes).unwrap();
-        assert_eq!(decoded.target_name, "user.main");
-        assert_eq!(decoded.target_identifier, "main");
+        assert!(matches!(decoded.mode, baml_exec::PackMode::Single));
+        assert_eq!(decoded.targets.len(), 1);
+        assert_eq!(decoded.targets[0].qualified_name, "user.main");
+        assert_eq!(decoded.targets[0].subcommand_name, "main");
         assert!(matches!(decoded.output_format, OutputFormat::Json));
     }
 
@@ -1108,9 +1393,13 @@ mod tests {
     #[test]
     fn test_load_project_empty_dir_errors() {
         let tmp = tempfile::tempdir().unwrap();
-        // Write a `baml.toml` so the project root is recognized, but
+        // Write a valid manifest so the project root is recognized, but
         // no `.baml` files in `baml_src/`.
-        std::fs::write(tmp.path().join("baml.toml"), "").unwrap();
+        std::fs::write(
+            tmp.path().join("baml.toml"),
+            "[package]\nname = \"empty\"\n",
+        )
+        .unwrap();
         std::fs::create_dir(tmp.path().join("baml_src")).unwrap();
 
         let mut args = pack_args();
@@ -1129,7 +1418,7 @@ mod tests {
     fn test_load_standalone_missing_file_errors() {
         let args = pack_args();
         let err = args
-            .load_standalone("/nonexistent/ghost/path.baml")
+            .load_standalone(Path::new("/nonexistent/ghost/path.baml"))
             .unwrap_err();
         let msg = format!("{err:?}"); // use debug to capture the full context chain
         assert!(
@@ -1150,8 +1439,8 @@ mod tests {
             "#,
         );
         let mut args = pack_args();
-        args.function = Some("Summarise".to_string()); // British spelling
-        let err = args.resolve_target(&engine).unwrap_err();
+        args.functions = vec!["Summarise".to_string()]; // British spelling
+        let err = args.resolve_targets(&engine).unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("Did you mean"),
@@ -1169,8 +1458,8 @@ mod tests {
     fn test_pack_resolve_function_flag_unknown_with_no_suggestions() {
         let engine = engine_from_source("function Greet() -> int { 1 }");
         let mut args = pack_args();
-        args.function = Some("totally_unrelated_xyz".to_string());
-        let err = args.resolve_target(&engine).unwrap_err();
+        args.functions = vec!["totally_unrelated_xyz".to_string()];
+        let err = args.resolve_targets(&engine).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("not found"), "got: {msg}");
         assert!(

--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -10,18 +10,20 @@ use crate::reporter::Reporter;
 /// [`ProjectDatabase`]. Returns the database, the canonical project root,
 /// and the list of loaded files.
 ///
-/// **Project marker required.** `from` must contain a `baml.toml` or a
-/// `baml_src/` subdirectory (matching the layout `baml run -e` already
-/// recognizes — see `run_command::run_expression`). Without that, the
-/// recursive walk would happily slurp every `.baml` file under cwd, which
-/// in workspace-shaped directories means hundreds of unrelated/conflicting
-/// fixtures. Symptom: `baml run`/`baml pack` appears to hang for tens of
-/// seconds (it's actually salsa churning through type inference on every
-/// fixture). Failing fast with a clear message is the fix.
+/// **`baml.toml` is required.** A project root must contain a `baml.toml`
+/// (Cargo-style). Without it, the recursive walk would happily slurp every
+/// `.baml` file under cwd, which in workspace-shaped directories means
+/// hundreds of unrelated/conflicting fixtures. Symptom: `baml run`/`baml
+/// pack` appears to hang for tens of seconds (it's actually salsa churning
+/// through type inference on every fixture). Failing fast with a clear
+/// message is the fix.
 ///
-/// When `baml_src/` exists, only files under that directory are loaded
-/// (mirroring `run_expression`'s `has_explicit_project` branch). If only
-/// `baml.toml` exists, the walk falls back to the project root.
+/// Standalone single-file callers (`baml run --file …`, `baml pack --file
+/// …`) skip this path entirely; they don't need a `baml.toml`.
+///
+/// When `baml_src/` exists alongside `baml.toml`, only files under that
+/// directory are loaded (mirroring `run_expression`'s `has_explicit_project`
+/// branch). Without `baml_src/`, the walk falls back to the project root.
 ///
 /// Callers decide how to surface an empty `files` result (e.g. `run` bails,
 /// `test` returns `NoTestsRun`, `generate` returns `Other`).
@@ -51,18 +53,24 @@ fn load_project_from_inner(
     let canonical = std::fs::canonicalize(from)
         .with_context(|| format!("Could not resolve path: {}", from.display()))?;
 
-    let has_baml_toml = canonical.join("baml.toml").exists();
-    let baml_src = canonical.join("baml_src");
-    let has_baml_src = baml_src.is_dir();
-    if !has_baml_toml && !has_baml_src {
+    let toml_path = canonical.join("baml.toml");
+    if !toml_path.exists() {
         anyhow::bail!(
-            "`{}` doesn't look like a BAML project.\n\
-             Expected `baml.toml` or a `baml_src/` directory at the project root.\n\
-             Pass `--from <project-dir>` or run from inside one.",
+            "`{}` doesn't look like a BAML project — no `baml.toml` found.\n\
+             Run `baml init` to create one, or pass `--from <project-dir>` to point\n\
+             at an existing project. For one-off scripts, use `--file <PATH>` instead.",
             canonical.display()
         );
     }
+    // Manifest validation, Cargo-style: `[package].name` is mandatory.
+    // Failing here — before any source discovery or compilation — gives
+    // the user the same fast feedback they get from a malformed
+    // `Cargo.toml`, rather than crashing several seconds in when a
+    // packaging verb tries to use the name.
+    validate_baml_toml(&toml_path)?;
 
+    let baml_src = canonical.join("baml_src");
+    let has_baml_src = baml_src.is_dir();
     let walk_root = if has_baml_src {
         baml_src
     } else {
@@ -81,6 +89,49 @@ fn load_project_from_inner(
     Ok((db, canonical, baml_files))
 }
 
+/// Read `<root>/baml.toml` and assert it has `[package]` with a `name`
+/// field, the way Cargo treats `Cargo.toml`'s `[package].name`. Returns
+/// the resolved name as a byproduct so single callers (e.g. pack output
+/// naming) can reuse it without re-parsing.
+pub(crate) fn validate_baml_toml(toml_path: &Path) -> Result<String> {
+    let content = std::fs::read_to_string(toml_path)
+        .with_context(|| format!("Failed to read {}", toml_path.display()))?;
+    let table: toml::Table = content
+        .parse()
+        .with_context(|| format!("Failed to parse {}", toml_path.display()))?;
+    let package = table
+        .get("package")
+        .and_then(|v| v.as_table())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{}: missing `[package]` table.\n\
+             Add:\n\n    [package]\n    name = \"<your-project-name>\"\n",
+                toml_path.display()
+            )
+        })?;
+    let name = package
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{}: `[package]` is missing `name = \"<your-project-name>\"`.",
+                toml_path.display()
+            )
+        })?;
+    if name.trim().is_empty() {
+        anyhow::bail!("{}: `[package].name` cannot be empty.", toml_path.display());
+    }
+    Ok(name.to_string())
+}
+
+/// Convenience: read and return `[package].name` for a known-valid
+/// manifest. The validation pass at load time means this is guaranteed
+/// to succeed for any path we've actually loaded as a project; the
+/// `Result` is purely for the file-IO surface.
+pub(crate) fn read_package_name(root: &Path) -> Result<String> {
+    validate_baml_toml(&root.join("baml.toml"))
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -96,7 +147,7 @@ mod tests {
     /// Without a `baml.toml` or `baml_src/`, refuse to compile rather
     /// than slurp the whole subtree.
     #[test]
-    fn rejects_dir_with_no_project_marker() {
+    fn rejects_dir_with_no_baml_toml() {
         let tmp = TempDir::new().unwrap();
         fs::write(
             tmp.path().join("loose.baml"),
@@ -111,14 +162,77 @@ mod tests {
             "got: {msg}"
         );
         assert!(msg.contains("baml.toml"), "got: {msg}");
-        assert!(msg.contains("baml_src/"), "got: {msg}");
+        assert!(
+            msg.contains("baml init") || msg.contains("--file"),
+            "got: {msg}"
+        );
+    }
+
+    /// `baml_src/` alone (no `baml.toml`) is now rejected — `baml.toml`
+    /// is required, mirroring Cargo's `Cargo.toml` requirement.
+    #[test]
+    fn rejects_baml_src_only_without_baml_toml() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("baml_src");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("main.baml"), "function main() -> int { 1 }").unwrap();
+
+        let err = load_project_from(tmp.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("baml.toml"), "got: {msg}");
+    }
+
+    /// `baml.toml` with no `[package]` table → manifest error at load
+    /// time, before any sources are discovered.
+    #[test]
+    fn rejects_baml_toml_without_package_table() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("baml.toml"), "# empty\n").unwrap();
+        let err = load_project_from(tmp.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("[package]"), "got: {msg}");
+    }
+
+    /// `baml.toml` with `[package]` but no `name` field → likewise.
+    #[test]
+    fn rejects_baml_toml_with_package_but_no_name() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("baml.toml"), "[package]\n").unwrap();
+        let err = load_project_from(tmp.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("name"), "got: {msg}");
+    }
+
+    /// Empty `[package].name = \"\"` is also rejected.
+    #[test]
+    fn rejects_baml_toml_with_empty_name() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("baml.toml"), "[package]\nname = \"\"\n").unwrap();
+        let err = load_project_from(tmp.path()).unwrap_err();
+        assert!(format!("{err}").contains("cannot be empty"));
+    }
+
+    /// `read_package_name` returns the name for a valid manifest.
+    #[test]
+    fn read_package_name_returns_field() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("baml.toml"),
+            "[package]\nname = \"my-app\"\n",
+        )
+        .unwrap();
+        assert_eq!(read_package_name(tmp.path()).unwrap(), "my-app");
+    }
+
+    fn valid_manifest() -> &'static str {
+        "[package]\nname = \"test-project\"\n"
     }
 
     /// `baml.toml`-only project root: walk recursively from the root.
     #[test]
     fn accepts_dir_with_baml_toml() {
         let tmp = TempDir::new().unwrap();
-        fs::write(tmp.path().join("baml.toml"), "").unwrap();
+        fs::write(tmp.path().join("baml.toml"), valid_manifest()).unwrap();
         fs::write(tmp.path().join("a.baml"), "function main() -> int { 1 }").unwrap();
 
         let (_db, _root, files) = load_project_from(tmp.path()).unwrap();
@@ -126,12 +240,13 @@ mod tests {
         assert!(files[0].ends_with("a.baml"));
     }
 
-    /// `baml_src/` project layout: only that subdirectory is walked, so
-    /// stray `.baml` files outside `baml_src/` (e.g. a stale top-level
-    /// `test_simple.baml`) aren't pulled in.
+    /// `baml.toml` + `baml_src/` project layout: only the `baml_src/`
+    /// subdirectory is walked, so stray `.baml` files outside (e.g. a
+    /// stale top-level `test_simple.baml`) aren't pulled in.
     #[test]
     fn baml_src_layout_walks_only_baml_src_subtree() {
         let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("baml.toml"), valid_manifest()).unwrap();
         let src = tmp.path().join("baml_src");
         fs::create_dir(&src).unwrap();
         fs::write(src.join("main.baml"), "function main() -> int { 1 }").unwrap();

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -14,6 +14,7 @@ use baml_db::{
 use baml_project::ProjectDatabase;
 use baml_workspace::discover_baml_files;
 use bex_engine::{BexEngine, FunctionCallContextBuilder, UserFunctionInfo};
+// `surface_clap_error` is defined later in this file.
 // For --log-file event sink.
 use clap::Args;
 use sys_native::{CallId, SysOpsExt};
@@ -31,21 +32,6 @@ struct ScriptExpansion {
     function: Option<String>,
     /// Arguments after `--` in the script body.
     extra_args: Vec<String>,
-}
-
-/// Result of target resolution.
-#[derive(Debug)]
-enum ResolvedTarget {
-    /// Direct function call (from --function, namespace main, etc.)
-    Function(String),
-    /// Script expansion from [scripts] in baml.toml.
-    Script(ScriptExpansion),
-}
-
-impl ResolvedTarget {
-    fn function(name: String) -> Self {
-        Self::Function(name)
-    }
 }
 
 /// Parse a script body (as pre-split tokens) into its components.
@@ -130,24 +116,30 @@ fn parse_script_body(tokens: &[String]) -> Result<ScriptExpansion> {
 
 #[derive(Args, Clone, Debug)]
 pub struct RunArgs {
-    /// Target: namespace name to run its `main`.
-    /// If omitted, runs `main` in the root namespace.
+    /// Positional target: function name to run as the sole entry point.
+    /// Mutually exclusive with `-f/--function` and `-e/--expression`.
     #[arg(value_name = "TARGET")]
     pub target: Option<String>,
 
-    /// Call a specific function directly (e.g. llm.Summarize or just Summarize).
-    #[arg(long)]
-    pub function: Option<String>,
+    /// Run a specific function, repeatable. With one `-f` the auto-CLI
+    /// still surfaces the function as a subcommand (post-`--` tokens
+    /// must start with the subcommand name); with multiple `-f` the
+    /// binary multiplexes between them.
+    /// Mutually exclusive with positional `<TARGET>` and `-e`.
+    #[arg(short = 'f', long = "function", value_name = "NAME")]
+    pub functions: Vec<String>,
 
     /// Evaluate a BAML expression. Use -e @file to read from a file, -e - for stdin.
-    #[arg(short = 'e')]
+    /// Mutually exclusive with positional `<TARGET>` and `-f`.
+    #[arg(short = 'e', long = "expression")]
     pub expression: Option<String>,
 
-    /// JSON arguments: inline JSON string, @file, or - for stdin.
-    #[arg(long)]
-    pub json_args: Option<String>,
+    /// Standalone single-file source. Loads only this file (no project
+    /// discovery). Mutually exclusive with `--from`.
+    #[arg(long, value_name = "PATH")]
+    pub file: Option<PathBuf>,
 
-    /// List runnable targets (scripts, namespace mains, functions).
+    /// List runnable targets (scripts, functions).
     #[arg(long)]
     pub list: bool,
 
@@ -167,12 +159,13 @@ pub struct RunArgs {
     #[arg(long, short = 'h')]
     pub help: bool,
 
-    /// Project root directory.
+    /// Project root directory. Ignored when `--file` is set.
     #[arg(long, default_value = ".")]
     pub from: PathBuf,
 
-    /// Arguments passed to the target function (after `--` separator).
-    /// These are parsed as auto-CLI flags derived from the function signature.
+    /// Arguments passed to the target after `--`. Parsed as auto-CLI
+    /// flags derived from the function signature(s). With multiple `-f`
+    /// the first token after `--` is the chosen subcommand name.
     #[arg(last = true)]
     pub target_args: Vec<String>,
 }
@@ -295,7 +288,7 @@ impl RunArgs {
         // expression given) before constructing the Reporter, so the
         // spinner doesn't briefly draw a frame above the help text.
         if self.help
-            && self.function.is_none()
+            && self.functions.is_empty()
             && self.target.is_none()
             && self.expression.is_none()
         {
@@ -307,15 +300,11 @@ impl RunArgs {
     }
 
     fn run_with_reporter(&self, reporter: &Reporter) -> Result<crate::ExitCode> {
-        // BEP-027 §"Target resolution": `--function <ns>.<name>` and
-        // `-e '<expr>'` are alternative dispatch modes that "replace the
-        // positional target entirely." Either of them is mutually
-        // exclusive with both the other and with a positional target.
-        // Reject the conflict up front instead of silently preferring
-        // one and ignoring the rest.
+        // Dispatch modes are mutually exclusive. Positional target /
+        // `-f` (one or many) / `-e` all replace each other.
         let dispatch_modes: &[(&str, bool)] = &[
             ("`<target>`", self.target.is_some()),
-            ("`--function`", self.function.is_some()),
+            ("`-f`", !self.functions.is_empty()),
             ("`-e`", self.expression.is_some()),
         ];
         let used: Vec<&str> = dispatch_modes
@@ -329,17 +318,38 @@ impl RunArgs {
             );
         }
 
-        // `--json-args` feeds typed parameters of the resolved function.
-        // Expression mode has no function signature to bind against, so
-        // `--json-args` is meaningless there. Reject the combination
-        // rather than silently dropping the JSON, which would be a
-        // particularly painful footgun in a CI pipeline.
-        if self.expression.is_some() && self.json_args.is_some() {
+        // `--file` is the standalone-source alternative to `--from`. Both
+        // pointing at sources would be ambiguous (which one wins?), so
+        // reject the combination up front. We only enforce this when
+        // `--from` is set to something other than its default `.`,
+        // because clap can't tell "user passed `.`" from "user passed
+        // nothing." If `--file` is set and `--from` was left at the
+        // default, treat that as fine.
+        if self.file.is_some() && self.from != Path::new(".") {
             anyhow::bail!(
-                "`-e` is not compatible with `--json-args`. \
-                 Expression mode has no function signature to bind JSON keys \
-                 to — inline the values in the expression instead."
+                "`--file` and `--from` are mutually exclusive — `--file` already names \
+                 the single source to load."
             );
+        }
+
+        // Expression mode short-circuits before reaching project / file
+        // loading, so combining `-e` with surfaces that change *what* is
+        // loaded silently does nothing. Reject up front to avoid the
+        // footgun.
+        if self.expression.is_some() {
+            if self.file.is_some() {
+                anyhow::bail!(
+                    "`-e` is not compatible with `--file`. Expression mode \
+                     evaluates inline source; remove one of the two."
+                );
+            }
+            if self.list {
+                anyhow::bail!(
+                    "`-e` is not compatible with `--list`. Expression mode \
+                     evaluates an expression; `--list` enumerates targets — \
+                     pick one."
+                );
+            }
         }
 
         let event_sink: Option<Arc<dyn bex_events::EventSink>> =
@@ -350,154 +360,150 @@ impl RunArgs {
                 bex_events_native::start_stderr()
             });
 
-        if self.help && (self.function.is_none() && self.target.is_none()) {
+        if self.help
+            && self.functions.is_empty()
+            && self.target.is_none()
+            && self.expression.is_none()
+        {
             Self::print_run_help();
             return Ok(crate::ExitCode::Success);
         }
 
         if let Some(expr_source) = &self.expression {
-            // BEP-027 §"`baml.argv`": `argv[1]` for `-e` is "the
-            // expression source". We load the text up front (only once —
-            // `-e -` reads stdin and the engine compile re-uses the same
-            // string) and use the loaded body for both `argv[1]` and the
-            // synthetic compilation unit.
+            // `-e -` reads stdin / `-e @file` reads file. Load once so
+            // the engine compile and `argv[1]` see the same text.
             let expr_body = load_expression_source(expr_source)?;
             return self.run_expression(&expr_body, event_sink, reporter);
         }
 
-        let argv = self.build_argv();
-
-        let (db, mut engine, needs_format_hint) =
-            if self.target.as_ref().is_some_and(|t| t.ends_with(".baml")) {
-                self.load_and_compile_standalone(
-                    self.target.as_ref().unwrap(),
-                    event_sink.clone(),
-                    argv.clone(),
-                    reporter,
-                )?
-            } else {
-                self.load_and_compile(event_sink.clone(), argv.clone(), reporter)?
-            };
-        let _ = db; // keep db alive for engine lifetime
-        Self::emit_format_hint_if_needed(reporter, needs_format_hint);
-
-        // BEP-027 §"`baml.argv`": patch `argv[1]` post-compile so it
-        // matches the spec's "however the user named the target" rule
-        // using engine-canonical names rather than the user's raw input.
-        //
-        //   - Root `main` (no positional/function/expr) → filepath of
-        //     the file containing `main`.
-        //   - `--function` → the qualified function name with the
-        //     `user.` package prefix stripped, so `--function
-        //     user.llm.X` and `--function llm.X` both surface as
-        //     `argv[1] = "llm.X"`.
-        if self.target.is_none() && self.function.is_none() && self.expression.is_none() {
-            if let Some(main_info) = engine.find_user_function("main") {
-                if !main_info.source_file.is_empty() {
-                    let mut patched = argv.clone();
-                    if patched.len() >= 2 {
-                        patched[1] = main_info.source_file.clone();
-                        engine.set_argv(patched);
-                    }
-                }
-            }
-        } else if let Some(func) = &self.function {
-            if let Some(info) = engine.find_user_function(func) {
-                let display = info.display_name;
-                if display != *func && argv.len() >= 2 {
-                    let mut patched = argv.clone();
-                    patched[1] = display;
-                    engine.set_argv(patched);
-                }
-            }
-        }
-
-        let toml_content = std::fs::read_to_string(self.from.join("baml.toml")).unwrap_or_default();
-        let scripts = Self::parse_scripts(&toml_content);
-        let namespaces = collect_namespaces(&engine);
-
+        // `--list` short-circuit doesn't need a resolved target; load
+        // the project and print before we get to dispatch.
         if self.list {
+            let bootstrap_argv = vec![
+                std::env::current_exe()
+                    .ok()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "baml".to_string()),
+                "--list".to_string(),
+            ];
+            let (db, engine, _) =
+                self.load_and_compile(event_sink.clone(), bootstrap_argv, reporter)?;
+            let _ = db;
+            // `--file` mode is hermetic — skip the project `[scripts]`
+            // lookup the same way `run_single_target` does.
+            let scripts = if self.file.is_some() {
+                HashMap::new()
+            } else {
+                let toml_content =
+                    std::fs::read_to_string(self.from.join("baml.toml")).unwrap_or_default();
+                Self::parse_scripts(&toml_content)
+            };
+            let namespaces = collect_namespaces(&engine);
             return self.print_list(&engine, &scripts, &namespaces, &self.output_format);
         }
 
+        // No target → print help and exit non-zero. (Implicit `main` no
+        // longer exists.)
+        if self.target.is_none() && self.functions.is_empty() {
+            Self::print_run_help();
+            return Ok(crate::ExitCode::Other);
+        }
+
+        if let Some(target) = &self.target {
+            // Helpful redirect when the user typed a path as the
+            // positional (e.g. `baml run baml_src/main.baml`). Positional
+            // `<TARGET>` is always a function name; for a `.baml` source
+            // use `--file`.
+            if looks_like_path(target) {
+                anyhow::bail!(
+                    "positional `<TARGET>` is a function name, not a file path. \
+                     For a single-file source, use `--file {target}` and pass the \
+                     function via `-f <NAME>`. For example:\n\
+                     \n    baml run --file {target} -f <NAME>\n",
+                );
+            }
+            return self.run_single_target(target, event_sink, reporter);
+        }
+        self.run_subcommand_targets(event_sink, reporter)
+    }
+
+    /// Positional `<TARGET>` path: one function, no subcommand layer.
+    /// `[scripts]` aliases are resolved here too (positional only).
+    fn run_single_target(
+        &self,
+        target: &str,
+        event_sink: Option<Arc<dyn bex_events::EventSink>>,
+        reporter: &Reporter,
+    ) -> Result<crate::ExitCode> {
+        let argv = self.build_argv_for_single(target);
+        let (db, mut engine, needs_format_hint) =
+            self.load_and_compile(event_sink.clone(), argv.clone(), reporter)?;
+        let _ = db;
+        Self::emit_format_hint_if_needed(reporter, needs_format_hint);
+
+        // `[scripts]` are a project-mode concept. In `--file` (standalone)
+        // mode the project's `baml.toml` shouldn't be consulted — the
+        // file is hermetic by intent — so an empty `scripts` map skips
+        // both expansion and validation.
+        let (toml_content, scripts) = if self.file.is_some() {
+            (String::new(), HashMap::new())
+        } else {
+            let content = std::fs::read_to_string(self.from.join("baml.toml")).unwrap_or_default();
+            let parsed = Self::parse_scripts(&content);
+            (content, parsed)
+        };
+        let namespaces = collect_namespaces(&engine);
         self.validate_scripts(&engine, &scripts, &namespaces, &toml_content)?;
 
-        let resolved = self.resolve_target(&engine, &scripts)?;
-
-        let (function_name, effective_target_args, was_script) = match resolved {
-            ResolvedTarget::Function(name) => (name, self.target_args.clone(), false),
-            ResolvedTarget::Script(expansion) => {
-                let func = expansion.function.unwrap_or_else(|| "main".to_string());
+        // Resolve to (function_name, effective_args, was_script).
+        let (function_name, effective_target_args, was_script) =
+            if let Some(script_tokens) = scripts.get(target) {
+                self.vlog(format_args!(
+                    "Expanding script `{target}`: {script_tokens:?}"
+                ));
+                let expansion = parse_script_body(script_tokens)?;
+                let func = expansion.function.ok_or_else(|| {
+                    anyhow!(
+                        "Script `{target}` has no `--function` and there is no implicit \
+                         entry point. Add `--function <name>` to the script body."
+                    )
+                })?;
                 if engine.find_user_function(&func).is_none() {
-                    // Script body's --function target is unresolvable.
-                    // `validate_scripts` already catches this at load time;
-                    // this is defensive in case validation is bypassed.
                     return Err(Self::function_not_found_error(&engine, &func));
                 }
                 let mut merged_args = expansion.extra_args;
                 merged_args.extend(self.target_args.iter().cloned());
                 (func, merged_args, true)
-            }
-        };
+            } else if engine.find_user_function(target).is_some() {
+                (target.to_string(), self.target_args.clone(), false)
+            } else {
+                return Err(Self::target_not_found_error_in(
+                    &scripts, &engine, target, &self.from,
+                ));
+            };
 
-        // BEP-027 §"`baml.argv`": for script-alias dispatch, `argv[1]`
-        // surfaces the *post-expansion* canonical name rather than the
-        // script alias. Script aliases are transparent indirection — the
-        // program reports what actually ran, using the same rules the
-        // direct (non-aliased) dispatch path uses:
-        //
-        //   - Script expands to root `main` (no `--function` in body) →
-        //     filepath of the file containing `main`, matching `baml
-        //     run` (no target).
-        //   - Script expands to a named function → the function's
-        //     display name (`user.` prefix stripped).
-        if was_script {
-            if let Some(info) = engine.find_user_function(&function_name) {
-                let resolved_label = if info.display_name == "main" && !info.source_file.is_empty()
-                {
-                    // Root main case: use the file path so script-aliased
-                    // and direct invocations of root main produce the
-                    // same `argv[1]`.
-                    info.source_file
-                } else {
-                    info.display_name
-                };
-                let mut patched: Vec<String> = engine.argv().to_vec();
-                if patched.len() >= 2 {
-                    patched[1] = resolved_label;
-                    engine.set_argv(patched);
-                }
+        // Patch `argv[1]` to the engine-canonical display name (strips
+        // `user.` prefix) so scripts and the direct path agree.
+        if let Some(info) = engine.find_user_function(&function_name) {
+            let display = info.display_name.clone();
+            let mut patched: Vec<String> = engine.argv().to_vec();
+            if patched.len() >= 2 && (was_script || display != *target) {
+                patched[1] = display;
+                engine.set_argv(patched);
             }
         }
 
         let func_info = engine
             .find_user_function(&function_name)
             .ok_or_else(|| anyhow!("Function `{function_name}` not found"))?;
-
-        // BEP-027 §"Auto-CLI conventions": `help` is reserved at entry-point
-        // resolution. Reject before printing help so a target declaring a
-        // `help` parameter doesn't get its `--help <string>` rendered as if
-        // valid. The same check runs again inside dispatch_target as a
-        // safety net for non-help invocations.
         baml_exec::validate_help_param(&engine, &function_name)?;
 
-        // BEP-027 §"What `baml pack` changes" reserves `--help` only on
-        // typed targets — parameterless `main()` owns its full argv.
-        // The verb-level `--help` (before `--`) is handled upfront via
-        // `print_run_help`; per-target `--help` arrives in
-        // `effective_target_args` and is classified by clap's parser
-        // below.
         let target_is_typed = !func_info.param_names.is_empty();
-
-        // Route post-`--` tokens through the same clap-driven parser
-        // that the packed binary uses. Help requests and parse errors
-        // come back as `clap::Error`; we distinguish them by `kind()`
-        // so `--help` exits cleanly and bad flags exit non-zero.
         let parsed = if target_is_typed {
             let display = function_name
                 .strip_prefix("user.")
                 .unwrap_or(&function_name);
-            let bin_name = format!("baml run --function {display} --");
+            let bin_name = format!("baml run {display} --");
             match baml_exec::parse_target_argv(
                 &bin_name,
                 &function_name,
@@ -505,45 +511,132 @@ impl RunArgs {
                 &effective_target_args,
             ) {
                 Ok(p) => p,
-                Err(err) => {
-                    use baml_exec::clap_reexport::ErrorKind;
-                    let kind = err.kind();
-                    // Help / version: render to stdout and exit success.
-                    // Parse errors: stderr + non-zero. Suspend the
-                    // spinner first so the multi-line clap block lands
-                    // intact instead of intermixed with ticks.
-                    reporter.abandon();
-                    let _ = err.print();
-                    return match kind {
-                        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
-                            Ok(crate::ExitCode::Success)
-                        }
-                        _ => Ok(crate::ExitCode::Other),
-                    };
-                }
+                Err(err) => return surface_clap_error(reporter, err),
             }
         } else {
             baml_exec::ParsedTargetArgs::default()
         };
 
-        // `--json-args` can come from the verb-level flag (parsed by
-        // clap on the run command) OR from the per-target clap parser.
-        // The verb-level form wins because it's the explicit override.
-        let json_args = match &self.json_args {
+        let json_args = match parsed.json_source.as_deref() {
             Some(source) => Some(baml_exec::load_json_source(source)?),
-            None => match parsed.json_source.as_deref() {
-                Some(source) => Some(baml_exec::load_json_source(source)?),
-                None => None,
-            },
+            None => None,
         };
 
-        self.vlog(format_args!("Calling {function_name}"));
+        self.dispatch_and_finish(
+            engine,
+            &function_name,
+            parsed.cli_values,
+            json_args,
+            event_sink,
+            reporter,
+        )
+    }
 
-        // Cargo emits `     Running …` right before the program's
-        // stdout starts. Same shape here: persist a `Running <name>`
-        // line, then clear the spinner so the target's stdout writes
-        // don't collide with a still-ticking lamb below.
-        reporter.status("Running", &function_name);
+    /// `-f` mode: build a multi-subcommand parser, dispatch the chosen one.
+    fn run_subcommand_targets(
+        &self,
+        event_sink: Option<Arc<dyn bex_events::EventSink>>,
+        reporter: &Reporter,
+    ) -> Result<crate::ExitCode> {
+        let argv = self.build_argv_for_subcommand();
+        let (db, mut engine, needs_format_hint) =
+            self.load_and_compile(event_sink.clone(), argv.clone(), reporter)?;
+        let _ = db;
+        Self::emit_format_hint_if_needed(reporter, needs_format_hint);
+
+        // Resolve each `-f` to its canonical info. Collect into a stable
+        // (TargetEntry, UserFunctionInfo) list — the entry holds names
+        // that the clap subcommand layer keys on, the info is the
+        // signature.
+        let mut entries: Vec<baml_exec::TargetEntry> = Vec::with_capacity(self.functions.len());
+        let mut lookups: HashMap<String, UserFunctionInfo> = HashMap::new();
+        for func in &self.functions {
+            let Some(info) = engine.find_user_function(func) else {
+                return Err(Self::function_not_found_error(&engine, func));
+            };
+            baml_exec::validate_help_param(&engine, &info.qualified_name)?;
+            let display = info
+                .qualified_name
+                .strip_prefix("user.")
+                .unwrap_or(&info.qualified_name)
+                .to_string();
+            let subcommand = display.rsplit('.').next().unwrap_or(&display).to_string();
+            if let Some(prev) = entries.iter().find(|e| e.subcommand_name == subcommand) {
+                anyhow::bail!(
+                    "two `-f` targets share subcommand name `{subcommand}` \
+                     (`{}` and `{}`). Subcommand names come from the last `.`-segment \
+                     of the function name; rename one of them.",
+                    prev.display_name,
+                    display,
+                );
+            }
+            entries.push(baml_exec::TargetEntry {
+                qualified_name: info.qualified_name.clone(),
+                display_name: display.clone(),
+                subcommand_name: subcommand,
+            });
+            lookups.insert(info.qualified_name.clone(), info);
+        }
+
+        // Build the parse bin_name as the reinvocation prefix so the
+        // help text is copy-pasteable.
+        let bin_name = format!(
+            "baml run {} --",
+            self.functions
+                .iter()
+                .map(|f| format!("-f {f}"))
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+        let (chosen, parsed) = match baml_exec::parse_multi_target_argv(
+            &bin_name,
+            &entries,
+            &lookups,
+            &self.target_args,
+        ) {
+            Ok(v) => v,
+            Err(err) => return surface_clap_error(reporter, err),
+        };
+
+        // Patch argv[1] to the chosen subcommand name.
+        let chosen_entry = entries
+            .iter()
+            .find(|e| e.qualified_name == chosen)
+            .expect("parse returned an unregistered subcommand");
+        let mut patched = engine.argv().to_vec();
+        if patched.len() >= 2 {
+            patched[1] = chosen_entry.subcommand_name.clone();
+            engine.set_argv(patched);
+        }
+
+        let json_args = match parsed.json_source.as_deref() {
+            Some(source) => Some(baml_exec::load_json_source(source)?),
+            None => None,
+        };
+
+        self.dispatch_and_finish(
+            engine,
+            &chosen,
+            parsed.cli_values,
+            json_args,
+            event_sink,
+            reporter,
+        )
+    }
+
+    /// Shared tail: spawn the runtime, run dispatch, render the
+    /// `Running` / `Finished` lines.
+    fn dispatch_and_finish(
+        &self,
+        engine: BexEngine,
+        function_name: &str,
+        cli_values: HashMap<String, bex_engine::BexExternalValue>,
+        json_args: Option<serde_json::Value>,
+        event_sink: Option<Arc<dyn bex_events::EventSink>>,
+        reporter: &Reporter,
+    ) -> Result<crate::ExitCode> {
+        self.vlog(format_args!("Calling {function_name}"));
+        reporter.status("Running", function_name);
         reporter.abandon();
 
         let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
@@ -552,8 +645,8 @@ impl RunArgs {
         let start = std::time::Instant::now();
         let dispatch_result = rt.block_on(baml_exec::dispatch_target(
             Arc::clone(&engine),
-            &function_name,
-            parsed.cli_values,
+            function_name,
+            cli_values,
             json_args,
             output_format,
         ));
@@ -566,12 +659,10 @@ impl RunArgs {
 
         match dispatch_result {
             Ok(baml_exec::DispatchResult::Ok) => {
-                reporter.finish("Finished", &function_name);
+                reporter.finish("Finished", function_name);
                 Ok(crate::ExitCode::Success)
             }
             Ok(baml_exec::DispatchResult::TargetError) => Ok(crate::ExitCode::TargetError),
-            // `baml.sys.exit(code)` short-circuits the engine; honor the user's
-            // code as the process exit code, clamped to the C `int` range.
             Ok(baml_exec::DispatchResult::Exit(code)) => {
                 std::process::exit(baml_exec::clamp_exit_code(code));
             }
@@ -593,51 +684,33 @@ impl RunArgs {
     ///
     /// - `-e`            → placeholder (the raw `-e` argument). Callers
     ///   should use [`Self::build_argv_for_expression`] with the already-
-    ///   loaded source text so `argv[1]` is the **expression source** per
-    ///   spec, not the `@path` or `-` reference.
-    /// - `<file.baml>`   → the canonicalized absolute path.
-    /// - `<namespace>`   → the namespace name verbatim (e.g. `"eval"`).
-    /// - `<script>`      → the script name as placeholder; patched
-    ///   **post-resolution** to the canonical function name the alias
-    ///   expanded to (e.g. `baml run dev` where `dev = "--function
-    ///   llm.Foo"` → `argv[1] = "llm.Foo"`). This treats script aliases
-    ///   as transparent indirection — the program sees what actually ran.
-    /// - `--function`    → placeholder; patched post-compile to the
-    ///   engine-canonical display name (drops any `user.` prefix the
-    ///   user spelled).
-    /// - no target       → placeholder `"main"`; patched post-compile to
-    ///   the filepath of the file containing `function main`.
-    fn build_argv(&self) -> Vec<String> {
+    ///   loaded source text so `argv[1]` is the **expression source**.
+    /// - positional `<TARGET>` → the target name verbatim; patched
+    ///   post-resolve to the engine display name (drops `user.` prefix
+    ///   the user may have spelled) or to the post-expansion function
+    ///   name for `[scripts]` aliases.
+    /// - `-f` (multi-target) → placeholder; patched after parse to the
+    ///   chosen subcommand name.
+    fn build_argv_for_single(&self, target: &str) -> Vec<String> {
         let executable = std::env::current_exe()
             .ok()
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_else(|| "baml".to_string());
+        let mut argv = vec![executable, target.to_string()];
+        argv.extend(self.target_args.iter().cloned());
+        argv
+    }
 
-        let entry = if let Some(expr) = &self.expression {
-            // Expression mode placeholder. Callers that have already
-            // resolved the expression body (post-`load_expression_source`)
-            // should use `build_argv_for_expression` instead so `argv[1]`
-            // carries the actual source text rather than the `@path` or
-            // `-` reference.
-            expr.clone()
-        } else if let Some(func) = &self.function {
-            func.clone()
-        } else if let Some(target) = &self.target {
-            // For `.baml` file targets, resolve to an absolute path so argv[1]
-            // is stable regardless of the caller's cwd.
-            if target.ends_with(".baml") {
-                std::fs::canonicalize(target)
-                    .ok()
-                    .map(|p| p.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| target.clone())
-            } else {
-                target.clone()
-            }
-        } else {
-            "main".to_string()
-        };
-
-        let mut argv = vec![executable, entry];
+    /// Multi-target placeholder: `argv[1]` is the empty string until
+    /// the subcommand is parsed off the trailing tokens, then patched
+    /// by the caller. Post-`--` tokens are appended verbatim so
+    /// `baml.sys.argv()` reflects exactly what the user typed.
+    fn build_argv_for_subcommand(&self) -> Vec<String> {
+        let executable = std::env::current_exe()
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "baml".to_string());
+        let mut argv = vec![executable, String::new()];
         argv.extend(self.target_args.iter().cloned());
         argv
     }
@@ -657,13 +730,18 @@ impl RunArgs {
         argv
     }
 
-    /// Load the project, check diagnostics, compile to bytecode, create engine.
+    /// Load the project (or standalone `--file`), check diagnostics,
+    /// compile to bytecode, create engine.
     fn load_and_compile(
         &self,
         event_sink: Option<Arc<dyn bex_events::EventSink>>,
         argv: Vec<String>,
         reporter: &Reporter,
     ) -> Result<(ProjectDatabase, BexEngine, bool)> {
+        if let Some(file) = self.file.as_deref() {
+            return self.load_and_compile_standalone(file, event_sink, argv, reporter);
+        }
+
         // `load_project_from_reporting` emits one `Loading <file>`
         // line per discovered source file (cargo-style per-unit
         // progress) — no aggregate `Loading <project>` needed.
@@ -704,14 +782,15 @@ impl RunArgs {
     /// The same file runs identically on any machine regardless of project context.
     fn load_and_compile_standalone(
         &self,
-        file_path: &str,
+        file_path: &Path,
         event_sink: Option<Arc<dyn bex_events::EventSink>>,
         argv: Vec<String>,
         reporter: &Reporter,
     ) -> Result<(ProjectDatabase, BexEngine, bool)> {
-        reporter.spin("Loading", file_path);
-        let canonical = std::fs::canonicalize(Path::new(file_path))
-            .with_context(|| format!("File not found: {file_path}"))?;
+        let display = file_path.display().to_string();
+        reporter.spin("Loading", &display);
+        let canonical = std::fs::canonicalize(file_path)
+            .with_context(|| format!("File not found: {display}"))?;
         self.vlog(format_args!(
             "Standalone mode: loading {}",
             canonical.display()
@@ -728,16 +807,16 @@ impl RunArgs {
         db.set_project_root(parent);
         db.add_or_update_file(&canonical, &content);
 
-        reporter.spin("Checking", file_path);
+        reporter.spin("Checking", &display);
         self.check_project_diagnostics(
             &db,
-            &format!("Cannot run: compilation errors in {file_path}"),
+            &format!("Cannot run: compilation errors in {display}"),
             reporter,
         )?;
         // See note in `load_and_compile`: "Resolving" is the honest
         // verb when --list is the destination, "Compiling" otherwise.
         let compile_verb = if self.list { "Resolving" } else { "Compiling" };
-        reporter.spin(compile_verb, file_path);
+        reporter.spin(compile_verb, &display);
         let engine = self.compile_to_engine(&db, event_sink, argv)?;
         self.vlog(format_args!(
             "Compiled {} function(s) from standalone file",
@@ -782,9 +861,11 @@ impl RunArgs {
         };
 
         let mut db = ProjectDatabase::new();
-        let has_explicit_project = from
-            .as_ref()
-            .is_some_and(|f| f.join("baml.toml").exists() || f.join("baml_src").exists());
+        // Project marker: matches `project_load::load_project_from_inner`.
+        // `baml.toml` is the marker; `baml_src/` alone no longer qualifies
+        // (would let `baml run -e` pick up project context that every
+        // other verb refuses).
+        let has_explicit_project = from.as_ref().is_some_and(|f| f.join("baml.toml").exists());
 
         let project_root = if has_explicit_project {
             let root = from.as_ref().unwrap();
@@ -886,73 +967,8 @@ impl RunArgs {
     }
 
     // ========================================================================
-    // Target resolution
+    // `[scripts]` parsing
     // ========================================================================
-
-    /// Resolve the run target to a qualified function name the engine understands.
-    ///
-    /// Resolution cascade:
-    /// 1. `--function` flag → direct function call
-    /// 2. No target → root namespace's `main`
-    /// 3. Target ends in `.baml` → hermetic standalone
-    /// 4. Target matches a `[scripts]` entry in `baml.toml` → expand alias
-    /// 5. Target matches a namespace with a `main` → that namespace's main
-    /// 6. Otherwise → error with suggestions
-    fn resolve_target(
-        &self,
-        engine: &BexEngine,
-        scripts: &HashMap<String, Vec<String>>,
-    ) -> Result<ResolvedTarget> {
-        if let Some(func) = &self.function {
-            if engine.find_user_function(func).is_some() {
-                return Ok(ResolvedTarget::function(func.clone()));
-            }
-            // `--function` only dispatches to functions, so the
-            // suggestion set is functions — not scripts/namespaces/files.
-            return Err(Self::function_not_found_error(engine, func));
-        }
-
-        match &self.target {
-            None => {
-                if engine.function_exists("main") {
-                    Ok(ResolvedTarget::function("main".to_string()))
-                } else {
-                    anyhow::bail!(
-                        "No `main` function found in the root namespace.\n\
-                         Use `baml run --function <name>` to call a specific function,\n\
-                         or `baml run --list` to see available targets."
-                    );
-                }
-            }
-            Some(target) => {
-                if target.ends_with(".baml") {
-                    if engine.function_exists("main") {
-                        return Ok(ResolvedTarget::function("main".to_string()));
-                    }
-                    anyhow::bail!(
-                        "Standalone file `{target}` has no `main` function.\n\
-                         Use `baml run --function <name>` to call a specific function."
-                    );
-                }
-
-                if let Some(script_tokens) = scripts.get(target.as_str()) {
-                    self.vlog(format_args!(
-                        "Expanding script `{target}`: {script_tokens:?}"
-                    ));
-                    return Ok(ResolvedTarget::Script(parse_script_body(script_tokens)?));
-                }
-
-                let ns_main = format!("{target}.main");
-                if engine.function_exists(&ns_main) {
-                    return Ok(ResolvedTarget::function(ns_main));
-                }
-
-                Err(Self::target_not_found_error_in(
-                    scripts, engine, target, &self.from,
-                ))
-            }
-        }
-    }
 
     /// Parse `[scripts]` from raw `baml.toml` content.
     ///
@@ -1559,6 +1575,29 @@ fn extract_flag_keys(tokens: &[String]) -> Vec<String> {
     keys
 }
 
+/// Heuristic: does the positional `<TARGET>` look like a filesystem
+/// path rather than a function name? See pack_command's twin helper —
+/// kept duplicated rather than hoisted so each command owns its own
+/// "redirect to --file" hint message.
+fn looks_like_path(target: &str) -> bool {
+    target.contains('/') || target.contains('\\') || target.ends_with(".baml")
+}
+
+/// Render a clap error and return the matching CLI exit code.
+/// Help / version requests render to stdout and exit success; all other
+/// kinds go to stderr with a non-zero exit. The spinner is abandoned
+/// first so the multi-line clap block lands cleanly above the cursor.
+fn surface_clap_error(reporter: &Reporter, err: clap::Error) -> Result<crate::ExitCode> {
+    use baml_exec::clap_reexport::ErrorKind;
+    let kind = err.kind();
+    reporter.abandon();
+    let _ = err.print();
+    Ok(match kind {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => crate::ExitCode::Success,
+        _ => crate::ExitCode::Other,
+    })
+}
+
 /// Load expression source from -e argument: inline string, @file, or - for stdin.
 fn load_expression_source(source: &str) -> Result<String> {
     if source == "-" {
@@ -1806,9 +1845,9 @@ mod tests {
     fn run_args() -> RunArgs {
         RunArgs {
             target: None,
-            function: None,
+            functions: Vec::new(),
             expression: None,
-            json_args: None,
+            file: None,
             list: false,
             output_format: OutputFormat::Debug,
             log_file: None,
@@ -1819,20 +1858,19 @@ mod tests {
         }
     }
 
-    // ── Dispatch-mode mutex (BEP-027 §"Target resolution") ────────────
+    // ── Dispatch-mode mutex ───────────────────────────────────────────
 
-    /// `--function` and a positional target are mutually exclusive
-    /// dispatch modes.
+    /// `-f` and a positional target are mutually exclusive dispatch modes.
     #[test]
     fn test_run_rejects_target_plus_function() {
         let mut args = run_args();
         args.target = Some("eval".into());
-        args.function = Some("X".into());
+        args.functions = vec!["X".into()];
         let err = args.run().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("mutually exclusive"), "got: {msg}");
         assert!(
-            msg.contains("`<target>`") && msg.contains("`--function`"),
+            msg.contains("`<target>`") && msg.contains("`-f`"),
             "got: {msg}"
         );
     }
@@ -1852,19 +1890,16 @@ mod tests {
         );
     }
 
-    /// `-e` and `--function` are mutually exclusive.
+    /// `-e` and `-f` are mutually exclusive.
     #[test]
     fn test_run_rejects_function_plus_expression() {
         let mut args = run_args();
-        args.function = Some("X".into());
+        args.functions = vec!["X".into()];
         args.expression = Some("2 + 2".into());
         let err = args.run().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("mutually exclusive"), "got: {msg}");
-        assert!(
-            msg.contains("`--function`") && msg.contains("`-e`"),
-            "got: {msg}"
-        );
+        assert!(msg.contains("`-f`") && msg.contains("`-e`"), "got: {msg}");
     }
 
     /// All three dispatch modes together → mutex error names all three.
@@ -1872,28 +1907,162 @@ mod tests {
     fn test_run_rejects_three_dispatch_modes() {
         let mut args = run_args();
         args.target = Some("t".into());
-        args.function = Some("F".into());
+        args.functions = vec!["F".into()];
         args.expression = Some("e".into());
         let err = args.run().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("`<target>`"));
-        assert!(msg.contains("`--function`"));
+        assert!(msg.contains("`-f`"));
         assert!(msg.contains("`-e`"));
     }
 
-    // ── `-e` + `--json-args` rejection ─────────────────────────────────
-
-    /// Expression mode has no function signature to bind JSON keys to;
-    /// silently dropping the JSON would be a footgun in CI pipelines.
+    /// `-e` + `--file` is rejected — `-e` evaluates inline source so a
+    /// separate `--file` would be silently ignored.
     #[test]
-    fn test_run_rejects_expression_plus_json_args() {
+    fn test_run_rejects_expression_plus_file() {
         let mut args = run_args();
         args.expression = Some("2 + 2".into());
-        args.json_args = Some("{}".into());
+        args.file = Some(PathBuf::from("a.baml"));
         let err = args.run().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("`-e`"), "got: {msg}");
-        assert!(msg.contains("--json-args"), "got: {msg}");
+        assert!(msg.contains("--file"), "got: {msg}");
+    }
+
+    /// `-e` + `--list` is rejected — `--list` enumerates project
+    /// targets; expression mode has none.
+    #[test]
+    fn test_run_rejects_expression_plus_list() {
+        let mut args = run_args();
+        args.expression = Some("2 + 2".into());
+        args.list = true;
+        let err = args.run().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("`-e`"), "got: {msg}");
+        assert!(msg.contains("--list"), "got: {msg}");
+    }
+
+    /// `--file` and `--from` are mutually exclusive (both name a source).
+    #[test]
+    fn test_run_rejects_file_plus_explicit_from() {
+        let mut args = run_args();
+        args.target = Some("X".into());
+        args.file = Some(PathBuf::from("a.baml"));
+        args.from = PathBuf::from("./project");
+        let err = args.run().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("mutually exclusive"), "got: {msg}");
+        assert!(msg.contains("--file"), "got: {msg}");
+    }
+
+    /// `--file` with default `--from` (i.e. `.`) is fine — we can't tell
+    /// "user passed `.`" from "user passed nothing" at the clap layer,
+    /// so the mutex only fires when `--from` is explicitly non-default.
+    #[test]
+    fn test_run_allows_file_with_default_from() {
+        let mut args = run_args();
+        args.target = Some("X".into());
+        args.file = Some(PathBuf::from("a.baml"));
+        // args.from is `PathBuf::from(".")` (the default).
+        // The validation pass shouldn't reject this; the actual file load
+        // will fail later but for a different reason.
+        // We can't call .run() here without hitting filesystem so probe
+        // the same predicate `run_with_reporter` would.
+        assert!(args.file.is_some());
+        assert_eq!(args.from, Path::new("."));
+    }
+
+    // ── Clap derive parse tests ──────────────────────────────────────
+
+    /// `-f` is repeatable through the clap derive. Regression test for
+    /// the derive macro silently collapsing repeated short flags into
+    /// `Option<String>` instead of `Vec<String>`.
+    #[test]
+    fn test_run_dash_f_is_repeatable() {
+        use clap::{CommandFactory, FromArgMatches, Parser};
+        #[derive(Parser)]
+        #[command(disable_help_flag = true)]
+        struct Wrapper {
+            #[command(flatten)]
+            args: RunArgs,
+        }
+        let cmd = Wrapper::command();
+        let matches = cmd
+            .clone()
+            .try_get_matches_from(["run", "-f", "a", "-f", "b", "--function", "c"])
+            .unwrap();
+        let parsed = Wrapper::from_arg_matches(&matches).unwrap();
+        assert_eq!(parsed.args.functions, vec!["a", "b", "c"]);
+        assert!(parsed.args.target.is_none());
+    }
+
+    /// `--file` binds to the PathBuf field.
+    #[test]
+    fn test_run_file_flag_parses() {
+        use clap::Parser;
+        #[derive(Parser)]
+        #[command(disable_help_flag = true)]
+        struct Wrapper {
+            #[command(flatten)]
+            args: RunArgs,
+        }
+        let parsed = Wrapper::try_parse_from(["run", "describe", "--file", "x.baml"]).unwrap();
+        assert_eq!(parsed.args.target.as_deref(), Some("describe"));
+        assert_eq!(parsed.args.file.as_deref(), Some(Path::new("x.baml")));
+    }
+
+    /// Tokens after `--` land in `target_args` verbatim, not consumed by
+    /// any earlier flag.
+    #[test]
+    fn test_run_post_dash_dash_tokens_are_verbatim() {
+        use clap::Parser;
+        #[derive(Parser)]
+        #[command(disable_help_flag = true)]
+        struct Wrapper {
+            #[command(flatten)]
+            args: RunArgs,
+        }
+        let parsed = Wrapper::try_parse_from([
+            "run",
+            "-f",
+            "a",
+            "--",
+            "a",
+            "--ty",
+            "string",
+            "--json-args",
+            "{}",
+        ])
+        .unwrap();
+        assert_eq!(parsed.args.functions, vec!["a"]);
+        assert_eq!(
+            parsed.args.target_args,
+            vec!["a", "--ty", "string", "--json-args", "{}"]
+        );
+    }
+
+    /// The verb-level `--json-args` flag was removed. A user that types
+    /// it pre-`--` should hit clap's unknown-flag path, not silently
+    /// land it somewhere.
+    #[test]
+    fn test_run_rejects_verb_level_json_args() {
+        use clap::{CommandFactory, Parser};
+        #[derive(Parser)]
+        #[command(disable_help_flag = true)]
+        struct Wrapper {
+            #[command(flatten)]
+            args: RunArgs,
+        }
+        let err = Wrapper::command()
+            .try_get_matches_from(["run", "--json-args", "{}", "describe"])
+            .unwrap_err();
+        assert!(
+            matches!(
+                err.kind(),
+                clap::error::ErrorKind::UnknownArgument | clap::error::ErrorKind::InvalidSubcommand
+            ),
+            "got: {err}"
+        );
     }
 
     // ── `--list` empty-targets JSON shape (BEP-027 §`--list`) ──────────

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -544,39 +544,7 @@ impl RunArgs {
         let _ = db;
         Self::emit_format_hint_if_needed(reporter, needs_format_hint);
 
-        // Resolve each `-f` to its canonical info. Collect into a stable
-        // (TargetEntry, UserFunctionInfo) list — the entry holds names
-        // that the clap subcommand layer keys on, the info is the
-        // signature.
-        let mut entries: Vec<baml_exec::TargetEntry> = Vec::with_capacity(self.functions.len());
-        let mut lookups: HashMap<String, UserFunctionInfo> = HashMap::new();
-        for func in &self.functions {
-            let Some(info) = engine.find_user_function(func) else {
-                return Err(Self::function_not_found_error(&engine, func));
-            };
-            baml_exec::validate_help_param(&engine, &info.qualified_name)?;
-            let display = info
-                .qualified_name
-                .strip_prefix("user.")
-                .unwrap_or(&info.qualified_name)
-                .to_string();
-            let subcommand = display.rsplit('.').next().unwrap_or(&display).to_string();
-            if let Some(prev) = entries.iter().find(|e| e.subcommand_name == subcommand) {
-                anyhow::bail!(
-                    "two `-f` targets share subcommand name `{subcommand}` \
-                     (`{}` and `{}`). Subcommand names come from the last `.`-segment \
-                     of the function name; rename one of them.",
-                    prev.display_name,
-                    display,
-                );
-            }
-            entries.push(baml_exec::TargetEntry {
-                qualified_name: info.qualified_name.clone(),
-                display_name: display.clone(),
-                subcommand_name: subcommand,
-            });
-            lookups.insert(info.qualified_name.clone(), info);
-        }
+        let (entries, lookups) = self.resolve_subcommand_targets(&engine)?;
 
         // Build the parse bin_name as the reinvocation prefix so the
         // help text is copy-pasteable.
@@ -622,6 +590,52 @@ impl RunArgs {
             event_sink,
             reporter,
         )
+    }
+
+    /// Walk `self.functions`, resolve each to an engine-canonical
+    /// `(TargetEntry, UserFunctionInfo)` pair, and reject duplicate
+    /// subcommand names. Mirrors `pack_command::resolve_targets`'
+    /// `-f` path so `baml run -f` and `baml pack -f` see the same
+    /// resolution shape; kept as a method here rather than hoisted to
+    /// `baml_exec` because the error messages reference `baml run`'s
+    /// help text.
+    fn resolve_subcommand_targets(
+        &self,
+        engine: &BexEngine,
+    ) -> Result<(
+        Vec<baml_exec::TargetEntry>,
+        HashMap<String, UserFunctionInfo>,
+    )> {
+        let mut entries: Vec<baml_exec::TargetEntry> = Vec::with_capacity(self.functions.len());
+        let mut lookups: HashMap<String, UserFunctionInfo> = HashMap::new();
+        for func in &self.functions {
+            let Some(info) = engine.find_user_function(func) else {
+                return Err(Self::function_not_found_error(engine, func));
+            };
+            baml_exec::validate_help_param(engine, &info.qualified_name)?;
+            let display = info
+                .qualified_name
+                .strip_prefix("user.")
+                .unwrap_or(&info.qualified_name)
+                .to_string();
+            let subcommand = display.rsplit('.').next().unwrap_or(&display).to_string();
+            if let Some(prev) = entries.iter().find(|e| e.subcommand_name == subcommand) {
+                anyhow::bail!(
+                    "two `-f` targets share subcommand name `{subcommand}` \
+                     (`{}` and `{}`). Subcommand names come from the last `.`-segment \
+                     of the function name; rename one of them.",
+                    prev.display_name,
+                    display,
+                );
+            }
+            entries.push(baml_exec::TargetEntry {
+                qualified_name: info.qualified_name.clone(),
+                display_name: display.clone(),
+                subcommand_name: subcommand,
+            });
+            lookups.insert(info.qualified_name.clone(), info);
+        }
+        Ok((entries, lookups))
     }
 
     /// Shared tail: spawn the runtime, run dispatch, render the
@@ -1840,6 +1854,20 @@ mod tests {
 
     // ── Default-valued `RunArgs` fixture for behavior tests ───────────
 
+    /// Engine fixture for namespace tests — `compile_multi_file`
+    /// supports folder-based namespaces (`ns_<name>/foo.baml`) which the
+    /// single-source `compile_source` helper can't express.
+    fn engine_from_files(files: &[(&str, &str)]) -> BexEngine {
+        let snapshot = baml_project::testing::compile_multi_file(files);
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("BexEngine::new should succeed")
+    }
+
     /// Build a `RunArgs` with default everything; tests flip individual
     /// fields. Keeps test bodies focused on the field under test.
     fn run_args() -> RunArgs {
@@ -2117,5 +2145,98 @@ mod tests {
     #[test]
     fn test_parse_scripts_empty_input_no_warn_empty_result() {
         assert!(RunArgs::parse_scripts("").is_empty());
+    }
+
+    // ── Namespaced `-f` targets (folder-based `ns_<name>/`) ──────────
+
+    /// `baml run -f llm.Summarize` resolves to the namespaced function
+    /// and surfaces `Summarize` (the leaf segment) as the subcommand
+    /// name the user types after `--`.
+    #[test]
+    fn test_run_subcommand_resolves_namespaced_target() {
+        let engine = engine_from_files(&[(
+            "ns_llm/summarize.baml",
+            "function Summarize(text: string) -> string { text }",
+        )]);
+        let mut args = run_args();
+        args.functions = vec!["llm.Summarize".into()];
+        let (entries, lookups) = args.resolve_subcommand_targets(&engine).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].qualified_name, "user.llm.Summarize");
+        assert_eq!(entries[0].display_name, "llm.Summarize");
+        assert_eq!(entries[0].subcommand_name, "Summarize");
+        assert!(lookups.contains_key("user.llm.Summarize"));
+    }
+
+    /// `-f` across namespaces builds one entry per function, each
+    /// keyed on its leaf segment.
+    #[test]
+    fn test_run_subcommand_multi_namespaced() {
+        let engine = engine_from_files(&[
+            (
+                "ns_llm/summarize.baml",
+                "function Summarize(text: string) -> string { text }",
+            ),
+            (
+                "ns_util/greet.baml",
+                "function Greet(name: string) -> string { name }",
+            ),
+        ]);
+        let mut args = run_args();
+        args.functions = vec!["llm.Summarize".into(), "util.Greet".into()];
+        let (entries, _) = args.resolve_subcommand_targets(&engine).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].display_name, "llm.Summarize");
+        assert_eq!(entries[0].subcommand_name, "Summarize");
+        assert_eq!(entries[1].display_name, "util.Greet");
+        assert_eq!(entries[1].subcommand_name, "Greet");
+    }
+
+    /// Two namespaces exporting the same leaf → subcommand-name
+    /// collision is rejected with both fully-qualified names cited.
+    /// Same regression check as the pack-side equivalent.
+    #[test]
+    fn test_run_subcommand_namespaced_name_collision_errors() {
+        let engine = engine_from_files(&[
+            ("ns_llm/foo.baml", "function Foo() -> int { 1 }"),
+            ("ns_util/foo.baml", "function Foo() -> int { 2 }"),
+        ]);
+        let mut args = run_args();
+        args.functions = vec!["llm.Foo".into(), "util.Foo".into()];
+        let err = args.resolve_subcommand_targets(&engine).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("share subcommand name `Foo`"), "got: {msg}");
+        assert!(msg.contains("llm.Foo"), "got: {msg}");
+        assert!(msg.contains("util.Foo"), "got: {msg}");
+    }
+
+    /// Bare-name lookup also resolves namespaced targets via the
+    /// shared resolver's suffix scan — `Summarize` finds
+    /// `llm.Summarize` when it's the unique match.
+    #[test]
+    fn test_run_subcommand_namespaced_resolves_via_bare_name() {
+        let engine = engine_from_files(&[(
+            "ns_llm/summarize.baml",
+            "function Summarize(text: string) -> string { text }",
+        )]);
+        let mut args = run_args();
+        args.functions = vec!["Summarize".into()];
+        let (entries, _) = args.resolve_subcommand_targets(&engine).unwrap();
+        assert_eq!(entries[0].qualified_name, "user.llm.Summarize");
+        assert_eq!(entries[0].subcommand_name, "Summarize");
+    }
+
+    /// Unknown `-f` target → "function not found" error with the same
+    /// suggestion-engine output we use for the single-target path.
+    #[test]
+    fn test_run_subcommand_unknown_function_errors() {
+        let engine = engine_from_files(&[(
+            "ns_llm/summarize.baml",
+            "function Summarize(text: string) -> string { text }",
+        )]);
+        let mut args = run_args();
+        args.functions = vec!["DoesNotExist".into()];
+        let err = args.resolve_subcommand_targets(&engine).unwrap_err();
+        assert!(format!("{err}").contains("not found"));
     }
 }

--- a/baml_language/crates/baml_exec/src/clap_target.rs
+++ b/baml_language/crates/baml_exec/src/clap_target.rs
@@ -21,11 +21,14 @@ use std::collections::HashMap;
 use anyhow::Result;
 use bex_engine::{BexExternalValue, Ty, UserFunctionInfo};
 use clap::{
-    Arg, Command,
+    Arg, ArgMatches, Command,
     builder::{PossibleValuesParser, styling},
 };
 
-use crate::auto_cli::{is_auto_cli_primitive, parse_cli_value};
+use crate::{
+    auto_cli::{is_auto_cli_primitive, parse_cli_value},
+    envelope::TargetEntry,
+};
 
 /// Coerce a runtime [`String`] into a `&'static str` clap can consume.
 ///
@@ -107,6 +110,87 @@ pub fn parse_target_argv(
         .collect();
     let matches = cmd.try_get_matches_from(argv)?;
 
+    let cli_values = extract_cli_values(func_info, &matches).map_err(|(name, err)| {
+        clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            format!("invalid value for `--{name}`: {err}\n"),
+        )
+        .with_cmd(&build_target_command(bin_name, function_name, func_info))
+    })?;
+    let json_source = matches.get_one::<String>("json-args").cloned();
+
+    Ok(ParsedTargetArgs {
+        cli_values,
+        json_source,
+    })
+}
+
+/// Multi-subcommand variant: `bin_name <subcommand> [OPTIONS]`. Each entry
+/// in `targets` becomes one subcommand; the chosen subcommand's typed
+/// args are decoded into a [`ParsedTargetArgs`].
+///
+/// `lookups` maps `qualified_name` → [`UserFunctionInfo`] for every entry
+/// in `targets`. Caller is responsible for keeping the two in sync.
+///
+/// Returns `(chosen_qualified_name, ParsedTargetArgs)`. Help requests
+/// (top-level or per-subcommand), unknown subcommands, unknown flags, and
+/// missing required values all come back as `clap::Error`.
+pub fn parse_multi_target_argv(
+    bin_name: &str,
+    targets: &[TargetEntry],
+    lookups: &HashMap<String, UserFunctionInfo>,
+    tokens: &[String],
+) -> Result<(String, ParsedTargetArgs), clap::Error> {
+    let cmd = build_multi_target_command(bin_name, targets, lookups);
+
+    let argv: Vec<String> = std::iter::once(bin_name.to_string())
+        .chain(tokens.iter().cloned())
+        .collect();
+    let matches = cmd.try_get_matches_from(argv)?;
+
+    // `subcommand_required(true)` ensures clap rejects empty invocations
+    // with `MissingSubcommand` before we reach here, so the `None` arm is
+    // a defensive bail rather than a real reachable state.
+    let (sub_name, sub_matches) = matches.subcommand().ok_or_else(|| {
+        clap::Error::raw(
+            clap::error::ErrorKind::MissingSubcommand,
+            "no subcommand specified\n",
+        )
+    })?;
+
+    let entry = targets
+        .iter()
+        .find(|t| t.subcommand_name == sub_name)
+        .expect("clap matched a subcommand that wasn't registered");
+    let info = lookups
+        .get(&entry.qualified_name)
+        .expect("lookups missing entry for registered subcommand");
+
+    let cli_values = extract_cli_values(info, sub_matches).map_err(|(name, err)| {
+        clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            format!("invalid value for `--{name}`: {err}\n"),
+        )
+        .with_cmd(&build_multi_target_command(bin_name, targets, lookups))
+    })?;
+    let json_source = sub_matches.get_one::<String>("json-args").cloned();
+
+    Ok((
+        entry.qualified_name.clone(),
+        ParsedTargetArgs {
+            cli_values,
+            json_source,
+        },
+    ))
+}
+
+/// Pull typed primitive values out of `matches` for a single target.
+/// Returns `Err((param_name, message))` on conversion failure so the
+/// caller can attach the proper `clap::Command` for nice rendering.
+fn extract_cli_values(
+    func_info: &UserFunctionInfo,
+    matches: &ArgMatches,
+) -> Result<HashMap<String, BexExternalValue>, (String, String)> {
     let mut cli_values = HashMap::new();
     for (name, ty) in func_info
         .param_names
@@ -124,22 +208,10 @@ pub fn parse_target_argv(
         // unknown flags, repeated flags) — semantic conversion of
         // primitives still lives here so enum/null/optional handling
         // doesn't get duplicated.
-        let value = parse_cli_value(raw, ty).map_err(|e| {
-            clap::Error::raw(
-                clap::error::ErrorKind::ValueValidation,
-                format!("invalid value for `--{name}`: {e}\n"),
-            )
-            .with_cmd(&build_target_command(bin_name, function_name, func_info))
-        })?;
+        let value = parse_cli_value(raw, ty).map_err(|e| (name.clone(), format!("{e}")))?;
         cli_values.insert(name.clone(), value);
     }
-
-    let json_source = matches.get_one::<String>("json-args").cloned();
-
-    Ok(ParsedTargetArgs {
-        cli_values,
-        json_source,
-    })
+    Ok(cli_values)
 }
 
 /// Build the clap [`Command`] that backs a typed target's CLI.
@@ -155,7 +227,20 @@ fn build_target_command(
     func_info: &UserFunctionInfo,
 ) -> Command {
     let display = function_name.strip_prefix("user.").unwrap_or(function_name);
-    let about = function_signature(display, func_info);
+    build_target_command_with_name(bin_name, display, func_info).styles(CLAP_STYLING)
+}
+
+/// Per-target [`Command`] builder, parameterized on the command name so
+/// it can be reused as both the top-level single-target command and a
+/// subcommand of a multi-target parser. Styling is the caller's job —
+/// the top-level command applies [`CLAP_STYLING`] once, which clap
+/// propagates to every subcommand it owns.
+fn build_target_command_with_name(
+    cmd_name: &str,
+    display_name: &str,
+    func_info: &UserFunctionInfo,
+) -> Command {
+    let about = function_signature(display_name, func_info);
 
     // Clap's `Id` and `Str` types are constructible from `&'static str`,
     // not `String`. For runtime-built commands the standard escape hatch
@@ -163,9 +248,8 @@ fn build_target_command(
     // string bytes that survive the process. That's the same memory
     // pattern as a compile-time clap derive (one-time string allocation
     // per binary), just deferred to the first call.
-    let mut cmd = Command::new(leak(bin_name.to_string()))
+    let mut cmd = Command::new(leak(cmd_name.to_string()))
         .about(about)
-        .styles(CLAP_STYLING)
         // Clap's default `help` subcommand makes no sense for a typed
         // target — entry points don't have subcommands.
         .disable_help_subcommand(true)
@@ -198,14 +282,19 @@ fn build_target_command(
             .get(idx)
             .copied()
             .unwrap_or(false);
-        let required = !has_default;
         let name_static: &'static str = leak(name.clone());
         let value_name: &'static str = leak(ty.to_string());
         let mut arg = Arg::new(name_static)
             .long(name_static)
-            .value_name(value_name)
-            .required(required);
-        if has_default {
+            .value_name(value_name);
+        // `--json-args` is an alternative delivery channel — a primitive
+        // param is satisfied by `--json-args` even without its `--name`
+        // flag, so require the flag only when neither `--json-args` nor
+        // a default is in play. `dispatch` does the final "every param
+        // bound?" check with a typed error if anything is missing.
+        if !has_default {
+            arg = arg.required_unless_present("json-args");
+        } else {
             arg = arg.help("[optional]");
         }
         // Validate finite-domain types at parse time so clap can offer
@@ -246,6 +335,38 @@ fn build_target_command(
     }
 
     cmd
+}
+
+/// Build a multi-subcommand clap [`Command`]: `bin_name <SUB>` with one
+/// subcommand per [`TargetEntry`]. Each subcommand owns the same
+/// per-parameter args as [`build_target_command_with_name`] would
+/// produce, plus a per-subcommand `--json-args`.
+fn build_multi_target_command(
+    bin_name: &str,
+    targets: &[TargetEntry],
+    lookups: &HashMap<String, UserFunctionInfo>,
+) -> Command {
+    let mut root = Command::new(leak(bin_name.to_string()))
+        .styles(CLAP_STYLING)
+        // Every target is a subcommand; clap's auto-generated `help`
+        // subcommand is fine here (unlike the single-target case) and
+        // is the convention multi-subcommand CLIs follow.
+        .disable_version_flag(true)
+        // Empty invocations should print the top-level help and exit
+        // non-zero, mirroring `git`/`cargo`. clap's combination of
+        // `subcommand_required(true) + arg_required_else_help(true)`
+        // does both.
+        .subcommand_required(true)
+        .arg_required_else_help(true);
+
+    for entry in targets {
+        let info = lookups
+            .get(&entry.qualified_name)
+            .expect("lookups must include every registered target");
+        let sub = build_target_command_with_name(&entry.subcommand_name, &entry.display_name, info);
+        root = root.subcommand(sub);
+    }
+    root
 }
 
 /// `function llm.Summarize(text: string, max_words: int [optional]) -> string`
@@ -489,5 +610,434 @@ mod tests {
         let info = func_info(&["text"], vec![ty_string()], vec![false], ty_string());
         let err = parse_target_argv("./Test", "user.Test", &info, &["--help".into()]).unwrap_err();
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
+
+    // ── Defaulted parameters ──────────────────────────────────────────
+
+    /// A primitive param with `has_default = true` is omittable on the
+    /// CLI — clap doesn't mark it required, and the parser succeeds even
+    /// with no value supplied. The dispatch layer handles the omission
+    /// downstream via `OmittedDefault`.
+    #[test]
+    fn parse_target_argv_defaulted_primitive_can_be_omitted() {
+        let info = func_info(
+            &["text", "count"],
+            vec![ty_string(), ty_int()],
+            vec![false, true], // count has a default
+            ty_string(),
+        );
+        let parsed = parse_target_argv(
+            "./Test",
+            "user.Test",
+            &info,
+            &["--text".into(), "hi".into()],
+        )
+        .expect("missing defaulted `--count` should NOT error");
+        // `count` is absent from cli_values — caller's dispatch will
+        // turn that into `OmittedDefault` so the BAML default runs.
+        assert!(parsed.cli_values.contains_key("text"));
+        assert!(
+            !parsed.cli_values.contains_key("count"),
+            "defaulted-and-omitted params don't appear in cli_values"
+        );
+    }
+
+    /// Defaulted param *passed explicitly* binds like any other primitive.
+    #[test]
+    fn parse_target_argv_defaulted_primitive_can_be_overridden() {
+        let info = func_info(&["count"], vec![ty_int()], vec![true], ty_string());
+        let parsed = parse_target_argv(
+            "./Test",
+            "user.Test",
+            &info,
+            &["--count".into(), "42".into()],
+        )
+        .unwrap();
+        assert_eq!(parsed.cli_values.len(), 1);
+    }
+
+    /// The missing-required error names only the *non-defaulted* missing
+    /// params; a defaulted param being absent isn't an error and isn't
+    /// surfaced.
+    #[test]
+    fn parse_target_argv_missing_required_skips_defaulted() {
+        let info = func_info(
+            &["text", "count"],
+            vec![ty_string(), ty_int()],
+            vec![false, true],
+            ty_string(),
+        );
+        let err = parse_target_argv("./Test", "user.Test", &info, &[]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        let rendered = format!("{err}");
+        assert!(
+            rendered.contains("--text"),
+            "should name `--text`; got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("--count"),
+            "must NOT cite defaulted `--count` as missing; got: {rendered}"
+        );
+    }
+
+    /// Bool with default → CLI surfaces `[optional]` annotation in help
+    /// and stays omittable. Behavioral check via successful parse with
+    /// no `--flag` token.
+    #[test]
+    fn parse_target_argv_defaulted_bool_omittable() {
+        let info = func_info(&["flag"], vec![ty_bool()], vec![true], ty_string());
+        let parsed =
+            parse_target_argv("./Test", "user.Test", &info, &[]).expect("optional bool ok");
+        assert!(parsed.cli_values.is_empty());
+    }
+
+    /// Defaulted param + `--json-args` providing a value → `--json-args`
+    /// carries the value to dispatch. The clap layer doesn't see it (we
+    /// stash `json_source` for dispatch to merge), but the parse must
+    /// succeed without `--name` being supplied either.
+    #[test]
+    fn parse_target_argv_defaulted_satisfied_by_json_args() {
+        let info = func_info(&["count"], vec![ty_int()], vec![true], ty_string());
+        let parsed = parse_target_argv(
+            "./Test",
+            "user.Test",
+            &info,
+            &["--json-args".into(), r#"{"count": 42}"#.into()],
+        )
+        .unwrap();
+        assert!(parsed.cli_values.is_empty());
+        assert_eq!(
+            parsed.json_source.as_deref(),
+            Some(r#"{"count": 42}"#),
+            "json_source should carry through verbatim"
+        );
+    }
+
+    // ── Defaulted params on the multi-subcommand parser ─────────────
+
+    /// Subcommand variant of `defaulted_primitive_can_be_omitted` — a
+    /// defaulted param under a subcommand can be left off, and the
+    /// chosen subcommand's other required params are still validated.
+    #[test]
+    fn parse_multi_target_argv_defaulted_param_under_subcommand_omittable() {
+        let mut info = func_info(
+            &["text", "count"],
+            vec![ty_string(), ty_int()],
+            vec![false, true],
+            ty_string(),
+        );
+        info.qualified_name = "user.summarize".into();
+        info.display_name = "summarize".into();
+        let entry = TargetEntry {
+            qualified_name: "user.summarize".into(),
+            display_name: "summarize".into(),
+            subcommand_name: "summarize".into(),
+        };
+        let mut lookups = HashMap::new();
+        lookups.insert("user.summarize".to_string(), info);
+
+        let (chosen, parsed) = parse_multi_target_argv(
+            "./cli",
+            &[entry],
+            &lookups,
+            &["summarize".into(), "--text".into(), "hi".into()],
+        )
+        .expect("defaulted `count` should be omittable");
+        assert_eq!(chosen, "user.summarize");
+        assert!(parsed.cli_values.contains_key("text"));
+        assert!(!parsed.cli_values.contains_key("count"));
+    }
+
+    /// Subcommand with a required param missing while a defaulted param
+    /// is also absent → error names only the required one.
+    #[test]
+    fn parse_multi_target_argv_missing_required_under_subcommand_names_only_required() {
+        let mut info = func_info(
+            &["text", "count"],
+            vec![ty_string(), ty_int()],
+            vec![false, true],
+            ty_string(),
+        );
+        info.qualified_name = "user.summarize".into();
+        info.display_name = "summarize".into();
+        let entry = TargetEntry {
+            qualified_name: "user.summarize".into(),
+            display_name: "summarize".into(),
+            subcommand_name: "summarize".into(),
+        };
+        let mut lookups = HashMap::new();
+        lookups.insert("user.summarize".to_string(), info);
+
+        let err = parse_multi_target_argv("./cli", &[entry], &lookups, &["summarize".into()])
+            .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        let rendered = format!("{err}");
+        assert!(rendered.contains("--text"), "got: {rendered}");
+        assert!(
+            !rendered.contains("--count"),
+            "defaulted param must not appear in the missing-required list; got: {rendered}"
+        );
+    }
+
+    /// `--json-args` alone satisfies a primitive parameter — the
+    /// `required_unless_present` flag wiring means we don't get a
+    /// false-positive `MissingRequiredArgument`. Regression test for the
+    /// bug where `./cli describe --json-args='{"ty":"x"}'` was rejected.
+    #[test]
+    fn parse_target_argv_primitive_satisfied_by_json_args() {
+        let info = func_info(&["ty"], vec![ty_string()], vec![false], ty_string());
+        let parsed = parse_target_argv(
+            "./Test",
+            "user.Test",
+            &info,
+            &["--json-args".into(), r#"{"ty":"x"}"#.into()],
+        )
+        .expect("--json-args alone should satisfy primitive param");
+        // Primitive isn't on the CLI side; the value flows in through
+        // json_source and `dispatch` decodes it later.
+        assert!(parsed.cli_values.is_empty());
+        assert_eq!(parsed.json_source.as_deref(), Some(r#"{"ty":"x"}"#));
+    }
+
+    // ── parse_multi_target_argv ───────────────────────────────────────
+
+    /// Helper: build a `TargetEntry` + matching `func_info` pair for one
+    /// function. Subcommand name defaults to the display name's last
+    /// `.`-segment, matching `pack_command`'s `resolve_one`.
+    fn target_entry(
+        qualified: &str,
+        info_param_names: &[&str],
+        info_param_types: Vec<Ty>,
+        info_param_defaults: Vec<bool>,
+    ) -> (TargetEntry, UserFunctionInfo) {
+        let display = qualified.strip_prefix("user.").unwrap_or(qualified);
+        let sub = display.rsplit('.').next().unwrap_or(display);
+        let mut info = func_info(
+            info_param_names,
+            info_param_types,
+            info_param_defaults,
+            ty_string(),
+        );
+        info.qualified_name = qualified.to_string();
+        info.display_name = display.to_string();
+        let entry = TargetEntry {
+            qualified_name: qualified.to_string(),
+            display_name: display.to_string(),
+            subcommand_name: sub.to_string(),
+        };
+        (entry, info)
+    }
+
+    /// Take ownership of the target pairs and split into the two shapes
+    /// `parse_multi_target_argv` wants: an ordered `entries` slice and a
+    /// `lookups` map keyed on qualified name. Returning by value avoids
+    /// the `.clone()`-per-pair pattern at call sites.
+    fn split_targets(
+        pairs: Vec<(TargetEntry, UserFunctionInfo)>,
+    ) -> (Vec<TargetEntry>, HashMap<String, UserFunctionInfo>) {
+        let mut entries = Vec::with_capacity(pairs.len());
+        let mut lookups = HashMap::with_capacity(pairs.len());
+        for (entry, info) in pairs {
+            lookups.insert(info.qualified_name.clone(), info);
+            entries.push(entry);
+        }
+        (entries, lookups)
+    }
+
+    /// Happy path: two subcommands, user picks one, typed value comes
+    /// back bound to that subcommand's signature.
+    #[test]
+    fn parse_multi_target_argv_dispatches_to_subcommand() {
+        let (entries, lookups) = split_targets(vec![
+            target_entry("user.describe", &["ty"], vec![ty_string()], vec![false]),
+            target_entry(
+                "user.greet",
+                &["name", "excited"],
+                vec![ty_string(), ty_bool()],
+                vec![false, false],
+            ),
+        ]);
+
+        let (chosen, parsed) = parse_multi_target_argv(
+            "./cli",
+            &entries,
+            &lookups,
+            &[
+                "greet".into(),
+                "--name".into(),
+                "Avery".into(),
+                "--excited".into(),
+                "true".into(),
+            ],
+        )
+        .expect("greet subcommand should parse");
+        assert_eq!(chosen, "user.greet");
+        assert_eq!(parsed.cli_values.len(), 2);
+        assert!(parsed.json_source.is_none());
+    }
+
+    /// No subcommand → `arg_required_else_help(true)` fires as
+    /// `DisplayHelpOnMissingArgumentOrSubcommand`, NOT `DisplayHelp`.
+    /// The host classifies this as exit-non-zero (vs. user-asked `-h`
+    /// which is exit-0).
+    #[test]
+    fn parse_multi_target_argv_empty_invocation_is_not_help_request() {
+        let (entries, lookups) = split_targets(vec![target_entry(
+            "user.describe",
+            &["ty"],
+            vec![ty_string()],
+            vec![false],
+        )]);
+        let err = parse_multi_target_argv("./cli", &entries, &lookups, &[]).unwrap_err();
+        assert!(
+            !matches!(err.kind(), clap::error::ErrorKind::DisplayHelp),
+            "empty must not classify as a help request (would route to exit 0); got: {err}"
+        );
+    }
+
+    /// User typed `-h` after the subcommand → that subcommand's help
+    /// renders (`DisplayHelp`), distinct from the no-subcommand case.
+    #[test]
+    fn parse_multi_target_argv_subcommand_help_is_display_help() {
+        let (entries, lookups) = split_targets(vec![target_entry(
+            "user.describe",
+            &["ty"],
+            vec![ty_string()],
+            vec![false],
+        )]);
+        let err = parse_multi_target_argv(
+            "./cli",
+            &entries,
+            &lookups,
+            &["describe".into(), "--help".into()],
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
+
+    /// Unknown subcommand → clap's `InvalidSubcommand` (with did-you-mean).
+    #[test]
+    fn parse_multi_target_argv_unknown_subcommand_errors() {
+        let (entries, lookups) = split_targets(vec![target_entry(
+            "user.describe",
+            &["ty"],
+            vec![ty_string()],
+            vec![false],
+        )]);
+        let err =
+            parse_multi_target_argv("./cli", &entries, &lookups, &["greet".into()]).unwrap_err();
+        assert!(
+            matches!(
+                err.kind(),
+                clap::error::ErrorKind::InvalidSubcommand | clap::error::ErrorKind::UnknownArgument
+            ),
+            "got: {err}"
+        );
+    }
+
+    /// `--json-args` after the subcommand alone satisfies primitive
+    /// params. Same `required_unless_present` regression coverage as the
+    /// single-target variant, but on the multi-target parser.
+    #[test]
+    fn parse_multi_target_argv_json_args_satisfies_primitive() {
+        let (entries, lookups) = split_targets(vec![target_entry(
+            "user.describe",
+            &["ty"],
+            vec![ty_string()],
+            vec![false],
+        )]);
+        let (chosen, parsed) = parse_multi_target_argv(
+            "./cli",
+            &entries,
+            &lookups,
+            &[
+                "describe".into(),
+                "--json-args".into(),
+                r#"{"ty":"x"}"#.into(),
+            ],
+        )
+        .expect("--json-args alone should satisfy `ty`");
+        assert_eq!(chosen, "user.describe");
+        assert!(parsed.cli_values.is_empty());
+        assert_eq!(parsed.json_source.as_deref(), Some(r#"{"ty":"x"}"#));
+    }
+
+    /// Missing required *under* the subcommand (no `--json-args`, no
+    /// `--ty`) → `MissingRequiredArgument`. Confirms the per-subcommand
+    /// required check still fires when `--json-args` isn't filling in.
+    #[test]
+    fn parse_multi_target_argv_missing_required_under_subcommand() {
+        let (entries, lookups) = split_targets(vec![target_entry(
+            "user.describe",
+            &["ty"],
+            vec![ty_string()],
+            vec![false],
+        )]);
+        let err =
+            parse_multi_target_argv("./cli", &entries, &lookups, &["describe".into()]).unwrap_err();
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "got: {err}"
+        );
+    }
+
+    /// Each subcommand owns its own `--name` namespace — passing
+    /// subcommand A's flag inside subcommand B is an unknown-flag error,
+    /// not a silent accept.
+    #[test]
+    fn parse_multi_target_argv_subcommand_flags_are_isolated() {
+        let (entries, lookups) = split_targets(vec![
+            target_entry("user.describe", &["ty"], vec![ty_string()], vec![false]),
+            target_entry(
+                "user.greet",
+                &["name", "excited"],
+                vec![ty_string(), ty_bool()],
+                vec![false, false],
+            ),
+        ]);
+        let err = parse_multi_target_argv(
+            "./cli",
+            &entries,
+            &lookups,
+            &["describe".into(), "--name".into(), "Avery".into()],
+        )
+        .unwrap_err();
+        assert!(
+            matches!(
+                err.kind(),
+                clap::error::ErrorKind::UnknownArgument | clap::error::ErrorKind::InvalidSubcommand
+            ),
+            "describe shouldn't accept greet's `--name`; got: {err}"
+        );
+    }
+
+    /// Verb-level (pre-subcommand) `--json-args` is NOT accepted — the
+    /// spec puts json args inside the chosen subcommand, not at root.
+    /// This test pins the design so a future "global args" rework
+    /// doesn't quietly add it.
+    #[test]
+    fn parse_multi_target_argv_does_not_accept_root_json_args() {
+        let (entries, lookups) = split_targets(vec![target_entry(
+            "user.describe",
+            &["ty"],
+            vec![ty_string()],
+            vec![false],
+        )]);
+        let err = parse_multi_target_argv(
+            "./cli",
+            &entries,
+            &lookups,
+            &[
+                "--json-args".into(),
+                r#"{"ty":"x"}"#.into(),
+                "describe".into(),
+            ],
+        )
+        .unwrap_err();
+        assert!(
+            !matches!(err.kind(), clap::error::ErrorKind::DisplayHelp),
+            "root `--json-args` should be a parse error, not help; got: {err}"
+        );
     }
 }

--- a/baml_language/crates/baml_exec/src/envelope.rs
+++ b/baml_language/crates/baml_exec/src/envelope.rs
@@ -1,8 +1,9 @@
 // `PackEnvelope` is the on-disk shape that `baml pack` writes into the
 // embedded section of a packaged binary, and that `baml-pack-host` reads
 // back at startup. It wraps the compiled program with the entry metadata
-// the host needs to dispatch — the target function to invoke and the
-// output format to use when printing the return value.
+// the host needs to dispatch — the target function (or functions, in
+// subcommand mode) to invoke and the output format to use when printing
+// the return value.
 
 use bex_vm_types::types::Program;
 
@@ -18,6 +19,35 @@ use crate::output::OutputFormat;
 /// libsui backend (Mach-O / ELF / PE-resource) handles it cleanly.
 pub const PACK_SECTION_NAME: &str = "baaaaaaaaaaaaaml";
 
+/// One entry-point baked into a packaged binary.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct TargetEntry {
+    /// Fully qualified name of the target function (engine form, includes
+    /// any `user.` prefix). Used to look up the function at dispatch.
+    pub qualified_name: String,
+
+    /// Display name (qualified, but with the `user.` prefix stripped).
+    /// Drives the per-target help text and `argv[1]` in single-target mode.
+    pub display_name: String,
+
+    /// CLI subcommand name in subcommand mode — the last `.`-segment of
+    /// `display_name`. In single-target mode this is the value packed
+    /// binaries surface as `argv[1]`.
+    pub subcommand_name: String,
+}
+
+/// Dispatch shape baked into the binary.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub enum PackMode {
+    /// One target, no subcommand layer. Flags on the binary bind directly
+    /// to the target's parameters: `./summarize --text=hi`.
+    Single,
+    /// Multiple targets, each as a subcommand: `./cli summarize --text=hi`.
+    /// Also used when the user passes a single `-f/--function`: the
+    /// subcommand layer is forced so signature changes are visible.
+    Subcommand,
+}
+
 /// Wire format embedded into a packaged binary.
 ///
 /// Stable across `baml pack` / `baml-pack-host` versions built from the
@@ -28,15 +58,12 @@ pub struct PackEnvelope {
     /// The compiled BAML program.
     pub program: Program,
 
-    /// Fully qualified name of the entry-point function, baked in at
-    /// pack time. Host invokes this as the entry point.
-    pub target_name: String,
+    /// Dispatch shape — single target or subcommand multiplex.
+    pub mode: PackMode,
 
-    /// `argv[1]` for the running binary, per BEP-027 §"baml.argv in
-    /// packaged binaries". For file-backed targets this is the file's
-    /// basename; otherwise the qualified function/namespace name or
-    /// the literal `"main"` for root main packages.
-    pub target_identifier: String,
+    /// One entry per packed target. In [`PackMode::Single`] this is
+    /// exactly one element; in [`PackMode::Subcommand`] one or more.
+    pub targets: Vec<TargetEntry>,
 
     /// Output serialization format, baked in at pack time.
     pub output_format: OutputFormat,

--- a/baml_language/crates/baml_exec/src/lib.rs
+++ b/baml_language/crates/baml_exec/src/lib.rs
@@ -22,7 +22,7 @@ pub mod json_coerce;
 pub mod output;
 
 pub use auto_cli::{is_auto_cli_primitive, parse_cli_value};
-pub use clap_target::{CLAP_STYLING, ParsedTargetArgs, parse_target_argv};
+pub use clap_target::{CLAP_STYLING, ParsedTargetArgs, parse_multi_target_argv, parse_target_argv};
 pub use diag_print::{print_anyhow_error, print_error, print_warning};
 
 /// Subset of `clap` re-exported so downstream binaries (pack-host) can
@@ -35,6 +35,6 @@ pub use dispatch::{
     DispatchResult, build_args_from_signature, clamp_exit_code, dispatch_target,
     validate_help_param,
 };
-pub use envelope::{PACK_SECTION_NAME, PackEnvelope};
+pub use envelope::{PACK_SECTION_NAME, PackEnvelope, PackMode, TargetEntry};
 pub use json_coerce::load_json_source;
 pub use output::{OutputFormat, example_value, format_value, write_output};

--- a/baml_language/crates/baml_pack_host/src/main.rs
+++ b/baml_language/crates/baml_pack_host/src/main.rs
@@ -2,30 +2,33 @@
 //
 // Startup:
 //   1. Extract `PackEnvelope` (bitcode) from the OS-native embedded section.
-//   2. Build `baml.argv` per BEP-027 §"baml.argv in packaged binaries":
-//        argv[0] = path to this binary
-//        argv[1] = target identifier baked in at pack time
-//        argv[2+] = every token on the command line after the binary name
-//   3. Initialize the BAML engine with the embedded program and argv.
-//   4. Parse argv[2..] through the runtime clap parser
-//      ([`baml_exec::parse_target_argv`]) — this gives `--help` /
+//   2. Decide single-target vs multi-subcommand dispatch from
+//      `envelope.mode`.
+//   3. Initialize the BAML engine with the embedded program and the
+//      argv shape the chosen mode expects.
+//   4. Parse argv through the runtime clap parser
+//      ([`baml_exec::parse_target_argv`] or
+//      [`baml_exec::parse_multi_target_argv`]) — this gives `--help` /
 //      unknown-flag / missing-required handling for free, with the same
 //      brand-purple styling as `baml run`'s top-level clap.
-//   5. Dispatch to the target via `baml_exec::dispatch_target` and write
-//      the return value in the baked-in output format.
+//   5. Dispatch to the resolved target via `baml_exec::dispatch_target`
+//      and write the return value in the baked-in output format.
 //
 // Exit codes: 0 on success, non-zero on error. To set a non-zero exit
 // code from BAML, the program calls `baml.sys.exit(code)`.
 
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+// `process::exit` is intentional — the BAML target may call
+// `baml.sys.exit(code)` to short-circuit the engine with a specific
+// exit code, which we honour by terminating the process directly.
+#![allow(clippy::print_stdout, clippy::print_stderr, clippy::exit)]
 
-use std::{process::ExitCode, sync::Arc};
+use std::{collections::HashMap, process::ExitCode, sync::Arc};
 
 use baml_exec::{
-    DispatchResult, PACK_SECTION_NAME, PackEnvelope, clamp_exit_code, dispatch_target,
-    load_json_source, parse_target_argv, print_error,
+    DispatchResult, PACK_SECTION_NAME, PackEnvelope, PackMode, clamp_exit_code, dispatch_target,
+    load_json_source, parse_multi_target_argv, parse_target_argv, print_error,
 };
-use bex_engine::BexEngine;
+use bex_engine::{BexEngine, UserFunctionInfo};
 use sys_native::SysOpsExt;
 
 fn extract_envelope() -> Result<PackEnvelope, String> {
@@ -37,6 +40,10 @@ fn extract_envelope() -> Result<PackEnvelope, String> {
 }
 
 /// Build `baml.argv` per BEP-027 §"baml.argv in packaged binaries".
+///
+/// `argv[1]` is the target identifier for single-target packs; for
+/// multi-subcommand packs the host overrides it after parsing the
+/// subcommand off the command line (see `main`).
 fn build_argv(target_identifier: &str) -> Vec<String> {
     let mut os_args = std::env::args();
     let exe = os_args
@@ -52,11 +59,8 @@ fn build_argv(target_identifier: &str) -> Vec<String> {
 /// Whether the target is typed — i.e. has one or more parameters whose
 /// types drive the auto-CLI. Parameterless targets own their full argv
 /// and bypass the clap layer entirely.
-fn target_is_typed(engine: &BexEngine, target_name: &str) -> bool {
-    engine
-        .function_params(target_name)
-        .map(|params| !params.is_empty())
-        .unwrap_or(false)
+fn target_is_typed(info: &UserFunctionInfo) -> bool {
+    !info.param_names.is_empty()
 }
 
 fn main() -> ExitCode {
@@ -68,7 +72,23 @@ fn main() -> ExitCode {
         }
     };
 
-    let argv = build_argv(&envelope.target_identifier);
+    match envelope.mode {
+        PackMode::Single => run_single(envelope),
+        PackMode::Subcommand => run_subcommand(envelope),
+    }
+}
+
+/// Single-target dispatch: the binary acts like a one-shot CLI; flags on
+/// the binary bind directly to the target's parameters.
+fn run_single(envelope: PackEnvelope) -> ExitCode {
+    debug_assert_eq!(
+        envelope.targets.len(),
+        1,
+        "single mode = exactly one target"
+    );
+    let target = &envelope.targets[0];
+
+    let argv = build_argv(&target.subcommand_name);
 
     let engine = match BexEngine::new(
         envelope.program,
@@ -83,31 +103,27 @@ fn main() -> ExitCode {
         }
     };
 
-    let raw_cli_tokens: &[String] = if argv.len() > 2 { &argv[2..] } else { &[] };
+    let Some(func_info) = engine.find_user_function(&target.qualified_name) else {
+        print_error(format_args!(
+            "function `{}` not found",
+            target.qualified_name
+        ));
+        return ExitCode::FAILURE;
+    };
 
-    // Parameterless targets own their full argv — including `--help`,
-    // which they're free to interpret however they like. Skip the clap
-    // layer for them. Typed targets route through clap so help/parse
-    // errors are uniformly rendered.
-    let parsed = if target_is_typed(&engine, &envelope.target_name) {
-        let Some(func_info) = engine.find_user_function(&envelope.target_name) else {
-            print_error(format_args!(
-                "function `{}` not found",
-                envelope.target_name
-            ));
-            return ExitCode::FAILURE;
-        };
+    let raw_cli_tokens: &[String] = if argv.len() > 2 { &argv[2..] } else { &[] };
+    let parsed = if target_is_typed(&func_info) {
         let bin_name = std::env::args()
             .next()
             .unwrap_or_else(|| "./binary".to_string());
-        match parse_target_argv(&bin_name, &envelope.target_name, &func_info, raw_cli_tokens) {
-            Ok(parsed) => parsed,
+        match parse_target_argv(
+            &bin_name,
+            &target.qualified_name,
+            &func_info,
+            raw_cli_tokens,
+        ) {
+            Ok(p) => p,
             Err(err) => {
-                // Clap classifies help/version requests as `Err` with a
-                // specific kind; route those to stdout + success so
-                // `./packed-bin --help` exits cleanly. Other kinds
-                // (missing required, unknown arg, etc.) print to stderr
-                // and fail.
                 use baml_exec::clap_reexport::ErrorKind;
                 let kind = err.kind();
                 let _ = err.print();
@@ -121,6 +137,105 @@ fn main() -> ExitCode {
         baml_exec::ParsedTargetArgs::default()
     };
 
+    finalize_dispatch(
+        engine,
+        &target.qualified_name,
+        parsed,
+        envelope.output_format,
+    )
+}
+
+/// Multi-subcommand dispatch: the binary acts like a multi-tool, with
+/// one subcommand per packed function.
+fn run_subcommand(envelope: PackEnvelope) -> ExitCode {
+    // `argv[1]` is the user's subcommand token after parsing; rebuild
+    // os-level argv first so we can pass the trailing tokens to clap.
+    let mut os_args = std::env::args();
+    let exe = os_args
+        .next()
+        .unwrap_or_else(|| "baml-pack-host".to_string());
+    let trailing: Vec<String> = os_args.collect();
+
+    // Engine init needs argv at construction time. Use a placeholder for
+    // `argv[1]` and patch it once the subcommand is resolved, while the
+    // engine is still uniquely owned (pre-Arc).
+    let mut bootstrap_argv = Vec::with_capacity(2 + trailing.len());
+    bootstrap_argv.push(exe.clone());
+    bootstrap_argv.push(String::new());
+    bootstrap_argv.extend(trailing.iter().cloned());
+
+    let mut engine = match BexEngine::new(
+        envelope.program,
+        Arc::new(sys_native::SysOps::native()),
+        None,
+        bootstrap_argv,
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            print_error(format_args!("failed to initialize engine: {e}"));
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Per-target lookups for the clap subcommand builder. Built once,
+    // shared with `parse_multi_target_argv`.
+    let mut lookups: HashMap<String, UserFunctionInfo> = HashMap::new();
+    for entry in &envelope.targets {
+        match engine.find_user_function(&entry.qualified_name) {
+            Some(info) => {
+                lookups.insert(entry.qualified_name.clone(), info);
+            }
+            None => {
+                print_error(format_args!(
+                    "function `{}` not found in packed program",
+                    entry.qualified_name
+                ));
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    let (chosen, parsed) =
+        match parse_multi_target_argv(&exe, &envelope.targets, &lookups, &trailing) {
+            Ok(v) => v,
+            Err(err) => {
+                use baml_exec::clap_reexport::ErrorKind;
+                let kind = err.kind();
+                let _ = err.print();
+                // `DisplayHelp` is the "user asked for help" exit-0 path;
+                // `DisplayHelpOnMissingArgumentOrSubcommand` is clap auto-
+                // showing help because the invocation was invalid, which
+                // must exit non-zero so scripted callers can detect it.
+                return match kind {
+                    ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => ExitCode::SUCCESS,
+                    _ => ExitCode::FAILURE,
+                };
+            }
+        };
+
+    // Patch `argv[1]` to the resolved subcommand identifier so
+    // `baml.sys.argv()` matches what the user typed (BEP-027 §"`baml.argv`
+    // in packaged binaries").
+    let chosen_entry = envelope
+        .targets
+        .iter()
+        .find(|t| t.qualified_name == chosen)
+        .expect("parse_multi_target_argv returned an unregistered target");
+    let mut patched = engine.argv().to_vec();
+    if patched.len() >= 2 {
+        chosen_entry.subcommand_name.clone_into(&mut patched[1]);
+        engine.set_argv(patched);
+    }
+
+    finalize_dispatch(Arc::new(engine), &chosen, parsed, envelope.output_format)
+}
+
+fn finalize_dispatch(
+    engine: Arc<BexEngine>,
+    target_name: &str,
+    parsed: baml_exec::ParsedTargetArgs,
+    output_format: baml_exec::OutputFormat,
+) -> ExitCode {
     let json_args = match parsed.json_source {
         Some(source) => match load_json_source(&source) {
             Ok(v) => Some(v),
@@ -142,18 +257,15 @@ fn main() -> ExitCode {
 
     let result = rt.block_on(dispatch_target(
         engine,
-        &envelope.target_name,
+        target_name,
         parsed.cli_values,
         json_args,
-        envelope.output_format,
+        output_format,
     ));
 
     match result {
         Ok(DispatchResult::Ok) => ExitCode::SUCCESS,
         Ok(DispatchResult::TargetError) => ExitCode::FAILURE,
-        // `baml.sys.exit(code)`: narrow to `i32` and terminate. Further
-        // OS-specific narrowing — the low 8 bits on Unix — is the shell's
-        // problem.
         Ok(DispatchResult::Exit(code)) => std::process::exit(clamp_exit_code(code)),
         Err(e) => {
             print_error(e);


### PR DESCRIPTION
## Summary
- `baml run` / `baml pack` migrate to an autocli surface: functions become subcommands, parameters become flags, and the same dispatch contract runs both inside `baml run` and inside the packaged binary.
- `baml.toml` is now mandatory as the project marker with `[package].name` required (Cargo-style manifest validation at load time).
- Adds `baml init [PATH] [--name NAME]` to scaffold a project.

## Run/pack surface
- `-f/--function <NAME>` is repeatable. With one or more `-f` the produced binary multiplexes between targets as subcommands; a bare positional `<TARGET>` packs a single-entry binary (no subcommand layer).
- `--file <PATH>` loads a single source hermetically (mutually exclusive with `--from`); replaces the dropped `.baml` positional.
- `--json-args` moves to post-`--` / per-subcommand; the verb-level flag is gone. `required_unless_present(\"json-args\")` lets `--json-args` alone satisfy required primitives.
- Path-shaped positionals (`baml_src/main.baml`) get a friendly redirect to `--file`.
- Drops implicit `main`, namespace `<ns>.main` shorthand, and verb-level `--json-args`. Empty `baml run` prints help and exits non-zero.

## Project / manifest
- `baml.toml` validated at load time; missing/empty manifests error before sources are touched.
- `baml_src/`-only directories no longer qualify as projects.
- `baml init [PATH] [--name NAME]` writes `baml.toml` + `baml_src/main.baml`.

## Pack output naming
- `--file foo.baml` → file stem (hermetic, ignores adjacent `baml.toml`).
- Project mode → `[package].name` (guaranteed present after manifest tightening). Drops the silent function-name fallback that masked missing manifests in subcommand-mode packs.

## Internals
- `PackEnvelope` now carries `mode: PackMode` + `targets: Vec<TargetEntry>`.
- New `parse_multi_target_argv` in `baml_exec` drives both `baml run -f a -f b` and the packed-binary host.
- `baml_pack_host` branches on `PackMode::Single`/`Subcommand` and patches `argv[1]` to the chosen subcommand post-parse.

## Test plan
- [x] 5608 workspace tests pass via `cargo nextest r --no-fail-fast --no-default-features --features ring-crypto`
- [x] `clippy` clean on `baml_cli`, `baml_exec`, `baml_pack_host`
- [x] New unit coverage: multi-subcommand parser, namespaced targets (`ns_<name>/`), `--json-args`-only invocations, defaulted parameter handling at the clap layer, manifest validation, path-shaped positional redirect, `-e` × `--file`/`--list` rejection, pack output naming across all modes, `baml init` scaffolding
- [x] End-to-end smoke: `baml init` → `baml run` (positional + multi `-f`) → `baml pack` (single + multi + `--file`) → running the resulting binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `baml new` to scaffold projects alongside `baml init`.
  * `baml pack` can produce single-entry or multi-subcommand executables from multiple functions.
  * `baml run` supports multi-target subcommand dispatch and hermetic single-file execution via `--file`.

* **Bug Fixes**
  * Refuses to overwrite existing manifests or destination paths; stricter project-name validation and clearer path-vs-file errors.

* **Refactor**
  * Projects now require a top-level manifest; packaged runtime dispatch updated to single vs subcommand modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->