### PR TITLE
chore(baml_language): bump salsa to 0.26.2 (crates.io)

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -3988,6 +3988,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -6986,14 +6991,15 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa"
-version = "0.24.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=cdd0b85516a52c18b8a6d17a2279a96ed6c3e198#cdd0b85516a52c18b8a6d17a2279a96ed6c3e198"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4612ff789805e65c87e9b38cb749a293212a615af065bed8a2001086801498c3"
 dependencies = [
  "boxcar",
  "compact_str 0.9.0",
  "crossbeam-queue",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "hashlink",
  "indexmap 2.14.0",
  "intrusive-collections",
@@ -7006,17 +7012,20 @@ dependencies = [
  "smallvec",
  "thin-vec",
  "tracing",
+ "typeid",
 ]
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.24.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=cdd0b85516a52c18b8a6d17a2279a96ed6c3e198#cdd0b85516a52c18b8a6d17a2279a96ed6c3e198"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e354cbac6939b9b09cd9c11fb419a53e64b4a0f755d929f56a09f4cc752e41"
 
 [[package]]
 name = "salsa-macros"
-version = "0.24.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=cdd0b85516a52c18b8a6d17a2279a96ed6c3e198#cdd0b85516a52c18b8a6d17a2279a96ed6c3e198"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3067861075c2b80608f84ad49fb88f2c7610b94cdf8b4201e79ddee87f8980c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8499,6 +8508,12 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.2",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -175,7 +175,7 @@ reqwest = { version = "0.13.1", default-features = false, features = [
 rowan = { version = "0.16" }
 rustls = { version = "0.23.37", default-features = false }
 rustc-hash = { version = "2.1" }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "cdd0b85516a52c18b8a6d17a2279a96ed6c3e198", default-features = false, features = [
+salsa = { version = "0.26", default-features = false, features = [
   "compact_str",
   "macros",
   "salsa_unstable",

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -21,14 +21,15 @@ pub use trivia_classifier::{EmittableTrivia, TriviaInfo};
 pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatterError> {
     let mut db = ProjectDatabase::new();
     let source_file = db.add_file("file.baml", source);
-    format_salsa(&db, source_file, options)
+    format_salsa(&db, source_file, *options)
 }
 
 #[salsa::tracked]
+#[allow(clippy::drop_non_drop)] // salsa macro expands to drop() of the args tuple
 pub fn format_salsa(
     db: &dyn salsa::Database,
     file: baml_db::SourceFile,
-    options: &'_ FormatOptions,
+    options: FormatOptions,
 ) -> Result<String, FormatterError> {
     let tokens = baml_compiler_lexer::lex_file(db, file);
     let (parsed, errors) = baml_compiler_parser::parse_file(&tokens);
@@ -40,7 +41,7 @@ pub fn format_salsa(
     let trivia = TriviaInfo::classify_trivia(&cst);
     let strong_ast = ast::SourceFile::from_cst(SyntaxElement::Node(cst))?;
 
-    let mut printer = Printer::new_empty(file.text(db), options, &trivia);
+    let mut printer = Printer::new_empty(file.text(db), &options, &trivia);
     printer.print(
         &strong_ast,
         Shape {
@@ -52,7 +53,7 @@ pub fn format_salsa(
     Ok(printer.output)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FormatOptions {
     /// Maximum line width before wrapping kicks in. Default: `100`
     pub line_width: usize,

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -4055,7 +4055,7 @@ impl CompilerRunner {
 
             // Format the source code using baml_fmt
             let format_options = baml_fmt::FormatOptions::default();
-            match baml_fmt::format_salsa(&self.db, *source_file, &format_options) {
+            match baml_fmt::format_salsa(&self.db, *source_file, format_options) {
                 Ok(formatted) => {
                     writeln!(output, "{}", formatted).ok();
                     let status = if file_recomputed {


### PR DESCRIPTION
## Summary

- Switch salsa from a pre-0.25.0 git rev (`cdd0b85`) to the published **0.26.2** release on crates.io. That's 55 upstream commits, spanning v0.25.0 → v0.25.1 → v0.25.2 → v0.26.0 → v0.26.1 → v0.26.2.
- Only one API break: salsa 0.26 no longer accepts `&'_ T` as a tracked-function arg (the lifetime can't outlive `'static`). `format_salsa` now takes `FormatOptions` by value; `FormatOptions` is now `Copy` (it's two `usize`s).
- One `#[allow(clippy::drop_non_drop)]` on `format_salsa` for a warning from inside salsa's own macro expansion (`drop()` of the args tuple).

## Why

The pinned git rev was from Feb 2026, pre-0.25.0. Moving to crates.io gets us:

- 55 upstream commits of bug fixes (mostly around cycle correctness — `#1068`, `#1050`, `#1061`).
- Reduced monomorphization in `maybe_changed_after` / `execute_maybe_iterate` (`#1046`, `#1047`) — modest compile-time win.
- Opt-in access to `CancellationToken` (`#1007`) — useful for the LSP.
- Compile-time LRU opt-out via `#[salsa::tracked(no_lru)]` (`#1051`).

No headline runtime perf change.

## Test plan

- [x] `cargo check --workspace --no-default-features --features ring-crypto --all-targets`
- [x] `cargo nextest r --no-fail-fast --no-default-features --features ring-crypto` — all 5630 tests pass
- [x] `cargo clippy -p baml_fmt --all-targets` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to the latest stable release for improved compatibility and performance
  * Refactored internal formatter handling for improved code structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->