### PR TITLE
feat(beps): add agent-friendly comments API and reply functionality

### DIFF
--- a/typescript/apps/beps/src/app/api/agent/beps/[number]/comments/reply/route.ts
+++ b/typescript/apps/beps/src/app/api/agent/beps/[number]/comments/reply/route.ts
@@ -1,0 +1,277 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../../../../../../../convex/_generated/api";
+import type { Id } from "../../../../../../../../convex/_generated/dataModel";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+function jsonResponse(body: unknown, status = 200): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      ...CORS_HEADERS,
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, {
+    status: 204,
+    headers: CORS_HEADERS,
+  });
+}
+
+interface AuthenticatedUser {
+  _id: string;
+  name: string;
+  role: string;
+}
+
+async function authenticateRequest(
+  request: NextRequest,
+  convex: ConvexHttpClient
+): Promise<{ user: AuthenticatedUser } | { error: string; status: number }> {
+  const authHeader = request.headers.get("Authorization");
+
+  if (!authHeader) {
+    return {
+      error: "Missing Authorization header. Use 'Authorization: Bearer <token>'.",
+      status: 401,
+    };
+  }
+
+  if (!authHeader.startsWith("Bearer ")) {
+    return {
+      error: "Invalid Authorization header format. Use 'Authorization: Bearer <token>'.",
+      status: 401,
+    };
+  }
+
+  const token = authHeader.slice(7); // Remove "Bearer " prefix
+
+  if (!token) {
+    return { error: "Empty token.", status: 401 };
+  }
+
+  try {
+    const user = await convex.query(api.users.authenticateWithToken, { token });
+
+    if (!user) {
+      return { error: "Invalid or expired token.", status: 401 };
+    }
+
+    return { user };
+  } catch {
+    return {
+      error: "Authentication failed.",
+      status: 500,
+    };
+  }
+}
+
+function formatBepNumber(num: number): string {
+  return `BEP-${String(num).padStart(3, "0")}`;
+}
+
+interface BepVersion {
+  _id: Id<"bepVersions">;
+  version: number;
+}
+
+interface ReplyRequest {
+  commentId: string;
+  content: string;
+  type?: "discussion" | "concern" | "question";
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ number: string }> }
+): Promise<Response> {
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!convexUrl) {
+    return jsonResponse(
+      { error: "Missing NEXT_PUBLIC_CONVEX_URL environment variable." },
+      500
+    );
+  }
+
+  const resolvedParams = await params;
+  const bepNumber = parseInt(resolvedParams.number, 10);
+  if (isNaN(bepNumber)) {
+    return jsonResponse({ error: "Invalid BEP number." }, 400);
+  }
+
+  const convex = new ConvexHttpClient(convexUrl);
+
+  // Authenticate via Bearer token
+  const authResult = await authenticateRequest(request, convex);
+  if ("error" in authResult) {
+    return jsonResponse({ error: authResult.error }, authResult.status);
+  }
+  const { user } = authResult;
+
+  let body: ReplyRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON body." }, 400);
+  }
+
+  // Validate required fields
+  if (!body.commentId || typeof body.commentId !== "string") {
+    return jsonResponse({ error: "Missing or invalid 'commentId' field." }, 400);
+  }
+  if (!body.content || typeof body.content !== "string") {
+    return jsonResponse({ error: "Missing or invalid 'content' field." }, 400);
+  }
+
+  const trimmedContent = body.content.trim();
+  if (trimmedContent.length === 0) {
+    return jsonResponse({ error: "Content cannot be empty." }, 400);
+  }
+
+  try {
+    // Fetch the BEP to verify it exists
+    const bepData = await convex.query(api.beps.getByNumber, { number: bepNumber });
+
+    if (!bepData) {
+      return jsonResponse(
+        { error: `${formatBepNumber(bepNumber)} not found.` },
+        404
+      );
+    }
+
+    // Get the current version (first in the desc-sorted list)
+    const versions = bepData.versions as BepVersion[];
+    const currentVersion = versions.length > 0 ? versions[0] : null;
+
+    if (!currentVersion) {
+      return jsonResponse(
+        { error: `No version found for ${formatBepNumber(bepNumber)}.` },
+        404
+      );
+    }
+
+    // Verify the parent comment exists and belongs to this BEP
+    const allComments = await convex.query(api.comments.allByBepNewestFirst, {
+      bepId: bepData._id,
+      versionId: currentVersion._id,
+      includeResolved: true,
+    });
+
+    const parentComment = allComments.find(
+      (c) => String(c._id) === body.commentId
+    );
+
+    if (!parentComment) {
+      return jsonResponse(
+        {
+          error: `Comment with ID '${body.commentId}' not found in ${formatBepNumber(bepNumber)} v${currentVersion.version}.`,
+          hint: "The commentId must be from the current version of the BEP.",
+        },
+        404
+      );
+    }
+
+    // Use the root comment if replying to a nested reply
+    const rootCommentId = parentComment.parentId ?? parentComment._id;
+
+    // Add the reply comment
+    const commentId = await convex.mutation(api.comments.add, {
+      bepId: bepData._id,
+      versionId: currentVersion._id,
+      pageId: parentComment.pageId,
+      parentId: rootCommentId,
+      authorId: user._id as Id<"users">,
+      type: body.type ?? "discussion",
+      content: trimmedContent,
+      // Include anchor so reply appears in context
+      anchor: parentComment.anchor,
+    });
+
+    const origin = request.nextUrl.origin;
+    return jsonResponse({
+      success: true,
+      commentId: String(commentId),
+      repliedTo: {
+        commentId: body.commentId,
+        author: parentComment.authorName,
+      },
+      author: user.name,
+      bep: {
+        number: bepNumber,
+        id: formatBepNumber(bepNumber),
+        version: currentVersion.version,
+      },
+      viewUrl: `${origin}/beps/${bepNumber}`,
+    });
+  } catch (err) {
+    return jsonResponse(
+      {
+        error: "Failed to add reply.",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      500
+    );
+  }
+}
+
+// Also support GET to show usage instructions
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ number: string }> }
+): Promise<Response> {
+  const resolvedParams = await params;
+  const bepNumber = parseInt(resolvedParams.number, 10);
+  const origin = request.nextUrl.origin;
+
+  return jsonResponse({
+    endpoint: `POST ${origin}/api/agent/beps/${bepNumber}/comments/reply`,
+    description: "Reply to a comment on this BEP",
+    authentication: {
+      method: "Bearer token",
+      header: "Authorization: Bearer <your-api-token>",
+      tokenSource: `Get your API token from ${origin}/profile`,
+    },
+    requestBody: {
+      commentId: {
+        type: "string",
+        required: true,
+        description: "The ID of the comment to reply to (from the comments endpoint)",
+      },
+      content: {
+        type: "string",
+        required: true,
+        description: "The markdown content of your reply",
+      },
+      type: {
+        type: "string",
+        required: false,
+        default: "discussion",
+        options: ["discussion", "concern", "question"],
+        description: "The type of comment",
+      },
+    },
+    example: {
+      curl: `curl -X POST "${origin}/api/agent/beps/${bepNumber}/comments/reply" \\
+  -H "Authorization: Bearer <your-token>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "commentId": "<comment-id-from-comments-endpoint>",
+    "content": "Your reply here"
+  }'`,
+    },
+    relatedEndpoints: {
+      getComments: `GET ${origin}/api/agent/beps/${bepNumber}/comments`,
+    },
+  });
+}

