### PR TITLE
chore(ci): standardize mise setup

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -1,0 +1,59 @@
+name: "Setup mise"
+description: |
+  Install mise and every tool pinned in mise.toml, sharing a single cache
+  scope across every baml_language workflow.
+
+  Centralizing the action version + cache settings here means future bumps
+  (e.g. when jdx/mise-action ships a new major, or when we want to bust
+  the cache prefix) only need to touch this one file.
+
+  Cache key composition (per the jdx/mise-action README): the default
+  cache key already includes a platform identifier such as
+  `linux-x64-ubuntu24` or `macos-arm64-macos15`, so cross-platform
+  isolation is automatic. Sharing `cache_key_prefix` (`mise-baml1` —
+  our own, not the upstream default) + the hash of mise.toml is what
+  makes the cache scope shared across workflows that run on the same
+  platform.
+
+inputs:
+  install_args:
+    description: |
+      Space-separated list of tool names passed through to `mise install`,
+      restricting installation to just those tools (e.g. "cargo:wasm-pack"
+      for a wasm-pack-only job). If empty, every tool in mise.toml is
+      installed.
+
+      Callers should pass the narrowest set their job actually uses —
+      mise.toml has a lot of `cargo:*` entries (cargo-watch, ripgrep,
+      just, bacon, cross, prek, wasm-pack) and even with binstall some
+      of them fall back to source compiles or hit crates.io rate limits.
+      Skipping them when they aren't needed is the cheapest win.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # cargo-binstall must be on PATH *before* `mise install` resolves
+    # the `cargo:*` entries in mise.toml — otherwise mise's cargo
+    # backend silently falls back to `cargo install` (compile from
+    # source). With `cargo_binstall = true` set in mise.toml's [settings]
+    # and cargo-binstall on PATH here, every `cargo:bacon`, `cargo:cross`,
+    # `cargo:wasm-pack`, `cargo:prek`, ... in mise.toml installs from a
+    # prebuilt binary in seconds instead of minutes.
+    #
+    # Skipped when the job's install_args has no `cargo:*` entries
+    # (and isn't the all-tools default) — there's nothing for binstall
+    # to do then, and even the ~5s download adds up across the workflow.
+    - name: Install cargo-binstall
+      if: ${{ inputs.install_args == '' || contains(inputs.install_args, 'cargo:') }}
+      uses: cargo-bins/cargo-binstall@main
+
+    - name: Install mise
+      uses: jdx/mise-action@v4.0.1
+      with:
+        # Our own prefix (not the upstream default), shared across every
+        # baml_language workflow. Bump the trailing number to invalidate
+        # every consumer's cache at once.
+        cache_key_prefix: mise-baml1
+        install_args: ${{ inputs.install_args }}

--- a/.github/actions/setup-node2/action.yml
+++ b/.github/actions/setup-node2/action.yml
@@ -17,7 +17,9 @@ inputs:
   pnpm-version:
     description: 'pnpm version to install'
     required: false
-    default: '9.12.0'
+    # Keep in sync with typescript2/package.json `packageManager` and the
+    # root mise.toml `npm:pnpm` entry.
+    default: '11.1.3'
 
 runs:
   using: 'composite'
@@ -26,6 +28,10 @@ runs:
       uses: pnpm/action-setup@v4
       with:
         version: ${{ inputs.pnpm-version }}
+        # Point at typescript2/package.json explicitly — otherwise the action
+        # reads the root package.json (which pins a different pnpm version for
+        # the legacy workspace) and aborts on the mismatch.
+        package_json_file: ${{ inputs.working-directory }}/package.json
         run_install: false
 
     - name: Setup Node.js

--- a/.github/workflows/build-python-sdk.reusable.yaml
+++ b/.github/workflows/build-python-sdk.reusable.yaml
@@ -69,6 +69,10 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      # NOTE: we deliberately do NOT use ./.github/actions/setup-mise here.
+      # The host Python version pins the abi3 floor of the resulting wheel,
+      # so we want a specific Python (3.10, matching the abi3-py310 target)
+      # rather than whatever mise.toml's `python` is pinned to today.
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -296,18 +296,18 @@ jobs:
           save-if: false
           shared-key: ${{ matrix.rust-cache-key }}
 
-      - name: "Setup Python 3.10+"
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
 
