### PR TITLE
feat(ci): add ARM Linux, musl targets and AUR publishing for baml_language

### DIFF
--- a/.github/workflows/release-baml-language-alpha.yml
+++ b/.github/workflows/release-baml-language-alpha.yml
@@ -206,13 +206,6 @@ jobs:
             binary: baml-cli.exe
             pack_host: baml-pack-host.exe
             archive_ext: zip
-          - target: aarch64-pc-windows-msvc
-            os: blacksmith-4vcpu-windows-2025
-            binary: baml-cli.exe
-            pack_host: baml-pack-host.exe
-            archive_ext: zip
-            windows_arm: true
-            cross_arch: true
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container || '' }}
     timeout-minutes: 45
@@ -241,16 +234,6 @@ jobs:
       - name: Install cross
         if: matrix.cross
         run: cargo install cross
-
-      # aws-lc-sys requires clang-cl to assemble ARM64 .S files on Windows
-      # (cl.exe doesn't understand GNU assembler syntax)
-      - name: Setup clang-cl for Windows ARM64
-        if: matrix.windows_arm
-        shell: pwsh
-        run: |
-          echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
-          echo "CC_aarch64_pc_windows_msvc=clang-cl" >> $env:GITHUB_ENV
-          echo "CXX_aarch64_pc_windows_msvc=clang-cl" >> $env:GITHUB_ENV
 
       - name: Build baml-cli
         env:
