### PR TITLE
fix(ci): drop aarch64-pc-windows-msvc from baml_language release validator

### DIFF
--- a/.github/workflows/release-baml-language-alpha.yml
+++ b/.github/workflows/release-baml-language-alpha.yml
@@ -415,7 +415,6 @@ jobs:
               "x86_64-unknown-linux-musl",
               "aarch64-unknown-linux-musl",
               "x86_64-pc-windows-msvc",
-              "aarch64-pc-windows-msvc",
           }
           missing = expected - target_assets.keys()
           if missing:


### PR DESCRIPTION
## Summary
- #3559 added `aarch64-pc-windows-msvc` to the expected-targets set in `release-baml-language-alpha.yml` but no matching matrix entry actually builds it, so the publish step fails with `missing release assets for ['aarch64-pc-windows-msvc']`.
- We've decided not to ship arm64 Windows, so this just drops the target from the validator set.

## Test plan
- [ ] Next baml_language alpha release run reaches the publish step without the `missing release assets` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release artifact validation to support Windows x86_64 builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->