-      - name: "Install uv"
-        uses: astral-sh/setup-uv@v8.1.0
+      # sdk_test_* crates shell out to `uv sync` against the generated
+      # Python project under target/uv-cache. python + uv are the only
+      # mise tools the matrix needs.
+      - name: "Install mise"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "python uv"
 
       # `cargo test --no-run` drives each sdk_test crate's build.rs,
       # which is where the editable `baml_core` install + per-fixture
@@ -502,12 +502,6 @@ jobs:
     name: "snapshot tests"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
-    env:
-      # Disable Python + pipx tools: mise 2025.12.12 downloads a broken
-      # freethreaded Python build that's missing a lib/ directory.
-      # Rig test scripts use system Python via uv (the standalone uv binary
-      # mise installs handles its own Python via `uv run`).
-      MISE_DISABLE_TOOLS: python,pipx:uv,pipx:ruff,pipx:maturin
     steps:
       - uses: actions/checkout@v6
         with:
@@ -532,12 +526,13 @@ jobs:
         with:
           tool: cargo-insta,cargo-nextest
 
+      # rig test scripts shell out to `uv run` (and bring their own
+      # Python via uv), so the only mise tools snapshot-tests needs are
+      # python + uv.
       - name: "Install mise"
-        uses: jdx/mise-action@v2
-        # Pinning to old version because newer versions time out on the npm backend,
-        # see https://github.com/jdx/mise/discussions/7630
+        uses: ./.github/actions/setup-mise
         with:
-          version: 2025.12.12
+          install_args: "python uv"
 
       - name: "Build tests with --timings"
         run: cargo test --no-run -p baml_tests -p baml_cli -p baml_lsp2_actions --all-features --timings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,11 +244,6 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     timeout-minutes: 20
-    env:
-      # Disable Python + pipx tools: mise 2025.12.12 downloads a broken
-      # freethreaded Python build that's missing a lib/ directory.
-      # Prek hooks only need Rust + cargo tools; Python scripts use system Python + uv.
-      MISE_DISABLE_TOOLS: python,pipx:uv,pipx:ruff,pipx:maturin
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@v6
@@ -267,22 +262,15 @@ jobs:
           save-if: false
           shared-key: "linux-cargo"
 
-      - name: "Install cargo-binstall"
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf \
-            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
-            | bash
-        working-directory: baml_language
-
-      - name: "Install uv"
-        uses: astral-sh/setup-uv@v8.1.0
-
+      # prek hooks invoke cargo (from rustup), mise tasks that shell out
+      # to cargo, and python scripts that begin with `#!/usr/bin/env -S
+      # uv run --script` (e.g. bep:readme, validate-markdown). We don't
+      # need go/ruby/node/etc here, just the prek binary itself + a
+      # python/uv pair for the hook scripts.
       - name: "Install mise"
-        uses: jdx/mise-action@v2
-        # Pinning to old version because newer versions time out on the npm backend,
-        # see https://github.com/jdx/mise/discussions/7630
+        uses: ./.github/actions/setup-mise
         with:
-          version: 2025.12.12
+          install_args: "cargo:prek python uv"
 
       - name: "Cache prek"
         uses: actions/cache@v5
@@ -405,10 +393,6 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.proto == 'true'
     timeout-minutes: 20
-    env:
-      # See the matching comment on `prek` — mise 2025.12.12 ships a broken
-      # freethreaded Python build; this job doesn't need Python or pipx tools.
-      MISE_DISABLE_TOOLS: python,pipx:uv,pipx:ruff,pipx:maturin
     steps:
       - name: "Checkout"
         uses: actions/checkout@v6
@@ -427,13 +411,14 @@ jobs:
           save-if: false
           shared-key: "linux-cargo"
 
-      # mise provides go, node, pnpm, protoc, and protoc-gen-go per mise.toml.
+      # bridge_ctypes/build.rs needs `protoc`; bridge_go/build.sh needs
+      # `protoc` + `protoc-gen-go`; bridge_nodejs needs node + pnpm.
+      # The `cargo build -p bridge_ctypes` step uses cargo from rustup
+      # (not mise), so we don't need `go` itself here either.
       - name: "Install mise"
-        uses: jdx/mise-action@v2
-        # Pinning to old version because newer versions time out on the npm backend,
-        # see https://github.com/jdx/mise/discussions/7630
+        uses: ./.github/actions/setup-mise
         with:
-          version: 2025.12.12
+          install_args: "node npm:pnpm protoc protoc-gen-go"
 
       # Rust (prost) + Python (protoc) — both driven by bridge_ctypes/build.rs.
       # Writes Python pb2/pyi into baml_language/sdks/python/src/baml_core/cffi/v1/.

