### PR TITLE
chore(ci): disable CodSpeed performance analysis

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -37,8 +37,7 @@
 # | --------------- | --------------------- | ----------------------------------------------- |
 # | `linux-cargo`   | `cargo-test-linux`    | `sdk-tests/linux`, `cargo-doc`,                 |
 # |                 |                       | `snapshot-tests`, `ci.yaml::prek`,              |
-# |                 |                       | `ci.yaml::proto-sync`,                          |
-# |                 |                       | `ci.yaml::benchmarks-instrumented`              |
+# |                 |                       | `ci.yaml::proto-sync`                           |
 # | `linux-wasm`    | `cargo-test-wasm`     | —                                               |
 # | `linux-msrv`    | `cargo-build-msrv`    | —                                               |
 # | `macos-cargo`   | `cargo-test-macos`    | `sdk-tests/macos`                               |
@@ -48,7 +47,7 @@
 # the broadest target/ tree (`cargo test --no-run --all-features`
 # across the whole workspace) — that's the most useful seed for the
 # subcommand variants the readers run (`cargo doc`, narrower
-# snapshot tests, codspeed builds, the sdks/nodejs/bridge_nodejs build, prek's
+# snapshot tests, the sdks/nodejs/bridge_nodejs build, prek's
 # checks). Per-OS cargo-test jobs are the savers on macos/windows
 # for the same reason.
 #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -469,80 +469,6 @@ jobs:
           fi
           echo "All generated proto files are in sync."
 
-  benchmarks-instrumented:
-    name: "benchmarks instrumented (baml)"
-    # Must stay on the same runner family as the `linux-cargo` saver
-    # (cargo-test-linux). Swatinem/rust-cache hashes every installed rustup
-    # toolchain into the env-hash, and GitHub-hosted `ubuntu-latest` ships a
-    # different pre-installed stable than the Blacksmith ubuntu-2404 image,
-    # which used to flip the cache prefix and force a cold build.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: determine_changes
-    # Run benchmarks when any Rust code changes, on manual opt-in, or on push to main/canary.
-    # Skip merge_group since they already ran in the PR.
-    if: |
-      github.event_name != 'merge_group' &&
-      (
-        needs.determine_changes.outputs.code == 'true' ||
-        github.ref == 'refs/heads/main' ||
-        github.ref == 'refs/heads/canary' ||
-        contains(github.event.pull_request.body, 'RUN_CODSPEED=1')
-      )
-    timeout-minutes: 30
-    steps:
-      - name: "Checkout Branch"
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
-      - name: "Install Rust toolchain"
-        run: rustup show
-        working-directory: baml_language
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-          # See the cache strategy explanation at the top of cargo-tests.reusable.yaml.
-          save-if: false
-          shared-key: "linux-cargo"
-
-      - name: "Install codspeed"
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-codspeed
-
-      - name: "Build benchmarks"
-        run: cargo codspeed build -p baml_tests -m walltime
-        working-directory: baml_language
-
-      # CodSpeed's walltime runner auto-installs `linux-tools-$(uname -r)` so
-      # its bundled `perf` matches the running kernel. Blacksmith's ubuntu-2404
-      # image runs a kernel Ubuntu's apt repos don't ship a matching
-      # `linux-tools-*` package for, so that step bails with
-      # `Unable to locate package linux-tools-<kernel>`. Pre-install
-      # `linux-tools-common` + `linux-tools-generic` instead: the generic meta
-      # package pulls in a perf binary at `/usr/lib/linux-tools-*/perf`, which
-      # CodSpeed's `get_working_perf_executable()` falls back to via
-      # `find /usr/lib -path "/usr/lib/linux-tools-*/perf"` when `which perf`
-      # fails — at which point CodSpeed's own apt install short-circuits.
-      # Source: https://github.com/CodSpeedHQ/runner/blob/main/src/executor/wall_time/profiler/perf/{setup,perf_executable}.rs
-      - name: "Pre-install perf for CodSpeed (Blacksmith image)"
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends linux-tools-common linux-tools-generic
-          # Smoke-test: at least one of these must succeed, otherwise CodSpeed
-          # will silently fall through to its own broken apt install path.
-          perf --version || ls /usr/lib/linux-tools-*/perf
-
-      - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@v4
-        continue-on-error: true
-        with:
-          mode: walltime
-          run: cd baml_language && cargo codspeed run
-          token: ${{ secrets.CODSPEED_TOKEN }}
-
   # CI Failure Alert - Required status check using "skipped = success" pattern
   # See: https://devopsdirective.com/posts/2025/08/github-actions-required-checks-for-conditional-jobs/
   #
@@ -564,7 +490,6 @@ jobs:
       - webview-tests
       - miri-tests
       - proto-sync
-      - benchmarks-instrumented
     # Only run if something failed or was cancelled (otherwise skip → success)
     if: ${{ failure() || cancelled() }}
     steps:
@@ -585,7 +510,6 @@ jobs:
           echo "| webview-tests | ${{ needs.webview-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| miri-tests | ${{ needs.miri-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| proto-sync | ${{ needs.proto-sync.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| benchmarks-instrumented | ${{ needs.benchmarks-instrumented.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "::error::One or more CI jobs failed!"
           exit 1


### PR DESCRIPTION
## Summary
- Drop the `benchmarks-instrumented` job from `ci.yaml` and remove it from the `ci-failure-alert` aggregator (needs list + summary table).
- Clean up the now-stale `benchmarks-instrumented` / "codspeed builds" references in `cargo-tests.reusable.yaml`'s cache-strategy comment.
- CodSpeed is being replaced with an in-house benchmarking system.

The `codspeed-divan-compat` dev-deps in `baml_language/Cargo.toml` and `engine/baml-vm/Cargo.toml` are intentionally kept — they behave as a drop-in `divan` outside `cargo codspeed` builds, so local benchmarks still work. They can be swapped back to plain `divan` when the replacement lands.

## Test plan
- [ ] CI on this PR runs without the `benchmarks-instrumented` job and without `ci-failure-alert` referencing it.
- [ ] If "CI - BAML Language / CI Failure Alert" is configured as a required status check, confirm it still resolves correctly (skipped-as-success) on green PRs.
- [ ] Local `cargo bench` / `cargo test --benches` in `baml_language` still compiles and runs (sanity check that the `codspeed-divan-compat` drop-in still works without CodSpeed instrumentation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD infrastructure by removing redundant benchmark instrumentation job from the workflow pipeline.
  * Updated internal workflow configuration cache strategy documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->