### PR TITLE
Trim unused cargo features to shrink baml-cli (~160 KiB __TEXT)

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -109,15 +109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +949,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -982,21 +973,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if 1.0.4",
- "libc",
- "miniz_oxide",
- "object 0.37.3",
- "rustc-demangle",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1395,7 +1371,7 @@ dependencies = [
  "sys_types",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tower-http",
  "tracing",
  "tracing-log",
@@ -3369,12 +3345,6 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
@@ -3653,12 +3623,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gl_generator"
@@ -4797,7 +4761,7 @@ dependencies = [
  "editpe",
  "image",
  "libc",
- "object 0.36.3",
+ "object",
  "sha2 0.10.9",
  "windows-sys 0.48.0",
  "zerocopy 0.7.35",
@@ -5682,15 +5646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5841,10 +5796,8 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "backtrace",
  "cfg-if 1.0.4",
  "libc",
- "petgraph 0.6.5",
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
@@ -5916,21 +5869,11 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap 2.14.0",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
 ]
@@ -6198,7 +6141,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph 0.8.3",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
@@ -6714,7 +6657,6 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
@@ -6810,12 +6752,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -8137,18 +8073,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -8156,7 +8080,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -8468,23 +8392,6 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -8703,12 +8610,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -943,7 +943,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
- "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
@@ -953,7 +952,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -972,7 +970,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1354,7 +1351,7 @@ dependencies = [
  "bex_heap",
  "bex_project",
  "bridge_ctypes",
- "crossbeam",
+ "crossbeam-channel",
  "futures",
  "indexmap 2.14.0",
  "log",
@@ -1619,7 +1616,6 @@ dependencies = [
  "bex_vm_types",
  "indexmap 2.14.0",
  "once_cell",
- "tokio",
 ]
 
 [[package]]
@@ -1658,7 +1654,7 @@ dependencies = [
  "bex_external_types",
  "bex_heap",
  "bex_vm_types",
- "crossbeam",
+ "crossbeam-channel",
  "log",
  "lsp-server",
  "lsp-types",
@@ -1722,7 +1718,7 @@ dependencies = [
  "bex_resource_types",
  "bex_vm_types",
  "codspeed-divan-compat",
- "colored",
+ "console",
  "getrandom 0.2.17",
  "indexmap 2.14.0",
  "log",
@@ -2654,42 +2650,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -8251,7 +8215,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -169,7 +169,7 @@ lsp-types = "0.95.0"
 notify = "7.0"
 once_cell = "1.19"
 ouroboros = "0.18.5"
-parking_lot = { version = "0.12", features = [ "deadlock_detection" ] }
+parking_lot = { version = "0.12" }
 paste = "1.0"
 percent-encoding = "2.3"
 pretty_assertions = { version = "1.4" }
@@ -183,7 +183,6 @@ ratatui = "0.29"
 regex = { version = "1.10.2" }
 base64 = "0.22"
 reqwest = { version = "0.13.1", default-features = false, features = [
-  "json",
   "stream",
 ] }
 rowan = { version = "0.16" }
@@ -213,9 +212,9 @@ thiserror = { version = "2.0.0" }
 toml = { version = "0.8" }
 toml_edit = { version = "0.22" }
 tokio = { version = "1.36" }
-tokio-tungstenite = { version = "0.28.0" }
+tokio-tungstenite = { version = "0.29.0" }
 tokio-util = { version = "0.7" }
-tower-http = { version = "0.6.6", features = [ "fs", "cors" ] }
+tower-http = { version = "0.6.6", features = [ "fs" ] }
 tracing = { version = "0.1.40" }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -128,7 +128,7 @@ aws-smithy-async = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev
 aws-smithy-runtime-api = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac", features = [ "client" ] }
 aws-smithy-types = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac" }
 aws-types = { git = "https://github.com/boundaryml/aws-sdk-rust.git", rev = "28d4f67bac1214320320905c1f6908ea32b6b0ac" }
-axum = { version = "0.8.4", features = [ "ws" ] }
+axum = { version = "0.8.4", default-features = false, features = [ "http1", "matched-path", "original-uri", "query", "tokio", "ws" ] }
 # `serde` mode rather than bitcode's native Encode/Decode: Program and its
 # transitive type graph (bex_vm_types + baml_type) are already serde-derived,
 # and Encode/Decode would require derives on ~60 types plus custom impls for
@@ -142,10 +142,9 @@ cargo_metadata = { version = "0.23.1" }
 cbindgen = "0.28.0"
 clap = { version = "4.4.6", features = [ "cargo", "derive" ] }
 clap-cargo = "0.14.1"
-colored = { version = "2.1.0" }
 console = "0.16"
 console_error_panic_hook = "0.1"
-crossbeam = { version = "0.8.4", features = [ "crossbeam-channel" ] }
+crossbeam-channel = { version = "0.5" }
 crossterm = "0.28"
 ctrlc = "3.4"
 derive_more = { version = "2.1.1", features = [ "from" ] }

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -34,7 +34,7 @@ codegen_python = { workspace = true }
 sys_native = { workspace = true }
 anyhow = { workspace = true }
 bitcode = { workspace = true }
-clap = { workspace = true, features = [ "color", "env" ] }
+clap = { workspace = true, features = [ "color" ] }
 clap-cargo = { workspace = true }
 console = { workspace = true }
 ctrlc = { workspace = true }
@@ -43,7 +43,7 @@ indexmap = { workspace = true }
 indicatif = { workspace = true }
 libsui = { workspace = true }
 regex = { workspace = true }
-reqwest = { workspace = true, features = [ "blocking" ] }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -28,6 +28,7 @@ use std::{
     io::{Cursor, Read},
     path::{Path, PathBuf},
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::{Context, Result, anyhow};
@@ -520,7 +521,13 @@ fn download_release_asset(url: &str) -> Result<Vec<u8>> {
     let rt = tokio::runtime::Runtime::new()
         .context("Failed to create tokio runtime for release asset download")?;
     rt.block_on(async {
-        let response = reqwest::get(url)
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .context("Failed to build HTTP client for release asset download")?;
+        let response = client
+            .get(url)
+            .send()
             .await
             .with_context(|| format!("Failed to download BAML release asset from {url}"))?
             .error_for_status()

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -517,14 +517,20 @@ fn download_host_binary_from_release(target: &str, host_name: &str) -> Result<Ve
 }
 
 fn download_release_asset(url: &str) -> Result<Vec<u8>> {
-    let response = reqwest::blocking::get(url)
-        .with_context(|| format!("Failed to download BAML release asset from {url}"))?
-        .error_for_status()
-        .with_context(|| format!("Failed to download BAML release asset from {url}"))?;
-    let bytes = response
-        .bytes()
-        .with_context(|| format!("Failed to read BAML release asset from {url}"))?;
-    Ok(bytes.to_vec())
+    let rt = tokio::runtime::Runtime::new()
+        .context("Failed to create tokio runtime for release asset download")?;
+    rt.block_on(async {
+        let response = reqwest::get(url)
+            .await
+            .with_context(|| format!("Failed to download BAML release asset from {url}"))?
+            .error_for_status()
+            .with_context(|| format!("Failed to download BAML release asset from {url}"))?;
+        let bytes = response
+            .bytes()
+            .await
+            .with_context(|| format!("Failed to read BAML release asset from {url}"))?;
+        Ok(bytes.to_vec())
+    })
 }
 
 fn verify_release_archive_checksum(archive_bytes: &[u8], archive_url: &str) -> Result<()> {

--- a/baml_language/crates/baml_lsp_server/Cargo.toml
+++ b/baml_language/crates/baml_lsp_server/Cargo.toml
@@ -54,7 +54,7 @@ rustls = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = [ "sync", "rt-multi-thread", "fs", "net", "time", "macros" ] }
+tokio = { workspace = true, features = [ "sync", "rt-multi-thread", "net", "time", "macros" ] }
 tokio-tungstenite = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }

--- a/baml_language/crates/baml_lsp_server/Cargo.toml
+++ b/baml_language/crates/baml_lsp_server/Cargo.toml
@@ -41,7 +41,7 @@ sys_types = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
-crossbeam = { workspace = true }
+crossbeam-channel = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 log = { workspace = true }

--- a/baml_language/crates/baml_lsp_server/src/lib.rs
+++ b/baml_language/crates/baml_lsp_server/src/lib.rs
@@ -124,7 +124,7 @@ pub fn run_server(playground_via_browser: bool) -> anyhow::Result<()> {
     let baml_vfs = bex_project::BamlVFS::new(vfs);
 
     // Stdio sender (LSP client sender)
-    let (writer_tx, writer_rx) = crossbeam::channel::unbounded::<lsp_server::Message>();
+    let (writer_tx, writer_rx) = crossbeam_channel::unbounded::<lsp_server::Message>();
     let writer_tx = Arc::new(writer_tx);
     let lsp_sender: Arc<dyn bex_project::LspClientSenderTrait + Send + Sync> =
         Arc::new(native_lsp_sender::NativeLspSender::new(&writer_tx));

--- a/baml_language/crates/baml_lsp_server/src/native_lsp_sender.rs
+++ b/baml_language/crates/baml_lsp_server/src/native_lsp_sender.rs
@@ -6,7 +6,7 @@
 use std::sync::Weak;
 
 use bex_project::LspError;
-use crossbeam::channel::Sender;
+use crossbeam_channel::Sender;
 use lsp_server::Message;
 
 #[derive(Clone)]

--- a/baml_language/crates/bex_external_types/Cargo.toml
+++ b/baml_language/crates/bex_external_types/Cargo.toml
@@ -14,5 +14,3 @@ bex_vm_types = { workspace = true }
 indexmap = { workspace = true }
 once_cell = { workspace = true }
 
-[dev-dependencies]
-tokio = { workspace = true, features = [ "fs", "net", "rt" ] }

--- a/baml_language/crates/bex_project/Cargo.toml
+++ b/baml_language/crates/bex_project/Cargo.toml
@@ -37,7 +37,7 @@ bex_vm_types = { workspace = true }
 sys_ops = { workspace = true }
 sys_types = { workspace = true }
 async-trait = { workspace = true }
-crossbeam = { workspace = true }
+crossbeam-channel = { workspace = true }
 log = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }

--- a/baml_language/crates/bex_vm/Cargo.toml
+++ b/baml_language/crates/bex_vm/Cargo.toml
@@ -25,7 +25,7 @@ bex_heap = { workspace = true }
 bex_resource_types = { workspace = true }
 bex_vm_types = { workspace = true }
 base64 = { workspace = true }
-colored = { workspace = true }
+console = { workspace = true }
 getrandom = { workspace = true }
 indexmap = { workspace = true }
 log = { workspace = true }

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -33,7 +33,7 @@ use bex_vm_types::{
     indexable::{GlobalIndex, ObjectPool},
     types::{Function, Object, Value},
 };
-use colored::{Color, Colorize};
+use console::Style;
 
 /// Display format for bytecode output.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -335,22 +335,22 @@ fn display_object_ptr(ptr: HeapPtr) -> String {
 /// See [`display_bytecode`] for more information.
 const COLUMN_MARGIN: usize = 3;
 
-/// Get color for instruction based on its type
-fn instruction_color(instruction: &Instruction) -> Color {
+/// Get color style for an instruction based on its type.
+fn instruction_style(instruction: &Instruction) -> Style {
     match instruction {
-        Instruction::NotifyBlock(_) => Color::BrightYellow,
+        Instruction::NotifyBlock(_) => Style::new().yellow().bright(),
         Instruction::LoadConst(_)
         | Instruction::LoadVar(_)
         | Instruction::LoadGlobal(_)
         | Instruction::LoadField(_)
         | Instruction::LoadArrayElement
-        | Instruction::LoadMapElement => Color::Blue,
+        | Instruction::LoadMapElement => Style::new().blue(),
         Instruction::StoreVar(_)
         | Instruction::StoreGlobal(_)
         | Instruction::StoreField(_)
         | Instruction::InitField(_)
         | Instruction::StoreArrayElement
-        | Instruction::StoreMapElement => Color::Green,
+        | Instruction::StoreMapElement => Style::new().green(),
         Instruction::BinOp(_)
         | Instruction::CmpOp(_)
         | Instruction::AddInt
@@ -364,61 +364,63 @@ fn instruction_color(instruction: &Instruction) -> Color {
         | Instruction::DivFloat
         | Instruction::CmpIntOp(_)
         | Instruction::CmpFloatOp(_)
-        | Instruction::UnaryOp(_) => Color::BrightBlue,
+        | Instruction::UnaryOp(_) => Style::new().blue().bright(),
         Instruction::Jump(_)
         | Instruction::PopJumpIfFalse(_)
         | Instruction::JumpIfFalse(_)
         | Instruction::JumpTable { .. }
-        | Instruction::DenseTag(_) => Color::Yellow,
-        Instruction::Call { .. } | Instruction::CallIndirect => Color::Magenta,
+        | Instruction::DenseTag(_) => Style::new().yellow(),
+        Instruction::Call { .. } | Instruction::CallIndirect => Style::new().magenta(),
         Instruction::Return | Instruction::Pop(_) | Instruction::Copy(_) | Instruction::Throw => {
-            Color::Red
+            Style::new().red()
         }
         Instruction::AllocMap(_)
         | Instruction::AllocInstance { .. }
         | Instruction::AllocVariant(_)
-        | Instruction::AllocArray(_) => Color::Cyan,
-        Instruction::SysOp(_) | Instruction::Spawn | Instruction::Await => Color::BrightGreen,
-        Instruction::Watch(_) | Instruction::Unwatch(_) | Instruction::Notify(_) => {
-            Color::BrightRed
+        | Instruction::AllocArray(_) => Style::new().cyan(),
+        Instruction::SysOp(_) | Instruction::Spawn | Instruction::Await => {
+            Style::new().green().bright()
         }
-        Instruction::VizEnter(_) | Instruction::VizExit(_) => Color::BrightYellow,
+        Instruction::Watch(_) | Instruction::Unwatch(_) | Instruction::Notify(_) => {
+            Style::new().red().bright()
+        }
+        Instruction::VizEnter(_) | Instruction::VizExit(_) => Style::new().yellow().bright(),
         Instruction::Discriminant
         | Instruction::TypeTag
         | Instruction::IsType(_)
         | Instruction::LoadType(_)
-        | Instruction::ThrowIfPanic => Color::BrightBlue,
-        Instruction::Unreachable => Color::BrightRed,
+        | Instruction::ThrowIfPanic => Style::new().blue().bright(),
+        Instruction::Unreachable => Style::new().red().bright(),
         Instruction::MakeClosure { .. }
         | Instruction::MakeBoundMethod(_)
-        | Instruction::MakeCell => Color::Cyan,
+        | Instruction::MakeCell => Style::new().cyan(),
         Instruction::LoadDeref(_) | Instruction::LoadCapture(_) | Instruction::CaptureRef(_) => {
-            Color::Blue
+            Style::new().blue()
         }
-        Instruction::StoreDeref(_) | Instruction::StoreCapture(_) => Color::Green,
-        Instruction::SendEvent => Color::BrightGreen,
+        Instruction::StoreDeref(_) | Instruction::StoreCapture(_) => Style::new().green(),
+        Instruction::SendEvent => Style::new().green().bright(),
     }
 }
 
 struct Col {
     text: String,
     char_count: usize,
-    color: Color,
+    style: Style,
 }
 
 impl From<String> for Col {
     fn from(text: String) -> Self {
         Self {
             char_count: text.chars().count(),
-            color: Color::White,
+            style: Style::new(),
             text,
         }
     }
 }
 
 impl Col {
-    fn with_color(mut self, color: Color) -> Self {
-        self.color = color;
+    fn with_style(mut self, style: Style) -> Self {
+        self.style = style;
         self
     }
 }
@@ -480,13 +482,13 @@ pub fn display_bytecode(
         // since a single line could emit multiple instructions
         let source_line = display_source_line_cell(function, instruction_ptr, &mut last_line);
 
-        let instruction_color = instruction_color(&function.bytecode.instructions[instruction_ptr]);
+        let instr_style = instruction_style(&function.bytecode.instructions[instruction_ptr]);
 
         // Table format is [LINE, IP, INSTR, META].
         let row = [
             Col::from(source_line),
             Col::from(instruction_ptr.to_string()),
-            Col::from(instruction).with_color(instruction_color),
+            Col::from(instruction).with_style(instr_style),
             Col::from(metadata),
         ];
 
@@ -522,23 +524,21 @@ pub fn display_bytecode(
                 width = 0;
             }
 
-            let mut colored_text = col.text.normal();
-
-            // Apply color based on column, only if output is to a TTY
+            // Apply color based on column, only if output is to a TTY.
+            // ANSI codes don't change the visual character count, so we
+            // pad based on `col.char_count` after pushing the styled text.
             if use_colors {
-                colored_text = match j {
-                    0 => col.text.bright_black(),   // Line numbers in gray
-                    1 => col.text.white(),          // IP in white
-                    2 => col.text.color(col.color), // Instruction with type-based color
-                    3 => col.text.bright_cyan(),    // Metadata in cyan
-                    _ => col.text.normal(),
-                }
+                let style = match j {
+                    0 => Style::new().black().bright(), // Line numbers in gray
+                    1 => Style::new().white(),          // IP in white
+                    2 => col.style.clone(),             // Instruction with type-based color
+                    3 => Style::new().cyan().bright(),  // Metadata in cyan
+                    _ => Style::new(),
+                };
+                table.push_str(&style.apply_to(&col.text).to_string());
+            } else {
+                table.push_str(&col.text);
             }
-
-            // For colored strings, we need to use the actual character count
-            // not the length with ANSI codes. Also, `to_string` has to be
-            // called here so that ANSI codes are inserted.
-            table.push_str(&colored_text.to_string());
             for _ in col.char_count..width {
                 table.push(' ');
             }


### PR DESCRIPTION
## Summary
- Drop cargo features pulling code nothing in the workspace calls: `tower-http/cors`, `reqwest/json`, `parking_lot/deadlock_detection`, `clap/env` (in baml_cli), tokio `fs` (in baml_lsp_server).
- Bump `tokio-tungstenite` 0.28 -> 0.29 to match axum 0.8's transitive copy (dedup at link).
- Drop `reqwest/blocking` and route `pack_command::download_release_asset` through a transient tokio runtime (mirrors `run_command.rs` pattern).

## Measurements
`target/release/baml-cli` `__TEXT` segment:
- baseline:    13,451,264 bytes
- after PR:    13,287,424 bytes
- **delta:     −163,840 bytes (~160 KiB)**

## Why these are safe
Each dropped feature was verified to have zero call sites in the workspace:
- `tower_http::cors::*` -> 0 hits (playground uses a hand-rolled `cors_middleware`).
- `.json(` / `.json::<` / `Response::json` -> 0 hits in reqwest usage.
- `parking_lot::deadlock` API -> 0 hits.
- `#[arg(env=...)]` / `#[clap(env=...)]` -> 0 hits.
- `tokio::fs::` in `baml_lsp_server/` -> 0 hits.

## Test plan
- [x] `cargo build --release -p baml_cli` (passes; measured above)
- [x] `cargo nextest r --no-fail-fast --no-default-features --features ring-crypto` (5679/5683 passed; 4 pre-existing `sdk_test_python_pydantic2 *::pytest` failures unrelated to this change — pyright variants of the same tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependencies and optimized feature flags to reduce overhead and keep networking components current.
  * Bumped tokio-tungstenite to 0.29.0 for improved websocket/network behavior.

* **Refactor**
  * Switched CLI download flow to an asynchronous implementation for better responsiveness and timeout handling.

* **Style**
  * Updated debug output styling to use a different terminal styling backend, preserving colored output and padding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->