--- a/.github/workflows/wasm-pack-tests.reusable.yaml
+++ b/.github/workflows/wasm-pack-tests.reusable.yaml
@@ -43,10 +43,11 @@ jobs:
           # Share cache across similar Linux WASM jobs for better hit rates
           shared-key: "linux-wasm"
 
-      - name: "Install wasm-pack"
-        uses: taiki-e/install-action@v2
+      # Only wasm-pack is needed here.
+      - name: "Install mise"
+        uses: ./.github/actions/setup-mise
         with:
-          tool: wasm-pack
+          install_args: "cargo:wasm-pack"
 
       # NOTE: if you add a crate with wasm-gated tests, add a step here.
       - name: "Run wasm-pack tests (baml_playground_wasm)"

--- a/.github/workflows/webview-tests.reusable.yaml
+++ b/.github/workflows/webview-tests.reusable.yaml
@@ -40,10 +40,12 @@ jobs:
           # Share cache across similar Linux WASM jobs for better hit rates
           shared-key: "linux-wasm"
 
-      - name: "Install wasm-pack"
-        uses: taiki-e/install-action@v2
+      # node + pnpm come from setup-node2 above; we only need mise for
+      # wasm-pack here.
+      - name: "Install mise"
+        uses: ./.github/actions/setup-mise
         with:
-          tool: wasm-pack
+          install_args: "cargo:wasm-pack"
 
       # Path-mapped imports from app-vscode-webview resolve into pkg-playground/wasm
       # and pkg-proto/src/generated, so both must be present before tsc runs.
@@ -88,10 +90,12 @@ jobs:
           # Share cache across similar Linux WASM jobs for better hit rates
           shared-key: "linux-wasm"
 
-      - name: "Install wasm-pack"
-        uses: taiki-e/install-action@v2
+      # node + pnpm come from setup-node2 above; we only need mise for
+      # wasm-pack here.
+      - name: "Install mise"
+        uses: ./.github/actions/setup-mise
         with:
-          tool: wasm-pack
+          install_args: "cargo:wasm-pack"
 
       - name: "Build WASM"
         run: pnpm --filter pkg-playground build:wasm
@@ -126,10 +130,12 @@ jobs:
           # Share cache across similar Linux WASM jobs for better hit rates
           shared-key: "linux-wasm"
 
-      - name: "Install wasm-pack"
-        uses: taiki-e/install-action@v2
+      # node + pnpm come from setup-node2 above; we only need mise for
+      # wasm-pack here.
+      - name: "Install mise"
+        uses: ./.github/actions/setup-mise
         with:
-          tool: wasm-pack
+          install_args: "cargo:wasm-pack"
 
       - name: "Build WASM"
         run: pnpm --filter pkg-playground build:wasm

--- a/mise.toml
+++ b/mise.toml
@@ -32,7 +32,7 @@ protoc = "27.1"
 "pipx:maturin" = "latest"
 
 # Node tools
-"npm:pnpm" = "10.14.0"
+"npm:pnpm" = "11.1.3"
 "npm:@infisical/cli" = "latest"
 
 [tasks]

--- a/typescript2/package.json
+++ b/typescript2/package.json
@@ -21,7 +21,7 @@
     "lint": "turbo run lint",
     "clean": "pnpm -r clean"
   },
-  "packageManager": "pnpm@9.12.0",
+  "packageManager": "pnpm@11.1.3",
   "devDependencies": {
     "turbo": "^2.8.9",
     "typescript": "^5.7.0",

--- a/typescript2/pnpm-workspace.yaml
+++ b/typescript2/pnpm-workspace.yaml
@@ -2,5 +2,15 @@ packages:
   - "pkg-*"
   - "app-*"
 
+# pnpm 11 promotes un-approved postinstall builds to errors. Approve the
+# transitive build-script dependencies the lockfile currently pulls in.
+allowBuilds:
+  '@bufbuild/buf': true
+  '@mongodb-js/zstd': true
+  esbuild: true
+  msw: true
+  node-liblzma: true
+  unrs-resolver: true
+
 catalog:
   jotai: ^2.10.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a local reusable CI step to install pinned developer tools and replaced scattered installs across workflows.
  * Added an option to restrict which tools are installed per run and conditional use of prebuilt cargo binaries for cargo-prefixed tools.
  * Standardized cache scoping to improve cross-run cache reuse and speed up CI; updated workflows to use the new step (including wasm-pack).
* **Documentation**
  * Clarified Python host selection rationale in the build workflow (abi3/host interpreter choices).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->