### PR TITLE
sdk_tests: move nodejs_typescript pnpm setup out of build.rs into set…

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -309,13 +309,6 @@ jobs:
       - name: "Install uv"
         uses: astral-sh/setup-uv@v5
 
-      # `cargo test --no-run` drives each sdk_test crate's build.rs,
-      # which is where the editable `baml_core` install + per-fixture
-      # `uv sync` / `pnpm install` happens (serially, once). Failures
-      # there are recorded into `$OUT_DIR/build_diagnostics.txt`
-      # instead of aborting the build — they surface via the
-      # `build_diagnostics::no_build_failures` test in the run-step
-      # below. See `sdk_tests/build/src/lib.rs::BuildDiagnostics`.
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
         working-directory: baml_language

--- a/baml_language/.config/nextest.toml
+++ b/baml_language/.config/nextest.toml
@@ -1,0 +1,11 @@
+nextest-version = "0.9.98"
+
+experimental = ["setup-scripts"]
+
+# nodejs tests need `.node` addon. build it, install fixtures. fire only when nodejs test selected.
+[scripts.setup.nodejs_typescript_pnpm]
+command = './sdk_tests/crates/nodejs_typescript/setup.sh'
+
+[[profile.default.scripts]]
+filter = 'package(=sdk_test_nodejs_typescript)'
+setup = 'nodejs_typescript_pnpm'

--- a/baml_language/sdk_tests/README.md
+++ b/baml_language/sdk_tests/README.md
@@ -11,11 +11,14 @@ SDKs no matter the output language.
 Codegen runs in each crate's `build.rs` via the full
 `baml_project::build_symbol_pool` pipeline (parse → HIR → TIR →
 `SymbolPool` → emitter), mirroring the path `baml-cli generate`