--- a/typescript/apps/beps/src/app/api/agent/beps/[number]/comments/route.ts
+++ b/typescript/apps/beps/src/app/api/agent/beps/[number]/comments/route.ts
@@ -1,0 +1,461 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../../../../../../convex/_generated/api";
+import type { Id } from "../../../../../../../convex/_generated/dataModel";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+function jsonResponse(body: unknown, status = 200): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      ...CORS_HEADERS,
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, {
+    status: 204,
+    headers: CORS_HEADERS,
+  });
+}
+
+interface RawComment {
+  _id: Id<"comments">;
+  bepId: Id<"beps">;
+  versionId?: Id<"bepVersions">;
+  pageId?: Id<"bepPages">;
+  authorId: Id<"users">;
+  authorName: string;
+  parentId?: Id<"comments">;
+  rootCommentId?: Id<"comments">;
+  type: string;
+  content: string;
+  anchor?: {
+    nodeId: string;
+    nodeType: string;
+    nodeText: string;
+  };
+  resolved: boolean;
+  resolvedByName?: string;
+  resolvedAt?: number;
+  createdAt: number;
+  updatedAt: number;
+  pageName?: string;
+  pageSlug?: string;
+  versionNumber?: number;
+  parentAuthorName?: string;
+}
+
+interface BepPage {
+  _id: Id<"bepPages">;
+  slug: string;
+  title: string;
+  content: string;
+}
+
+interface BepVersion {
+  _id: Id<"bepVersions">;
+  version: number;
+}
+
+interface ExportComment {
+  id: string;
+  type: string;
+  content: string;
+  author: string;
+  createdAt: string;
+  resolved: boolean;
+  resolvedBy?: string;
+  location: {
+    page: string;
+    pageSlug: string | null;
+  };
+  anchor?: {
+    type: string;
+    text: string;
+    context?: string;
+  };
+  replies: ExportReply[];
+}
+
+interface ExportReply {
+  id: string;
+  content: string;
+  author: string;
+  createdAt: string;
+}
+
+function extractMarkdownContext(
+  content: string | undefined,
+  anchorText: string,
+  contextLines: number = 3
+): string | null {
+  if (!content || !anchorText) return null;
+
+  const lines = content.split("\n");
+  const anchorTextLower = anchorText.toLowerCase().trim();
+
+  let matchLineIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].toLowerCase().includes(anchorTextLower.slice(0, 50))) {
+      matchLineIndex = i;
+      break;
+    }
+  }
+
+  if (matchLineIndex === -1) {
+    const words = anchorTextLower.split(/\s+/).filter((w) => w.length > 3);
+    for (let i = 0; i < lines.length; i++) {
+      const lineLower = lines[i].toLowerCase();
+      const matchCount = words.filter((w) => lineLower.includes(w)).length;
+      if (matchCount >= Math.min(3, words.length)) {
+        matchLineIndex = i;
+        break;
+      }
+    }
+  }
+
+  if (matchLineIndex === -1) return null;
+
+  const startLine = Math.max(0, matchLineIndex - contextLines);
+  const endLine = Math.min(lines.length, matchLineIndex + contextLines + 1);
+
+  return lines.slice(startLine, endLine).join("\n");
+}
+
+function formatBepNumber(num: number): string {
+  return `BEP-${String(num).padStart(3, "0")}`;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ number: string }> }
+): Promise<Response> {
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!convexUrl) {
+    return jsonResponse(
+      { error: "Missing NEXT_PUBLIC_CONVEX_URL environment variable." },
+      500
+    );
+  }
+
+  const resolvedParams = await params;
+  const bepNumber = parseInt(resolvedParams.number, 10);
+  if (isNaN(bepNumber)) {
+    return jsonResponse({ error: "Invalid BEP number." }, 400);
+  }
+
+  const convex = new ConvexHttpClient(convexUrl);
+  const searchParams = request.nextUrl.searchParams;
+  const includeResolved = searchParams.get("includeResolved") === "true";
+  const format = (searchParams.get("format") ?? "json").toLowerCase();
+
+  try {
+    // Use getByNumber which fetches everything including pages and versions
+    const bepData = await convex.query(api.beps.getByNumber, { number: bepNumber });
+
+    if (!bepData) {
+      return jsonResponse(
+        { error: `${formatBepNumber(bepNumber)} not found.` },
+        404
+      );
+    }
+
+    // Get the current version (first in the desc-sorted list)
+    const versions = bepData.versions as BepVersion[];
+    const currentVersion = versions.length > 0 ? versions[0] : null;
+
+    if (!currentVersion) {
+      return jsonResponse(
+        { error: `No version found for ${formatBepNumber(bepNumber)}.` },
+        404
+      );
+    }
+
+    const rawComments = (await convex.query(api.comments.allByBepNewestFirst, {
+      bepId: bepData._id,
+      versionId: currentVersion._id,
+      includeResolved,
+    })) as RawComment[];
+
+    const pages = bepData.pages as BepPage[];
+
+    const pageContentMap: Record<string, string> = {
+      _main: bepData.content ?? "",
+    };
+    for (const page of pages) {
+      pageContentMap[page.slug] = page.content;
+    }
+
+    const rootComments = rawComments.filter((c) => !c.parentId);
+    const repliesByParent = new Map<string, RawComment[]>();
+
+    for (const comment of rawComments) {
+      if (comment.parentId) {
+        const parentId = String(comment.parentId);
+        const existing = repliesByParent.get(parentId) || [];
+        existing.push(comment);
+        repliesByParent.set(parentId, existing);
+      }
+    }
+
+    const exportComments: ExportComment[] = rootComments.map((comment) => {
+      const pageSlug = comment.pageSlug ?? null;
+      const pageKey = pageSlug ?? "_main";
+      const pageContent = pageContentMap[pageKey];
+
+      let anchorContext: string | undefined;
+      if (comment.anchor && pageContent) {
+        const context = extractMarkdownContext(
+          pageContent,
+          comment.anchor.nodeText
+        );
+        if (context) {
+          anchorContext = context;
+        }
+      }
+
+      const replies = repliesByParent.get(String(comment._id)) || [];
+      replies.sort((a, b) => a.createdAt - b.createdAt);
+
+      return {
+        id: String(comment._id),
+        type: comment.type,
+        content: comment.content,
+        author: comment.authorName,
+        createdAt: new Date(comment.createdAt).toISOString(),
+        resolved: comment.resolved,
+        resolvedBy: comment.resolvedByName,
+        location: {
+          page: comment.pageName ?? "README",
+          pageSlug,
+        },
+        anchor: comment.anchor
+          ? {
+              type: comment.anchor.nodeType,
+              text: comment.anchor.nodeText,
+              ...(anchorContext ? { context: anchorContext } : {}),
+            }
+          : undefined,
+        replies: replies.map((reply) => ({
+          id: String(reply._id),
+          content: reply.content,
+          author: reply.authorName,
+          createdAt: new Date(reply.createdAt).toISOString(),
+        })),
+      };
+    });
+
+    const stats = {
+      total: rootComments.length,
+      byType: {
+        discussion: rootComments.filter((c) => c.type === "discussion").length,
+        concern: rootComments.filter((c) => c.type === "concern").length,
+        question: rootComments.filter((c) => c.type === "question").length,
+      },
+      resolved: rootComments.filter((c) => c.resolved).length,
+      unresolved: rootComments.filter((c) => !c.resolved).length,
+      totalReplies: rawComments.filter((c) => c.parentId).length,
+    };
+
+    if (format === "markdown") {
+      const markdown = generateCommentsMarkdown(
+        bepNumber,
+        bepData.title,
+        currentVersion.version,
+        exportComments,
+        stats
+      );
+      return new Response(markdown, {
+        status: 200,
+        headers: {
+          ...CORS_HEADERS,
+          "Cache-Control": "no-store",
+          "Content-Type": "text/markdown; charset=utf-8",
+        },
+      });
+    }
+
+    const origin = request.nextUrl.origin;
+    return jsonResponse({
+      bep: {
+        number: bepNumber,
+        id: formatBepNumber(bepNumber),
+        title: bepData.title,
+        version: currentVersion.version,
+      },
+      stats,
+      comments: exportComments,
+      usage: {
+        reply: `POST ${origin}/api/agent/beps/${bepNumber}/comments/reply`,
+        replyBody: {
+          commentId: "<comment-id>",
+          content: "<your reply>",
+        },
+      },
+    });
+  } catch (err) {
+    return jsonResponse(
+      {
+        error: "Failed to fetch comments.",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      502
+    );
+  }
+}
+
+function generateCommentsMarkdown(
+  bepNumber: number,
+  title: string,
+  version: number,
+  comments: ExportComment[],
+  stats: {
+    total: number;
+    byType: { discussion: number; concern: number; question: number };
+    resolved: number;
+    unresolved: number;
+    totalReplies: number;
+  }
+): string {
+  const bepId = formatBepNumber(bepNumber);
+
+  let md = `# Comments - ${bepId}: ${title}
+
+> **Version:** ${version}
+> **Total Comments:** ${stats.total} (${stats.unresolved} unresolved, ${stats.resolved} resolved)
+> **Replies:** ${stats.totalReplies}
+
+## Summary by Type
+
+| Type | Count |
+|------|-------|
+| Discussion | ${stats.byType.discussion} |
+| Concern | ${stats.byType.concern} |
+| Question | ${stats.byType.question} |
+
+---
+
+`;
+
+  const unresolvedConcerns = comments.filter(
+    (c) => c.type === "concern" && !c.resolved
+  );
+  if (unresolvedConcerns.length > 0) {
+    md += `## ⚠️ Unresolved Concerns (${unresolvedConcerns.length})
+
+These require attention before the BEP can progress.
+
+`;
+    for (const comment of unresolvedConcerns) {
+      md += formatCommentMarkdown(comment);
+    }
+  }
+
+  const unresolvedQuestions = comments.filter(
+    (c) => c.type === "question" && !c.resolved
+  );
+  if (unresolvedQuestions.length > 0) {
+    md += `## ❓ Unanswered Questions (${unresolvedQuestions.length})
+
+`;
+    for (const comment of unresolvedQuestions) {
+      md += formatCommentMarkdown(comment);
+    }
+  }
+
+  const unresolvedDiscussions = comments.filter(
+    (c) => c.type === "discussion" && !c.resolved
+  );
+  if (unresolvedDiscussions.length > 0) {
+    md += `## 💬 Open Discussions (${unresolvedDiscussions.length})
+
+`;
+    for (const comment of unresolvedDiscussions) {
+      md += formatCommentMarkdown(comment);
+    }
+  }
+
+  const resolved = comments.filter((c) => c.resolved);
+  if (resolved.length > 0) {
+    md += `## ✅ Resolved (${resolved.length})
+
+<details>
+<summary>View resolved comments</summary>
+
+`;
+    for (const comment of resolved) {
+      md += formatCommentMarkdown(comment);
+    }
+    md += `</details>
+
+`;
+  }
+
+  return md;
+}
+
+function formatCommentMarkdown(comment: ExportComment): string {
+  const typeEmoji =
+    comment.type === "concern"
+      ? "⚠️"
+      : comment.type === "question"
+        ? "❓"
+        : "💬";
+
+  let md = `### ${typeEmoji} ${comment.author} on ${comment.location.page}
+
+**ID:** \`${comment.id}\`
+**Date:** ${comment.createdAt}
+${comment.resolved ? `**Status:** ✅ Resolved by ${comment.resolvedBy}` : "**Status:** Open"}
+
+`;
+
+  if (comment.anchor) {
+    md += `**Referenced text:**
+> ${comment.anchor.text.slice(0, 200)}${comment.anchor.text.length > 200 ? "..." : ""}
+
+`;
+    if (comment.anchor.context) {
+      md += `**Context (surrounding markdown):**
+\`\`\`markdown
+${comment.anchor.context}
+\`\`\`
+
+`;
+    }
+  }
+
+  md += `**Comment:**
+${comment.content}
+
+`;
+
+  if (comment.replies.length > 0) {
+    md += `**Replies (${comment.replies.length}):**
+
+`;
+    for (const reply of comment.replies) {
+      md += `> **${reply.author}** (${reply.createdAt}):
+> ${reply.content.split("\n").join("\n> ")}
+
+`;
+    }
+  }
+
+  md += `---
+
+`;
+
+  return md;
+}

