### PR TITLE
test: fix node sdk_tests on windows

### DIFF
--- a/baml_language/.config/nextest.toml
+++ b/baml_language/.config/nextest.toml
@@ -2,10 +2,22 @@ nextest-version = "0.9.98"
 
 experimental = ["setup-scripts"]
 
-# nodejs tests need `.node` addon. build it, install fixtures. fire only when nodejs test selected.
-[scripts.setup.nodejs_typescript_pnpm]
+# nodejs tests need `.node` addon. build it, install fixtures. fire only
+# when a nodejs_typescript test is selected. setup.sh / setup.ps1 are
+# byte-for-byte equivalent — same pnpm steps in the host shell of each
+# platform.
+[scripts.setup.nodejs_typescript_pnpm_unix]
 command = './sdk_tests/crates/nodejs_typescript/setup.sh'
+
+[scripts.setup.nodejs_typescript_pnpm_win]
+command = ['powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', './sdk_tests/crates/nodejs_typescript/setup.ps1']
 
 [[profile.default.scripts]]
 filter = 'package(=sdk_test_nodejs_typescript)'
-setup = 'nodejs_typescript_pnpm'
+platform = { host = 'cfg(unix)' }
+setup = 'nodejs_typescript_pnpm_unix'
+
+[[profile.default.scripts]]
+filter = 'package(=sdk_test_nodejs_typescript)'
+platform = { host = 'cfg(windows)' }
+setup = 'nodejs_typescript_pnpm_win'

--- a/baml_language/sdk_tests/README.md
+++ b/baml_language/sdk_tests/README.md
@@ -60,18 +60,20 @@ Targets in tree:
   `sdk_tests/harness_setup/src/nodejs_typescript.rs`). The native
   `.node` addon build and per-fixture `pnpm install` live in
   [`crates/nodejs_typescript/setup.sh`](./crates/nodejs_typescript/setup.sh)
-  rather than build.rs. `cargo nextest run` invokes setup.sh
-  automatically (configured as a nextest setup-script binding in
-  [`baml_language/.config/nextest.toml`](../.config/nextest.toml)),
+  (Unix) and the parallel
+  [`setup.ps1`](./crates/nodejs_typescript/setup.ps1) (Windows),
+  rather than build.rs. `cargo nextest run` invokes the right one
+  automatically via two platform-filtered setup-script bindings in
+  [`baml_language/.config/nextest.toml`](../.config/nextest.toml),
   so the common run flow is just:
 
   ```bash
   cargo nextest run -p sdk_test_nodejs_typescript
   ```
 
