### PR TITLE
Add `if let` expressions

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -599,6 +599,17 @@ pub enum Expr {
         then_branch: ExprId,
         else_branch: Option<ExprId>,
     },
+    /// `if let PATTERN = SCRUTINEE { THEN } else { ELSE }` — refutable
+    /// pattern match in condition position. Bindings introduced by `pattern`
+    /// are in scope inside `then_branch` only (never in `else_branch` and
+    /// never after the `if let`). Unlike `Stmt::Let`, the pattern is
+    /// expected to be *refutable*; an irrefutable pattern earns a warning.
+    IfLet {
+        pattern: PatId,
+        scrutinee: ExprId,
+        then_branch: ExprId,
+        else_branch: Option<ExprId>,
+    },
     Match {
         scrutinee: ExprId,
         scrutinee_type: Option<TypeAnnotId>,

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -612,6 +612,7 @@ impl LoweringContext {
             SyntaxKind::UNARY_EXPR => self.lower_unary_expr(node),
             SyntaxKind::CALL_EXPR => self.lower_call_expr(node),
             SyntaxKind::IF_EXPR => self.lower_if_expr(node),
+            SyntaxKind::IF_LET_EXPR => self.lower_if_let_expr(node),
             SyntaxKind::MATCH_EXPR => self.lower_match_expr(node),
             SyntaxKind::CATCH_EXPR => self.lower_catch_expr(node),
             SyntaxKind::THROW_EXPR => self.lower_throw_expr(node),
@@ -1096,6 +1097,62 @@ impl LoweringContext {
         self.alloc_expr(
             Expr::If {
                 condition,
+                then_branch,
+                else_branch,
+            },
+            node.text_range(),
+        )
+    }
+
+    fn lower_if_let_expr(&mut self, node: &SyntaxNode) -> ExprId {
+        // CST shape: `if let PATTERN = SCRUTINEE THEN_BLOCK (else (BLOCK | IF_EXPR | IF_LET_EXPR))?`
+        //
+        // Children we care about, in source order:
+        //   1. PATTERN
+        //   2. scrutinee expression (may be a bare WORD/literal token, not a node)
+        //   3. then-branch (BLOCK_EXPR)
+        //   4. else-branch (BLOCK_EXPR | IF_EXPR | IF_LET_EXPR), optional
+        //
+        // The scrutinee can appear as either a wrapper node (PATH_EXPR,
+        // BINARY_EXPR, …) or as a bare token (single identifier / literal), so
+        // we mirror `lower_if_expr` and walk children-with-tokens.
+        let mut pattern = None;
+        let mut exprs: Vec<ExprId> = Vec::new();
+        for elem in node.children_with_tokens() {
+            match elem {
+                rowan::NodeOrToken::Node(child) => {
+                    if child.kind() == SyntaxKind::PATTERN {
+                        if pattern.is_none() {
+                            pattern = Some(self.lower_pattern(&child));
+                        }
+                    } else {
+                        exprs.push(self.lower_expr(&child));
+                    }
+                }
+                rowan::NodeOrToken::Token(token) => {
+                    if let Some(expr_id) = self.try_lower_bare_token(&token) {
+                        exprs.push(expr_id);
+                    }
+                }
+            }
+        }
+
+        let pattern =
+            pattern.unwrap_or_else(|| self.alloc_pattern(Pattern::Wildcard, node.text_range()));
+        let scrutinee = exprs
+            .first()
+            .copied()
+            .unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.text_range()));
+        let then_branch = exprs
+            .get(1)
+            .copied()
+            .unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.text_range()));
+        let else_branch = exprs.get(2).copied();
+
+        self.alloc_expr(
+            Expr::IfLet {
+                pattern,
+                scrutinee,
                 then_branch,
                 else_branch,
             },
@@ -1772,6 +1829,7 @@ impl LoweringContext {
                     | SyntaxKind::ENV_ACCESS_EXPR
                     | SyntaxKind::INDEX_EXPR
                     | SyntaxKind::IF_EXPR
+                    | SyntaxKind::IF_LET_EXPR
                     | SyntaxKind::MATCH_EXPR
                     | SyntaxKind::BLOCK_EXPR
                     | SyntaxKind::PAREN_EXPR

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -447,6 +447,35 @@ impl<'db> SemanticIndexBuilder<'db> {
                     self.walk_expr(*else_branch, body, source_map, true);
                 }
             }
+            ast::Expr::IfLet {
+                pattern,
+                scrutinee,
+                then_branch,
+                else_branch,
+            } => {
+                // Scrutinee is evaluated in the enclosing scope.
+                self.walk_expr(*scrutinee, body, source_map, true);
+
+                // Then-branch sees pattern bindings; push a fresh scope and
+                // register them before walking. Mirrors `walk_match_arm`.
+                let then_span = source_map.expr_span(*then_branch);
+                self.push_scope(ScopeKind::MatchArm, None, then_span);
+                let visible_from = source_map.pattern_span(*pattern).start();
+                self.register_local_pattern(
+                    *pattern,
+                    DefinitionSite::PatternBinding(*pattern),
+                    body,
+                    source_map,
+                    visible_from,
+                );
+                self.walk_expr(*then_branch, body, source_map, true);
+                self.pop_scope();
+
+                if let Some(else_branch) = else_branch {
+                    // Else-branch never sees pattern bindings.
+                    self.walk_expr(*else_branch, body, source_map, true);
+                }
+            }
             ast::Expr::Match {
                 scrutinee, arms, ..
             } => {

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -2284,6 +2284,15 @@ impl LoweringContext<'_> {
                 self.lower_if(expr_id, condition, then_branch, else_branch, dest);
             }
 
+            AstExpr::IfLet {
+                pattern,
+                scrutinee,
+                then_branch,
+                else_branch,
+            } => {
+                self.lower_if_let(expr_id, pattern, scrutinee, then_branch, else_branch, dest);
+            }
+
             AstExpr::Binary { op, lhs, rhs } => {
                 self.lower_binary(expr_id, op, lhs, rhs, dest);
             }
@@ -4387,6 +4396,61 @@ impl LoweringContext<'_> {
             self.builder.goto(bb_join);
         }
 