--- a/typescript/apps/beps/src/lib/export-all-utils.ts
+++ b/typescript/apps/beps/src/lib/export-all-utils.ts
@@ -598,6 +598,57 @@ Downloads all BEPs as a ZIP archive. No authentication required.
 | \`versionMode\` | No | \`"new"\` (default) or \`"current"\` |
 
 *At least one of \`title\`, \`content\`, or \`pages\` must be provided.
+
+---
+
+## Comments API
+
+### Get Comments (GET /api/agent/beps/{number}/comments)
+
+Fetch all comments for a BEP's current version. No authentication required.
+
+\`\`\`bash
+# JSON format (default)
+curl "${apiBaseUrl}/api/agent/beps/41/comments"
+
+# Markdown format (agent-friendly)
+curl "${apiBaseUrl}/api/agent/beps/41/comments?format=markdown"
+
+# Include resolved comments
+curl "${apiBaseUrl}/api/agent/beps/41/comments?includeResolved=true"
+\`\`\`
+
+| Param | Type | Description |
+|-------|------|-------------|
+| \`format\` | string | \`json\` (default) or \`markdown\` |
+| \`includeResolved\` | boolean | Include resolved comments (default: false) |
+
+Response includes:
+- Comment threads with author, type, content, and context
+- Anchored text (what the comment references)
+- Surrounding markdown context
+- Reply threads
+
+### Reply to Comment (POST /api/agent/beps/{number}/comments/reply)
+
+Reply to an existing comment. Requires authentication.
+
+\`\`\`bash
+curl -X POST "${apiBaseUrl}/api/agent/beps/41/comments/reply" \\
+  -H "Authorization: Bearer <your-api-token>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "commentId": "<comment-id-from-comments-endpoint>",
+    "content": "Your reply here",
+    "type": "discussion"
+  }'
+\`\`\`
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| \`commentId\` | Yes | ID of the comment to reply to |
+| \`content\` | Yes | Markdown content of your reply |
+| \`type\` | No | \`discussion\` (default), \`concern\`, or \`question\` |
 `;
 
   return md;