-  For plain `cargo test`, run setup.sh manually between
-  `cargo test --no-run` and `cargo test`. Re-run after bridge_nodejs
-  Rust changes or after adding a new fixture.
+  For plain `cargo test`, run setup.sh (or setup.ps1 on Windows)
+  manually between `cargo test --no-run` and `cargo test`. Re-run
+  after bridge_nodejs Rust changes or after adding a new fixture.
 
 ```bash
 # Run every Python+pydantic2 test across all fixtures
@@ -143,7 +145,8 @@ sdk_tests/
         │                                 # [build-dependencies] sdk_test_harness_setup
         │                                 # [dev-dependencies]   sdk_test_harness_runner
         ├── build.rs                      # one-liner → sdk_test_harness_setup::nodejs_typescript::run_all()
-        ├── setup.sh                      # pnpm build:debug (bridge_nodejs) + per-fixture pnpm install
+        ├── setup.sh                      # pnpm build:debug (bridge_nodejs) + per-fixture pnpm install (Unix)
+        ├── setup.ps1                     # parallel script for Windows; nextest picks one by host cfg
         ├── src/lib.rs                    # invokes sdk_test_harness_runner::nodejs_typescript::test_suite!()
         ├── docstrings_etc/
         │   ├── customizable/             # tracked: *.test.ts — copied into generated/
@@ -205,10 +208,10 @@ sdk_tests/
    - For nodejs_typescript: pnpm side is OUT of build.rs. The
      per-fixture `pnpm install` and the prereq `pnpm build:debug`
      of bridge_nodejs's native `.node` addon live in
-     `crates/nodejs_typescript/setup.sh`, run separately after
-     `cargo test --no-run`. Populates `node_modules/` from the
-     shared `target/pnpm-store/`. Tests then only do read-only
-     work against the populated tree.
+     `crates/nodejs_typescript/setup.sh` (Unix) or `setup.ps1`
+     (Windows), run separately after `cargo test --no-run`.
+     Populates `node_modules/` from the shared `target/pnpm-store/`.
+     Tests then only do read-only work against the populated tree.
    - Emits `OUT_DIR/<generator>_tests.rs` — a generated source file
      containing a `::sdk_test_harness_runner::build_diagnostics!(...)` macro
      invocation at the top followed by one `mod <fixture> { … }`

--- a/baml_language/sdk_tests/crates/nodejs_typescript/setup.ps1
+++ b/baml_language/sdk_tests/crates/nodejs_typescript/setup.ps1
@@ -1,0 +1,48 @@
+# Per-fixture pnpm setup for the sdk_test_nodejs_typescript crate — Windows.
+#
+# Windows counterpart of setup.sh. Invoked automatically by
+# `cargo nextest run` via the setup-script binding in
+# `baml_language/.config/nextest.toml` (host = cfg(windows)).
+# For plain `cargo test` (no nextest), run this manually after
+# `cargo test --no-run` populates each fixture's `generated/package.json`.
+#
+# See setup.sh for the rationale on `pnpm build:debug` + per-fixture
+# `pnpm install --ignore-workspace`; the steps are identical.
+
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+$WorkspaceRoot = (Resolve-Path '..\..\..').Path
+$BridgeNodejs = Join-Path $WorkspaceRoot 'sdks\nodejs\bridge_nodejs'
+
+# Shared pnpm store under target/ so per-fixture installs hardlink from
+# one location rather than fetching N copies.
+$env:npm_config_store_dir = Join-Path $WorkspaceRoot 'target\pnpm-store'
+New-Item -ItemType Directory -Force -Path $env:npm_config_store_dir | Out-Null
+
+# 1. Native `.node` addon. See setup.sh for why we do NOT `pnpm install`
+#    inside bridge_nodejs (it's a member of the repo-root workspace).
+Write-Host '==> pnpm build:debug in sdks/nodejs/bridge_nodejs'
+Push-Location $BridgeNodejs
+try {
+    pnpm build:debug
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+} finally {
+    Pop-Location
+}
+
+# 2. Per-fixture `pnpm install`. `--ignore-workspace` is required so pnpm
+#    doesn't walk up to the repo-root workspace and skip the install.
+Get-ChildItem -Directory | ForEach-Object {
+    $generated = Join-Path $_.FullName 'generated'
+    if (Test-Path $generated) {
+        Write-Host "==> pnpm install in $($_.Name)/generated"
+        Push-Location $generated
+        try {
+            pnpm install --ignore-workspace
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        } finally {
+            Pop-Location
+        }
+    }
+}

--- a/baml_language/sdk_tests/crates/nodejs_typescript/setup.sh
+++ b/baml_language/sdk_tests/crates/nodejs_typescript/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Per-fixture pnpm setup for the sdk_test_nodejs_typescript crate.
+# Per-fixture pnpm setup for the sdk_test_nodejs_typescript crate — Unix.
+# Windows uses the parallel `setup.ps1`; keep the two in sync.
 #
 # Invoked automatically by `cargo nextest run` via the setup-script
 # binding in `baml_language/.config/nextest.toml` — whenever the run

--- a/baml_language/sdk_tests/harness_setup/src/nodejs_typescript.rs
+++ b/baml_language/sdk_tests/harness_setup/src/nodejs_typescript.rs
@@ -14,21 +14,24 @@
 //! crate while the stub stays in place — see [`IGNORE_REASON`].
 //!
 //! **pnpm steps live in
-//! `sdk_tests/crates/nodejs_typescript/setup.sh`**, NOT in build.rs.
-//! `cargo nextest run` invokes setup.sh automatically via the
-//! setup-script binding in `baml_language/.config/nextest.toml`:
+//! `sdk_tests/crates/nodejs_typescript/setup.sh`** (Unix) or
+//! **`setup.ps1`** (Windows), NOT in build.rs. `cargo nextest run`
+//! invokes the right one automatically via two platform-filtered
+//! setup-script bindings (`cfg(unix)` / `cfg(windows)`) in
+//! `baml_language/.config/nextest.toml`:
 //!
 //! ```sh
 //! cd baml_language
 //! cargo nextest run -p sdk_test_nodejs_typescript
 //! ```
 //!
-//! For plain `cargo test` (no nextest), run setup.sh manually
-//! between `cargo test --no-run` and `cargo test`. Re-run setup.sh
-//! when bridge_nodejs's Rust source changes (the `.node` addon needs
-//! rebuilding) or when adding a new fixture. build.rs's job is just
-//! codegen + scaffold emit — it writes the per-fixture
-//! `package.json` / `tsconfig.json` that setup.sh consumes.
+//! For plain `cargo test` (no nextest), run setup.sh (or setup.ps1
+//! on Windows) manually between `cargo test --no-run` and
+//! `cargo test`. Re-run when bridge_nodejs's Rust source changes
+//! (the `.node` addon needs rebuilding) or when adding a new
+//! fixture. build.rs's job is just codegen + scaffold emit — it
+//! writes the per-fixture `package.json` / `tsconfig.json` that
+//! the setup script consumes.
 //!
 //! Auto-discovery story: build.rs emits
 //! `OUT_DIR/nodejs_typescript_tests.rs` (a sequence of


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added host-specific Node.js/TypeScript test setup so the appropriate setup runs on Unix vs Windows, and introduced a Windows setup counterpart.
  * Configured a shared package store to reuse downloads across test runs.

* **Documentation**
  * Updated test docs to describe cross-platform setup, the separate per-host setup step after build, and the shared package-store behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->