+        self.builder.set_current_block(bb_else);
+        if let Some(else_expr) = else_branch {
+            self.lower_expr(else_expr, dest);
+        } else {
+            self.builder
+                .assign(dest, Rvalue::Use(Operand::Constant(Constant::Null)));
+        }
+        if !self.builder.is_current_terminated() {
+            self.builder.goto(bb_join);
+        }
+
+        self.builder.set_current_block(bb_join);
+    }
+
+    /// MIR lowering for `if let PATTERN = SCRUTINEE { THEN } else { ELSE }`.
+    ///
+    /// Same shape as a two-arm match (`PATTERN => then, _ => else`), but we
+    /// emit it inline rather than synthesizing a match. The pattern test
+    /// jumps to the then-block on success (where we bind names from the
+    /// pattern before lowering the body) and to the else-block on failure.
+    fn lower_if_let(
+        &mut self,
+        _expr_id: AstExprId,
+        pattern: AstPatId,
+        scrutinee: AstExprId,
+        then_branch: AstExprId,
+        else_branch: Option<AstExprId>,
+        dest: Place,
+    ) {
+        let scrutinee_local = self.try_resolve_to_local(scrutinee).unwrap_or_else(|| {
+            let op = self.lower_to_operand(scrutinee);
+            let ty = self.expr_ty(scrutinee);
+            self.operand_to_local(op, ty)
+        });
+
+        let bb_then = self.builder.create_block();
+        let bb_else = self.builder.create_block();
+        let bb_join = self.builder.create_block();
+
+        self.lower_pattern_test(scrutinee_local, pattern, bb_then, bb_else);
+
+        // Then-branch: bind pattern locals, lower body, restore on exit.
+        self.builder.set_current_block(bb_then);
+        let saved_locals = self.locals.clone();
+        let watched_depth = self.watched_locals_stack.len();
+        self.bind_pattern(scrutinee_local, pattern);
+        self.lower_expr(then_branch, dest.clone());
+        if !self.builder.is_current_terminated() {
+            self.emit_unwatch_to_depth(watched_depth);
+            self.builder.goto(bb_join);
+        }
+        self.restore_locals_after_scope(saved_locals, watched_depth);
+
+        // Else-branch: no bindings from the pattern, just lower the else
+        // (or write Null if absent — same as plain `if` with no else).
         self.builder.set_current_block(bb_else);
         if let Some(else_expr) = else_branch {
             self.lower_expr(else_expr, dest);

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -1815,6 +1815,39 @@ impl<'db> TypeInferenceBuilder<'db> {
                     shadowed.truncate(saved_len);
                 }
             }
+            Expr::IfLet {
+                pattern,
+                scrutinee,
+                then_branch,
+                else_branch,
+            } => {
+                Self::collect_default_expr_forward_references(
+                    *scrutinee,
+                    body,
+                    later_params,
+                    shadowed,
+                    refs,
+                );
+                let saved_len = shadowed.len();
+                Self::push_pattern_bindings(*pattern, body, shadowed);
+                Self::collect_default_expr_forward_references(
+                    *then_branch,
+                    body,
+                    later_params,
+                    shadowed,
+                    refs,
+                );
+                shadowed.truncate(saved_len);
+                if let Some(else_branch) = else_branch {
+                    Self::collect_default_expr_forward_references(
+                        *else_branch,
+                        body,
+                        later_params,
+                        shadowed,
+                        refs,
+                    );
+                }
+            }
             Expr::Is { scrutinee, .. } => {
                 // The pattern has no body and its bindings don't escape, so we
                 // only need to recurse into the scrutinee.
@@ -2634,6 +2667,19 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                 result_ty
             }
+            Expr::IfLet {
+                pattern,
+                scrutinee,
+                then_branch,
+                else_branch,
+            } => self.infer_if_let_expr(
+                expr_id,
+                *pattern,
+                *scrutinee,
+                *then_branch,
+                *else_branch,
+                body,
+            ),
             Expr::Call { .. } => {
                 // Delegate to check_expr with Ty::Unknown so the generic
                 // inference logic in check_expr handles all call expressions.
@@ -3242,6 +3288,24 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.record_expr_type(expr_id, ty.clone());
                 ty
             }
+            // IfLet: like `If`, push the expected type into both branches —
+            // critical for the function-body tail-expression path so that
+            // `if let pat = e { v1 } else { v2 }` doesn't report
+            // "missing return" when the if-let *is* the return value.
+            Expr::IfLet {
+                pattern,
+                scrutinee,
+                then_branch,
+                else_branch,
+            } => self.check_if_let_expr(
+                expr_id,
+                *pattern,
+                *scrutinee,
+                *then_branch,
+                *else_branch,
+                body,
+                expected,
+            ),
             // If: check both branches against expected type
             Expr::If {
                 condition,
@@ -4184,6 +4248,152 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
 
         Self::join_all(&arm_types)
+    }
+
+    /// Type-check `if let PATTERN = SCRUTINEE { THEN } else { ELSE }`.
+    ///
+    /// Refutable pattern match in condition position. Modeled on
+    /// [`Self::infer_match_expr`] with effectively two arms:
+    ///   - the user-written pattern (binds names in the then-branch)
+    ///   - an implicit wildcard arm (the else-branch)
+    ///
+    /// Side effects:
+    /// - Pattern bindings registered in `self.locals` for the then-branch only
+    ///   (snapshot/restore around the body).
+    /// - Scrutinee local narrowed to `matched_ty` in the then-branch, and to
+    ///   the complement type in the else-branch (when the scrutinee is a
+    ///   simple-path local).
+    /// - If the matrix says the pattern is irrefutable, emit a warning at the
+    ///   pattern span suggesting `let` instead.
+    /// - Joined branch types returned as the if-let's value; if there is no
+    ///   else, the type is `Void`.
+    fn infer_if_let_expr(
+        &mut self,
+        if_let_expr_id: ExprId,
+        pattern_id: PatId,
+        scrutinee_expr_id: ExprId,
+        then_branch: ExprId,
+        else_branch: Option<ExprId>,
+        body: &ExprBody,
+    ) -> Ty {
+        self.if_let_expr_common(
+            if_let_expr_id,
+            pattern_id,
+            scrutinee_expr_id,
+            then_branch,
+            else_branch,
+            body,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn check_if_let_expr(
+        &mut self,
+        if_let_expr_id: ExprId,
+        pattern_id: PatId,
+        scrutinee_expr_id: ExprId,
+        then_branch: ExprId,
+        else_branch: Option<ExprId>,
+        body: &ExprBody,
+        expected: &Ty,
+    ) -> Ty {
+        let ty = self.if_let_expr_common(
+            if_let_expr_id,
+            pattern_id,
+            scrutinee_expr_id,
+            then_branch,
+            else_branch,
+            body,
+            Some(expected),
+        );
+        self.record_expr_type(if_let_expr_id, ty.clone());
+        ty
+    }
+
+    /// Shared inference/checking core for `Expr::IfLet`. When `expected` is
+    /// `Some`, branches are propagated through `check_expr` (giving the
+    /// function-body tail-expression path the same expected-type flow as
+    /// `if`/`match`); when `None`, they're inferred bottom-up.
+    #[allow(clippy::too_many_arguments)]
+    fn if_let_expr_common(
+        &mut self,
+        if_let_expr_id: ExprId,
+        pattern_id: PatId,
+        scrutinee_expr_id: ExprId,
+        then_branch: ExprId,
+        else_branch: Option<ExprId>,
+        body: &ExprBody,
+        expected: Option<&Ty>,
+    ) -> Ty {
+        let scrutinee_ty = self.infer_expr(scrutinee_expr_id, body);
+        let scrutinee_name = match &body.exprs[scrutinee_expr_id] {
+            Expr::Path(segments) if segments.len() == 1 => Some(segments[0].clone()),
+            _ => None,
+        };
+
+        // Lower the pattern against the scrutinee type. Same machinery as
+        // `match` arms — does subtype check, populates `pattern_types`.
+        let result = self.analyze_and_lower(pattern_id, &scrutinee_ty, body, then_branch);
+        let matched_ty = result.matched_ty.clone();
+
+        // Then-branch: push a fresh scope, narrow scrutinee, register
+        // pattern bindings, then infer/check the body.
+        let snapshot = self.snapshot_scoped_locals();
+        if let Some(name) = &scrutinee_name {
+            self.narrow_local(name.clone(), matched_ty.clone());
+        }
+        self.finalize_pattern_lowering(pattern_id, &result, None, None, &scrutinee_ty);
+        let then_ty = match expected {
+            Some(exp) => self.check_expr(then_branch, body, exp),
+            None => self.infer_expr(then_branch, body),
+        };
+        self.restore_scoped_locals(&snapshot);
+
+        // Else-branch: narrow scrutinee to the complement (residual type
+        // after subtracting matched_ty), then infer/check.
+        let else_ty = if let Some(else_expr) = else_branch {
+            let else_snapshot = self.snapshot_scoped_locals();
+            if let Some(name) = &scrutinee_name {
+                let complement =
+                    crate::narrowing::subtract_pattern_type(&scrutinee_ty, &matched_ty);
+                self.narrow_local(name.clone(), complement);
+            }
+            let ty = match expected {
+                Some(exp) => self.check_expr(else_expr, body, exp),
+                None => self.infer_expr(else_expr, body),
+            };
+            self.restore_scoped_locals(&else_snapshot);
+            Some(ty)
+        } else {
+            None
+        };
+
+        // Refutability check: run the matrix with a single arm. If nothing
+        // is missing, the pattern covers every value of the scrutinee — the
+        // else branch is dead.
+        let scrutinee_ty_for_matrix = self.matrix_normalize_scrut(&scrutinee_ty);
+        let report = crate::pattern_lowering::compute_match_usefulness(
+            self,
+            std::slice::from_ref(&result.dpat),
+            scrutinee_ty_for_matrix,
+        );
+        if report.missing.is_empty() {
+            let err = crate::infer_context::TirTypeError::IrrefutablePatternInIfLet;
+            if let Some(sm) = self.body_source_map.as_ref() {
+                self.context
+                    .report_warning_at_span(err, sm.pattern_span(pattern_id));
+            } else {
+                self.context.report_warning_simple(err, if_let_expr_id);
+            }
+        }
+
+        match else_ty {
+            Some(else_ty) => Self::join_types(&then_ty, &else_ty),
+            None => Ty::Void {
+                attr: TyAttr::default(),
+            },
+        }
     }
 
     /// Type-check `<expr> is <pattern>` (Rust `matches!`-style pattern test).
@@ -5147,6 +5357,18 @@ impl<'db> TypeInferenceBuilder<'db> {
                 else_branch,
             } => {
                 self.collect_throw_facts_from_expr(*condition, body, out);
+                self.collect_throw_facts_from_expr(*then_branch, body, out);
+                if let Some(else_expr) = else_branch {
+                    self.collect_throw_facts_from_expr(*else_expr, body, out);
+                }
+            }
+            Expr::IfLet {
+                scrutinee,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                self.collect_throw_facts_from_expr(*scrutinee, body, out);
                 self.collect_throw_facts_from_expr(*then_branch, body, out);
                 if let Some(else_expr) = else_branch {
                     self.collect_throw_facts_from_expr(*else_expr, body, out);

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -4027,6 +4027,57 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn check_stmt_with_early_return_narrowing(&mut self, stmt_id: StmtId, body: &ExprBody) -> bool {
         let stmt = &body.stmts[stmt_id];
 
+        // `Stmt::Expr(Expr::IfLet { ... })` — same shape as the `Expr::If`
+        // case below, but the narrowing is implicit in the pattern rather
+        // than explicit in a boolean condition. When the then-branch
+        // diverges and execution can continue past the statement, the
+        // scrutinee narrows to the complement of the matched type for the
+        // rest of the enclosing block.
+        if let baml_compiler2_ast::Stmt::Expr(if_let_expr_id) = stmt {
+            let if_let_expr = &body.exprs[*if_let_expr_id];
+            if let Expr::IfLet {
+                pattern,
+                scrutinee,
+                then_branch,
+                ..
+            } = if_let_expr
+            {
+                let pattern = *pattern;
+                let scrutinee = *scrutinee;
+                let then_branch = *then_branch;
+
+                // Resolve the scrutinee name + matched type *before*
+                // running check_stmt so we can apply the residual
+                // narrowing afterward without re-walking the if-let.
+                let scrutinee_ty = self.infer_expr(scrutinee, body);
+                let scrutinee_name = match &body.exprs[scrutinee] {
+                    Expr::Path(segments) if segments.len() == 1 => Some(segments[0].clone()),
+                    _ => None,
+                };
+
+                let stmt_diverges = self.check_stmt(stmt_id, body);
+
+                if let Some(name) = scrutinee_name {
+                    let then_ty = self.expressions.get(&then_branch);
+                    let then_diverged = matches!(then_ty, Some(Ty::Never { .. }));
+                    if then_diverged && !stmt_diverges {
+                        // Look up the matched type recorded by
+                        // `analyze_and_lower_no_subtype_check` keyed on the
+                        // pattern's PatId. The if-let's inference already
+                        // populated this; we just subtract to get the
+                        // complement.
+                        if let Some(matched_ty) = self.pattern_types.get(&pattern).cloned() {
+                            let complement =
+                                crate::narrowing::subtract_pattern_type(&scrutinee_ty, &matched_ty);
+                            self.narrow_local(name, complement);
+                        }
+                    }
+                }
+
+                return stmt_diverges;
+            }
+        }
+
         // Only special-case `Stmt::Expr(Expr::If { ... })`
         if let baml_compiler2_ast::Stmt::Expr(if_expr_id) = stmt {
             let if_expr = &body.exprs[*if_expr_id];
@@ -4307,6 +4358,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             body,
             Some(expected),
         );
+        // Without an else, the if-let evaluates to `Void`. Using it in
+        // value position is the same error as `if cond { ... }` without
+        // an else — `Expr::If`'s check arm reports `VoidUsedAsValue`
+        // here, and we match that.
+        if else_branch.is_none() && !matches!(expected, Ty::Void { .. } | Ty::Unknown { .. }) {
+            self.context
+                .report_simple(TirTypeError::VoidUsedAsValue, if_let_expr_id);
+        }
         self.record_expr_type(if_let_expr_id, ty.clone());
         ty
     }

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -134,6 +134,9 @@ pub enum TirTypeError {
     RefutablePatternInLet {
         context: crate::builder::IrrefutableContextKind,
     },
+    /// An `if let` pattern that covers every value of the scrutinee — the
+    /// `else` branch is unreachable. Suggests using a plain `let` instead.
+    IrrefutablePatternInIfLet,
     /// Catch binding cannot be typed as `any` or `unknown`.
     InvalidCatchBindingType { type_name: String },
     /// Inferred escaping throws are not covered by the declared throws contract.
@@ -375,6 +378,10 @@ impl fmt::Display for TirTypeError {
                 f,
                 "refutable pattern in {} binding; refutable patterns belong in `match`",
                 context.as_str()
+            ),
+            TirTypeError::IrrefutablePatternInIfLet => write!(
+                f,
+                "irrefutable `if let` pattern; the `else` branch is unreachable — use a plain `let` binding instead"
             ),
             TirTypeError::InvalidCatchBindingType { type_name } => write!(
                 f,

--- a/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
@@ -205,6 +205,18 @@ fn collect_from_expr<C: ThrowsAnalysisContext>(
                 collect_from_expr(context, *else_expr, body, out);
             }
         }
+        Expr::IfLet {
+            scrutinee,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            collect_from_expr(context, *scrutinee, body, out);
+            collect_from_expr(context, *then_branch, body, out);
+            if let Some(else_expr) = else_branch {
+                collect_from_expr(context, *else_expr, body, out);
+            }
+        }
         Expr::Match {
             scrutinee, arms, ..
         } => {

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -67,6 +67,8 @@ pub enum DiagnosticId {
     DuplicateMethod,
     DuplicateBinding,
     RefutablePatternInLet,
+    /// `if let` pattern that always matches — the `else` branch is dead.
+    IrrefutablePatternInIfLet,
     DuplicateAttribute,
     UnknownAttribute,
     InvalidAttributeContext,
@@ -233,6 +235,7 @@ impl DiagnosticId {
             DiagnosticId::DuplicateMethod => "E0093",
             DiagnosticId::DuplicateBinding => "E0094",
             DiagnosticId::RefutablePatternInLet => "E0111",
+            DiagnosticId::IrrefutablePatternInIfLet => "E0112",
             DiagnosticId::DuplicateAttribute => "E0014",
             DiagnosticId::UnknownAttribute => "E0015",
             DiagnosticId::InvalidAttributeContext => "E0016",

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -196,6 +196,14 @@ pub(crate) struct Parser<'a> {
     /// available to `parse_spawn_expr`. Counter so nested spawns nest
     /// correctly.
     suppress_object_literal_depth: u32,
+    /// Suppresses destructure patterns (`Class { fields }`) in pattern
+    /// position, mirroring Rust's `Restrictions::NO_STRUCT_LITERAL` for
+    /// struct literals in `if` / `while` condition expressions. Bumped
+    /// around `parse_expr` calls in those condition positions; reset
+    /// (`mem::take` + restore) when entering a `PAREN_PATTERN` or
+    /// `ARRAY_PATTERN` so nested patterns regain normal destructure
+    /// parsing. Counter so nested conditions nest correctly.
+    suppress_destructure_pattern_depth: u32,
 }
 
 impl<'a> Parser<'a> {
@@ -210,6 +218,7 @@ impl<'a> Parser<'a> {
             suppress_catch_depth: 0,
             testset_body_depth: 0,
             suppress_object_literal_depth: 0,
+            suppress_destructure_pattern_depth: 0,
         }
     }
 
@@ -3034,11 +3043,26 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_if_expr(&mut self) {
+        // `if let PATTERN = SCRUTINEE { ... }` is a distinct refutable form.
+        // Decided here by peeking past `if` for a `let` token — patterns
+        // always start with `let` (BAML's binding marker), and no normal
+        // expression starts with `let`, so this is unambiguous.
+        if self.peek(1).map(|t| t.kind) == Some(TokenKind::Let) {
+            self.parse_if_let_expr();
+            return;
+        }
+
         self.with_node(SyntaxKind::IF_EXPR, |p| {
             p.expect(TokenKind::If);
 
-            // Condition
+            // Condition: suppress destructure patterns (`Class { … }`) so
+            // they don't eat the then-block. Mirrors Rust's
+            // `NO_STRUCT_LITERAL` restriction. Users who want a
+            // destructure here must wrap it in parens — parens reset the
+            // suppression in `parse_pattern_atom`.
+            p.suppress_destructure_pattern_depth += 1;
             p.parse_expr();
+            p.suppress_destructure_pattern_depth -= 1;
 
             // Then block
             if p.at(TokenKind::LBrace) {
@@ -3056,6 +3080,47 @@ impl<'a> Parser<'a> {
                     p.parse_if_expr();
                 } else if p.at(TokenKind::LBrace) {
                     // else block
+                    p.parse_block_expr();
+                } else {
+                    p.error_unexpected_token("'if' or block after 'else'".to_string());
+                }
+            }
+        });
+    }
+
+    /// Parse `if let PATTERN = SCRUTINEE { ... } else { ... }`.
+    ///
+    /// Caller has already verified the token sequence starts with `if let`.
+    /// The `let` itself is consumed by `parse_pattern` (BAML patterns carry
+    /// their own leading `let` binding marker), matching how `let` statements
+    /// parse.
+    fn parse_if_let_expr(&mut self) {
+        self.with_node(SyntaxKind::IF_LET_EXPR, |p| {
+            p.expect(TokenKind::If);
+            // `let` is consumed inside parse_pattern → parse_let_pattern.
+            p.parse_pattern();
+
+            if !p.eat(TokenKind::Equals) {
+                p.error_unexpected_token("'=' after if-let pattern".to_string());
+            }
+
+            // Scrutinee — exclude assignment operators (same as let-stmt).
+            p.parse_expr_bp(3);
+
+            // Then block
+            if p.at(TokenKind::LBrace) {
+                p.parse_block_expr();
+            } else {
+                p.error_unexpected_token("block after if-let scrutinee".to_string());
+            }
+
+            // Optional else, with `else if` / `else if let` chaining.
+            if p.at(TokenKind::Else) {
+                p.bump(); // else
+
+                if p.at(TokenKind::If) {
+                    p.parse_if_expr();
+                } else if p.at(TokenKind::LBrace) {
                     p.parse_block_expr();
                 } else {
                     p.error_unexpected_token("'if' or block after 'else'".to_string());
@@ -3226,7 +3291,11 @@ impl<'a> Parser<'a> {
             } else {
                 self.with_node(SyntaxKind::PAREN_PATTERN, |p| {
                     p.bump(); // (
+                    // Parens reset destructure suppression: `if (x is Foo
+                    // { f })` should still allow the destructure.
+                    let saved = std::mem::take(&mut p.suppress_destructure_pattern_depth);
                     p.parse_pattern();
+                    p.suppress_destructure_pattern_depth = saved;
                     p.expect(TokenKind::RParen);
                 });
             }
@@ -3239,7 +3308,12 @@ impl<'a> Parser<'a> {
         }
 
         if self.at(TokenKind::LBracket) {
+            // Arrays use `[` / `]` so the closing bracket terminates the
+            // atom cleanly — sub-patterns inside should regain normal
+            // destructure parsing.
+            let saved = std::mem::take(&mut self.suppress_destructure_pattern_depth);
             self.parse_array_pattern();
+            self.suppress_destructure_pattern_depth = saved;
             return;
         }
 
@@ -3256,7 +3330,13 @@ impl<'a> Parser<'a> {
         // A bare WORD may start a destructure (`Class { ... }`,
         // `Class<int> { ... }`) or a type/path pattern. Look ahead through
         // dotted segments and optional trailing generic args for a `{`.
-        if self.at(TokenKind::Word) && self.looks_like_destructure_pattern() {
+        // In condition position (`if x is Class { … }`) we suppress this
+        // so the `{` stays available for the outer block; users can still
+        // write destructure via `(x is Class { f })`.
+        if self.at(TokenKind::Word)
+            && self.suppress_destructure_pattern_depth == 0
+            && self.looks_like_destructure_pattern()
+        {
             self.parse_destructure_pattern(false);
             return;
         }
@@ -3491,7 +3571,9 @@ impl<'a> Parser<'a> {
 
         // Decide between simple binding (`let x`) and destructure
         // (`let Class { ... }`) by peeking past dotted segments for `{`.
-        if self.looks_like_destructure_pattern() {
+        // Same condition-position suppression as `parse_pattern_atom` —
+        // `if x is let Class { f }` would otherwise eat the then-block.
+        if self.suppress_destructure_pattern_depth == 0 && self.looks_like_destructure_pattern() {
             self.parse_path();
             if self.at(TokenKind::Less) && self.looks_like_generic_args() {
                 self.parse_generic_args();
@@ -3820,8 +3902,11 @@ impl<'a> Parser<'a> {
         self.with_node(SyntaxKind::WHILE_STMT, |p| {
             p.expect(TokenKind::While);
 
-            // Condition
+            // Condition: same destructure suppression as `if` — see
+            // `parse_if_expr` for rationale.
+            p.suppress_destructure_pattern_depth += 1;
             p.parse_expr();
+            p.suppress_destructure_pattern_depth -= 1;
 
             // Body
             if p.at(TokenKind::LBrace) {
@@ -4424,10 +4509,15 @@ impl<'a> Parser<'a> {
             // Lambda expression: (params) -> [RetType] { body }
             self.parse_lambda_expr();
         } else if self.at(TokenKind::LParen) {
-            // Parenthesized expression
+            // Parenthesized expression. Parens reset the destructure
+            // suppression: `if (x is Foo { f })` lets the user opt back
+            // into a destructure that condition-position would otherwise
+            // forbid.
             self.with_node(SyntaxKind::PAREN_EXPR, |p| {
                 p.bump(); // (
+                let saved = std::mem::take(&mut p.suppress_destructure_pattern_depth);
                 p.parse_expr();
+                p.suppress_destructure_pattern_depth = saved;
                 p.expect(TokenKind::RParen);
             });
         } else if self.at(TokenKind::LBracket) {
@@ -5838,6 +5928,153 @@ mod tests {
         assert!(
             errors.is_empty(),
             "expected no parse errors, got: {errors:#?}"
+        );
+    }
+
+    #[test]
+    fn is_class_in_condition_does_not_eat_then_block() {
+        // Regression: `if x is Class { body }` used to be parsed as
+        // `if x is Class { body }` where `{ body }` was the destructure
+        // pattern's body — the if-block was eaten. We follow Rust's
+        // approach for struct literals in condition position: in
+        // `if`/`while` conditions, `Path {` is parsed as just the path,
+        // leaving `{` for the outer block.
+        let source = r#"
+function f(x: int | string) -> string {
+  if x is string {
+    "str"
+  } else {
+    "other"
+  }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        // The IF_EXPR should have a BLOCK_EXPR child (the then-block).
+        let if_expr = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::IF_EXPR)
+            .expect("expected IF_EXPR node");
+        let block_count = if_expr
+            .children()
+            .filter(|n| n.kind() == SyntaxKind::BLOCK_EXPR)
+            .count();
+        assert_eq!(
+            block_count, 2,
+            "IF_EXPR should have two BLOCK_EXPR children (then + else); destructure must not consume the then-block"
+        );
+    }
+
+    #[test]
+    fn is_class_destructure_in_condition_with_user_class() {
+        // Same as above but with a user class, which is the case the
+        // chained if-let test originally tripped over.
+        let source = r#"
+class Empty {}
+
+function f(r: int | Empty) -> string {
+  if r is Empty {
+    "empty"
+  } else {
+    "other"
+  }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let if_expr = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::IF_EXPR)
+            .expect("expected IF_EXPR node");
+        let block_count = if_expr
+            .children()
+            .filter(|n| n.kind() == SyntaxKind::BLOCK_EXPR)
+            .count();
+        assert_eq!(block_count, 2);
+
+        // The IS_EXPR's pattern is just the type `Empty`, no destructure.
+        let dest_count = root
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::DESTRUCTURE_PATTERN)
+            .count();
+        assert_eq!(
+            dest_count, 0,
+            "no destructure pattern should be produced in condition position"
+        );
+    }
+
+    #[test]
+    fn is_class_destructure_with_parens_in_condition_still_works() {
+        // Escape hatch: parens reset the destructure suppression. The
+        // user can still write a destructure inside `is` by wrapping the
+        // whole pattern in parens (even though `is`-bindings don't
+        // escape, the parser must not reject this form).
+        let source = r#"
+class User { name string }
+
+function f(r: int | User) -> string {
+  if (r is User { name }) {
+    "user"
+  } else {
+    "other"
+  }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        let dest_count = root
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::DESTRUCTURE_PATTERN)
+            .count();
+        assert_eq!(
+            dest_count, 1,
+            "parens-wrapped destructure in condition should still parse as DESTRUCTURE_PATTERN"
+        );
+    }
+
+    #[test]
+    fn if_let_expr_parses() {
+        // `if let PATTERN = SCRUTINEE { ... } else { ... }` produces an
+        // IF_LET_EXPR node (distinct from IF_EXPR), with PATTERN as a child.
+        let source = r#"
+function f(r: int | string) -> string {
+  if let v: int = r {
+    "int"
+  } else {
+    "other"
+  }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let if_let_count = root
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::IF_LET_EXPR)
+            .count();
+        assert_eq!(if_let_count, 1, "expected one IF_LET_EXPR node");
+
+        // No plain IF_EXPR should sneak in.
+        let if_count = root
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::IF_EXPR)
+            .count();
+        assert_eq!(if_count, 0, "expected no IF_EXPR nodes for if-let form");
+
+        // The IF_LET_EXPR should have a PATTERN child.
+        let if_let = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::IF_LET_EXPR)
+            .unwrap();
+        let pat_count = if_let
+            .children()
+            .filter(|n| n.kind() == SyntaxKind::PATTERN)
+            .count();
+        assert_eq!(
+            pat_count, 1,
+            "IF_LET_EXPR should have exactly one PATTERN child"
         );
     }
 

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -3097,15 +3097,28 @@ impl<'a> Parser<'a> {
     fn parse_if_let_expr(&mut self) {
         self.with_node(SyntaxKind::IF_LET_EXPR, |p| {
             p.expect(TokenKind::If);
-            // `let` is consumed inside parse_pattern → parse_let_pattern.
-            p.parse_pattern();
+            // Pattern. For top-level array patterns (`let [a, b]`), the
+            // `let` keyword has to be consumed at the statement level
+            // because `parse_let_pattern` only handles binding /
+            // destructure shapes after `let`. Mirrors `parse_let_stmt`.
+            if p.peek(1).map(|t| t.kind) == Some(TokenKind::LBracket) {
+                p.bump(); // statement `let`
+                p.parse_pattern();
+            } else {
+                // `let` is consumed inside parse_pattern → parse_let_pattern.
+                p.parse_pattern();
+            }
 
             if !p.eat(TokenKind::Equals) {
                 p.error_unexpected_token("'=' after if-let pattern".to_string());
             }
 
-            // Scrutinee — exclude assignment operators (same as let-stmt).
+            // Scrutinee — exclude assignment operators (same as let-stmt),
+            // and apply condition-position destructure suppression so a
+            // trailing `is Class { ... }` doesn't eat the then-block.
+            p.suppress_destructure_pattern_depth += 1;
             p.parse_expr_bp(3);
+            p.suppress_destructure_pattern_depth -= 1;
 
             // Then block
             if p.at(TokenKind::LBrace) {
@@ -6031,6 +6044,81 @@ function f(r: int | User) -> string {
         assert_eq!(
             dest_count, 1,
             "parens-wrapped destructure in condition should still parse as DESTRUCTURE_PATTERN"
+        );
+    }
+
+    #[test]
+    fn if_let_scrutinee_suppresses_destructure() {
+        // Regression (CodeRabbit on #3579): the if-let scrutinee is in
+        // condition position; a trailing `is Class { ... }` in the
+        // scrutinee must not consume the then-block as a destructure
+        // pattern body.
+        let source = r#"
+class Empty {}
+
+function f(b: bool, r: int | Empty) -> string {
+  if let v: bool = r is Empty {
+    "yes"
+  } else {
+    "no"
+  }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        // The if-let must have two BLOCK_EXPR children (then + else); no
+        // DESTRUCTURE_PATTERN should be produced.
+        let if_let = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::IF_LET_EXPR)
+            .expect("expected IF_LET_EXPR");
+        let block_count = if_let
+            .children()
+            .filter(|n| n.kind() == SyntaxKind::BLOCK_EXPR)
+            .count();
+        assert_eq!(
+            block_count, 2,
+            "IF_LET_EXPR should have two BLOCK_EXPR children (scrutinee's `is Empty {{ ... }}` must not eat the then-block)"
+        );
+        let dest_count = if_let
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::DESTRUCTURE_PATTERN)
+            .count();
+        assert_eq!(dest_count, 0);
+    }
+
+    #[test]
+    fn if_let_accepts_top_level_array_pattern() {
+        // Regression (CodeRabbit on #3579): `if let [a, b] = xs { ... }`
+        // used to error because `parse_let_pattern` demanded an identifier
+        // after `let`. Mirror the let-stmt handling — when `let` is
+        // followed by `[`, consume the keyword and parse an array pattern.
+        let source = r#"
+function f(xs: int[]) -> int {
+  if let [a, b] = xs {
+    a + b
+  } else {
+    0
+  }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        // We should have exactly one IF_LET_EXPR with an ARRAY_PATTERN
+        // somewhere inside it (under the PATTERN wrapper).
+        let if_let = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::IF_LET_EXPR)
+            .expect("expected IF_LET_EXPR");
+        let array_count = if_let
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::ARRAY_PATTERN)
+            .count();
+        assert_eq!(
+            array_count, 1,
+            "expected exactly one ARRAY_PATTERN in the if-let"
         );
     }
 

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -2395,6 +2395,7 @@ impl LetStmt {
                     | SyntaxKind::OPTIONAL_INDEX_EXPR
                     | SyntaxKind::OPTIONAL_CALL_EXPR
                     | SyntaxKind::IF_EXPR
+                    | SyntaxKind::IF_LET_EXPR
                     | SyntaxKind::MATCH_EXPR
                     | SyntaxKind::CATCH_EXPR
                     | SyntaxKind::THROW_EXPR
@@ -2573,6 +2574,7 @@ impl BlockExpr {
                         | SyntaxKind::UNARY_EXPR
                         | SyntaxKind::CALL_EXPR
                         | SyntaxKind::IF_EXPR
+                        | SyntaxKind::IF_LET_EXPR
                         | SyntaxKind::MATCH_EXPR
                         | SyntaxKind::CATCH_EXPR
                         | SyntaxKind::THROW_EXPR

--- a/baml_language/crates/baml_compiler_syntax/src/syntax_kind.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/syntax_kind.rs
@@ -252,6 +252,13 @@ pub enum SyntaxKind {
     PAREN_EXPR,
     BLOCK_EXPR,
     IF_EXPR,
+    /// `if let PATTERN = SCRUTINEE { THEN } (else (BLOCK | IF_EXPR | IF_LET_EXPR))?`
+    ///
+    /// Refutable pattern match in a condition position. Pattern bindings are
+    /// in scope inside `THEN` only — not in `else` or after the `if let`.
+    /// Children, in order: `PATTERN`, scrutinee expr, then `BLOCK_EXPR`,
+    /// optional else `BLOCK_EXPR` / `IF_EXPR` / `IF_LET_EXPR`.
+    IF_LET_EXPR,
     MATCH_EXPR,
     MATCH_ARM,
     MATCH_PATTERN,

--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -22,6 +22,7 @@ pub enum Expression {
     Is(IsExpr),
     Unary(UnaryExpr),
     If(IfExpr),
+    IfLet(IfLetExpr),
     Match(MatchExpr),
     Call(CallExpr),
     Index(IndexExpr),
@@ -46,6 +47,7 @@ impl Expression {
         !matches!(
             self,
             Expression::If(_)
+                | Expression::IfLet(_)
                 | Expression::Match(_)
                 | Expression::Lambda(_)
                 | Expression::Unknown(_)
@@ -73,6 +75,7 @@ impl FromCST for Expression {
             SyntaxKind::IS_EXPR => IsExpr::from_cst(elem).map(Expression::Is)?,
             SyntaxKind::UNARY_EXPR => UnaryExpr::from_cst(elem).map(Expression::Unary)?,
             SyntaxKind::IF_EXPR => IfExpr::from_cst(elem).map(Expression::If)?,
+            SyntaxKind::IF_LET_EXPR => IfLetExpr::from_cst(elem).map(Expression::IfLet)?,
             SyntaxKind::MATCH_EXPR => MatchExpr::from_cst(elem).map(Expression::Match)?,
             SyntaxKind::CALL_EXPR => CallExpr::from_cst(elem).map(Expression::Call)?,
             SyntaxKind::INDEX_EXPR => IndexExpr::from_cst(elem).map(Expression::Index)?,
@@ -126,6 +129,7 @@ impl Expression {
             Expression::Is(is) => is.single_line_width(input),
             Expression::Unary(unary) => unary.single_line_width(input),
             Expression::If(_) => None,
+            Expression::IfLet(_) => None,
             Expression::Match(_) => None,
             Expression::Call(call) => call.single_line_width(input),
             Expression::Index(index) => index.single_line_width(input),
@@ -172,6 +176,7 @@ impl Printable for Expression {
             Expression::Is(is) => is.print(shape, printer),
             Expression::Unary(unary) => unary.print(shape, printer),
             Expression::If(if_expr) => if_expr.print(shape, printer),
+            Expression::IfLet(if_let_expr) => if_let_expr.print(shape, printer),
             Expression::Match(match_expr) => match_expr.print(shape, printer),
             Expression::EnvAccess(env) => env.print(shape, printer),
             Expression::Block(block) => block.print(shape, printer),
@@ -196,6 +201,7 @@ impl Printable for Expression {
             Expression::Is(is) => is.leftmost_token(),
             Expression::Unary(unary) => unary.leftmost_token(),
             Expression::If(if_expr) => if_expr.leftmost_token(),
+            Expression::IfLet(if_let_expr) => if_let_expr.leftmost_token(),
             Expression::Match(match_expr) => match_expr.leftmost_token(),
             Expression::Call(call) => call.leftmost_token(),
             Expression::Index(index) => index.leftmost_token(),
@@ -223,6 +229,7 @@ impl Printable for Expression {
             Expression::Is(is) => is.rightmost_token(),
             Expression::Unary(unary) => unary.rightmost_token(),
             Expression::If(if_expr) => if_expr.rightmost_token(),
+            Expression::IfLet(if_let_expr) => if_let_expr.rightmost_token(),
             Expression::Match(match_expr) => match_expr.rightmost_token(),
             Expression::Call(call) => call.rightmost_token(),
             Expression::Index(index) => index.rightmost_token(),
@@ -1057,9 +1064,12 @@ impl FromCST for IfExpr {
         let else_branch = if let Some(elem) = it.next() {
             let else_token = t::Else::from_cst(elem)?;
 
-            let else_body_node = it.expect_node("else body (if or block)")?;
+            let else_body_node = it.expect_node("else body (if, if-let, or block)")?;
             let else_body = match else_body_node.kind() {
                 SyntaxKind::IF_EXPR => ElseExpr::If(Box::new(IfExpr::from_cst(
+                    SyntaxElement::Node(else_body_node),
+                )?)),
+                SyntaxKind::IF_LET_EXPR => ElseExpr::IfLet(Box::new(IfLetExpr::from_cst(
                     SyntaxElement::Node(else_body_node),
                 )?)),
                 SyntaxKind::BLOCK_EXPR => ElseExpr::Block(Box::new(BlockExpr::from_cst(
@@ -1067,7 +1077,7 @@ impl FromCST for IfExpr {
                 )?)),
                 _ => {
                     return Err(StrongAstError::UnexpectedKindDesc {
-                        expected_desc: "IF_EXPR or BLOCK_EXPR".into(),
+                        expected_desc: "IF_EXPR, IF_LET_EXPR, or BLOCK_EXPR".into(),
                         found: else_body_node.kind(),
                         at: else_body_node.text_range(),
                     });
@@ -1145,11 +1155,13 @@ impl Printable for IfExpr {
     }
 }
 
-/// Used in [`IfExpr`] to represent the else/else-if branch.
+/// Used in [`IfExpr`] / [`IfLetExpr`] to represent the else/else-if branch.
 #[derive(Debug)]
 pub enum ElseExpr {
     /// else if
     If(Box<IfExpr>),
+    /// else if let
+    IfLet(Box<IfLetExpr>),
     /// final else block
     Block(Box<BlockExpr>),
 }
@@ -1158,19 +1170,144 @@ impl Printable for ElseExpr {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         match self {
             ElseExpr::If(if_expr) => if_expr.print(shape, printer),
+            ElseExpr::IfLet(if_let_expr) => if_let_expr.print(shape, printer),
             ElseExpr::Block(block) => block.print(shape, printer),
         }
     }
     fn leftmost_token(&self) -> TextRange {
         match self {
             ElseExpr::If(if_expr) => if_expr.leftmost_token(),
+            ElseExpr::IfLet(if_let_expr) => if_let_expr.leftmost_token(),
             ElseExpr::Block(block) => block.leftmost_token(),
         }
     }
     fn rightmost_token(&self) -> TextRange {
         match self {
             ElseExpr::If(if_expr) => if_expr.rightmost_token(),
+            ElseExpr::IfLet(if_let_expr) => if_let_expr.rightmost_token(),
             ElseExpr::Block(block) => block.rightmost_token(),
+        }
+    }
+}
+
+/// Corresponds to a [`SyntaxKind::IF_LET_EXPR`] node.
+///
+/// `if let PATTERN = SCRUTINEE BLOCK (else (BLOCK | IF_EXPR | IF_LET_EXPR))?`
+#[derive(Debug)]
+pub struct IfLetExpr {
+    pub keyword: t::If,
+    /// `let PATTERN` — the leading `let` is part of the pattern grammar
+    /// (`parse_let_pattern`), so it's stored inside `pattern` rather than
+    /// as a separate token.
+    pub pattern: MatchPattern,
+    pub equals: t::Equals,
+    pub scrutinee: Box<Expression>,
+    pub block: BlockExpr,
+    pub else_branch: Option<(t::Else, ElseExpr)>,
+}
+
+impl FromCST for IfLetExpr {
+    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
+        let node = StrongAstError::assert_is_node(elem)?;
+        StrongAstError::assert_kind_node(&node, SyntaxKind::IF_LET_EXPR)?;
+
+        let mut it = SyntaxNodeIter::new(&node);
+
+        // KW_IF
+        let keyword = it.expect_parse()?;
+
+        // PATTERN (consumes its own leading `let` token)
+        let pattern = it.expect_parse()?;
+
+        // `=` separator between pattern and scrutinee
+        let equals = it.expect_parse()?;
+
+        // Scrutinee: any expression
+        let scrutinee_elem = it.expect_next("if-let scrutinee expression")?;
+        let scrutinee = Box::new(Expression::from_cst(scrutinee_elem)?);
+
+        // Then block
+        let block: BlockExpr = it.expect_parse()?;
+
+        // Optional else / else-if / else-if-let
+        let else_branch = if let Some(elem) = it.next() {
+            let else_token = t::Else::from_cst(elem)?;
+            let else_body_node = it.expect_node("else body (if, if-let, or block)")?;
+            let else_body = match else_body_node.kind() {
+                SyntaxKind::IF_EXPR => ElseExpr::If(Box::new(IfExpr::from_cst(
+                    SyntaxElement::Node(else_body_node),
+                )?)),
+                SyntaxKind::IF_LET_EXPR => ElseExpr::IfLet(Box::new(IfLetExpr::from_cst(
+                    SyntaxElement::Node(else_body_node),
+                )?)),
+                SyntaxKind::BLOCK_EXPR => ElseExpr::Block(Box::new(BlockExpr::from_cst(
+                    SyntaxElement::Node(else_body_node),
+                )?)),
+                _ => {
+                    return Err(StrongAstError::UnexpectedKindDesc {
+                        expected_desc: "IF_EXPR, IF_LET_EXPR, or BLOCK_EXPR".into(),
+                        found: else_body_node.kind(),
+                        at: else_body_node.text_range(),
+                    });
+                }
+            };
+            Some((else_token, else_body))
+        } else {
+            None
+        };
+
+        it.expect_end()?;
+
+        Ok(IfLetExpr {
+            keyword,
+            pattern,
+            equals,
+            scrutinee,
+            block,
+            else_branch,
+        })
+    }
+}
+
+impl KnownKind for IfLetExpr {
+    fn kind() -> SyntaxKind {
+        SyntaxKind::IF_LET_EXPR
+    }
+}
+
+impl Printable for IfLetExpr {
+    fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        printer.print_raw_token(&self.keyword);
+        printer.print_str(" ");
+        // `if let PATTERN = SCRUTINEE { ... }` — pattern carries its own
+        // leading `let`. No surrounding parens around the pattern or
+        // scrutinee (unlike plain `if`, where parens are canonicalised
+        // around the condition).
+        printer.print(&self.pattern, shape.clone());
+        printer.print_str(" ");
+        printer.print_raw_token(&self.equals);
+        printer.print_str(" ");
+        printer.print(&*self.scrutinee, shape.clone());
+        printer.print_str(" ");
+        printer.print(&self.block, shape.clone());
+
+        if let Some((else_kw, else_expr)) = &self.else_branch {
+            printer.print_str(" ");
+            printer.print_raw_token(else_kw);
+            printer.print_str(" ");
+            printer.print(else_expr, shape);
+        }
+
+        PrintInfo::default_multi_lined()
+    }
+    fn leftmost_token(&self) -> TextRange {
+        self.keyword.span()
+    }
+    fn rightmost_token(&self) -> TextRange {
+        if let Some((_, else_expr)) = &self.else_branch {
+            else_expr.rightmost_token()
+        } else {
+            self.block.rightmost_token()
         }
     }
 }

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -296,3 +296,65 @@ mod is_format_tests {
         assert_formats_to(source, source);
     }
 }
+
+#[cfg(test)]
+mod if_let_format_tests {
+    //! Formatter tests for `if let PATTERN = SCRUTINEE { ... } else { ... }`.
+
+    use super::*;
+
+    fn assert_formats_to(source: &str, expected: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed on `if let`");
+        assert_eq!(
+            formatted, expected,
+            "formatter output didn't match expected\n--- got ---\n{formatted}\n--- want ---\n{expected}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    #[test]
+    fn test_if_let_basic_binding() {
+        let source = "function f(r: int | string) -> string {\n    if let v: int = r {\n        \"int\"\n    } else {\n        \"other\"\n    }\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_if_let_no_else() {
+        // Statement form — no else branch, expression evaluates to void.
+        let source = "function f(r: int | string) -> void {\n    if let v: int = r {\n        let _ = v;\n    }\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_if_let_else_if_let_chain() {
+        // `else if let` should preserve the chain shape on one statement.
+        let source = "function f(r: int | string | bool) -> string {\n    if let v: int = r {\n        \"int\"\n    } else if let v: string = r {\n        v\n    } else {\n        \"bool\"\n    }\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_if_let_else_if_plain() {
+        // Mixing `if let` with a plain `else if` (using `is`) must format
+        // cleanly. Tests the IF_EXPR-after-IF_LET_EXPR else branch.
+        // Plain `if` conditions are canonicalised with parens by the
+        // formatter, hence the `if (r is string)` in the expected output.
+        let source = "function f(r: int | string) -> string {\n    if let v: int = r {\n        \"int\"\n    } else if r is string {\n        \"str\"\n    } else {\n        \"other\"\n    }\n}\n";
+        let expected = "function f(r: int | string) -> string {\n    if let v: int = r {\n        \"int\"\n    } else if (r is string) {\n        \"str\"\n    } else {\n        \"other\"\n    }\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    #[test]
+    fn test_if_let_destructure_pattern() {
+        // Class destructure pattern inside if-let.
+        let source = "class User {\n    name: string,\n    age: int,\n}\n\nfunction f(u: User) -> string {\n    if let User { name, age } = u {\n        name\n    } else {\n        \"none\"\n    }\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_if_let_or_pattern() {
+        let source = "class Ok {\n    value: string,\n}\n\nclass Warn {\n    value: string,\n}\n\nfunction f(r: Ok | Warn) -> string {\n    if let s: Ok | Warn = r {\n        s.value\n    } else {\n        \"none\"\n    }\n}\n";
+        assert_formats_to(source, source);
+    }
+}

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -896,6 +896,7 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::GenericClassDestructureRequiresTypeArgs { .. } => DiagnosticId::TypeMismatch,
         TirTypeError::RestSubPatternNotSupported => DiagnosticId::TypeMismatch,
         TirTypeError::RefutablePatternInLet { .. } => DiagnosticId::RefutablePatternInLet,
+        TirTypeError::IrrefutablePatternInIfLet => DiagnosticId::IrrefutablePatternInIfLet,
         TirTypeError::InvalidCatchBindingType { .. } => DiagnosticId::InvalidCatchBindingType,
         TirTypeError::ThrowsContractViolation { .. }
         | TirTypeError::CallbackThrowsContractViolation { .. } => {

--- a/baml_language/crates/baml_lsp2_actions/src/completions.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/completions.rs
@@ -305,6 +305,7 @@ fn detect_context(
             | SyntaxKind::PAREN_EXPR
             | SyntaxKind::BLOCK_EXPR
             | SyntaxKind::IF_EXPR
+            | SyntaxKind::IF_LET_EXPR
             | SyntaxKind::FOR_EXPR
             | SyntaxKind::LET_STMT
             | SyntaxKind::RETURN_STMT => {

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_basic.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_basic.baml
@@ -1,0 +1,37 @@
+// Basic if-let: simple binding plus narrowing on the scrutinee.
+class Ok {
+  value string
+}
+class Err {
+  message string
+}
+
+// Bind the scrutinee under a refined type.
+function RefineSimple(r: Ok | Err) -> string {
+  if let o: Ok = r {
+    o.value
+  } else {
+    "fallback"
+  }
+}
+
+// Without an else, the if-let returns void; here we use a statement form.
+function StatementForm(r: Ok | Err) -> string {
+  if let o: Ok = r {
+    return o.value;
+  }
+  "no-match"
+}
+
+// Pattern bindings only visible in the then-branch.
+function ElseSeesResidual(r: Ok | Err) -> string {
+  if let o: Ok = r {
+    o.value
+  } else {
+    r.message
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_binding_scope.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_binding_scope.baml
@@ -1,0 +1,74 @@
+// `if let` pattern bindings must not leak past the then-branch.
+class Ok {
+  value string
+}
+class Err {
+  message string
+}
+
+// `o` is bound inside the then-branch, must NOT escape after the if-let.
+function BindingDoesNotEscapeAfter(r: Ok | Err) -> string {
+  if let o: Ok = r {
+    let _ = o.value;
+  }
+  // `o` is out of scope here — must error.
+  o.value
+}
+
+// Same binding name, different if-let — no cross-contamination.
+function BindingDoesNotEscapeIntoSibling(r: Ok | Err) -> string {
+  if let o: Ok = r {
+    let _ = o.value;
+  }
+  if let o: Ok = r {
+    return o.value;
+  }
+  // `o` is out of scope here — must error.
+  o.value
+}
+
+// Else branch must NOT see the then-branch's binding.
+function BindingDoesNotLeakIntoElse(r: Ok | Err) -> string {
+  if let o: Ok = r {
+    o.value
+  } else {
+    // `o` is not visible here — must error.
+    o.value
+  }
+}
+
+//----
+//- diagnostics
+// error: unresolved name: o
+//     ╭─[ if_let_if_let_binding_scope.baml:13:4 ]
+//     │
+//  13 │ ╭─▶   }
+//     ┆ ┆   
+//  15 │ ├─▶   o.value
+//     │ │               
+//     │ ╰─────────────── unresolved name: o
+//     │     
+//     │     Note: Error code: E0003
+// ────╯
+// error: unresolved name: o
+//     ╭─[ if_let_if_let_binding_scope.baml:25:4 ]
+//     │
+//  25 │ ╭─▶   }
+//     ┆ ┆   
+//  27 │ ├─▶   o.value
+//     │ │               
+//     │ ╰─────────────── unresolved name: o
+//     │     
+//     │     Note: Error code: E0003
+// ────╯
+// error: unresolved name: o
+//     ╭─[ if_let_if_let_binding_scope.baml:34:11 ]
+//     │
+//  34 │ ╭─▶   } else {
+//     ┆ ┆   
+//  36 │ ├─▶     o.value
+//     │ │                 
+//     │ ╰───────────────── unresolved name: o
+//     │     
+//     │     Note: Error code: E0003
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_chained.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_chained.baml
@@ -1,0 +1,54 @@
+// `else if let` and `else if` chains.
+class Ok {
+  value string
+}
+class Err {
+  message string
+}
+class Empty {}
+
+// Plain `else if` after `if let`. The `is Empty { ... }` form is no
+// longer ambiguous with the then-block in condition position — the
+// parser suppresses destructure patterns there (Rust-style restriction).
+function MixedChainPlain(r: Ok | Err | Empty) -> string {
+  if let o: Ok = r {
+    o.value
+  } else if r is Empty {
+    "empty"
+  } else {
+    "other"
+  }
+}
+
+// `else if let` chain — each branch binds its own name.
+function IfLetChain(r: Ok | Err | Empty) -> string {
+  if let o: Ok = r {
+    o.value
+  } else if let e: Err = r {
+    e.message
+  } else {
+    "empty"
+  }
+}
+
+// `else if let` without a final else.
+function IfLetChainNoElse(r: Ok | Err) -> string {
+  if let o: Ok = r {
+    return o.value;
+  } else if let e: Err = r {
+    return e.message;
+  }
+  "unreachable"
+}
+
+//----
+//- diagnostics
+// warning: irrefutable `if let` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//     ╭─[ if_let_if_let_chained.baml:38:12 ]
+//     │
+//  38 │   } else if let e: Err = r {
+//     │            ─────┬─────  
+//     │                 ╰─────── irrefutable `if let` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//     │ 
+//     │ Note: Error code: E0112
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_composite_scrutinee.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_composite_scrutinee.baml
@@ -1,0 +1,25 @@
+// `if let pat = func()` — composite scrutinee (call expression, not a
+// path local). Bindings still work; no scrutinee-narrowing applies because
+// there's no name to narrow.
+class Ok {
+  value string
+}
+class Err {
+  message string
+}
+
+function maybe() -> Ok | Err {
+  Ok { value: "computed" }
+}
+
+function CompositeScrutinee() -> string {
+  if let o: Ok = maybe() {
+    o.value
+  } else {
+    "no match"
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_destructure.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_destructure.baml
@@ -1,0 +1,40 @@
+// if-let with class destructuring binds field names in the then-branch.
+class User {
+  name string
+  age int
+}
+
+// Plain destructure on a non-union scrutinee is irrefutable, so this should
+// warn — `else` can never fire.
+function DestructureIrrefutable(u: User) -> string {
+  if let User { name, age } = u {
+    name
+  } else {
+    "no name"
+  }
+}
+
+class Admin {
+  name string
+}
+
+// Refutable destructure: scrutinee is a union, pattern picks one variant.
+function DestructureRefutable(u: User | Admin) -> string {
+  if let User { name, age } = u {
+    name
+  } else {
+    "admin"
+  }
+}
+
+//----
+//- diagnostics
+// warning: irrefutable `if let` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//     ╭─[ if_let_if_let_destructure.baml:10:5 ]
+//     │
+//  10 │   if let User { name, age } = u {
+//     │     ───────────┬───────────  
+//     │                ╰───────────── irrefutable `if let` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//     │ 
+//     │ Note: Error code: E0112
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_irrefutable_warns.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_irrefutable_warns.baml
@@ -1,0 +1,20 @@
+// `if let` with an irrefutable pattern should warn — `else` is unreachable.
+function IrrefutablePlainBinding(x: int) -> int {
+  if let v = x {
+    v
+  } else {
+    0
+  }
+}
+
+//----
+//- diagnostics
+// warning: irrefutable `if let` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//    ╭─[ if_let_if_let_irrefutable_warns.baml:3:5 ]
+//    │
+//  3 │   if let v = x {
+//    │     ───┬──  
+//    │        ╰──── irrefutable `if let` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//    │ 
+//    │ Note: Error code: E0112
+// ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_nested_shadowing.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_nested_shadowing.baml
@@ -1,0 +1,25 @@
+// Nested if-let: inner binding shadows the outer one. After the inner
+// if-let, the outer binding must be back in scope. After both if-lets,
+// neither binding may be referenced.
+class Wrapper {
+  payload string
+}
+class Empty {}
+
+function Shadowing(outer: Wrapper | Empty, inner: Wrapper | Empty) -> string {
+  if let w: Wrapper = outer {
+    if let w: Wrapper = inner {
+      // `w` here is the inner binding.
+      w.payload
+    } else {
+      // Inner scope ended; outer `w` is back.
+      w.payload
+    }
+  } else {
+    "none"
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_no_else_in_value_position.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_no_else_in_value_position.baml
@@ -1,0 +1,22 @@
+// If-let with no else used in value position must emit `VoidUsedAsValue`,
+// mirroring plain `if` without else. (Caught by CodeRabbit on #3579.)
+
+function NoElseInValuePosition(x: int | string) -> string {
+  if let v: int = x {
+    "matched"
+  }
+}
+
+//----
+//- diagnostics
+// error: `if` without `else` cannot be used as a value; add an `else` branch
+//    ╭─[ if_let_if_let_no_else_in_value_position.baml:4:60 ]
+//    │
+//  4 │ ╭─▶ function NoElseInValuePosition(x: int | string) -> string {
+//    ┆ ┆   
+//  7 │ ├─▶   }
+//    │ │         
+//    │ ╰───────── `if` without `else` cannot be used as a value; add an `else` branch
+//    │     
+//    │     Note: Error code: E0001
+// ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_optional_scrutinee.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_optional_scrutinee.baml
@@ -1,0 +1,39 @@
+// Optional / nullable scrutinee: `if let x: T = optional_value` should
+// bind `x: T` in the then-branch and narrow the scrutinee to `null` in
+// the else-branch (when the scrutinee is a path local).
+
+// Simple primitive optional.
+function PrimitiveOptional(x: int?) -> int {
+  if let v: int = x {
+    v
+  } else {
+    // `x` narrows to `null` here.
+    0
+  }
+}
+
+// Class optional.
+class Item {
+  name string
+}
+
+function ClassOptional(item: Item?) -> string {
+  if let i: Item = item {
+    i.name
+  } else {
+    "none"
+  }
+}
+
+// Optional with destructuring.
+function DestructureOptional(item: Item?) -> string {
+  if let Item { name } = item {
+    name
+  } else {
+    "none"
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_or_pattern.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_or_pattern.baml
@@ -1,0 +1,25 @@
+// `if let A | B = ...` — or-pattern alternatives must bind the same names
+// across both sides; the binding's type joins both branches.
+class Ok {
+  value string
+}
+class Warn {
+  value string
+}
+class Err {
+  message string
+}
+
+// Both alternatives bind `s` to a class that has a `value` field. The
+// binding's type is `Ok | Warn`, and `.value` is the field common to both.
+function OrPatternBothBindValue(r: Ok | Warn | Err) -> string {
+  if let s: Ok | Warn = r {
+    s.value
+  } else {
+    r.message
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_post_diverge_narrowing.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_post_diverge_narrowing.baml
@@ -1,0 +1,23 @@
+// Post-diverge narrowing: when `if let P = x { return … }` and the
+// then-branch always diverges, `x` should narrow to the complement type
+// after the statement. Mirrors the same narrowing that `if x is P {
+// return … }` (and other diverging if-then forms) gives. Caught by
+// CodeRabbit on #3579.
+class Ok {
+  value string
+}
+class Err {
+  message string
+}
+
+function ResidualNarrowAfterDiverge(r: Ok | Err) -> string {
+  if let o: Ok = r {
+    return o.value;
+  }
+  // `r` should be narrowed to `Err` here — `r.message` must resolve.
+  r.message
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_throws.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_throws.baml
@@ -1,0 +1,44 @@
+// Throws analysis must flow through if-let: throws from the scrutinee and
+// from either branch are part of the function's effective throws set.
+
+// Scrutinee can throw — its throws must appear in the declared throws.
+// Returns a union so the if-let pattern stays refutable.
+function may_yield(x: int) -> int | string throws int {
+  if (x < 0) {
+    throw x
+  } else {
+    "fallback"
+  }
+}
+
+// Positive: both `int` (from scrutinee call) and `string` (from then-branch
+// throw) are declared. Refutable pattern keeps both branches live.
+function ThrowsThroughIfLet(x: int) -> string throws int | string {
+  if let n: int = may_yield(x) {
+    throw "then-branch threw"
+  } else {
+    "no match"
+  }
+}
+
+// Negative: declared throws missing the type thrown from the else-branch.
+// Refutable scrutinee type so the else branch is reachable.
+function ThrowsContractViolationInElse(v: int | string) -> string throws never {
+  if let n: int = v {
+    "matched"
+  } else {
+    throw "from else"
+  }
+}
+
+//----
+//- diagnostics
+// error: throws contract violation: `never` is missing string
+//     ╭─[ if_let_if_let_throws.baml:26:73 ]
+//     │
+//  26 │ function ThrowsContractViolationInElse(v: int | string) -> string throws never {
+//     │                                                                         ───┬──  
+//     │                                                                            ╰──── throws contract violation: `never` is missing string
+//     │ 
+//     │ Note: Error code: E0096
+// ────╯

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -163,6 +163,22 @@ pub(crate) mod support {
                     None => format!("if ({cond}) {then_desc}"),
                 }
             }
+            Expr::IfLet {
+                scrutinee,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                let scrut = expr_desc(*scrutinee, body);
+                let then_desc = expr_desc(*then_branch, body);
+                match else_branch {
+                    Some(eb) => format!(
+                        "if let <pat> = {scrut} {then_desc} else {}",
+                        expr_desc(*eb, body)
+                    ),
+                    None => format!("if let <pat> = {scrut} {then_desc}"),
+                }
+            }
             Expr::Match {
                 scrutinee, arms, ..
             } => {
@@ -1461,6 +1477,23 @@ pub(crate) mod support {
                             expr_desc_hir(*eb, body, prefix, local_type_names)
                         ),
                         None => format!("if ({cond}) {then_desc}"),
+                    }
+                }
+                Expr::IfLet {
+                    pattern,
+                    scrutinee,
+                    then_branch,
+                    else_branch,
+                } => {
+                    let pat = pat_desc_hir(*pattern, body, prefix, local_type_names);
+                    let scrut = expr_desc_hir(*scrutinee, body, prefix, local_type_names);
+                    let then_desc = expr_desc_hir(*then_branch, body, prefix, local_type_names);
+                    match else_branch {
+                        Some(eb) => format!(
+                            "if let {pat} = {scrut} {then_desc} else {}",
+                            expr_desc_hir(*eb, body, prefix, local_type_names)
+                        ),
+                        None => format!("if let {pat} = {scrut} {then_desc}"),
                     }
                 }
                 Expr::Match {

--- a/baml_language/crates/bex_engine/tests/control_flow.rs
+++ b/baml_language/crates/bex_engine/tests/control_flow.rs
@@ -100,3 +100,332 @@ async fn match_arm_return_returns_without_falling_through() -> anyhow::Result<()
     })
     .await
 }
+
+#[tokio::test]
+async fn if_let_takes_then_branch_when_pattern_matches() -> anyhow::Result<()> {
+    // Pattern matches → then-branch runs, binding visible inside.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function describe(r: Ok | Err) -> string {
+                if let o: Ok = r {
+                    o.value
+                } else {
+                    "no match"
+                }
+            }
+
+            function main() -> string {
+                describe(Ok { value: "hit" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("hit".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_takes_else_branch_when_pattern_does_not_match() -> anyhow::Result<()> {
+    // Pattern fails → else runs; scrutinee is narrowed to the complement, so
+    // `r.message` resolves on `Err`.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function describe(r: Ok | Err) -> string {
+                if let o: Ok = r {
+                    o.value
+                } else {
+                    r.message
+                }
+            }
+
+            function main() -> string {
+                describe(Err { message: "boom" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("boom".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_destructure_binds_fields_at_runtime() -> anyhow::Result<()> {
+    // Class destructure: shorthand field names are bound and readable in
+    // the then-branch.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class User { name string, age int }
+            class Admin { handle string }
+
+            function greet(u: User | Admin) -> string {
+                if let User { name, age } = u {
+                    name
+                } else {
+                    "admin"
+                }
+            }
+
+            function main() -> string {
+                greet(User { name: "alice", age: 30 })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("alice".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_else_if_let_chain_runs_correct_arm() -> anyhow::Result<()> {
+    // Three-way chain: first arm fails, second succeeds — second branch's
+    // body runs.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+            class Empty {}
+
+            function pick(r: Ok | Err | Empty) -> string {
+                if let o: Ok = r {
+                    o.value
+                } else if let e: Err = r {
+                    e.message
+                } else {
+                    "empty"
+                }
+            }
+
+            function main() -> string {
+                pick(Err { message: "second" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("second".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_chain_falls_through_to_final_else() -> anyhow::Result<()> {
+    // All preceding arms fail → final else runs.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+            class Empty {}
+
+            function pick(r: Ok | Err | Empty) -> string {
+                if let o: Ok = r {
+                    o.value
+                } else if let e: Err = r {
+                    e.message
+                } else {
+                    "empty"
+                }
+            }
+
+            function main() -> string {
+                pick(Empty {})
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("empty".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_or_pattern_dispatches_to_either_alternative() -> anyhow::Result<()> {
+    // `Ok | Warn` — both alternatives bind `s.value`. Same body runs for
+    // either class.
+    let cases = [
+        (r#"Ok { value: "ok!" }"#, "ok!"),
+        (r#"Warn { value: "warn!" }"#, "warn!"),
+        (r#"Err { message: "boom" }"#, "boom"),
+    ];
+    for (ctor, expected) in cases {
+        let source = format!(
+            r#"
+            class Ok {{ value string }}
+            class Warn {{ value string }}
+            class Err {{ message string }}
+
+            function describe(r: Ok | Warn | Err) -> string {{
+                if let s: Ok | Warn = r {{
+                    s.value
+                }} else {{
+                    r.message
+                }}
+            }}
+
+            function main() -> string {{
+                describe({ctor})
+            }}
+            "#
+        );
+        assert_engine_executes(EngineProgram {
+            source: Box::leak(source.into_boxed_str()),
+            entry: "main",
+            expected: Ok(BexExternalValue::String(expected.to_string())),
+            ..Default::default()
+        })
+        .await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn if_let_nested_shadowing_restores_outer_binding() -> anyhow::Result<()> {
+    // Inner if-let shadows `w` from the outer if-let. When the inner else
+    // runs, the outer `w` must be visible again (carrying the outer
+    // payload).
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Wrapper { payload string }
+            class Other {}
+
+            function pick(outer: Wrapper, inner: Wrapper | Other) -> string {
+                if let w: Wrapper = outer {
+                    if let w: Wrapper = inner {
+                        // Inner `w` shadows outer; we read the inner payload.
+                        w.payload
+                    } else {
+                        // Inner scope ended; outer `w` is visible again.
+                        w.payload
+                    }
+                } else {
+                    "none"
+                }
+            }
+
+            function main() -> string {
+                // Inner is `Other`, so the inner-else branch runs and we
+                // see the OUTER's payload, not the inner's.
+                pick(Wrapper { payload: "outer" }, Other {})
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("outer".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_composite_scrutinee_binds_call_result() -> anyhow::Result<()> {
+    // Scrutinee is a function call (not a path local). No scrutinee
+    // narrowing applies, but the pattern binding must still capture the
+    // call's result value.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function maybe() -> Ok | Err {
+                Ok { value: "from call" }
+            }
+
+            function main() -> string {
+                if let o: Ok = maybe() {
+                    o.value
+                } else {
+                    "no match"
+                }
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("from call".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_optional_scrutinee_some() -> anyhow::Result<()> {
+    // Nullable scrutinee where the value is present.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Item { name string }
+
+            function pick(item: Item?) -> string {
+                if let i: Item = item {
+                    i.name
+                } else {
+                    "none"
+                }
+            }
+
+            function main() -> string {
+                pick(Item { name: "alice" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("alice".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_optional_scrutinee_null() -> anyhow::Result<()> {
+    // Nullable scrutinee passing `null` — pattern fails, else branch runs.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Item { name string }
+
+            function pick(item: Item?) -> string {
+                if let i: Item = item {
+                    i.name
+                } else {
+                    "none"
+                }
+            }
+
+            function main() -> string {
+                pick(null)
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("none".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn if_let_statement_form_with_return_in_then() -> anyhow::Result<()> {
+    // No-else statement form: returns from inside the matched branch;
+    // unmatched falls through to the tail expression.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function first_value(r: Ok | Err) -> string {
+                if let o: Ok = r {
+                    return o.value;
+                }
+                "fell through"
+            }
+
+            function main() -> string {
+                first_value(Err { message: "ignored" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("fell through".to_string())),
+        ..Default::default()
+    })
+    .await
+}

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -599,6 +599,11 @@ fn expr_desc_spans<'db>(
             spans.extend(expr_desc_spans(*condition, body, inference));
             spans.push(DetailSpan::Code(") { ... }".into()));
         }
+        Expr::IfLet { scrutinee, .. } => {
+            spans.push(DetailSpan::Code("if let ... = ".into()));
+            spans.extend(expr_desc_spans(*scrutinee, body, inference));
+            spans.push(DetailSpan::Code(" { ... }".into()));
+        }
         Expr::Match { scrutinee, .. } => {
             spans.push(DetailSpan::Code("match (".into()));
             spans.extend(expr_desc_spans(*scrutinee, body, inference));
@@ -2054,6 +2059,7 @@ impl CompilerRunner {
                     .collect::<Vec<_>>()
                     .join("."),
                 Expr::If { .. } => "if ...".into(),
+                Expr::IfLet { .. } => "if let ...".into(),
                 Expr::Match { .. } => "match ...".into(),
                 Expr::Is { scrutinee, .. } => {
                     format!("{} is <pattern>", expr_desc(*scrutinee, body))


### PR DESCRIPTION
## Summary

Refutable pattern binding in condition position:

```baml
if let User { name } = u {
  name
} else {
  "no match"
}
```

* New `Expr::IfLet` AST node — distinct from `Expr::If`, no parse-time desugaring (cleaner diagnostics + LSP).
* TIR: `infer_if_let_expr` / `check_if_let_expr` reuse match's pattern infrastructure (`analyze_and_lower`, `finalize_pattern_lowering`, exhaustiveness matrix) for binding registration and refutability detection.
* MIR: `lower_if_let` via `lower_pattern_test` + `bind_pattern` (no desugaring).
* `else if let` chaining handled by the existing else-branch dispatch.
* Scrutinee narrowing in then-branch (matched type) and else-branch (residual) — same shape as `<expr> is <pat>`, plus pattern bindings.
* New warning `E0112 IrrefutablePatternInIfLet` when the matrix shows the pattern covers every value — `else` would be dead.
* Formatter (`baml_fmt`) handles the new node with `IfLetExpr` + `ElseExpr::IfLet`.

### Drive-by fix: `is`-destructure ambiguity

`if x is Class { ... }` used to greedily consume the then-block as a destructure pattern body, breaking common code like `else if r is Empty { ... }`. Mirrored Rust's `NO_STRUCT_LITERAL` restriction — destructure patterns are suppressed in `if`/`while` condition position, with parens as an escape hatch (`if (x is Class { f })`).

## Test plan

24 new tests:

- [x] 4 parser unit tests (CST shape, ambiguity regression, parens escape hatch)
- [x] 11 LSP fixture tests covering: basic narrowing & binding scope, destructuring, irrefutable-pattern warning, `else if`/`else if let` chaining, binding-doesn't-leak (3 cases), or-patterns, nested shadowing, composite scrutinee, optional scrutinee, throws-analysis flow
- [x] 6 formatter tests (basic, no-else, chain, mixed plain/let, destructure, or-pattern)
- [x] 11 end-to-end runtime tests in `bex_engine` (then/else dispatch, destructure binding at runtime, or-pattern alternatives, nested shadowing, composite scrutinee, optional scrutinee some/null, statement form, chain dispatch + fall-through)

Full workspace test run: **5710 / 5714 pass**. The 4 failures are pre-existing `sdk_test_python_pydantic2 *::pytest` cases blocked by a stale precompiled `baml_py.abi3.so` missing the `register_host_callable` symbol added by #3571 — unrelated to this PR.

## Follow-ups (not in this PR)

- `while let` — natural counterpart; same infrastructure would extend.
- Promote scrutinee narrowing through `&&` / `\|\|` chains for `if let`? (Rust doesn't; we don't either today.)
- Quick-fix code action for the irrefutable warning (convert to plain `let`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `if let` conditional pattern matching with scoped then-branch bindings, type narrowing, destructuring and or-pattern support, plus `else if let` / mixed `else if` chains.
  * Formatter and editor tooling now recognize and format `if let`; completions treat `if let` as a value-position expression.
* **Diagnostics**
  * New warning for irrefutable `if let` patterns (E0112) when the else branch is unreachable.
* **Tests**
  * Extensive unit/integration tests and fixtures covering scoping, chaining, throws, destructuring, nullable scrutinees, and formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->