--- a/typescript/apps/beps/src/lib/static/bep-script.ts
+++ b/typescript/apps/beps/src/lib/static/bep-script.ts
@@ -735,6 +735,20 @@ def main():
     open_parser = subparsers.add_parser("open", help="Open BEP in browser")
     open_parser.add_argument("ref", help="BEP number or slug")
     
+    # comments
+    comments_parser = subparsers.add_parser("comments", help="Fetch comments for a BEP")
+    comments_parser.add_argument("ref", help="BEP number or slug")
+    comments_parser.add_argument("--include-resolved", action="store_true", help="Include resolved comments")
+    comments_parser.add_argument("--format", choices=["json", "markdown"], default=None, help="Output format")
+    comments_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    
+    # reply
+    reply_parser = subparsers.add_parser("reply", help="Reply to a comment on a BEP")
+    reply_parser.add_argument("ref", help="BEP number or slug")
+    reply_parser.add_argument("comment_id", help="ID of the comment to reply to")
+    reply_parser.add_argument("content", help="Reply content")
+    reply_parser.add_argument("--type", choices=["discussion", "concern", "question"], default="discussion", help="Comment type")
+    
     args = parser.parse_args()
     
     if args.command is None:
@@ -748,6 +762,8 @@ def main():
         "diff": cmd_diff,
         "push": cmd_push,
         "open": cmd_open,