@@ -363,36 +346,12 @@ jobs:
           tar -xzf dist/*.tar.gz
           ./baml-cli --version
 
-  # Windows ARM is cross-compiled from x86, so we can't smoke test it in the build job.
-  # Run a separate job on a native Windows ARM runner to verify the binary works.
-  test-windows-arm:
-    name: Test Windows ARM binary
-    needs:
-      - prepare
-      - build
-    if: needs.prepare.outputs.should_run == 'true'
-    runs-on: windows-11-arm
-    timeout-minutes: 5
-    steps:
-      - name: Download Windows ARM archive
-        uses: actions/download-artifact@v4
-        with:
-          name: baml-language-archive-aarch64-pc-windows-msvc
-          path: dist
-
-      - name: Extract and test
-        shell: pwsh
-        run: |
-          Expand-Archive -Path dist\*.zip -DestinationPath .
-          .\baml-cli.exe --version
-
   publish:
     name: Publish Release
     needs:
       - prepare
       - build
       - test-arm-musl
-      - test-windows-arm
     if: needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.publish == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15

--- a/.github/workflows/release-baml-language-alpha.yml
+++ b/.github/workflows/release-baml-language-alpha.yml
@@ -184,14 +184,44 @@ jobs:
             binary: baml-cli
             pack_host: baml-pack-host
             archive_ext: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: blacksmith-4vcpu-ubuntu-2204-arm
+            binary: baml-cli
+            pack_host: baml-pack-host
+            archive_ext: tar.gz
+          - target: x86_64-unknown-linux-musl
+            os: blacksmith-4vcpu-ubuntu-2204
+            binary: baml-cli
+            pack_host: baml-pack-host
+            archive_ext: tar.gz
+            container: rust:alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2
+          - target: aarch64-unknown-linux-musl
+            os: blacksmith-4vcpu-ubuntu-2204
+            binary: baml-cli
+            pack_host: baml-pack-host
+            archive_ext: tar.gz
+            cross: true
           - target: x86_64-pc-windows-msvc
             os: blacksmith-4vcpu-windows-2025
             binary: baml-cli.exe
             pack_host: baml-pack-host.exe
             archive_ext: zip
+          - target: aarch64-pc-windows-msvc
+            os: blacksmith-4vcpu-windows-2025
+            binary: baml-cli.exe
+            pack_host: baml-pack-host.exe
+            archive_ext: zip
+            windows_arm: true
+            cross_arch: true
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container || '' }}
     timeout-minutes: 45
     steps:
+      - name: Install Alpine build dependencies
+        if: matrix.container
+        shell: sh
+        run: apk add --no-cache bash git cmake clang openssl-dev openssl-libs-static perl make python3
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -199,6 +229,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
+        if: ${{ !matrix.container }}
         uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.target }}
@@ -207,21 +238,38 @@ jobs:
           enable-cross: false
           skip-protoc: true
 
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross
+
+      # aws-lc-sys requires clang-cl to assemble ARM64 .S files on Windows
+      # (cl.exe doesn't understand GNU assembler syntax)
+      - name: Setup clang-cl for Windows ARM64
+        if: matrix.windows_arm
+        shell: pwsh
+        run: |
+          echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
+          echo "CC_aarch64_pc_windows_msvc=clang-cl" >> $env:GITHUB_ENV
+          echo "CXX_aarch64_pc_windows_msvc=clang-cl" >> $env:GITHUB_ENV
+
       - name: Build baml-cli
         env:
           BAML_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
           TARGET: ${{ matrix.target }}
-        run: cargo build --release --bin baml-cli --target "${TARGET}"
+          CARGO: ${{ matrix.cross && 'cross' || 'cargo' }}
+        run: $CARGO build --release --bin baml-cli --target "${TARGET}"
         working-directory: baml_language
 
       - name: Build baml-pack-host
         env:
           BAML_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
           TARGET: ${{ matrix.target }}
-        run: cargo build --release -p baml_pack_host --bin baml-pack-host --target "${TARGET}"
+          CARGO: ${{ matrix.cross && 'cross' || 'cargo' }}
+        run: $CARGO build --release -p baml_pack_host --bin baml-pack-host --target "${TARGET}"
         working-directory: baml_language
 
       - name: Smoke test version
+        if: ${{ !matrix.cross && !matrix.cross_arch }}
         env:
           EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
           TARGET: ${{ matrix.target }}
@@ -290,11 +338,61 @@ jobs:
             !dist/${{ matrix.target }}/staging/**
           if-no-files-found: error
 
+  # ARM musl is cross-compiled from x86, so we can't smoke test it in the build job.
+  # GitHub Actions' JS-based actions (like actions/checkout) don't work in Alpine
+  # containers on ARM runners, so we can't use a container there either.
+  # Instead, we run a separate job on a native ARM runner to verify the binary works.
+  test-arm-musl:
+    name: Test ARM musl binary
+    needs:
+      - prepare
+      - build
+    if: needs.prepare.outputs.should_run == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2204-arm
+    timeout-minutes: 5
+    steps:
+      - name: Download ARM musl archive
+        uses: actions/download-artifact@v4
+        with:
+          name: baml-language-archive-aarch64-unknown-linux-musl
+          path: dist
+
+      - name: Extract and test
+        run: |
+          set -euo pipefail
+          tar -xzf dist/*.tar.gz
+          ./baml-cli --version
+
+  # Windows ARM is cross-compiled from x86, so we can't smoke test it in the build job.
+  # Run a separate job on a native Windows ARM runner to verify the binary works.
+  test-windows-arm:
+    name: Test Windows ARM binary
+    needs:
+      - prepare
+      - build
+    if: needs.prepare.outputs.should_run == 'true'
+    runs-on: windows-11-arm
+    timeout-minutes: 5
+    steps:
+      - name: Download Windows ARM archive
+        uses: actions/download-artifact@v4
+        with:
+          name: baml-language-archive-aarch64-pc-windows-msvc
+          path: dist
+
+      - name: Extract and test
+        shell: pwsh
+        run: |
+          Expand-Archive -Path dist\*.zip -DestinationPath .
+          .\baml-cli.exe --version
+
   publish:
     name: Publish Release
     needs:
       - prepare
       - build
+      - test-arm-musl
+      - test-windows-arm
     if: needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.publish == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15
@@ -354,7 +452,11 @@ jobs:
               "aarch64-apple-darwin",
               "x86_64-apple-darwin",
               "x86_64-unknown-linux-gnu",
+              "aarch64-unknown-linux-gnu",
+              "x86_64-unknown-linux-musl",
+              "aarch64-unknown-linux-musl",
               "x86_64-pc-windows-msvc",
+              "aarch64-pc-windows-msvc",
           }
           missing = expected - target_assets.keys()
           if missing:

--- a/.github/workflows/release-baml-language-alpha.yml
+++ b/.github/workflows/release-baml-language-alpha.yml
@@ -526,3 +526,103 @@ jobs:
           }, indent=2, sort_keys=True) + "\n")
           PY
           gh api --method POST repos/BoundaryML/homebrew-baml/dispatches --input repository-dispatch.json
+
+  # AUR pkgver can't contain hyphens, so we convert 0.11.0-alpha.602 to 0.11.0.alpha.602.
+  # When we exit alpha and use stable semver (e.g. 0.11.0), this conversion becomes a no-op.
+  publish-to-aur:
+    name: Publish to AUR
+    needs:
+      - prepare
+      - publish
+    if: needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download release assets
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+
+          curl -fSL -o artifacts/x86_64.tar.gz \
+            "https://github.com/BoundaryML/baml/releases/download/baml-language-${VERSION}/baml-language-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fSL -o artifacts/aarch64.tar.gz \
+            "https://github.com/BoundaryML/baml/releases/download/baml-language-${VERSION}/baml-language-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+          curl -fSL -o artifacts/source.tar.gz \
+            "https://github.com/BoundaryML/baml/archive/refs/tags/baml-language-${VERSION}.tar.gz"
+
+          echo "SHA256_X86_64=$(sha256sum artifacts/x86_64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          echo "SHA256_AARCH64=$(sha256sum artifacts/aarch64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          echo "SHA256_SOURCE=$(sha256sum artifacts/source.tar.gz | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+      - name: Install makepkg
+        run: sudo apt-get update && sudo apt-get install -y pacman-package-manager
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.AUR_SSH_PRIVATE_KEY }}" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts
+          cat >> ~/.ssh/config << 'EOF'
+          Host aur.archlinux.org
+            IdentityFile ~/.ssh/aur
+            User aur
+          EOF
+
+      - name: Push baml-bin
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          VERSION_AUR="${VERSION//-/.}"  # AUR pkgver can't have hyphens
+
+          git clone ssh://aur@aur.archlinux.org/baml-bin.git aur-bin
+          cd aur-bin
+
+          cp ../packaging/aur/baml-bin/PKGBUILD .
+          sed -i "s/__VERSION__/${VERSION_AUR}/g" PKGBUILD
+          sed -i "s/__VERSION_ORIG__/${VERSION}/g" PKGBUILD
+          sed -i "s/__SHA256_X86_64__/${SHA256_X86_64}/g" PKGBUILD
+          sed -i "s/__SHA256_AARCH64__/${SHA256_AARCH64}/g" PKGBUILD
+
+          makepkg --printsrcinfo > .SRCINFO
+
+          git config user.name "BoundaryML Bot"
+          git config user.email "aur@boundaryml.com"
+          git add PKGBUILD .SRCINFO
+          if ! git diff --cached --quiet; then
+            git commit -m "Update to ${VERSION_AUR}"
+            git push
+          else
+            echo "No changes to commit for baml-bin"
+          fi
+
+      - name: Push baml
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          VERSION_AUR="${VERSION//-/.}"  # AUR pkgver can't have hyphens
+
+          git clone ssh://aur@aur.archlinux.org/baml.git aur-src
+          cd aur-src
+
+          cp ../packaging/aur/baml/PKGBUILD .
+          sed -i "s/__VERSION__/${VERSION_AUR}/g" PKGBUILD
+          sed -i "s/__VERSION_ORIG__/${VERSION}/g" PKGBUILD
+          sed -i "s/__SHA256__/${SHA256_SOURCE}/g" PKGBUILD
+
+          makepkg --printsrcinfo > .SRCINFO
+
+          git config user.name "BoundaryML Bot"
+          git config user.email "aur@boundaryml.com"
+          git add PKGBUILD .SRCINFO
+          if ! git diff --cached --quiet; then
+            git commit -m "Update to ${VERSION_AUR}"
+            git push
+          else
+            echo "No changes to commit for baml"
+          fi

--- a/.github/workflows/release-baml-language-alpha.yml
+++ b/.github/workflows/release-baml-language-alpha.yml
@@ -538,6 +538,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
 
       - name: Download release assets
         env:

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -56,7 +56,7 @@ toml = { workspace = true }
 zip = { workspace = true }
 
 [features]
-default = [ "native-tls", "aws-crypto" ]
+default = [ "aws-crypto" ]
 aws-crypto = [ "baml_lsp_server/aws-crypto", "bex_engine/aws-crypto", "sys_native/aws-crypto" ]
 ring-crypto = [ "baml_lsp_server/ring-crypto", "bex_engine/ring-crypto", "sys_native/ring-crypto" ]
 native-tls = [ "baml_lsp_server/native-tls" ]

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -633,7 +633,6 @@ fn release_host_target_triple() -> Result<&'static str> {
         ("linux", "aarch64", false) => Ok("aarch64-unknown-linux-gnu"),
         ("linux", "x86_64", true) => Ok("x86_64-unknown-linux-musl"),
         ("linux", "x86_64", false) => Ok("x86_64-unknown-linux-gnu"),
-        ("windows", "aarch64", _) => Ok("aarch64-pc-windows-msvc"),
         ("windows", "x86_64", _) => Ok("x86_64-pc-windows-msvc"),
         (os, arch, _) => anyhow::bail!(
             "No released `baml-pack-host` artifact is available for {arch}-{os}. \
@@ -660,7 +659,6 @@ const SUPPORTED_PACK_TARGETS: &[&str] = &[
     "aarch64-unknown-linux-musl",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
-    "aarch64-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
 ];
 

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -621,12 +621,21 @@ fn release_archive_filename(version: &str, target: &str) -> String {
 }
 
 fn release_host_target_triple() -> Result<&'static str> {
-    match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
-        ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
-        ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu"),
-        ("windows", "x86_64") => Ok("x86_64-pc-windows-msvc"),
-        (os, arch) => anyhow::bail!(
+    #[cfg(target_env = "musl")]
+    const IS_MUSL: bool = true;
+    #[cfg(not(target_env = "musl"))]
+    const IS_MUSL: bool = false;
+
+    match (std::env::consts::OS, std::env::consts::ARCH, IS_MUSL) {
+        ("macos", "aarch64", _) => Ok("aarch64-apple-darwin"),
+        ("macos", "x86_64", _) => Ok("x86_64-apple-darwin"),
+        ("linux", "aarch64", true) => Ok("aarch64-unknown-linux-musl"),
+        ("linux", "aarch64", false) => Ok("aarch64-unknown-linux-gnu"),
+        ("linux", "x86_64", true) => Ok("x86_64-unknown-linux-musl"),
+        ("linux", "x86_64", false) => Ok("x86_64-unknown-linux-gnu"),
+        ("windows", "aarch64", _) => Ok("aarch64-pc-windows-msvc"),
+        ("windows", "x86_64", _) => Ok("x86_64-pc-windows-msvc"),
+        (os, arch, _) => anyhow::bail!(
             "No released `baml-pack-host` artifact is available for {arch}-{os}. \
              Install `baml-pack-host` next to the `baml` binary to use `baml pack` on this platform."
         ),
@@ -634,22 +643,24 @@ fn release_host_target_triple() -> Result<&'static str> {
 }
 
 fn validate_release_target_triple(target: &str) -> Result<&str> {
-    match target {
-        "aarch64-apple-darwin"
-        | "x86_64-apple-darwin"
-        | "x86_64-unknown-linux-gnu"
-        | "x86_64-pc-windows-msvc" => Ok(target),
-        _ => anyhow::bail!(
+    if SUPPORTED_PACK_TARGETS.contains(&target) {
+        Ok(target)
+    } else {
+        anyhow::bail!(
             "Unsupported pack target `{target}`. Supported targets: {}",
             SUPPORTED_PACK_TARGETS.join(", ")
-        ),
+        )
     }
 }
 
 const SUPPORTED_PACK_TARGETS: &[&str] = &[
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
     "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
 ];
 

--- a/packaging/aur/baml-bin/PKGBUILD
+++ b/packaging/aur/baml-bin/PKGBUILD
@@ -1,0 +1,19 @@
+pkgname=baml-bin
+pkgver=__VERSION__
+pkgrel=1
+pkgdesc="BAML - the language for agents (prebuilt binary)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/BoundaryML/baml"
+license=('Apache-2.0')
+provides=('baml')
+conflicts=('baml')
+
+source_x86_64=("https://github.com/BoundaryML/baml/releases/download/baml-language-__VERSION_ORIG__/baml-language-__VERSION_ORIG__-x86_64-unknown-linux-gnu.tar.gz")
+source_aarch64=("https://github.com/BoundaryML/baml/releases/download/baml-language-__VERSION_ORIG__/baml-language-__VERSION_ORIG__-aarch64-unknown-linux-gnu.tar.gz")
+sha256sums_x86_64=('__SHA256_X86_64__')
+sha256sums_aarch64=('__SHA256_AARCH64__')
+
+package() {
+    install -Dm755 baml-cli "$pkgdir/usr/bin/baml-cli"
+    ln -s baml-cli "$pkgdir/usr/bin/baml"
+}

--- a/packaging/aur/baml/PKGBUILD
+++ b/packaging/aur/baml/PKGBUILD
@@ -12,6 +12,12 @@ conflicts=('baml-bin')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/BoundaryML/baml/archive/refs/tags/baml-language-__VERSION_ORIG__.tar.gz")
 sha256sums=('__SHA256__')
 
+prepare() {
+    cd "baml-baml-language-__VERSION_ORIG__/baml_language"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked
+}
+
 build() {
     cd "baml-baml-language-__VERSION_ORIG__/baml_language"
     export RUSTUP_TOOLCHAIN=stable

--- a/packaging/aur/baml/PKGBUILD
+++ b/packaging/aur/baml/PKGBUILD
@@ -1,0 +1,26 @@
+pkgname=baml
+pkgver=__VERSION__
+pkgrel=1
+pkgdesc="BAML - the language for agents (built from source)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/BoundaryML/baml"
+license=('Apache-2.0')
+makedepends=('rust' 'cargo' 'cmake' 'gcc')
+provides=('baml')
+conflicts=('baml-bin')
+
+source=("$pkgname-$pkgver.tar.gz::https://github.com/BoundaryML/baml/archive/refs/tags/baml-language-__VERSION_ORIG__.tar.gz")
+sha256sums=('__SHA256__')
+
+build() {
+    cd "baml-baml-language-__VERSION_ORIG__/baml_language"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --release --frozen --bin baml-cli
+}
+
+package() {
+    cd "baml-baml-language-__VERSION_ORIG__/baml_language"
+    install -Dm755 "target/release/baml-cli" "$pkgdir/usr/bin/baml-cli"
+    ln -s baml-cli "$pkgdir/usr/bin/baml"
+}


### PR DESCRIPTION
## Summary
- Adds `aarch64-unknown-linux-gnu` (ARM glibc) using Blacksmith ARM runners
- Adds `x86_64-unknown-linux-musl` (x86 musl/Alpine)
- Adds `aarch64-unknown-linux-musl` (ARM musl/Alpine)

## Test plan
- [ ] Manually trigger workflow on this branch with `publish_github_release: false`
- [ ] Verify all 7 targets build successfully
- [ ] Follow-up: update homebrew-baml formula to add ARM Linux support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arch Linux packaging (binaries and source) and automated publish-to-AUR for releases.
  * CLI packaging expanded to additional Linux targets (aarch64 & x86_64 musl/gnu) and Windows aarch64; pack command distinguishes musl vs gnu.

* **Chores**
  * Release pipeline expanded to build native and cross artifacts for new targets and will fail if expected assets are missing.
  * CLI default features reduced to enable only aws-crypto.

* **Tests**
  * Added native ARM MUSL validation job that runs built artifacts before publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->