-takes end-to-end. Each build script also runs `uv sync` /
-`pnpm install` once per fixture so the toolchain commands fired
-by the `#[test]`s only have to do read-only work against an
-already-populated tree. Build-script failures (missing tool,
-codegen panic, install non-zero exit) are recorded to
+takes end-to-end. python_pydantic2's build.rs also runs `uv sync`
+once per fixture. nodejs_typescript splits that out: the
+per-fixture `pnpm install` and the prereq `pnpm build:debug` of
+bridge_nodejs's native `.node` addon live in
+[`crates/nodejs_typescript/setup.sh`](./crates/nodejs_typescript/setup.sh) —
+run it once after `cargo test --no-run` (or `cargo build`).
+Build-script failures (missing tool, codegen panic, install
+non-zero exit, codegen file write errors) are recorded to
 `$OUT_DIR/build_diagnostics.txt` rather than aborted, and surface
 as a `build_diagnostics::no_build_failures` test (see
 [Soft-fail build.rs](#soft-fail-buildrs) below). Each build also
@@ -54,7 +57,21 @@ Targets in tree:
   panics: every fixture records a `codegen` diagnostic and
   `baml_sdk/` stays empty, so the toolchain commands can't pass.
   Drop the `#[ignore]`s when the emitter lands (`IGNORE_REASON` in
-  `sdk_tests/harness_setup/src/nodejs_typescript.rs`).
+  `sdk_tests/harness_setup/src/nodejs_typescript.rs`). The native
+  `.node` addon build and per-fixture `pnpm install` live in
+  [`crates/nodejs_typescript/setup.sh`](./crates/nodejs_typescript/setup.sh)
+  rather than build.rs. `cargo nextest run` invokes setup.sh
+  automatically (configured as a nextest setup-script binding in
+  [`baml_language/.config/nextest.toml`](../.config/nextest.toml)),
+  so the common run flow is just:
+
+  ```bash
+  cargo nextest run -p sdk_test_nodejs_typescript
+  ```
+
+  For plain `cargo test`, run setup.sh manually between
+  `cargo test --no-run` and `cargo test`. Re-run after bridge_nodejs
+  Rust changes or after adding a new fixture.
 
 ```bash
 # Run every Python+pydantic2 test across all fixtures
@@ -126,6 +143,7 @@ sdk_tests/
         │                                 # [build-dependencies] sdk_test_harness_setup
         │                                 # [dev-dependencies]   sdk_test_harness_runner
         ├── build.rs                      # one-liner → sdk_test_harness_setup::nodejs_typescript::run_all()
+        ├── setup.sh                      # pnpm build:debug (bridge_nodejs) + per-fixture pnpm install
         ├── src/lib.rs                    # invokes sdk_test_harness_runner::nodejs_typescript::test_suite!()
         ├── docstrings_etc/
         │   ├── customizable/             # tracked: *.test.ts — copied into generated/
@@ -180,12 +198,17 @@ sdk_tests/
    - Writes `crates/<generator>/<fixture>/generated/pyproject.toml`
      (or `package.json` + `tsconfig.json` for `nodejs_typescript`)
      with the per-fixture package name.
-   - Runs `uv sync` / `pnpm install` inside the generated dir,
+   - For python_pydantic2: runs `uv sync` inside the generated dir,
      serially per fixture. uv's editable install of `baml_core`
      (declared in `[tool.uv.sources]`) triggers the maturin build
-     of `bridge_python` once per fixture; pnpm populates
-     `node_modules/` from the shared `target/pnpm-store/`. Tests
-     then only do read-only work against the populated tree.
+     of `bridge_python` once per fixture.
+   - For nodejs_typescript: pnpm side is OUT of build.rs. The
+     per-fixture `pnpm install` and the prereq `pnpm build:debug`
+     of bridge_nodejs's native `.node` addon live in
+     `crates/nodejs_typescript/setup.sh`, run separately after
+     `cargo test --no-run`. Populates `node_modules/` from the
+     shared `target/pnpm-store/`. Tests then only do read-only
+     work against the populated tree.
    - Emits `OUT_DIR/<generator>_tests.rs` — a generated source file
      containing a `::sdk_test_harness_runner::build_diagnostics!(...)` macro
      invocation at the top followed by one `mod <fixture> { … }`
@@ -215,11 +238,13 @@ sdk_tests/
 ### Soft-fail build.rs
 
 `uv` / `pnpm` aren't required to *build* the workspace — only to
-*test* the SDK targets. Each generator's `build.rs` records
-env-dependent failures (missing tool, `to_source_code` panic, `uv
-sync` / `pnpm install` non-zero exit, codegen file write errors)
-to `$OUT_DIR/build_diagnostics.txt` and exits 0 instead of
-aborting. The `sdk_test_harness_runner::build_diagnostics!` macro expands
+*test* the SDK targets. python_pydantic2's `build.rs` records
+env-dependent failures (missing `uv`, `to_source_code` panic, `uv
+sync` non-zero exit, codegen file write errors) to
+`$OUT_DIR/build_diagnostics.txt` and exits 0 instead of aborting.
+nodejs_typescript's `build.rs` only does codegen + scaffold emit
+(no pnpm), so the soft-fail set is just codegen/write errors;
+pnpm failures hard-fail in `setup.sh` instead. The `sdk_test_harness_runner::build_diagnostics!` macro expands
 to a `mod build_diagnostics { #[test] fn no_build_failures }` that
 reads the file and fails with the records. `sdk_test_harness_setup`'s
 scaffold emitter stamps one invocation per generator scaffold —

--- a/baml_language/sdk_tests/crates/nodejs_typescript/Cargo.toml
+++ b/baml_language/sdk_tests/crates/nodejs_typescript/Cargo.toml
@@ -1,14 +1,3 @@
-# Node.js + TypeScript sdk-test crate. Mirrors python_pydantic2's
-# shape: fans out across every fixture under
-# `sdk_tests/fixtures/<fixture>/baml_src/`, codegens into
-# `<fixture>/generated/baml_sdk/`, and emits per-fixture `tsc` /
-# `jest` toolchain tests plus the shared
-# `build_diagnostics::no_build_failures` test. The generated
-# package.json file:-points at `sdks/nodejs/bridge_nodejs`, and
-# sdk_test_harness_setup's run_all runs `pnpm build:debug` there
-# as a prereq before per-fixture `pnpm install` (so the native
-# `.node` addon is present at jest time). The workspace
-# `pnpm install` (at repo root) must have been run once first.
 [package]
 name = "sdk_test_nodejs_typescript"
 version = "0.1.0"

--- a/baml_language/sdk_tests/crates/nodejs_typescript/setup.sh
+++ b/baml_language/sdk_tests/crates/nodejs_typescript/setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Per-fixture pnpm setup for the sdk_test_nodejs_typescript crate.
+#
+# Invoked automatically by `cargo nextest run` via the setup-script
+# binding in `baml_language/.config/nextest.toml` — whenever the run
+# selects any sdk_test_nodejs_typescript test. For plain `cargo test`
+# (no nextest) run this manually after `cargo test --no-run` populates
+# each fixture's `generated/package.json`.
+#
+# This script turns those generated/ dirs into a real `node_modules/`
+# tree and builds the native `.node` addon each fixture `file:`-links
+# to. Idempotent — re-runs are no-ops in steady state. Re-run after
+# bridge_nodejs Rust changes (addon is stale) or after adding a new
+# fixture.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"  # baml_language/sdk_tests/crates/nodejs_typescript
+
+WORKSPACE_ROOT="$(cd ../../.. && pwd)"
+BRIDGE_NODEJS="$WORKSPACE_ROOT/sdks/nodejs/bridge_nodejs"
+
+# Shared pnpm store under target/ so per-fixture installs hardlink from
+# one location rather than fetching N copies.
+export npm_config_store_dir="$WORKSPACE_ROOT/target/pnpm-store"
+mkdir -p "$npm_config_store_dir"
+
+# 1. Native `.node` addon. `pnpm build:debug` chains build:proto →
+#    build:napi-debug → build:ts_build → build:tag-generated-files; all
+#    incremental, no-op steady-state is cheap. Skipping this step makes
+#    every per-fixture jest fail with "Cannot find module
+#    './baml_node.<triple>.node'".
+#
+#    We do NOT `pnpm install` here — bridge_nodejs is a member of the
+#    repo-root pnpm-workspace.yaml. `pnpm install --ignore-workspace`
+#    inside it would wipe the workspace-installed `node_modules/` and
+#    reinstall with broken peer-dep resolution. If `node_modules/` is
+#    missing, `build:debug` fails with `pbjs: command not found` —
+#    that's the cue to run `pnpm install` at the repo root once.
+echo "==> pnpm build:debug in sdks/nodejs/bridge_nodejs"
+(cd "$BRIDGE_NODEJS" && pnpm build:debug)
+
+# 2. Per-fixture `pnpm install`. `--ignore-workspace` is required so pnpm
+#    doesn't walk up to the repo-root workspace and skip the install.
+#    The per-fixture `package.json` `file:`-points at bridge_nodejs, so
+#    the install resolves the dev toolchain (jest, ts-jest, typescript)
+#    plus the `@boundaryml/baml-node` runtime dep against the addon we
+#    just built.
+for fixture_dir in */generated; do
+    [[ -d "$fixture_dir" ]] || continue
+    echo "==> pnpm install in $fixture_dir"
+    (cd "$fixture_dir" && pnpm install --ignore-workspace)
+done

--- a/baml_language/sdk_tests/harness_setup/src/nodejs_typescript.rs
+++ b/baml_language/sdk_tests/harness_setup/src/nodejs_typescript.rs
@@ -13,12 +13,24 @@
 //! `build_diagnostics::no_build_failures`) is `#[ignore]`d on this
 //! crate while the stub stays in place — see [`IGNORE_REASON`].
 //!
-//! `pnpm install` runs in `build.rs` (serially, once per fixture)
-//! rather than from each `#[test]`; that's the only way to keep
-//! parallel test processes from racing on each fixture's
-//! `node_modules/.pnpm/` virtual store.
+//! **pnpm steps live in
+//! `sdk_tests/crates/nodejs_typescript/setup.sh`**, NOT in build.rs.
+//! `cargo nextest run` invokes setup.sh automatically via the
+//! setup-script binding in `baml_language/.config/nextest.toml`:
 //!
-//! Same auto-discovery story as `python_pydantic2`: build.rs emits
+//! ```sh
+//! cd baml_language
+//! cargo nextest run -p sdk_test_nodejs_typescript
+//! ```
+//!
+//! For plain `cargo test` (no nextest), run setup.sh manually
+//! between `cargo test --no-run` and `cargo test`. Re-run setup.sh
+//! when bridge_nodejs's Rust source changes (the `.node` addon needs
+//! rebuilding) or when adding a new fixture. build.rs's job is just
+//! codegen + scaffold emit — it writes the per-fixture
+//! `package.json` / `tsconfig.json` that setup.sh consumes.
+//!
+//! Auto-discovery story: build.rs emits
 //! `OUT_DIR/nodejs_typescript_tests.rs` (a sequence of
 //! `::sdk_test_harness_runner::*` invocations), the
 //! `sdk_test_harness_runner::nodejs_typescript::test_suite!()` macro
@@ -28,18 +40,15 @@
 //! `sdk_tests/crates/nodejs_typescript/<name>/`.
 
 use std::{
-    env, fs,
-    io::ErrorKind,
-    panic,
+    env, fs, panic,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use codegen_nodejs::NamingConvention;
 
 use crate::{
     BuildDiagnostics, copy_customizable, discover_fixtures, fixtures_root_from_manifest,
-    load_fixture, watch_dir, workspace_root_from_manifest,
+    load_fixture, watch_dir,
 };
 
 /// Reason string stamped onto every nodejs_typescript test's
@@ -52,12 +61,13 @@ use crate::{
 pub const IGNORE_REASON: &str = "codegen_nodejs is a stub; re-enable once the emitter lands";
 
 /// Per-fixture package.json. `__PACKAGE_NAME__` is substituted per
-/// fixture. `pnpm install` resolves the dev toolchain (jest +
-/// ts-jest + typescript + types); the BAML runtime dep on
-/// `@boundaryml/baml-node` (which would point at
-/// `sdks/nodejs/bridge_nodejs` via a `file:` source) is deliberately
-/// omitted while codegen_nodejs is a stub — adding it would force a
-/// NAPI build per fixture for no test value.
+/// fixture. The dev toolchain (jest + ts-jest + typescript + types)
+/// plus the BAML runtime dep on `@boundaryml/baml-node` (which
+/// `file:`-points at the bridge_nodejs source tree five levels up:
+/// `crates/nodejs_typescript/<F>/generated/` →
+/// `crates/nodejs_typescript/<F>/` → `crates/nodejs_typescript/` →
+/// `crates/` → `sdk_tests/` → `baml_language/`) is resolved by
+/// `setup.sh`'s per-fixture `pnpm install`.
 ///
 /// `haste.enableSymlinks = true` + `watchman = false` are required:
 /// `customizable/*.test.ts` files are symlinked into the generated
@@ -81,19 +91,19 @@ const PACKAGE_JSON_TEMPLATE: &str = include_str!("templates/package.json");
 /// `<F>/generated/node_modules/`.
 const TSCONFIG_JSON: &str = include_str!("templates/tsconfig.json");
 
-// `pnpm install --ignore-workspace` is required because the repo has
-// a top-level `pnpm-workspace.yaml` (at `/Users/sam/baml3/`); without
-// the flag pnpm walks up to that workspace and skips installing into
-// the fixture dir entirely. `ignore-workspace` is a CLI flag in
-// pnpm — it isn't an .npmrc setting, so it has to live on the
-// command rather than the per-fixture config.
-
+/// Shared pnpm store dir (`<workspace>/target/<CACHE_SUBDIR>`) —
+/// `setup.sh` exports `CACHE_ENV_VAR=<that path>` during install, and
+/// `sdk_test_harness_runner::run_test_cmd` sets the same env var when
+/// invoking tsc/jest. Harmless for tsc/jest (they don't read pnpm
+/// config) but keeps the harness_runner API uniform with python's uv
+/// cache plumbing.
 const CACHE_SUBDIR: &str = "pnpm-store";
 const CACHE_ENV_VAR: &str = "npm_config_store_dir";
 
 /// Entry point for `crates/nodejs_typescript/build.rs`. Discovers
 /// fixtures, runs codegen for each (best-effort — see module docs),
-/// writes templates, and emits the per-fixture test scaffold.
+/// writes templates, and emits the per-fixture test scaffold. Does
+/// NOT touch pnpm — that's setup.sh's job (see module docs).
 pub fn run_all() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let fixtures_root = fixtures_root_from_manifest(&manifest_dir);
@@ -112,23 +122,6 @@ pub fn run_all() {
         codegen_fixture(&fixtures_root, fixture, &manifest_dir, &mut diagnostics);
     }
 
-    // `pnpm install` is done here in build.rs, serially per fixture, so
-    // the parallel `#[test]` processes don't race on each fixture's
-    // `.pnpm` virtual store (pnpm's per-project install isn't safe under
-    // concurrent invocations into the same `node_modules/`). The tests
-    // themselves only run `tsc` / `jest`, which are read-only against
-    // an already-populated tree.
-    let store_dir = workspace_root_from_manifest(&manifest_dir)
-        .join("target")
-        .join(CACHE_SUBDIR);
-    fs::create_dir_all(&store_dir).unwrap();
-    for fixture in &fixtures {
-        let generated_dir = manifest_dir.join(fixture).join("generated");
-        if let Err(msg) = pnpm_install(&generated_dir, &store_dir) {
-            diagnostics.record("pnpm_install", fixture, msg);
-        }
-    }
-
     write_fixtures_tests_rs(&out_dir, &fixtures);
     diagnostics.finalize();
 
@@ -137,38 +130,6 @@ pub fn run_all() {
     for fixture in &fixtures {
         watch_dir(&manifest_dir.join(fixture).join("customizable"));
     }
-}
-
-fn pnpm_install(generated_fixture_dir: &Path, store_dir: &Path) -> Result<(), String> {
-    let spawn = Command::new("pnpm")
-        .args(["install", "--ignore-workspace"])
-        .current_dir(generated_fixture_dir)
-        .env(CACHE_ENV_VAR, store_dir)
-        .output();
-    let output = match spawn {
-        Ok(o) => o,
-        Err(e) if e.kind() == ErrorKind::NotFound => {
-            return Err(format!(
-                "spawn failed: `pnpm` not on PATH ({e})\nhint: install pnpm (https://pnpm.io) or via corepack"
-            ));
-        }
-        Err(e) => {
-            return Err(format!(
-                "failed to spawn `pnpm install` in {}: {e}",
-                generated_fixture_dir.display()
-            ));
-        }
-    };
-    if !output.status.success() {
-        return Err(format!(
-            "pnpm install failed in {} (exit {}):\nstdout: {}\nstderr: {}",
-            generated_fixture_dir.display(),
-            output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    Ok(())
 }
 
 fn codegen_fixture(


### PR DESCRIPTION
…up.sh, invoked by nextest setup-script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Node.js/TypeScript SDK test setup workflow by moving initialization steps outside of build-time execution.
  * Updated test infrastructure configuration and documentation to reflect the new setup process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->