+        "comments": cmd_comments,
+        "reply": cmd_reply,
     }
     
     return commands[args.command](args)

--- a/typescript/apps/beps/src/lib/static/bep-skill.ts
+++ b/typescript/apps/beps/src/lib/static/bep-skill.ts
@@ -20,6 +20,8 @@ You are working in a BEP (BAML Enhancement Proposal) repository. Use the \`./bep
 ./bep diff <ref>        # Diff local vs server (--full for unified diff)
 ./bep push <ref>        # Dry-run diff + prompt to push (-y to confirm)
 ./bep open <number>     # Open in browser
+./bep comments <number> # Fetch all comments for a BEP (current version)
+./bep reply <number> <comment-id> "message"  # Reply to a comment
 \`\`\`
 
 \`<ref>\` is a BEP number (e.g. \`41\`) or slug (e.g. \`my-feature\` for \`BEP-?-my-feature\`).
@@ -35,6 +37,19 @@ If \`$ARGUMENTS\` is a title/topic, create a new BEP:
 4. Run \`./bep diff <slug>\` to preview, then ask if user wants to push
 
 If no arguments, ask what the user wants to do.
+
+## Working with Comments
+
+To review and respond to feedback on a BEP:
+
+1. **Fetch comments**: \`./bep comments <number>\` to see all comments with context
+2. **Review concerns**: Look for ⚠️ concerns and ❓ questions that need addressing
+3. **Reply to feedback**: \`./bep reply <number> <comment-id> "Your response"\`
+
+Comment types:
+- \`discussion\` - General feedback (default)
+- \`concern\` - Blocking issue that needs resolution
+- \`question\` - Needs clarification
 
 ## BEP Writing Style
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

## Issue Reference
This PR adds new API endpoints for agents to work with BEP comments.

## Changes
This PR adds agent-friendly APIs for fetching and replying to BEP comments:

### New API Endpoints

1. **GET `/api/agent/beps/[number]/comments`** - Fetch all comments for a BEP's current version
   - Returns comment threads with author, type, content
   - Includes anchor text (what the comment references) 
   - Provides surrounding markdown context for inline comments
   - Supports both JSON and markdown output formats
   - Query params: `includeResolved`, `format`

2. **POST `/api/agent/beps/[number]/comments/reply`** - Reply to a comment
   - Requires Bearer token authentication
   - Validates comment belongs to current version
   - Supports comment types: discussion, concern, question

### Updated CLI (`./bep`)
- Added `./bep comments <number>` to fetch comments from terminal
- Added `./bep reply <number> <comment-id> "message"` to reply to comments

### Updated Documentation
- Updated bep-skill.ts with comment workflow instructions
- Updated INSTRUCTIONS.md template with new API documentation

## Testing
- [x] TypeScript compilation passes (`pnpm exec tsc --noEmit --skipLibCheck`)
- [x] Code follows existing patterns in the codebase

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
This enables agents to:
1. Pull all comments for a BEP with context (similar to the "all comments" UI page)
2. Reply to comments programmatically via authenticated API calls

Example usage:
```bash
# Get comments in markdown format
curl "https://beps.boundaryml.com/api/agent/beps/41/comments?format=markdown"

# Reply to a comment
curl -X POST "https://beps.boundaryml.com/api/agent/beps/41/comments/reply" \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"commentId": "abc123", "content": "Your reply here"}'
```
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1779404578815119?thread_ts=1779404578.815119&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-09d1c7d0-e041-5e72-b117-623e53e57350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09d1c7d0-e041-5e72-b117-623e53e57350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints and CLI commands to fetch and reply to BEP comments.
  * Support for multiple comment types: discussion, concern, and question.
  * Export comments as JSON or markdown format.

* **Documentation**
  * Updated instructions with Comments API reference, usage examples, and command reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->