### PR TITLE
Make spawn-raced VM slots crash-safe

### DIFF
--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -919,10 +919,10 @@ fn emit_glue_method(out: &mut String, method_name: &str, b: &NativeBuiltin) {
         .as_ref()
         .is_some_and(|r| r.receiver_type.is_mut());
     let needs_owned = matches!(b.vm_usage, VmUsage::MutRef) || b.may_yield || receiver_is_mut_self;
-    // Array/Map extractions return read/write guards that borrow `vm`. If
+    // Container extractions return read/write guards that borrow `vm`. If
     // the glue function's result conversion needs `&mut vm` (alloc_string /
     // alloc_array / alloc_map / alloc_uint8array), the guard's borrow would
-    // conflict — so clone the Array/Map up front in those cases. This is a
+    // conflict — so clone the container up front in those cases. This is a
     // separate flag from `needs_owned` because it must NOT propagate to
     // other extraction paths (the media-class path uses `needs_owned` for
     // its own reasons and switching it on here would break the receiver
@@ -1153,11 +1153,11 @@ fn emit_mut_receiver_extraction_indented(
         "Uint8Array" => "vm.as_uint8array_mut(&args[0])?".to_string(),
         _ => "vm.as_value_mut(&args[0])?".to_string(),
     };
-    // Array/Map now return a guard rather than `&mut Vec/IndexMap`. Bind
-    // mutably so the call site can take `&mut name` and let the
-    // DerefMut impl coerce to the underlying container.
+    // Container receivers now return a guard rather than `&mut Vec/IndexMap`.
+    // Bind mutably so the call site can take `&mut name` and let the DerefMut
+    // impl coerce to the underlying container.
     let mut_kw = match recv.class_name.as_str() {
-        "Array" | "Map" => "mut ",
+        "Array" | "Map" | "Uint8Array" => "mut ",
         _ => "",
     };
     writeln!(out, "{indent}let {mut_kw}{name} = {expr};").unwrap();
@@ -1251,7 +1251,7 @@ fn receiver_immut_extraction_expr(
     arraymap_needs_owned: bool,
 ) -> String {
     match recv.class_name.as_str() {
-        // Clone for Array/Map read receivers when the glue function would
+        // Clone for container read receivers when the glue function would
         // later need `&mut vm` after extraction (per `arraymap_needs_owned`).
         // Otherwise `vm.as_array(...)?` returns a guard whose lock is
         // released on drop — the cheap path.
@@ -1264,7 +1264,7 @@ fn receiver_immut_extraction_expr(
         }
         "Map" => {
             if arraymap_needs_owned {
-                format!("vm.as_map({val})?.clone()")
+                format!("vm.as_map({val})?.to_index_map()")
             } else {
                 format!("vm.as_map({val})?")
             }
@@ -1277,7 +1277,7 @@ fn receiver_immut_extraction_expr(
             }
         }
         "Uint8Array" => {
-            if needs_owned {
+            if arraymap_needs_owned {
                 format!("vm.as_uint8array({val})?.clone()")
             } else {
                 format!("vm.as_uint8array({val})?")
@@ -1392,7 +1392,7 @@ fn extraction_expr(
             if is_mut {
                 format!("vm.as_map_mut({val})?")
             } else if arraymap_needs_owned {
-                format!("vm.as_map({val})?.clone()")
+                format!("vm.as_map({val})?.to_index_map()")
             } else {
                 format!("vm.as_map({val})?")
             }
@@ -1409,7 +1409,7 @@ fn extraction_expr(
         BamlType::Uint8Array => {
             if is_mut {
                 format!("vm.as_uint8array_mut({val})?")
-            } else if needs_owned {
+            } else if arraymap_needs_owned {
                 format!("vm.as_uint8array({val})?.clone()")
             } else {
                 format!("vm.as_uint8array({val})?")
@@ -1430,8 +1430,8 @@ fn extraction_expr(
 
 fn call_arg_list(b: &NativeBuiltin, needs_owned: bool, arraymap_needs_owned: bool) -> String {
     let mut args: Vec<String> = Vec::new();
-    // For Array/Map we use the dedicated flag — these may be owned (cloned
-    // Vec/IndexMap) even when other types are passed by reference, because
+    // For guarded containers we use the dedicated flag — these may be owned
+    // (cloned Vec/IndexMap) even when other types are passed by reference, because
     // the guard's vm borrow forced an early clone.
     let is_ref = !needs_owned;
     let arraymap_is_ref = !arraymap_needs_owned;
@@ -1440,10 +1440,10 @@ fn call_arg_list(b: &NativeBuiltin, needs_owned: bool, arraymap_needs_owned: boo
         if !recv.receiver_type.is_static() {
             let name = receiver_param_name(recv);
             if recv.receiver_type.is_mut() {
-                // Array/Map mut receivers are now guards; take &mut name so
-                // DerefMut coerces to &mut Vec<Value> / &mut IndexMap.
+                // Container mut receivers are guards; take &mut name so
+                // DerefMut coerces to the underlying mutable reference.
                 let arg = match recv.class_name.as_str() {
-                    "Array" | "Map" => format!("&mut {name}"),
+                    "Array" | "Map" | "Uint8Array" => format!("&mut {name}"),
                     _ => name,
                 };
                 args.push(arg);
@@ -1454,7 +1454,7 @@ fn call_arg_list(b: &NativeBuiltin, needs_owned: bool, arraymap_needs_owned: boo
                 args.push(name);
             } else {
                 let recv_is_ref = match recv.class_name.as_str() {
-                    "Array" | "Map" => arraymap_is_ref,
+                    "Array" | "Map" | "Uint8Array" => arraymap_is_ref,
                     _ => is_ref,
                 };
                 args.push(call_arg_for_type(
@@ -1467,7 +1467,7 @@ fn call_arg_list(b: &NativeBuiltin, needs_owned: bool, arraymap_needs_owned: boo
     }
     for p in &b.params {
         let p_is_ref = match &p.ty {
-            BamlType::List(_) | BamlType::Map(_, _) => arraymap_is_ref,
+            BamlType::List(_) | BamlType::Map(_, _) | BamlType::Uint8Array => arraymap_is_ref,
             _ => is_ref,
         };
         args.push(call_arg_for_type(&p.name, &p.ty, p_is_ref));
@@ -1478,18 +1478,13 @@ fn call_arg_list(b: &NativeBuiltin, needs_owned: bool, arraymap_needs_owned: boo
 
 fn call_arg_for_type(name: &str, ty: &BamlType, is_ref: bool) -> String {
     match ty {
-        BamlType::List(_) | BamlType::Map(_, _) => {
-            if is_ref {
-                // Extraction returns an `Array/MapReadGuard`; take `&name` so
-                // its `Deref` impl coerces through `Vec<Value>` /
-                // `IndexMap<..>` to the slice / map reference the trait
-                // method signature expects.
-                format!("&{name}")
-            } else {
-                format!("&{name}")
-            }
+        BamlType::List(_) | BamlType::Map(_, _) | BamlType::Uint8Array => {
+            // Extraction returns a container guard on the borrowed path and an
+            // owned container on the cloned path. In both cases `&name` lets
+            // Deref/DerefMut coerce to the trait method's slice/map reference.
+            format!("&{name}")
         }
-        BamlType::String | BamlType::Uint8Array | BamlType::Media(_) => {
+        BamlType::String | BamlType::Media(_) => {
             if is_ref {
                 // Extraction already returned a reference — don't double-ref
                 name.to_string()
@@ -1502,8 +1497,10 @@ fn call_arg_for_type(name: &str, ty: &BamlType, is_ref: bool) -> String {
                 // Extraction returned Option<&T> — convert to match clean method signature
                 match inner.as_ref() {
                     BamlType::String => format!("{name}.map(String::as_str)"),
-                    BamlType::Uint8Array => format!("{name}.map(Vec::as_slice)"),
-                    // Option<&[Value]>, Option<&IndexMap>, Option<&MediaValue> — already correct
+                    BamlType::Uint8Array => format!("{name}.as_deref().map(Vec::as_slice)"),
+                    BamlType::List(_) => format!("{name}.as_deref().map(Vec::as_slice)"),
+                    BamlType::Map(_, _) => format!("{name}.as_deref().map(Box::as_ref)"),
+                    // Option<&MediaValue> — already correct
                     _ => name.to_string(),
                 }
             } else {
@@ -1511,6 +1508,7 @@ fn call_arg_for_type(name: &str, ty: &BamlType, is_ref: bool) -> String {
                 match inner.as_ref() {
                     BamlType::String => format!("{name}.as_deref()"),
                     BamlType::List(_) => format!("{name}.as_deref()"),
+                    BamlType::Uint8Array => format!("{name}.as_deref()"),
                     _ => {
                         if call_arg_needs_ref(inner) {
                             format!("{name}.as_ref()")

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -240,7 +240,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 .unwrap();
                 writeln!(
                     out,
-                    "{inner2}vm.as_rust_data::<T>(&self.instance.fields[{}])",
+                    "{inner2}vm.as_rust_data::<T>(&self.instance.load_field({}))",
                     field.index
                 )
                 .unwrap();
@@ -255,7 +255,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 writeln!(out, "{inner}pub fn {field_name}(&self) -> i64 {{").unwrap();
                 writeln!(
                     out,
-                    "{inner2}self.instance.fields[{}].as_int()",
+                    "{inner2}self.instance.load_field({}).as_int()",
                     field.index
                 )
                 .unwrap();
@@ -270,7 +270,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 writeln!(out, "{inner}pub fn {field_name}(&self) -> f64 {{").unwrap();
                 writeln!(
                     out,
-                    "{inner2}match self.instance.fields[{}].as_object_ptr() {{",
+                    "{inner2}match self.instance.load_field({}).as_object_ptr() {{",
                     field.index
                 )
                 .unwrap();
@@ -298,7 +298,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 writeln!(out, "{inner}pub fn {field_name}(&self) -> bool {{").unwrap();
                 writeln!(
                     out,
-                    "{inner2}self.instance.fields[{}].as_bool()",
+                    "{inner2}self.instance.load_field({}).as_bool()",
                     field.index
                 )
                 .unwrap();
@@ -318,7 +318,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 .unwrap();
                 writeln!(
                     out,
-                    "{inner2}vm.as_string(&self.instance.fields[{}])",
+                    "{inner2}vm.as_string(&self.instance.load_field({}))",
                     field.index
                 )
                 .unwrap();
@@ -337,7 +337,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 .unwrap();
                 writeln!(
                     out,
-                    "{inner2}vm.as_array(&self.instance.fields[{}])",
+                    "{inner2}vm.as_array(&self.instance.load_field({}))",
                     field.index
                 )
                 .unwrap();
@@ -356,7 +356,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 .unwrap();
                 writeln!(
                     out,
-                    "{inner2}vm.as_map(&self.instance.fields[{}])",
+                    "{inner2}vm.as_map(&self.instance.load_field({}))",
                     field.index
                 )
                 .unwrap();
@@ -378,7 +378,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 .unwrap();
                 writeln!(
                     out,
-                    "{inner2}if self.instance.fields[{}].is_null() {{",
+                    "{inner2}if self.instance.load_field({}).is_null() {{",
                     field.index
                 )
                 .unwrap();
@@ -388,10 +388,10 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
                 writeln!(out, "{inner2}}}").unwrap();
                 writeln!(out, "{inner}}}\n").unwrap();
             }
-            // Generic, Named, Media, Null — fallback to &Value
+            // Generic, Named, Media, Null — fallback to a copied Value.
             _ => {
-                writeln!(out, "{inner}pub fn {field_name}(&self) -> &Value {{").unwrap();
-                writeln!(out, "{inner2}&self.instance.fields[{}]", field.index).unwrap();
+                writeln!(out, "{inner}pub fn {field_name}(&self) -> Value {{").unwrap();
+                writeln!(out, "{inner2}self.instance.load_field({})", field.index).unwrap();
                 writeln!(out, "{inner}}}\n").unwrap();
             }
         }
@@ -411,14 +411,14 @@ fn view_optional_type_and_expr(
         BamlType::Int => (
             "Option<i64>".to_string(),
             format!(
-                "self.instance.fields[{field_index}].as_int().unwrap_or_else(|| panic!(\"{class_name}.{field_name}: expected Int\"))"
+                "self.instance.load_field({field_index}).as_int().unwrap_or_else(|| panic!(\"{class_name}.{field_name}: expected Int\"))"
             ),
         ),
         BamlType::Float => (
             "Option<f64>".to_string(),
             format!(
                 "{{ \
-                    let Some(ptr) = self.instance.fields[{field_index}].as_object_ptr() \
+                    let Some(ptr) = self.instance.load_field({field_index}).as_object_ptr() \
                         else {{ panic!(\"{class_name}.{field_name}: expected Float\") }}; \
                     let bex_vm_types::Object::Float(f) = (unsafe {{ ptr.get() }}) \
                         else {{ panic!(\"{class_name}.{field_name}: expected Float\") }}; \
@@ -429,18 +429,18 @@ fn view_optional_type_and_expr(
         BamlType::Bool => (
             "Option<bool>".to_string(),
             format!(
-                "self.instance.fields[{field_index}].as_bool().unwrap_or_else(|| panic!(\"{class_name}.{field_name}: expected Bool\"))"
+                "self.instance.load_field({field_index}).as_bool().unwrap_or_else(|| panic!(\"{class_name}.{field_name}: expected Bool\"))"
             ),
         ),
         BamlType::String => (
             "Option<&'v str>".to_string(),
             format!(
-                "vm.as_string(&self.instance.fields[{field_index}]).expect(\"{class_name}.{field_name}: expected String\")"
+                "vm.as_string(&self.instance.load_field({field_index})).expect(\"{class_name}.{field_name}: expected String\")"
             ),
         ),
         _ => (
-            "Option<&Value>".to_string(),
-            format!("&self.instance.fields[{field_index}]"),
+            "Option<Value>".to_string(),
+            format!("self.instance.load_field({field_index})"),
         ),
     }
 }

--- a/baml_language/crates/baml_builtins_codegen/src/codegen_native.rs
+++ b/baml_language/crates/baml_builtins_codegen/src/codegen_native.rs
@@ -396,7 +396,7 @@ fn extraction_rhs_expr(
             if is_mut {
                 quote!(vm.as_map_mut(#value_expr)?)
             } else {
-                quote!(vm.as_map(#value_expr)?.clone())
+                quote!(vm.as_map(#value_expr)?.to_index_map())
             }
         }
         t if t.starts_with("Option<") => {

--- a/baml_language/crates/baml_builtins_macros/src/codegen_native.rs
+++ b/baml_language/crates/baml_builtins_macros/src/codegen_native.rs
@@ -396,7 +396,7 @@ fn extraction_rhs_expr(
             if is_mut {
                 quote!(vm.as_map_mut(#value_expr)?)
             } else {
-                quote!(vm.as_map(#value_expr)?.clone())
+                quote!(vm.as_map(#value_expr)?.to_index_map())
             }
         }
         t if t.starts_with("Option<") => {

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -2547,7 +2547,7 @@ impl PullSink for StackifyCodegen<'_, '_> {
         }
         display.push('"');
         let obj_idx = self.objects.len();
-        self.objects.push(Object::Uint8Array(bytes.to_vec()));
+        self.objects.push(Object::Uint8Array(bytes.to_vec().into()));
         let idx = self.add_constant(ConstValue::Object(ObjectIndex::from_raw(obj_idx)));
         let inst = self.emit(Instruction::LoadConst(idx));
         self.set_operand(inst, OperandMeta::Const(display));

--- a/baml_language/crates/baml_tests/tests/spawn_array_race.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_array_race.rs
@@ -534,3 +534,118 @@ async fn racing_uint8array_sort_vs_grow_does_not_crash() {
         other => panic!("expected Int result, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn racing_captured_local_increment_does_not_crash() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> int {
+            let value = 0;
+            let a = spawn {
+                let i = 0;
+                while i < 400 {
+                    value = value + 1;
+                    i = i + 1;
+                };
+                0
+            };
+            let b = spawn {
+                let i = 0;
+                while i < 400 {
+                    value = value + 1;
+                    i = i + 1;
+                };
+                0
+            };
+            (await a) + (await b);
+            value
+        }
+        "#,
+        OptLevel::One,
+    );
+    let engine = Arc::new(
+        BexEngine::new(
+            program,
+            Arc::new(sys_ops::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("engine"),
+    );
+
+    let result = engine
+        .call_function_bound_args(
+            "user.main",
+            Vec::new(),
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(BexExternalValue::Int(value)) => {
+            assert!(
+                (0..=800).contains(&value),
+                "expected captured local value in 0..=800, got {value}"
+            );
+        }
+        other => panic!("expected Int result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn racing_class_field_increment_does_not_crash() {
+    let program = compile_source_with_opt(
+        r#"
+        class Counter {
+            value int
+        }
+
+        function bump(c: Counter, n: int) -> int {
+            let i = 0;
+            while i < n {
+                c.value = c.value + 1;
+                i = i + 1;
+            };
+            c.value
+        }
+
+        function main() -> int {
+            let c = Counter { value: 0 };
+            let a = spawn { bump(c, 400) };
+            let b = spawn { bump(c, 400) };
+            (await a) + (await b);
+            c.value
+        }
+        "#,
+        OptLevel::One,
+    );
+    let engine = Arc::new(
+        BexEngine::new(
+            program,
+            Arc::new(sys_ops::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("engine"),
+    );
+
+    let result = engine
+        .call_function_bound_args(
+            "user.main",
+            Vec::new(),
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(BexExternalValue::Int(value)) => {
+            assert!(
+                (0..=800).contains(&value),
+                "expected class field value in 0..=800, got {value}"
+            );
+        }
+        other => panic!("expected Int result, got {other:?}"),
+    }
+}

--- a/baml_language/crates/baml_tests/tests/spawn_array_race.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_array_race.rs
@@ -286,3 +286,251 @@ async fn racing_map_set_delete_does_not_crash() {
         other => panic!("expected Int result, got {other:?}"),
     }
 }
+
+/// Racing byte-array pushes have the same structural risk as normal arrays:
+/// `Vec<u8>` can reallocate while another fiber is reading or mutating it.
+#[tokio::test]
+async fn racing_uint8array_push_does_not_crash() {
+    let program = compile_source_with_opt(
+        r#"
+        function push_n(data: uint8array, n: int) -> int {
+            let i = 0;
+            while i < n {
+                data.push(i);
+                i = i + 1;
+            };
+            data.length()
+        }
+
+        function main() -> int {
+            let data = b"";
+            let a = spawn { push_n(data, 200) };
+            let b = spawn { push_n(data, 200) };
+            let c = spawn { push_n(data, 200) };
+            let d = spawn { push_n(data, 200) };
+            (await a) + (await b) + (await c) + (await d);
+            data.length()
+        }
+        "#,
+        OptLevel::One,
+    );
+    let engine = Arc::new(
+        BexEngine::new(
+            program,
+            Arc::new(sys_ops::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("engine"),
+    );
+
+    let result = engine
+        .call_function_bound_args(
+            "user.main",
+            Vec::new(),
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(BexExternalValue::Int(len)) => {
+            assert!(
+                (0..=800).contains(&len),
+                "expected uint8array length in 0..=800, got {len}"
+            );
+        }
+        other => panic!("expected Int result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn racing_uint8array_push_pop_does_not_crash() {
+    let program = compile_source_with_opt(
+        r#"
+        function push_n(data: uint8array, n: int) -> int {
+            let i = 0;
+            while i < n {
+                data.push(i);
+                i = i + 1;
+            };
+            0
+        }
+
+        function pop_n(data: uint8array, n: int) -> int {
+            let i = 0;
+            while i < n {
+                data.pop();
+                i = i + 1;
+            };
+            0
+        }
+
+        function main() -> int {
+            let data = b"\x01\x02\x03\x04\x05";
+            let p = spawn { push_n(data, 500) };
+            let q = spawn { pop_n(data, 500) };
+            (await p) + (await q);
+            data.length()
+        }
+        "#,
+        OptLevel::One,
+    );
+    let engine = Arc::new(
+        BexEngine::new(
+            program,
+            Arc::new(sys_ops::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("engine"),
+    );
+
+    let result = engine
+        .call_function_bound_args(
+            "user.main",
+            Vec::new(),
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(BexExternalValue::Int(len)) => {
+            assert!(
+                (0..=505).contains(&len),
+                "expected uint8array length in 0..=505, got {len}"
+            );
+        }
+        other => panic!("expected Int result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn racing_uint8array_index_read_vs_grow_does_not_crash() {
+    let program = compile_source_with_opt(
+        r#"
+        function grow_n(data: uint8array, n: int) -> int {
+            let i = 0;
+            while i < n {
+                data.push(i);
+                i = i + 1;
+            };
+            0
+        }
+
+        function read_n(data: uint8array, n: int) -> int {
+            let i = 0;
+            let acc = 0;
+            while i < n {
+                let len = data.length();
+                if len > 0 {
+                    acc = acc + data[0];
+                };
+                i = i + 1;
+            };
+            acc
+        }
+
+        function main() -> int {
+            let data = b"\x01";
+            let g = spawn { grow_n(data, 1000) };
+            let r1 = spawn { read_n(data, 500) };
+            let r2 = spawn { read_n(data, 500) };
+            (await g) + (await r1) + (await r2);
+            data.length()
+        }
+        "#,
+        OptLevel::One,
+    );
+    let engine = Arc::new(
+        BexEngine::new(
+            program,
+            Arc::new(sys_ops::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("engine"),
+    );
+
+    let result = engine
+        .call_function_bound_args(
+            "user.main",
+            Vec::new(),
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(BexExternalValue::Int(len)) => {
+            assert!(
+                (1..=1001).contains(&len),
+                "expected uint8array length in 1..=1001, got {len}"
+            );
+        }
+        other => panic!("expected Int result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn racing_uint8array_sort_vs_grow_does_not_crash() {
+    let program = compile_source_with_opt(
+        r#"
+        function push_n(data: uint8array, n: int) -> int {
+            let i = 0;
+            while i < n {
+                data.push(i);
+                i = i + 1;
+            };
+            0
+        }
+
+        function sort_n(data: uint8array, n: int) -> int {
+            let i = 0;
+            while i < n {
+                data.sort();
+                i = i + 1;
+            };
+            0
+        }
+
+        function main() -> int {
+            let data = b"\x03\x02\x01";
+            let p = spawn { push_n(data, 300) };
+            let s = spawn { sort_n(data, 100) };
+            (await p) + (await s);
+            data.length()
+        }
+        "#,
+        OptLevel::One,
+    );
+    let engine = Arc::new(
+        BexEngine::new(
+            program,
+            Arc::new(sys_ops::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("engine"),
+    );
+
+    let result = engine
+        .call_function_bound_args(
+            "user.main",
+            Vec::new(),
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(BexExternalValue::Int(len)) => {
+            assert!(
+                (3..=303).contains(&len),
+                "expected uint8array length in 3..=303, got {len}"
+            );
+        }
+        other => panic!("expected Int result, got {other:?}"),
+    }
+}

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -233,7 +233,7 @@ impl BexEngine {
             }),
             Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
             Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type((**ty).clone()))),
-            Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.clone())),
+            Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.to_vec())),
             Object::RustData(arc) => Ok(bex_external_types::try_convert_rust_data(arc)
                 .unwrap_or_else(|| BexExternalValue::RustData(arc.clone()))),
             Object::Closure(_) => Err(EngineError::CannotConvert {
@@ -1178,7 +1178,7 @@ pub(crate) fn vm_arg_to_external(vm: &BexVm, value: Value) -> BexExternalValue {
 
                     BexExternalValue::Instance { class_name, fields }
                 }
-                Object::Uint8Array(bytes) => BexExternalValue::Uint8Array(bytes.clone()),
+                Object::Uint8Array(bytes) => BexExternalValue::Uint8Array(bytes.to_vec()),
                 Object::Variant(variant) => {
                     let enum_obj = vm.get_object(variant.enm);
                     let Object::Enum(enm) = enum_obj else {

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -172,11 +172,12 @@ impl BexEngine {
                         .fields
                         .iter()
                         .zip(instance.fields.iter())
-                        .map(|(class_field, value)| {
+                        .map(|(class_field, slot)| {
+                            let value = slot.load();
                             Ok((
                                 class_field.name.clone(),
                                 self.convert_vm_value_to_external_with_type(
-                                    *value,
+                                    value,
                                     &class_field.field_type,
                                     permit,
                                 )?,
@@ -1171,8 +1172,11 @@ pub(crate) fn vm_arg_to_external(vm: &BexVm, value: Value) -> BexExternalValue {
                     let fields: indexmap::IndexMap<String, BexExternalValue> = class_fields
                         .iter()
                         .zip(instance.fields.iter())
-                        .map(|(class_field, value)| {
-                            (class_field.name.clone(), vm_arg_to_external(vm, *value))
+                        .map(|(class_field, slot)| {
+                            (
+                                class_field.name.clone(),
+                                vm_arg_to_external(vm, slot.load()),
+                            )
                         })
                         .collect();
 

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -35,6 +35,7 @@ pub enum BexValue<'a> {
     ExternalValue(&'a BexExternalValue),
     HeapPtr(&'a HeapPtr),
     Value(&'a Value),
+    OwnedValue(Value),
 }
 
 impl<'a> From<&'a BexExternalValue> for BexValue<'a> {
@@ -80,14 +81,14 @@ impl<'a> BexClass<'a> {
                     .ok_or_else(|| AccessError::FieldNotFound {
                         expected: name.to_string(),
                     })?;
-                let field =
-                    instance
-                        .fields
-                        .get(field_idx)
-                        .ok_or_else(|| AccessError::FieldNotFound {
-                            expected: name.to_string(),
-                        })?;
-                Ok(BexValue::Value(field))
+                let field = instance
+                    .fields
+                    .get(field_idx)
+                    .ok_or_else(|| AccessError::FieldNotFound {
+                        expected: name.to_string(),
+                    })?
+                    .load();
+                Ok(BexValue::OwnedValue(field))
             }
         }
     }
@@ -122,6 +123,7 @@ impl<'a> BexValue<'a> {
             BexValue::ExternalValue(value) => value.type_name().to_string(),
             BexValue::HeapPtr(ptr) => ptr.to_string(),
             BexValue::Value(value) => value.to_string(),
+            BexValue::OwnedValue(value) => value.to_string(),
         }
     }
 
@@ -129,6 +131,10 @@ impl<'a> BexValue<'a> {
         match self {
             BexValue::ExternalValue(BexExternalValue::Int(i)) => Ok(*i),
             BexValue::Value(v) => v.as_int().ok_or_else(|| AccessError::TypeMismatch {
+                expected: "int",
+                actual: v.to_string(),
+            }),
+            BexValue::OwnedValue(v) => v.as_int().ok_or_else(|| AccessError::TypeMismatch {
                 expected: "int",
                 actual: v.to_string(),
             }),
@@ -170,6 +176,10 @@ impl<'a> BexValue<'a> {
                 expected: "bool",
                 actual: v.to_string(),
             }),
+            BexValue::OwnedValue(v) => v.as_bool().ok_or_else(|| AccessError::TypeMismatch {
+                expected: "bool",
+                actual: v.to_string(),
+            }),
             other => Err(AccessError::TypeMismatch {
                 expected: "bool",
                 actual: other.type_name(),
@@ -181,6 +191,7 @@ impl<'a> BexValue<'a> {
         match self {
             BexValue::ExternalValue(BexExternalValue::Null) => Ok(()),
             BexValue::Value(v) if v.is_null() => Ok(()),
+            BexValue::OwnedValue(v) if v.is_null() => Ok(()),
             other => Err(AccessError::TypeMismatch {
                 expected: "null",
                 actual: other.type_name(),
@@ -205,6 +216,10 @@ impl<'a> BexValue<'a> {
             }
             BexValue::HeapPtr(ptr) => f(ptr),
             BexValue::Value(v) if v.is_object() => {
+                let ptr = v.as_object_ptr().expect("just checked is_object");
+                f(&ptr)
+            }
+            BexValue::OwnedValue(v) if v.is_object() => {
                 let ptr = v.as_object_ptr().expect("just checked is_object");
                 f(&ptr)
             }
@@ -655,6 +670,7 @@ fn owned_inner(
                 }
             }
         }
+        BexValue::OwnedValue(v) => owned_inner(BexValue::Value(&v), heap, lossy),
     }
 }
 
@@ -719,10 +735,10 @@ fn convert_object(
                 .fields
                 .iter()
                 .zip(instance.fields.iter())
-                .map(|(field, value)| {
+                .map(|(field, slot)| {
                     Ok((
                         field.name.clone(),
-                        owned_inner(BexValue::Value(value), heap, lossy)?,
+                        owned_inner(BexValue::OwnedValue(slot.load()), heap, lossy)?,
                     ))
                 })
                 .collect::<Result<_, _>>()?;

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -753,7 +753,7 @@ fn convert_object(
         }
         Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
         Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type((**ty).clone()))),
-        Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.clone())),
+        Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.to_vec())),
         Object::RustData(data) => Ok(bex_external_types::try_convert_rust_data(data)
             .unwrap_or_else(|| BexExternalValue::RustData(data.clone()))),
         Object::Float(f) => Ok(BexExternalValue::Float(*f)),

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -292,10 +292,8 @@ impl<'a> BexValue<'a> {
                         actual: obj.to_string(),
                     });
                 };
-                // SAFETY: host accessor invoked under a serialized FFI
-                // callback; no `spawn`ed mutator is concurrently active.
-                let data = unsafe { array.data_unchecked() };
-                Ok(data.iter().map(BexValue::Value).collect())
+                let data = array.to_vec();
+                Ok(data.into_iter().map(BexValue::OwnedValue).collect())
             }),
         }
     }
@@ -318,11 +316,10 @@ impl<'a> BexValue<'a> {
                         actual: obj.to_string(),
                     });
                 };
-                // SAFETY: see `as_array` above.
-                let data = unsafe { map.data_unchecked() };
+                let data = map.to_index_map();
                 Ok(data
-                    .iter()
-                    .map(|(k, v)| (k.clone(), BexValue::Value(v)))
+                    .into_iter()
+                    .map(|(k, v)| (k, BexValue::OwnedValue(v)))
                     .collect())
             }),
         }
@@ -703,11 +700,10 @@ fn convert_object(
             element_type: Ty::BuiltinUnknown {
                 attr: baml_type::TyAttr::default(),
             },
-            // SAFETY: host accessor invoked under a serialized FFI
-            // callback; no `spawn`ed mutator is concurrently active.
-            items: unsafe { array.data_unchecked() }
-                .iter()
-                .map(|item| owned_inner(BexValue::Value(item), heap, lossy))
+            items: array
+                .to_vec()
+                .into_iter()
+                .map(|item| owned_inner(BexValue::OwnedValue(item), heap, lossy))
                 .collect::<Result<_, _>>()?,
         }),
         Object::Map(map) => Ok(BexExternalValue::Map {
@@ -717,10 +713,10 @@ fn convert_object(
             value_type: Ty::BuiltinUnknown {
                 attr: baml_type::TyAttr::default(),
             },
-            // SAFETY: see `Object::Array` arm above.
-            entries: unsafe { map.data_unchecked() }
-                .iter()
-                .map(|(k, v)| Ok((k.clone(), owned_inner(BexValue::Value(v), heap, lossy)?)))
+            entries: map
+                .to_index_map()
+                .into_iter()
+                .map(|(k, v)| Ok((k, owned_inner(BexValue::OwnedValue(v), heap, lossy)?)))
                 .collect::<Result<_, _>>()?,
         }),
         Object::Instance(instance) => {

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -1975,13 +1975,13 @@ mod tests {
     fn test_gc_leaf_uint8array_preserved() {
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
-        let ptr = tlab.alloc(Object::Uint8Array(vec![1, 2, 3, 255]));
+        let ptr = tlab.alloc(Object::Uint8Array(vec![1, 2, 3, 255].into()));
 
         let (_, new_roots, _) = unsafe { heap.collect_garbage(&[ptr]) };
         let Object::Uint8Array(v) = (unsafe { new_roots[0].get() }) else {
             panic!("not uint8array")
         };
-        assert_eq!(v, &[1u8, 2, 3, 255]);
+        assert_eq!(v.lock().as_slice(), &[1u8, 2, 3, 255]);
     }
 
     #[test]

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -348,7 +348,7 @@ impl BexHeap {
             }
             Object::Instance(inst) => {
                 worklist.push(inst.class);
-                for value in &inst.fields {
+                for value in inst.field_values() {
                     if let Some(ptr) = value.as_object_ptr() {
                         worklist.push(ptr);
                     }
@@ -369,7 +369,7 @@ impl BexHeap {
                 }
             }
             Object::Cell(cell) => {
-                if let Some(ptr) = cell.value.as_object_ptr() {
+                if let Some(ptr) = cell.load().as_object_ptr() {
                     worklist.push(ptr);
                 }
             }
@@ -476,8 +476,10 @@ impl BexHeap {
                 if let Some(&new_ptr) = forwarding.get(&inst.class) {
                     inst.class = new_ptr;
                 }
-                for value in &mut inst.fields {
-                    self.fixup_value(value, forwarding);
+                for slot in &inst.fields {
+                    let mut value = slot.load();
+                    self.fixup_value(&mut value, forwarding);
+                    slot.store(value);
                 }
             }
             Object::Closure(closure) => {
@@ -495,7 +497,9 @@ impl BexHeap {
                 self.fixup_value(&mut bm.receiver, forwarding);
             }
             Object::Cell(cell) => {
-                self.fixup_value(&mut cell.value, forwarding);
+                let mut value = cell.load();
+                self.fixup_value(&mut value, forwarding);
+                cell.store(value);
             }
             Object::Variant(var) => {
                 // Update enum pointer
@@ -727,7 +731,7 @@ impl BexHeap {
                 worklist.extend(
                     inst.fields
                         .iter()
-                        .filter_map(Value::as_object_ptr)
+                        .filter_map(|slot| slot.load().as_object_ptr())
                         .filter(|ptr| self.generation_of(*ptr).is_young()),
                 );
             }
@@ -754,7 +758,7 @@ impl BexHeap {
                 }
             }
             Object::Cell(cell) => {
-                if let Some(ptr) = cell.value.as_object_ptr()
+                if let Some(ptr) = cell.load().as_object_ptr()
                     && self.generation_of(ptr).is_young()
                 {
                     worklist.push(ptr);
@@ -1127,11 +1131,11 @@ mod tests {
 
         let class_ptr = heap.compile_time_ptr(0);
         // Instance has 3 fields but class expects 1 — should panic on verify
-        let _bad_instance = tlab.alloc(Object::Instance(bex_vm_types::types::Instance {
-            class: class_ptr,
-            class_type_args: vec![],
-            fields: vec![Value::int(1), Value::int(2), Value::int(3)],
-        }));
+        let _bad_instance = tlab.alloc(Object::Instance(bex_vm_types::types::Instance::new(
+            class_ptr,
+            vec![],
+            vec![Value::int(1), Value::int(2), Value::int(3)],
+        )));
 
         let result = catch_unwind(AssertUnwindSafe(|| {
             heap.verify_quick();
@@ -1751,8 +1755,8 @@ mod tests {
             panic!("not instance")
         };
         assert_eq!(inst.fields.len(), 2);
-        assert!(inst.fields[0].is_object());
-        assert_eq!(inst.fields[1], Value::int(42));
+        assert!(inst.load_field(0).is_object());
+        assert_eq!(inst.load_field(1), Value::int(42));
 
         // Verify class is accessible through the instance
         let Object::Class(c) = (unsafe { inst.class.get() }) else {
@@ -1830,9 +1834,7 @@ mod tests {
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
         let inner = tlab.alloc_string("cell_content".to_string());
-        let cell_ptr = tlab.alloc(Object::Cell(Cell {
-            value: Value::object(inner),
-        }));
+        let cell_ptr = tlab.alloc(Object::Cell(Cell::new(Value::object(inner))));
 
         let roots = vec![cell_ptr];
         let (stats, new_roots, _) = unsafe { heap.collect_garbage(&roots) };
@@ -1841,7 +1843,7 @@ mod tests {
         let Object::Cell(c) = (unsafe { new_roots[0].get() }) else {
             panic!("not cell")
         };
-        let Some(inner_ptr) = c.value.as_object_ptr() else {
+        let Some(inner_ptr) = c.load().as_object_ptr() else {
             panic!("not object value")
         };
         let Object::String(s) = (unsafe { inner_ptr.get() }) else {
@@ -1857,9 +1859,7 @@ mod tests {
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
-        let cell_ptr = tlab.alloc(Object::Cell(Cell {
-            value: Value::int(42),
-        }));
+        let cell_ptr = tlab.alloc(Object::Cell(Cell::new(Value::int(42))));
         let roots = vec![cell_ptr];
         let (stats, new_roots, _) = unsafe { heap.collect_garbage(&roots) };
 
@@ -1867,7 +1867,7 @@ mod tests {
         let Object::Cell(c) = (unsafe { new_roots[0].get() }) else {
             panic!("not cell")
         };
-        assert_eq!(c.value, Value::int(42));
+        assert_eq!(c.load(), Value::int(42));
     }
 
     #[test]
@@ -2213,9 +2213,9 @@ mod tests {
 
         // Create A (array placeholder) and B (cell pointing to A), then patch A -> B
         let a = tlab.alloc_array(vec![]); // placeholder, will be patched
-        let b = tlab.alloc(Object::Cell(bex_vm_types::types::Cell {
-            value: Value::object(a),
-        }));
+        let b = tlab.alloc(Object::Cell(bex_vm_types::types::Cell::new(Value::object(
+            a,
+        ))));
         // Patch A to reference B, forming a cycle
         unsafe {
             *a.get_mut() = Object::Array(vec![Value::object(b)].into());
@@ -2234,7 +2234,7 @@ mod tests {
         let Object::Cell(cell) = (unsafe { b_ptr.get() }) else {
             panic!("not cell b")
         };
-        let Some(a_back) = cell.value.as_object_ptr() else {
+        let Some(a_back) = cell.load().as_object_ptr() else {
             panic!("cell.value not object")
         };
         // The back-pointer from B should point to the new location of A
@@ -2392,9 +2392,7 @@ mod tests {
         }));
 
         // --- Container: Object::Cell ---
-        let cell_container = tlab.alloc(Object::Cell(Cell {
-            value: Value::object(leaf_for_cell),
-        }));
+        let cell_container = tlab.alloc(Object::Cell(Cell::new(Value::object(leaf_for_cell))));
 
         // --- Container: Object::UnscheduledFuture ---
         // After BEP-034 phase D′ the spawn case is all that's left;
@@ -2414,11 +2412,11 @@ mod tests {
             type_tag: 0,
             ty_attr: TyAttr::default(),
         })));
-        let instance_container = tlab.alloc(Object::Instance(Instance {
-            class: class_ptr,
-            class_type_args: vec![],
-            fields: vec![Value::object(leaf_string)],
-        }));
+        let instance_container = tlab.alloc(Object::Instance(Instance::new(
+            class_ptr,
+            vec![],
+            vec![Value::object(leaf_string)],
+        )));
 
         // --- Container: Object::Variant ---
         let enum_ptr = tlab.alloc(Object::Enum(Box::new(Enum {
@@ -2501,7 +2499,7 @@ mod tests {
         let Object::Cell(cell) = (unsafe { new_roots[3].get() }) else {
             panic!("new_roots[3] not Cell")
         };
-        let Some(cell_leaf) = cell.value.as_object_ptr() else {
+        let Some(cell_leaf) = cell.load().as_object_ptr() else {
             panic!("cell.value not Object")
         };
         let Object::String(s) = (unsafe { cell_leaf.get() }) else {
@@ -2523,7 +2521,7 @@ mod tests {
         let Object::Instance(inst) = (unsafe { new_roots[5].get() }) else {
             panic!("new_roots[5] not Instance")
         };
-        let Some(inst_leaf) = inst.fields.first().and_then(|v| v.as_object_ptr()) else {
+        let Some(inst_leaf) = inst.fields.first().and_then(|v| v.load().as_object_ptr()) else {
             panic!("instance.fields[0] not Object")
         };
         let Object::String(s) = (unsafe { inst_leaf.get() }) else {

--- a/baml_language/crates/bex_heap/src/heap_debugger/real.rs
+++ b/baml_language/crates/bex_heap/src/heap_debugger/real.rs
@@ -318,8 +318,8 @@ impl BexHeap {
                     instance.fields.len(),
                     class.fields.len()
                 );
-                for value in &instance.fields {
-                    self.debug_assert_valid_value(value);
+                for slot in &instance.fields {
+                    self.debug_assert_valid_value(&slot.load());
                 }
             }
             Object::Variant(variant) => {
@@ -359,7 +359,7 @@ impl BexHeap {
                 self.debug_assert_valid_value(&bm.receiver);
             }
             Object::Cell(cell) => {
-                self.debug_assert_valid_value(&cell.value);
+                self.debug_assert_valid_value(&cell.load());
             }
             Object::Function(_)
             | Object::Class(_)

--- a/baml_language/crates/bex_heap/src/heap_guard.rs
+++ b/baml_language/crates/bex_heap/src/heap_guard.rs
@@ -4,6 +4,12 @@
 //! These ensure that we have only one of:
 //! - A single exclusive heap access [`HeapGuard`], or
 //! - Any number of non-exclusive tracked active heap permits [`ActiveHeapPermit`].
+//!
+//! Spawn-safety invariant: an active permit excludes moving/collecting GC, but
+//! it does not serialize multiple VM mutators. Heap objects reachable from
+//! spawned VMs must use object-level synchronization for mutable state. Raw
+//! heap/container access is only sound while holding [`HeapGuard`] (all mutators
+//! parked) or during proven single-threaded setup.
 
 use ::bex_vm_types::{HeapPtr, PermitProof, RootHaver};
 use ::core::{

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -180,11 +180,7 @@ impl Tlab {
     /// Allocate an instance object.
     #[inline]
     pub fn alloc_instance(&mut self, class: HeapPtr, fields: Vec<Value>) -> HeapPtr {
-        self.alloc(Object::Instance(Instance {
-            class,
-            class_type_args: vec![],
-            fields,
-        }))
+        self.alloc(Object::Instance(Instance::new(class, vec![], fields)))
     }
 
     /// Allocate a variant object.
@@ -529,7 +525,7 @@ mod tests {
                 Object::Instance(inst) => {
                     assert_eq!(inst.class, class_ptr);
                     assert_eq!(inst.fields.len(), 2);
-                    assert_eq!(inst.fields[0], Value::int(10));
+                    assert_eq!(inst.load_field(0), Value::int(10));
                 }
                 _ => panic!("Expected Instance"),
             }

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -174,7 +174,7 @@ impl Tlab {
     /// Allocate a map object.
     #[inline]
     pub fn alloc_map(&mut self, values: IndexMap<String, Value>) -> HeapPtr {
-        self.alloc(Object::Map(Box::new(values.into())))
+        self.alloc(Object::Map(values.into()))
     }
 
     /// Allocate an instance object.
@@ -196,7 +196,7 @@ impl Tlab {
     /// Allocate a uint8 array object.
     #[inline]
     pub fn alloc_uint8array(&mut self, data: Vec<u8>) -> HeapPtr {
-        self.alloc(Object::Uint8Array(data))
+        self.alloc(Object::Uint8Array(data.into()))
     }
 
     /// Allocate opaque Rust data on the heap.

--- a/baml_language/crates/bex_vm/src/package_baml/array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/array.rs
@@ -23,7 +23,10 @@ fn baml_eq(vm: &BexVm, a: Value, b: Value) -> bool {
                 _ => false,
             },
             (Object::Uint8Array(_), Object::Uint8Array(_)) => {
-                match (vm.as_uint8array(&a), vm.as_uint8array(&b)) {
+                match (
+                    vm.as_uint8array(&a).map(|bytes| bytes.to_vec()),
+                    vm.as_uint8array(&b).map(|bytes| bytes.to_vec()),
+                ) {
                     (Ok(lb), Ok(rb)) => lb == rb,
                     _ => false,
                 }

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -327,7 +327,7 @@ pub fn serde_to_value(vm: &mut BexVm, v: &serde_json::Value) -> Value {
                 .iter()
                 .map(|(k, v)| (k.clone(), serde_to_value(vm, v)))
                 .collect();
-            Value::object(vm.tlab.alloc(Object::Map(Box::new(entries.into()))))
+            Value::object(vm.tlab.alloc(Object::Map(entries.into())))
         }
     }
 }
@@ -798,9 +798,7 @@ fn ty_serde_to_value(
                     })?;
                     entries.insert(k.clone(), v);
                 }
-                Ok(Value::object(
-                    vm.tlab.alloc(Object::Map(Box::new(entries.into()))),
-                ))
+                Ok(Value::object(vm.tlab.alloc(Object::Map(entries.into()))))
             }
             _ => Err(raise_decode(vm, "expected object", path)),
         },
@@ -1311,7 +1309,7 @@ fn map_drive(
             Err(e) => return NativeCallResult::Error(e),
         }
     }
-    let map_val = Value::object(vm.tlab.alloc(Object::Map(Box::new(results.into()))));
+    let map_val = Value::object(vm.tlab.alloc(Object::Map(results.into())));
     NativeCallResult::Done(map_val)
 }
 

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -587,7 +587,7 @@ fn serialize_class_instance(
         Object::Instance(inst) => (
             inst.class,
             inst.class_type_args.clone(),
-            inst.fields.clone(),
+            inst.field_values().collect::<Vec<_>>(),
         ),
         _ => {
             return Err(raise_serialize(
@@ -697,7 +697,7 @@ fn read_media_value(vm: &BexVm, value: Value) -> Option<Arc<baml_builtins2::Medi
         _ => return None,
     };
     // Media classes have a single `_data: $rust_type` field.
-    let data_value = *inst.fields.first()?;
+    let data_value = inst.fields.first()?.load();
     let data_ptr = data_value.as_object_ptr()?;
     match vm.get_object(data_ptr) {
         Object::RustData(arc) => arc.clone().downcast::<baml_builtins2::MediaValue>().ok(),
@@ -960,11 +960,9 @@ fn deserialize_class_instance(
         field_values.push(v);
     }
 
-    Ok(Value::object(vm.tlab.alloc(Object::Instance(Instance {
-        class: class_ptr,
-        class_type_args: type_args.to_vec(),
-        fields: field_values,
-    }))))
+    Ok(Value::object(vm.tlab.alloc(Object::Instance(
+        Instance::new(class_ptr, type_args.to_vec(), field_values),
+    ))))
 }
 
 fn deserialize_enum_variant(

--- a/baml_language/crates/bex_vm/src/package_baml/media.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/media.rs
@@ -26,7 +26,7 @@ fn clone_media_value(
     // Step 1: get the _data field value (Copy) from the instance.
     let data_field: Value = {
         let instance = vm.as_instance(&media_val)?;
-        instance.fields[0]
+        instance.load_field(0)
         // `instance` borrow dropped here.
     };
 

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -87,23 +87,20 @@ fn deep_copy_value_recursive(
                 }
 
                 Object::Instance(instance) => {
-                    let placeholder_ptr = vm.tlab.alloc(Object::Instance(Instance {
-                        class: instance.class,
-                        class_type_args: instance.class_type_args.clone(),
-                        fields: Vec::new(),
-                    }));
+                    let placeholder_ptr = vm.tlab.alloc(Object::Instance(Instance::new(
+                        instance.class,
+                        instance.class_type_args.clone(),
+                        Vec::new(),
+                    )));
                     copied_objects.insert(ptr, placeholder_ptr);
 
                     let mut new_fields = Vec::with_capacity(instance.fields.len());
-                    for field in instance.fields {
+                    for field in instance.field_values() {
                         new_fields.push(deep_copy_value_recursive(vm, field, copied_objects));
                     }
 
-                    let new_instance = Instance {
-                        class: instance.class,
-                        class_type_args: instance.class_type_args,
-                        fields: new_fields,
-                    };
+                    let new_instance =
+                        Instance::new(instance.class, instance.class_type_args, new_fields);
                     // no GC write barrier because it is all in gen0
                     *vm.get_object_mut(placeholder_ptr) = Object::Instance(new_instance);
                     placeholder_ptr
@@ -210,7 +207,7 @@ fn deep_equals_recursive(
                             .fields
                             .iter()
                             .zip(b_inst.fields.iter())
-                            .all(|(a, b)| deep_equals_recursive(vm, *a, *b, visited))
+                            .all(|(a, b)| deep_equals_recursive(vm, a.load(), b.load(), visited))
                 }
 
                 (Object::Variant(a_var), Object::Variant(b_var)) => {

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -71,8 +71,7 @@ fn deep_copy_value_recursive(
                 }
 
                 Object::Map(map) => {
-                    let placeholder_ptr =
-                        vm.tlab.alloc(Object::Map(Box::new(IndexMap::new().into())));
+                    let placeholder_ptr = vm.tlab.alloc(Object::Map(IndexMap::new().into()));
                     copied_objects.insert(ptr, placeholder_ptr);
 
                     let snapshot = map.to_index_map();
@@ -83,7 +82,7 @@ fn deep_copy_value_recursive(
                     }
 
                     // no GC write barrier because it is all in gen0
-                    *vm.get_object_mut(placeholder_ptr) = Object::Map(Box::new(new_map.into()));
+                    *vm.get_object_mut(placeholder_ptr) = Object::Map(new_map.into());
                     placeholder_ptr
                 }
 
@@ -174,7 +173,11 @@ fn deep_equals_recursive(
             let result = match (vm.get_object(a_ptr), vm.get_object(b_ptr)) {
                 (Object::Float(a), Object::Float(b)) => (a.is_nan() && b.is_nan()) || a == b,
                 (Object::String(a), Object::String(b)) => a == b,
-                (Object::Uint8Array(a), Object::Uint8Array(b)) => a == b,
+                (Object::Uint8Array(a), Object::Uint8Array(b)) => {
+                    let a_snap = a.to_vec();
+                    let b_snap = b.to_vec();
+                    a_snap == b_snap
+                }
 
                 (Object::Array(a_values), Object::Array(b_values)) => {
                     // Snapshot under each lock before recursing; deep_equals

--- a/baml_language/crates/bex_vm/src/package_baml/unstable.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/unstable.rs
@@ -48,7 +48,7 @@ fn format_value_recursive(vm: &BexVm, value: Value, depth: usize) -> Result<Stri
 
                 let class_name = class.name.clone();
                 let class_fields = class.fields.clone();
-                let fields = instance.fields.clone();
+                let fields: Vec<_> = instance.field_values().collect();
 
                 let mut result = format!("{class_name} {{\n");
                 let field_indent = "    ".repeat(depth + 1);
@@ -136,7 +136,7 @@ fn format_value_recursive(vm: &BexVm, value: Value, depth: usize) -> Result<Stri
             }
             Object::BoundMethod(_) => Ok("<bound_method>".to_string()),
             Object::HostClosure(_) => Ok("<host_closure>".to_string()),
-            Object::Cell(cell) => Ok(format!("<cell {}>", cell.value)),
+            Object::Cell(cell) => Ok(format!("<cell {}>", cell.load())),
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Ok("<sentinel>".to_string()),
         },

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -982,12 +982,15 @@ impl BexVm {
         self.get_object(ptr).as_string()
     }
 
-    /// Get uint8array from a Value.
-    pub fn as_uint8array(&self, value: &Value) -> Result<&Vec<u8>, VmInternalError> {
+    /// Get uint8array from a Value. Acquires the container's mutex.
+    pub fn as_uint8array(
+        &self,
+        value: &Value,
+    ) -> Result<bex_vm_types::Uint8ArrayReadGuard<'_>, VmInternalError> {
         let ptr = self.as_object_ptr(*value, ObjectType::Uint8Array)?;
         let obj = self.get_object(ptr);
         match obj {
-            Object::Uint8Array(bytes) => Ok(bytes),
+            Object::Uint8Array(bytes) => Ok(bytes.lock()),
             _ => Err(VmInternalError::TypeError {
                 expected: ObjectType::Uint8Array.into(),
                 got: ObjectType::of(obj).into(),
@@ -995,11 +998,14 @@ impl BexVm {
         }
     }
 
-    /// Get mutable uint8array from a Value.
-    pub fn as_uint8array_mut(&mut self, value: &Value) -> Result<&mut Vec<u8>, VmInternalError> {
+    /// Get mutable uint8array from a Value. Acquires the container's mutex.
+    pub fn as_uint8array_mut(
+        &mut self,
+        value: &Value,
+    ) -> Result<bex_vm_types::Uint8ArrayWriteGuard<'_>, VmInternalError> {
         let ptr = self.as_object_ptr(*value, ObjectType::Uint8Array)?;
-        match self.get_object_mut(ptr) {
-            Object::Uint8Array(bytes) => Ok(bytes),
+        match self.get_object(ptr) {
+            Object::Uint8Array(bytes) => Ok(bytes.lock_mut()),
             other => Err(VmInternalError::TypeError {
                 expected: ObjectType::Uint8Array.into(),
                 got: ObjectType::of(other).into(),
@@ -1293,7 +1299,7 @@ impl BexVm {
     }
 
     pub fn alloc_map(&mut self, values: IndexMap<String, Value>) -> Value {
-        Value::object(self.tlab.alloc(Object::Map(Box::new(values.into()))))
+        Value::object(self.tlab.alloc(Object::Map(values.into())))
     }
 
     pub fn alloc_string(&mut self, s: String) -> Value {
@@ -2704,8 +2710,8 @@ impl BexVm {
                     })
                 }
                 (Object::Uint8Array(_), Object::Uint8Array(_)) => {
-                    let la = self.as_uint8array(&left)?;
-                    let ra = self.as_uint8array(&right)?;
+                    let la = self.as_uint8array(&left)?.to_vec();
+                    let ra = self.as_uint8array(&right)?.to_vec();
                     Value::bool(match op {
                         CmpOp::Eq => la == ra,
                         CmpOp::NotEq => la != ra,
@@ -3369,7 +3375,7 @@ impl BexVm {
                     } else {
                         IndexMap::new()
                     };
-                    let obj_index = self.tlab.alloc(Object::Map(Box::new(map.into())));
+                    let obj_index = self.tlab.alloc(Object::Map(map.into()));
                     self.stack.push(Value::object(obj_index));
                 }
 
@@ -4399,10 +4405,12 @@ impl BexVm {
                                 }
                             }
                             Object::Uint8Array(bytes) => {
-                                if i < 0 || (i as usize) >= bytes.len() {
-                                    Err((i, bytes.len()))
+                                let guard = bytes.lock();
+                                let len = guard.len();
+                                if i < 0 || (i as usize) >= len {
+                                    Err((i, len))
                                 } else {
-                                    Ok(Value::int(i64::from(bytes[i as usize])))
+                                    Ok(Value::int(i64::from(guard[i as usize])))
                                 }
                             }
                             other => {
@@ -4482,7 +4490,7 @@ impl BexVm {
                     // inner scope before any `&mut self` ops.
                     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                     let store_result: Result<Value, (i64, usize)> = {
-                        match self.get_object_mut(array_object_index) {
+                        match self.get_object(array_object_index) {
                             Object::Array(arr) => {
                                 let mut guard = arr.lock_mut();
                                 let len = guard.len();
@@ -4502,11 +4510,13 @@ impl BexVm {
                                     }
                                     .into());
                                 };
-                                if i < 0 || (i as usize) >= bytes.len() {
-                                    Err((i, bytes.len()))
+                                let mut guard = bytes.lock_mut();
+                                let len = guard.len();
+                                if i < 0 || (i as usize) >= len {
+                                    Err((i, len))
                                 } else {
-                                    let old = Value::int(i64::from(bytes[i as usize]));
-                                    bytes[i as usize] = byte_v;
+                                    let old = Value::int(i64::from(guard[i as usize]));
+                                    guard[i as usize] = byte_v;
                                     Ok(old)
                                 }
                             }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -236,16 +236,16 @@ mod tests {
     fn init_spread_preserves_pre_spread_watch_baseline() {
         let mut vm = test_vm(vec![test_class(2)]);
         let class_ptr = vm.idx_to_ptr(ObjectIndex::from_raw(0));
-        let source_ptr = vm.tlab.alloc(Object::Instance(Instance {
-            class: class_ptr,
-            class_type_args: Vec::new(),
-            fields: vec![Value::int(10), Value::int(2)],
-        }));
-        let dest_ptr = vm.tlab.alloc(Object::Instance(Instance {
-            class: class_ptr,
-            class_type_args: Vec::new(),
-            fields: vec![Value::int(1), Value::int(2)],
-        }));
+        let source_ptr = vm.tlab.alloc(Object::Instance(Instance::new(
+            class_ptr,
+            Vec::new(),
+            vec![Value::int(10), Value::int(2)],
+        )));
+        let dest_ptr = vm.tlab.alloc(Object::Instance(Instance::new(
+            class_ptr,
+            Vec::new(),
+            vec![Value::int(1), Value::int(2)],
+        )));
         let root = NodeId::HeapObject(dest_ptr);
         vm.watch.register_root(
             root,
@@ -279,7 +279,10 @@ mod tests {
         let Object::Instance(dest) = vm.get_object(dest_ptr) else {
             panic!("destination should remain an instance");
         };
-        assert_eq!(dest.fields, vec![Value::int(10), Value::int(2)]);
+        assert_eq!(
+            dest.field_values().collect::<Vec<_>>(),
+            vec![Value::int(10), Value::int(2)]
+        );
     }
 }
 
@@ -1061,7 +1064,7 @@ impl BexVm {
                 got: ObjectType::of(self.get_object(ptr)).into(),
             });
         }
-        match self.get_object_mut(ptr) {
+        match self.get_object(ptr) {
             Object::Array(arr) => Ok(arr.lock_mut()),
             _ => unreachable!("type was just checked"),
         }
@@ -1097,7 +1100,7 @@ impl BexVm {
                 got: ObjectType::of(self.get_object(index)).into(),
             });
         }
-        match self.get_object_mut(index) {
+        match self.get_object(index) {
             Object::Map(map) => Ok(map.lock_mut()),
             _ => unreachable!("type was just checked"),
         }
@@ -1318,11 +1321,10 @@ impl BexVm {
     /// TODO: Seems to low level for an embedder, provide an API that takes
     /// class name and mapping of field name => value instead.
     pub fn alloc_instance(&mut self, class: HeapPtr, fields: Vec<Value>) -> Value {
-        Value::object(self.tlab.alloc(Object::Instance(Instance {
-            class,
-            class_type_args: vec![],
-            fields,
-        })))
+        Value::object(
+            self.tlab
+                .alloc(Object::Instance(Instance::new(class, vec![], fields))),
+        )
     }
 
     // TODO: Same problem as above. Ideally takes (&str, &str) instead.
@@ -1646,11 +1648,9 @@ impl BexVm {
 
     pub(crate) fn alloc_error_value(&mut self, class: ErrorClass, fields: Vec<Value>) -> Value {
         let class_ptr = self.error_class_ptrs[class as usize];
-        let instance_ptr = self.tlab.alloc(Object::Instance(Instance {
-            class: class_ptr,
-            class_type_args: vec![],
-            fields,
-        }));
+        let instance_ptr =
+            self.tlab
+                .alloc(Object::Instance(Instance::new(class_ptr, vec![], fields)));
         Value::object(instance_ptr)
     }
 
@@ -1728,11 +1728,9 @@ impl BexVm {
     /// Allocate a `baml.panics.*` class instance using pre-resolved pointers.
     pub fn alloc_panic_value(&mut self, class: PanicClass, fields: Vec<Value>) -> Value {
         let class_ptr = self.panic_class_ptrs[class as usize];
-        let instance_ptr = self.tlab.alloc(Object::Instance(Instance {
-            class: class_ptr,
-            class_type_args: vec![],
-            fields,
-        }));
+        let instance_ptr =
+            self.tlab
+                .alloc(Object::Instance(Instance::new(class_ptr, vec![], fields)));
         Value::object(instance_ptr)
     }
 
@@ -2420,8 +2418,8 @@ impl BexVm {
                 .map(|copy| {
                     (
                         copy.dest,
-                        dest.fields[copy.dest],
-                        source.fields[copy.source],
+                        dest.load_field(copy.dest),
+                        source.load_field(copy.source),
                     )
                 })
                 .collect()
@@ -2444,10 +2442,10 @@ impl BexVm {
                 new_value,
             );
             self.heap.write_barrier(dest_ptr, new_value);
-            let Object::Instance(dest) = self.get_object_mut(dest_ptr) else {
+            let Object::Instance(dest) = self.get_object(dest_ptr) else {
                 unreachable!("destination instance already type-checked above");
             };
-            dest.fields[dest_field] = new_value;
+            dest.store_field(dest_field, new_value);
         }
 
         for (&root, old_value) in roots.iter().zip(old_roots_copies) {
@@ -2532,11 +2530,9 @@ impl BexVm {
             fields
         };
 
-        Ok(Value::object(self.tlab.alloc(Object::Instance(Instance {
-            class: class_ptr,
-            class_type_args,
-            fields,
-        }))))
+        Ok(Value::object(self.tlab.alloc(Object::Instance(
+            Instance::new(class_ptr, class_type_args, fields),
+        ))))
     }
 
     /// When a watched node changes, we need to update the graph topology
@@ -3258,7 +3254,7 @@ impl BexVm {
                         }
                         .into());
                     };
-                    let value = instance.fields[idx];
+                    let value = instance.load_field(idx);
                     self.stack.push(value);
                 }
 
@@ -3276,7 +3272,7 @@ impl BexVm {
                             }
                             .into());
                         };
-                        instance.fields[idx]
+                        instance.load_field(idx)
                     };
 
                     let watched_node = NodeId::HeapObject(obj_ptr);
@@ -3287,10 +3283,10 @@ impl BexVm {
                         new_value,
                     );
                     self.heap.write_barrier(obj_ptr, new_value);
-                    let Object::Instance(instance) = self.get_object_mut(obj_ptr) else {
+                    let Object::Instance(instance) = self.get_object(obj_ptr) else {
                         unreachable!("already type-checked above");
                     };
-                    instance.fields[idx] = new_value;
+                    instance.store_field(idx, new_value);
 
                     let notifications = self.process_notifications(watched_node)?;
                     if !notifications.is_empty() {
@@ -3306,14 +3302,14 @@ impl BexVm {
                     let instance_value = self.stack.ensure_pop();
                     let obj_ptr = self.as_object_ptr(instance_value, ObjectType::Instance)?;
                     self.heap.write_barrier(obj_ptr, new_value);
-                    let Object::Instance(instance) = self.get_object_mut(obj_ptr) else {
+                    let Object::Instance(instance) = self.get_object(obj_ptr) else {
                         return Err(VmInternalError::TypeError {
                             expected: ObjectType::Instance.into(),
                             got: ObjectType::of(self.get_object(obj_ptr)).into(),
                         }
                         .into());
                     };
-                    instance.fields[idx] = new_value;
+                    instance.store_field(idx, new_value);
                     self.stack.push(instance_value);
                 }
 
@@ -3420,11 +3416,11 @@ impl BexVm {
                     fields.resize(class.fields.len(), Value::NULL);
                     let instance_ptr =
                         self.tlab
-                            .alloc(Object::Instance(bex_vm_types::types::Instance {
-                                class: class_ptr,
+                            .alloc(Object::Instance(bex_vm_types::types::Instance::new(
+                                class_ptr,
                                 class_type_args,
                                 fields,
-                            }));
+                            )));
                     self.stack.push(Value::object(instance_ptr));
                 }
 
@@ -4145,7 +4141,7 @@ impl BexVm {
                 // ── MakeCell ──────────────────────────────────────────────────
                 OpCode::MakeCell => {
                     let value = self.stack.ensure_pop();
-                    let cell = Object::Cell(bex_vm_types::types::Cell { value });
+                    let cell = Object::Cell(bex_vm_types::types::Cell::new(value));
                     let ptr = self.tlab.alloc(cell);
                     self.stack.push(Value::object(ptr));
                 }
@@ -4259,7 +4255,7 @@ impl BexVm {
                         }
                         .into());
                     };
-                    self.stack.push(cell.value);
+                    self.stack.push(cell.load());
                 }
 
                 OpCode::StoreDeref => {
@@ -4278,7 +4274,7 @@ impl BexVm {
                         .into());
                     };
                     self.heap.write_barrier(cell_ptr, value);
-                    let obj = unsafe { cell_ptr.get_mut() };
+                    let obj = unsafe { cell_ptr.get() };
                     let Object::Cell(cell) = obj else {
                         return Err(VmInternalError::TypeError {
                             expected: ObjectType::Cell.into(),
@@ -4286,7 +4282,7 @@ impl BexVm {
                         }
                         .into());
                     };
-                    cell.value = value;
+                    cell.store(value);
                 }
 
                 // ── LoadCapture / StoreCapture / CaptureRef ───────────────────
@@ -4320,7 +4316,7 @@ impl BexVm {
                         }
                         .into());
                     };
-                    self.stack.push(cell.value);
+                    self.stack.push(cell.load());
                 }
 
                 OpCode::StoreCapture => {
@@ -4347,7 +4343,7 @@ impl BexVm {
                         .into());
                     };
                     self.heap.write_barrier(cell_ptr, value);
-                    let cell_obj = unsafe { cell_ptr.get_mut() };
+                    let cell_obj = unsafe { cell_ptr.get() };
                     let Object::Cell(cell) = cell_obj else {
                         return Err(VmInternalError::TypeError {
                             expected: ObjectType::Cell.into(),
@@ -4355,7 +4351,7 @@ impl BexVm {
                         }
                         .into());
                     };
-                    cell.value = value;
+                    cell.store(value);
                 }
 
                 OpCode::CaptureRef => {
@@ -4568,7 +4564,7 @@ impl BexVm {
                     // Take the map's write lock for capture-old + insert-new
                     // atomically. Guard drops before any `&mut self` ops.
                     let store_result: Result<Value, ObjectType> = {
-                        match self.get_object_mut(map_index) {
+                        match self.get_object(map_index) {
                             Object::Map(map) => {
                                 let mut guard = map.lock_mut();
                                 let old = guard.get(&key).copied().unwrap_or(Value::NULL);

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -890,14 +890,14 @@ impl BexVm {
     ///
     /// # Safety
     ///
-    /// This is safe for:
-    /// - Compile-time objects (immutable)
-    /// - Objects allocated by this VM's TLAB
-    /// - Objects from other VMs when they're not being mutated
+    /// The returned `&Object` may be aliased by other spawned VMs. It is safe
+    /// to inspect immutable object metadata through it, and to reach mutable
+    /// internals only when that field has its own synchronization (for example
+    /// `LockedContainer` data, atomic instance fields, cells, or futures).
     #[inline]
     pub fn get_object(&self, ptr: HeapPtr) -> &Object {
-        // SAFETY: Single-threaded execution within a VM. Objects are only
-        // written during allocation or field writes, both controlled by this VM.
+        // SAFETY: `HeapPtr` points into stable heap storage. Shared mutable
+        // state behind the object must provide its own synchronization.
         unsafe { ptr.get() }
     }
 
@@ -905,17 +905,17 @@ impl BexVm {
     ///
     /// # Safety
     ///
-    /// Caller must ensure exclusive access (typically via TLAB ownership
-    /// or single-threaded execution). Only runtime objects can be mutated.
+    /// Caller must ensure exclusive access to the heap object itself. `&mut
+    /// self` only proves exclusive access to this VM, not to objects shared with
+    /// spawned VMs. Mutator paths for shared state should use [`Self::get_object`]
+    /// plus the object's interior synchronization instead.
     #[inline]
     pub fn get_object_mut(&mut self, ptr: HeapPtr) -> &mut Object {
-        // SAFETY: We have &mut self, so no other code can access the VM.
-        // The TLAB ensures this VM has exclusive access to its allocated objects.
         debug_assert!(
             !self.heap.is_compile_time_ptr(ptr),
             "Cannot mutate compile-time object"
         );
-        // SAFETY: We have &mut self, ensuring exclusive access to this VM's objects
+        // SAFETY: caller upholds the object-exclusivity contract documented above.
         unsafe { ptr.get_mut() }
     }
 
@@ -1022,6 +1022,10 @@ impl BexVm {
     }
 
     /// Get mutable string from a Value.
+    ///
+    /// Strings are immutable at the current BAML language surface. Do not use
+    /// this for spawned user-code mutation unless strings gain the same
+    /// object-level synchronization as containers.
     pub fn as_string_mut(&mut self, value: &Value) -> Result<&mut String, VmInternalError> {
         let ptr = self.as_object_ptr(*value, ObjectType::String)?;
         self.get_object_mut(ptr).as_string_mut()

--- a/baml_language/crates/bex_vm/src/watch.rs
+++ b/baml_language/crates/bex_vm/src/watch.rs
@@ -471,7 +471,11 @@ pub fn track_watch_dependencies(watch: &mut Watch, parent: NodeId, path: Path, c
                 .fields
                 .iter()
                 .enumerate()
-                .filter_map(|(idx, v)| v.as_object_ptr().map(|p| (Path::InstanceField(idx), p)))
+                .filter_map(|(idx, v)| {
+                    v.load()
+                        .as_object_ptr()
+                        .map(|p| (Path::InstanceField(idx), p))
+                })
                 .collect(),
 
             Object::Array(array) => array
@@ -731,11 +735,7 @@ mod tests {
 
     /// Allocates an instance whose fields point to the given objects.
     fn instance(class: HeapPtr, fields: Vec<Value>) -> HeapPtr {
-        heap_alloc(Object::Instance(Instance {
-            class,
-            class_type_args: Vec::new(),
-            fields,
-        }))
+        heap_alloc(Object::Instance(Instance::new(class, Vec::new(), fields)))
     }
 
     #[test]
@@ -788,7 +788,7 @@ mod tests {
         // Close the cycle: mutate A's field to point to B.
         unsafe {
             if let Object::Instance(inst) = a.get_mut() {
-                inst.fields[0] = Value::object(b);
+                inst.store_field(0, Value::object(b));
             }
         }
 

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -27,14 +27,14 @@ pub use indexable::{
 };
 pub use roots::{PermitProof, RootHaver, WriteBarrier};
 pub use types::{
-    ArrayContainer, ArrayReadGuard, ArrayWriteGuard, Class, ClassField, ClientBuildMeta,
-    ClientBuildType, CollectorRef, ConstValue, Enum, EnumVariant, Function, FunctionKind,
-    FunctionMeta, FunctionOrigin, Future, FutureRead, HostClosure, Instance, LockedContainer,
-    LockedReadGuard, LockedWriteGuard, MapContainer, MapReadGuard, MapWriteGuard, MediaValue,
-    Object, ObjectType, PanicClass, Program, PromptAst, RetryPolicyMeta, SysOp, SysOpErrorCategory,
-    SysOpPanicCategory, TestArgValue, TestCase, Uint8ArrayContainer, Uint8ArrayReadGuard,
-    Uint8ArrayWriteGuard, UnscheduledFuture, Value, ValueKind, Variant, format_float,
-    sys_op_for_path, type_tags,
+    ArrayContainer, ArrayReadGuard, ArrayWriteGuard, AtomicValueSlot, Class, ClassField,
+    ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum, EnumVariant, Function,
+    FunctionKind, FunctionMeta, FunctionOrigin, Future, FutureRead, HostClosure, Instance,
+    LockedContainer, LockedReadGuard, LockedWriteGuard, MapContainer, MapReadGuard, MapWriteGuard,
+    MediaValue, Object, ObjectType, PanicClass, Program, PromptAst, RetryPolicyMeta, SysOp,
+    SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase, Uint8ArrayContainer,
+    Uint8ArrayReadGuard, Uint8ArrayWriteGuard, UnscheduledFuture, Value, ValueKind, Variant,
+    format_float, sys_op_for_path, type_tags,
 };
 
 /// Used to check if the VM should yield early.

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -29,10 +29,12 @@ pub use roots::{PermitProof, RootHaver, WriteBarrier};
 pub use types::{
     ArrayContainer, ArrayReadGuard, ArrayWriteGuard, Class, ClassField, ClientBuildMeta,
     ClientBuildType, CollectorRef, ConstValue, Enum, EnumVariant, Function, FunctionKind,
-    FunctionMeta, FunctionOrigin, Future, FutureRead, HostClosure, Instance, MapContainer,
-    MapReadGuard, MapWriteGuard, MediaValue, Object, ObjectType, PanicClass, Program, PromptAst,
-    RetryPolicyMeta, SysOp, SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase,
-    UnscheduledFuture, Value, ValueKind, Variant, format_float, sys_op_for_path, type_tags,
+    FunctionMeta, FunctionOrigin, Future, FutureRead, HostClosure, Instance, LockedContainer,
+    LockedReadGuard, LockedWriteGuard, MapContainer, MapReadGuard, MapWriteGuard, MediaValue,
+    Object, ObjectType, PanicClass, Program, PromptAst, RetryPolicyMeta, SysOp, SysOpErrorCategory,
+    SysOpPanicCategory, TestArgValue, TestCase, Uint8ArrayContainer, Uint8ArrayReadGuard,
+    Uint8ArrayWriteGuard, UnscheduledFuture, Value, ValueKind, Variant, format_float,
+    sys_op_for_path, type_tags,
 };
 
 /// Used to check if the VM should yield early.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -14,7 +14,7 @@ use std::{
     mem::MaybeUninit,
     sync::{
         Arc,
-        atomic::{AtomicU8, Ordering},
+        atomic::{AtomicU8, AtomicU64, Ordering},
     },
 };
 
@@ -538,8 +538,34 @@ pub struct Instance {
     /// `enclosing_generic_params()`: index 0 = first class param, etc.
     pub class_type_args: Vec<baml_type::Ty>,
 
-    /// Fields are accessed by index. No string lookups.
-    pub fields: Vec<Value>,
+    /// Fields are accessed by index. No string lookups. Each slot is atomic so
+    /// racing field reads/writes across `spawn` fibers cannot become a Rust
+    /// data race.
+    pub fields: Vec<AtomicValueSlot>,
+}
+
+impl Instance {
+    pub fn new(class: HeapPtr, class_type_args: Vec<baml_type::Ty>, fields: Vec<Value>) -> Self {
+        Self {
+            class,
+            class_type_args,
+            fields: fields.into_iter().map(AtomicValueSlot::new).collect(),
+        }
+    }
+
+    #[inline]
+    pub fn load_field(&self, idx: usize) -> Value {
+        self.fields[idx].load()
+    }
+
+    #[inline]
+    pub fn store_field(&self, idx: usize, value: Value) {
+        self.fields[idx].store(value);
+    }
+
+    pub fn field_values(&self) -> impl Iterator<Item = Value> + '_ {
+        self.fields.iter().map(AtomicValueSlot::load)
+    }
 }
 
 impl std::fmt::Display for Instance {
@@ -936,6 +962,62 @@ impl Default for Value {
     #[allow(clippy::inline_always)]
     fn default() -> Self {
         Self::NULL
+    }
+}
+
+/// Atomic storage for a single [`Value`].
+///
+/// This is used for heap slots whose value may be read and written by multiple
+/// spawned VM fibers (`Cell.value` and `Instance.fields`). It preserves
+/// atomicity of the 8-byte tagged value and uses release/acquire ordering so a
+/// newly stored object pointer is safely published to a racing reader.
+#[repr(transparent)]
+pub struct AtomicValueSlot(AtomicU64);
+
+impl AtomicValueSlot {
+    #[inline]
+    pub const fn new(value: Value) -> Self {
+        Self(AtomicU64::new(value.bits()))
+    }
+
+    #[inline]
+    pub fn load(&self) -> Value {
+        Value(self.0.load(Ordering::Acquire))
+    }
+
+    #[inline]
+    pub fn store(&self, value: Value) {
+        self.0.store(value.bits(), Ordering::Release);
+    }
+}
+
+impl From<Value> for AtomicValueSlot {
+    fn from(value: Value) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Clone for AtomicValueSlot {
+    fn clone(&self) -> Self {
+        Self::new(self.load())
+    }
+}
+
+impl std::fmt::Debug for AtomicValueSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.load().fmt(f)
+    }
+}
+
+impl Serialize for AtomicValueSlot {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.load().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AtomicValueSlot {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Value::deserialize(deserializer).map(Self::new)
     }
 }
 
@@ -1723,7 +1805,25 @@ pub struct HostClosure {
 /// both the enclosing scope and any closures share the same storage.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Cell {
-    pub value: Value,
+    pub value: AtomicValueSlot,
+}
+
+impl Cell {
+    pub fn new(value: Value) -> Self {
+        Self {
+            value: AtomicValueSlot::new(value),
+        }
+    }
+
+    #[inline]
+    pub fn load(&self) -> Value {
+        self.value.load()
+    }
+
+    #[inline]
+    pub fn store(&self, value: Value) {
+        self.value.store(value);
+    }
 }
 
 impl std::fmt::Display for Object {
@@ -1740,7 +1840,7 @@ impl std::fmt::Display for Object {
             }
             Object::BoundMethod(_) => write!(f, "<bound_method>"),
             Object::HostClosure(_) => write!(f, "<host_closure>"),
-            Object::Cell(cell) => write!(f, "<cell {}>", cell.value),
+            Object::Cell(cell) => write!(f, "<cell {}>", cell.load()),
             Object::String(string) => string.fmt(f),
             Object::Uint8Array(bytes) => write!(f, "<uint8array len={}>", bytes.len()),
             Object::Array(array) => write!(f, "<array len={}>", array.lock().len()),

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -1236,54 +1236,54 @@ impl PartialEq for CollectorRef {
     }
 }
 
-/// Heap-mutable array container. Pairs a `Vec<Value>` with a
-/// [`LazyBiasedMutex`] so cross-fiber `spawn`-racing mutations don't
-/// corrupt the Vec's internal `(ptr, len, cap)` triple.
-///
-/// Held inline by `Object::Array`. Size: 24 (Vec) + 1 (mutex) + padding = 32 bytes.
+/// Heap-mutable structural container. Pairs a dynamic backing store with a
+/// [`LazyBiasedMutex`] so cross-fiber `spawn`-racing mutations don't corrupt
+/// internal container state such as a `Vec`'s `(ptr, len, cap)` triple or an
+/// `IndexMap`'s hash table.
 ///
 /// # Soundness
 ///
-/// The inner `Vec<Value>` is wrapped in [`UnsafeCell`] so that both
+/// The inner value is wrapped in [`UnsafeCell`] so that both
 /// [`Self::lock`] and [`Self::lock_mut`] can take `&self`. Without this,
-/// the mutator-side `BexVm::as_array_mut` would have to call
+/// the mutator-side `BexVm::as_array_mut` / `as_map_mut` would have to call
 /// `get_object_mut`, which fabricates `&'static mut Object` for slots
 /// that — by design — are shared across `spawn` fibers, violating
 /// Rust's aliasing rules even though the [`LazyBiasedMutex`] provides
 /// actual mutual exclusion at the memory level.
 ///
-/// All access to `data` happens through the lock guards, which is the
-/// only place we materialize `&Vec<Value>` / `&mut Vec<Value>`.
+/// All mutator access to `data` happens through the lock guards, which is the
+/// only place we materialize shared or mutable references to the backing store.
 #[derive(Debug)]
-pub struct ArrayContainer {
+pub struct LockedContainer<T> {
     mutex: LazyBiasedMutex,
-    data: UnsafeCell<Vec<Value>>,
+    data: UnsafeCell<T>,
 }
 
-// SAFETY: cross-thread access is serialized by `mutex`. The `UnsafeCell`
-// is necessary so callers can take the lock via `&self` (the only sound
-// option when the container is reachable through aliased `&Object` from
-// the shared heap).
-unsafe impl Sync for ArrayContainer {}
+// SAFETY: cross-thread access is serialized by `mutex`. The `UnsafeCell` is
+// necessary so callers can take the lock via `&self` (the only sound option
+// when the container is reachable through aliased `&Object` from the shared
+// heap). `T: Send` is required because the protected backing store can move
+// between threads behind the lock.
+unsafe impl<T: Send> Sync for LockedContainer<T> {}
 
-impl ArrayContainer {
-    pub fn new(data: Vec<Value>) -> Self {
+impl<T> LockedContainer<T> {
+    pub fn new(data: T) -> Self {
         Self {
             mutex: LazyBiasedMutex::new(),
             data: UnsafeCell::new(data),
         }
     }
 
-    /// Acquire the container's mutex and return a read guard. The lock
-    /// is released when the guard is dropped.
-    pub fn lock(&self) -> ArrayReadGuard<'_> {
+    /// Acquire the container's mutex and return a read guard. The lock is
+    /// released when the guard is dropped.
+    pub fn lock(&self) -> LockedReadGuard<'_, T> {
         let access = self.mutex.enter();
         // SAFETY: we just acquired the lock; no other thread can hold a
         // `&mut` to `data` (the only place `&mut data` is materialized
         // is `lock_mut`, which also takes the lock). Lifetime is tied
         // to `&self`, which is tied to the access guard.
         let data = unsafe { &*self.data.get() };
-        ArrayReadGuard {
+        LockedReadGuard {
             data,
             _access: access,
         }
@@ -1294,13 +1294,13 @@ impl ArrayContainer {
     /// `&mut self`) so callers can lock through a shared reference
     /// obtained from the shared heap (`get_object`, not the unsound
     /// `get_object_mut`).
-    pub fn lock_mut(&self) -> ArrayWriteGuard<'_> {
+    pub fn lock_mut(&self) -> LockedWriteGuard<'_, T> {
         let access = self.mutex.enter();
         // SAFETY: the access guard provides mutual exclusion against
         // all other lock holders for this container. The returned
-        // `&mut Vec<Value>` lifetime is bounded by the guard's lifetime.
+        // `&mut T` lifetime is bounded by the guard's lifetime.
         let data = unsafe { &mut *self.data.get() };
-        ArrayWriteGuard {
+        LockedWriteGuard {
             data,
             _access: access,
         }
@@ -1321,7 +1321,7 @@ impl ArrayContainer {
     /// For any path where a `spawn`ed fiber may be running, use
     /// [`Self::lock`] instead.
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe fn data_unchecked(&self) -> &Vec<Value> {
+    pub unsafe fn data_unchecked(&self) -> &T {
         // SAFETY: caller upholds the no-concurrent-writer contract.
         unsafe { &*self.data.get() }
     }
@@ -1335,36 +1335,14 @@ impl ArrayContainer {
     /// must hold the only `&mut ArrayContainer` (or otherwise
     /// guarantee no other readers).
     #[allow(clippy::missing_safety_doc, clippy::mut_from_ref)]
-    pub unsafe fn data_unchecked_mut(&self) -> &mut Vec<Value> {
+    pub unsafe fn data_unchecked_mut(&self) -> &mut T {
         // SAFETY: caller upholds the contract.
         unsafe { &mut *self.data.get() }
     }
-
-    /// Locked convenience: number of elements.
-    pub fn len(&self) -> usize {
-        self.lock().len()
-    }
-
-    /// Locked convenience: whether the array is empty.
-    pub fn is_empty(&self) -> bool {
-        self.lock().is_empty()
-    }
-
-    /// Locked convenience: copy the element at `idx`, or `None` if out
-    /// of bounds. `Value` is `Copy`, so no borrow is held past the
-    /// lock release.
-    pub fn get(&self, idx: usize) -> Option<Value> {
-        self.lock().get(idx).copied()
-    }
-
-    /// Locked convenience: snapshot the underlying `Vec<Value>`.
-    pub fn to_vec(&self) -> Vec<Value> {
-        self.lock().clone()
-    }
 }
 
-impl From<Vec<Value>> for ArrayContainer {
-    fn from(data: Vec<Value>) -> Self {
+impl<T> From<T> for LockedContainer<T> {
+    fn from(data: T) -> Self {
         Self::new(data)
     }
 }
@@ -1372,111 +1350,105 @@ impl From<Vec<Value>> for ArrayContainer {
 // Cloning takes the lock so a concurrent writer can't tear `data` mid-clone.
 // The contention state (the in-flight access counter) is not part of the
 // logical value of the source.
-impl Clone for ArrayContainer {
+impl<T: Clone> Clone for LockedContainer<T> {
     fn clone(&self) -> Self {
         let guard = self.lock();
         Self::new(guard.clone())
     }
 }
 
-/// Read guard for an [`ArrayContainer`]. Holds the container's
+impl<T> LockedContainer<Vec<T>> {
+    /// Locked convenience: number of elements.
+    pub fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    /// Locked convenience: whether the container is empty.
+    pub fn is_empty(&self) -> bool {
+        self.lock().is_empty()
+    }
+}
+
+impl<T: Copy> LockedContainer<Vec<T>> {
+    /// Locked convenience: copy the element at `idx`, or `None` if out of bounds.
+    pub fn get(&self, idx: usize) -> Option<T> {
+        self.lock().get(idx).copied()
+    }
+}
+
+impl<T: Clone> LockedContainer<Vec<T>> {
+    /// Locked convenience: snapshot the underlying `Vec<T>`.
+    pub fn to_vec(&self) -> Vec<T> {
+        self.lock().clone()
+    }
+}
+
+/// Read guard for a [`LockedContainer`]. Holds the container's
 /// [`LazyBiasedMutex`] for the duration of the guard's lifetime.
-pub struct ArrayReadGuard<'a> {
-    data: &'a Vec<Value>,
+pub struct LockedReadGuard<'a, T> {
+    data: &'a T,
     _access: crate::lazy_biased_mutex::AccessGuard<'a>,
 }
 
-impl std::ops::Deref for ArrayReadGuard<'_> {
-    type Target = Vec<Value>;
-    fn deref(&self) -> &Vec<Value> {
+impl<T> std::ops::Deref for LockedReadGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
         self.data
     }
 }
 
-/// Write guard for an [`ArrayContainer`]. Holds the container's
+/// Write guard for a [`LockedContainer`]. Holds the container's
 /// [`LazyBiasedMutex`] for the duration of the guard's lifetime.
-pub struct ArrayWriteGuard<'a> {
-    data: &'a mut Vec<Value>,
+pub struct LockedWriteGuard<'a, T> {
+    data: &'a mut T,
     _access: crate::lazy_biased_mutex::AccessGuard<'a>,
 }
 
-impl std::ops::Deref for ArrayWriteGuard<'_> {
-    type Target = Vec<Value>;
-    fn deref(&self) -> &Vec<Value> {
+impl<T> std::ops::Deref for LockedWriteGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
         self.data
     }
 }
 
-impl std::ops::DerefMut for ArrayWriteGuard<'_> {
-    fn deref_mut(&mut self) -> &mut Vec<Value> {
+impl<T> std::ops::DerefMut for LockedWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
         self.data
     }
 }
 
-/// Heap-mutable map container. Pairs an `IndexMap<String, Value>` with a
-/// [`LazyBiasedMutex`]. Boxed by `Object::Map` because `IndexMap` is
-/// already 72 bytes — inlining the mutex would push the Object variant
-/// past the 80-byte size cap.
+/// Heap-mutable array container.
 ///
-/// See [`ArrayContainer`] for the soundness rationale around `UnsafeCell`
-/// and `&self`-based locking.
-#[derive(Debug)]
-pub struct MapContainer {
-    mutex: LazyBiasedMutex,
-    data: UnsafeCell<IndexMap<String, Value>>,
+/// Held inline by `Object::Array`. Size: 24 (Vec) + 1 (mutex) + padding = 32 bytes.
+pub type ArrayContainer = LockedContainer<Vec<Value>>;
+pub type ArrayReadGuard<'a> = LockedReadGuard<'a, Vec<Value>>;
+pub type ArrayWriteGuard<'a> = LockedWriteGuard<'a, Vec<Value>>;
+
+/// Heap-mutable byte-array container. Same synchronization strategy as
+/// [`ArrayContainer`], but over a `Vec<u8>` backing store.
+pub type Uint8ArrayContainer = LockedContainer<Vec<u8>>;
+pub type Uint8ArrayReadGuard<'a> = LockedReadGuard<'a, Vec<u8>>;
+pub type Uint8ArrayWriteGuard<'a> = LockedWriteGuard<'a, Vec<u8>>;
+
+/// Heap-mutable map container. Pairs a boxed `IndexMap<String, Value>` with
+/// the generic [`LockedContainer`] lock/guard machinery.
+///
+/// `IndexMap` is 72 bytes before the lock, so storing it inline would push
+/// `Object` past its size cap. Storing only the backing map behind `Box<_>`
+/// keeps the container itself small while avoiding an extra indirection around
+/// the lock.
+pub type MapContainer = LockedContainer<Box<IndexMap<String, Value>>>;
+pub type MapReadGuard<'a> = LockedReadGuard<'a, Box<IndexMap<String, Value>>>;
+pub type MapWriteGuard<'a> = LockedWriteGuard<'a, Box<IndexMap<String, Value>>>;
+
+impl MapReadGuard<'_> {
+    /// Snapshot the underlying `IndexMap`.
+    pub fn to_index_map(&self) -> IndexMap<String, Value> {
+        self.as_ref().clone()
+    }
 }
 
-// SAFETY: as for `ArrayContainer` — cross-thread access is serialized by
-// `mutex`, and the `UnsafeCell` allows locking through `&self`.
-unsafe impl Sync for MapContainer {}
-
-impl MapContainer {
-    pub fn new(data: IndexMap<String, Value>) -> Self {
-        Self {
-            mutex: LazyBiasedMutex::new(),
-            data: UnsafeCell::new(data),
-        }
-    }
-
-    pub fn lock(&self) -> MapReadGuard<'_> {
-        let access = self.mutex.enter();
-        // SAFETY: lock acquired; see `ArrayContainer::lock`.
-        let data = unsafe { &*self.data.get() };
-        MapReadGuard {
-            data,
-            _access: access,
-        }
-    }
-
-    pub fn lock_mut(&self) -> MapWriteGuard<'_> {
-        let access = self.mutex.enter();
-        // SAFETY: lock acquired; see `ArrayContainer::lock_mut`.
-        let data = unsafe { &mut *self.data.get() };
-        MapWriteGuard {
-            data,
-            _access: access,
-        }
-    }
-
-    /// Unlocked accessor; same safety contract as
-    /// [`ArrayContainer::data_unchecked`].
-    ///
-    /// # Safety
-    /// See [`ArrayContainer::data_unchecked`].
-    #[allow(clippy::missing_safety_doc)]
-    pub unsafe fn data_unchecked(&self) -> &IndexMap<String, Value> {
-        // SAFETY: caller upholds the no-concurrent-writer contract.
-        unsafe { &*self.data.get() }
-    }
-
-    /// # Safety
-    /// See [`ArrayContainer::data_unchecked_mut`].
-    #[allow(clippy::missing_safety_doc, clippy::mut_from_ref)]
-    pub unsafe fn data_unchecked_mut(&self) -> &mut IndexMap<String, Value> {
-        // SAFETY: caller upholds the contract.
-        unsafe { &mut *self.data.get() }
-    }
-
+impl LockedContainer<Box<IndexMap<String, Value>>> {
     /// Locked convenience: number of entries.
     pub fn len(&self) -> usize {
         self.lock().len()
@@ -1494,50 +1466,13 @@ impl MapContainer {
 
     /// Locked convenience: snapshot the underlying `IndexMap`.
     pub fn to_index_map(&self) -> IndexMap<String, Value> {
-        self.lock().clone()
+        self.lock().to_index_map()
     }
 }
 
-impl From<IndexMap<String, Value>> for MapContainer {
+impl From<IndexMap<String, Value>> for LockedContainer<Box<IndexMap<String, Value>>> {
     fn from(data: IndexMap<String, Value>) -> Self {
-        Self::new(data)
-    }
-}
-
-impl Clone for MapContainer {
-    fn clone(&self) -> Self {
-        let guard = self.lock();
-        Self::new(guard.clone())
-    }
-}
-
-pub struct MapReadGuard<'a> {
-    data: &'a IndexMap<String, Value>,
-    _access: crate::lazy_biased_mutex::AccessGuard<'a>,
-}
-
-impl std::ops::Deref for MapReadGuard<'_> {
-    type Target = IndexMap<String, Value>;
-    fn deref(&self) -> &IndexMap<String, Value> {
-        self.data
-    }
-}
-
-pub struct MapWriteGuard<'a> {
-    data: &'a mut IndexMap<String, Value>,
-    _access: crate::lazy_biased_mutex::AccessGuard<'a>,
-}
-
-impl std::ops::Deref for MapWriteGuard<'_> {
-    type Target = IndexMap<String, Value>;
-    fn deref(&self) -> &IndexMap<String, Value> {
-        self.data
-    }
-}
-
-impl std::ops::DerefMut for MapWriteGuard<'_> {
-    fn deref_mut(&mut self) -> &mut IndexMap<String, Value> {
-        self.data
+        Self::new(Box::new(data))
     }
 }
 
@@ -1596,18 +1531,20 @@ pub enum Object {
     /// otherwise.
     String(String),
 
-    /// Byte array (uint8array).
-    Uint8Array(Vec<u8>),
+    /// Byte array (uint8array). Wrapped in [`Uint8ArrayContainer`] so the
+    /// underlying `Vec<u8>` is protected by a [`LazyBiasedMutex`] against
+    /// racing mutation under `spawn`.
+    Uint8Array(Uint8ArrayContainer),
 
     /// List of values. Wrapped in [`ArrayContainer`] so the underlying
     /// `Vec<Value>` is protected by a [`LazyBiasedMutex`] against racing
     /// mutation under `spawn`.
     Array(ArrayContainer),
 
-    /// Map of values. Boxed because `MapContainer` is heavy (`IndexMap` +
-    /// mutex) and Map ops are less hot than Array ops; the indirection
-    /// keeps `Object` total size under 80 bytes.
-    Map(Box<MapContainer>),
+    /// Map of values. Wrapped in [`MapContainer`] so the underlying
+    /// `IndexMap` is protected by a [`LazyBiasedMutex`] against racing
+    /// mutation under `spawn`.
+    Map(MapContainer),
 
     /// Boxed 64-bit float. Floats are heap-allocated because `Value`
     /// itself is a single tagged 64-bit word with no inline encoding
@@ -1672,9 +1609,9 @@ impl Serialize for Object {
             Self::BoundMethod(v) => ObjectSerde::BoundMethod(v.clone()),
             Self::Cell(v) => ObjectSerde::Cell(v.clone()),
             Self::String(v) => ObjectSerde::String(v.clone()),
-            Self::Uint8Array(v) => ObjectSerde::Uint8Array(v.clone()),
+            Self::Uint8Array(v) => ObjectSerde::Uint8Array(v.lock().clone()),
             Self::Array(v) => ObjectSerde::Array(v.lock().clone()),
-            Self::Map(v) => ObjectSerde::Map(v.lock().clone()),
+            Self::Map(v) => ObjectSerde::Map(v.to_index_map()),
             Self::Float(v) => ObjectSerde::Float(*v),
             Self::Future(v) => ObjectSerde::Future(v.clone()),
             Self::UnscheduledFuture(v) => ObjectSerde::UnscheduledFuture(v.clone()),
@@ -1712,9 +1649,9 @@ impl<'de> Deserialize<'de> for Object {
             ObjectSerde::BoundMethod(v) => Self::BoundMethod(v),
             ObjectSerde::Cell(v) => Self::Cell(v),
             ObjectSerde::String(v) => Self::String(v),
-            ObjectSerde::Uint8Array(v) => Self::Uint8Array(v),
+            ObjectSerde::Uint8Array(v) => Self::Uint8Array(Uint8ArrayContainer::new(v)),
             ObjectSerde::Array(v) => Self::Array(ArrayContainer::new(v)),
-            ObjectSerde::Map(v) => Self::Map(Box::new(MapContainer::new(v))),
+            ObjectSerde::Map(v) => Self::Map(v.into()),
             ObjectSerde::Float(v) => Self::Float(v),
             ObjectSerde::Future(v) => Self::Future(v),
             ObjectSerde::UnscheduledFuture(v) => Self::UnscheduledFuture(v),

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -1397,8 +1397,8 @@ impl<T> LockedContainer<T> {
     ///
     /// - GC traversal while the stop-the-world barrier is engaged
     ///   (all mutator threads are parked).
-    /// - Host accessor invocations during a serialized FFI callback.
     /// - Single-threaded engine setup / init.
+    /// - Other code that has independently stopped all VM mutators.
     ///
     /// For any path where a `spawn`ed fiber may be running, use
     /// [`Self::lock`] instead.

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -5073,7 +5073,9 @@ fn format_vm_value(value: &bex_vm_types::Value, vm: &bex_vm::BexVm) -> String {
                             .fields
                             .iter()
                             .zip(inst.fields.iter())
-                            .map(|(f, val)| format!("{}: {}", f.name, format_vm_value(val, vm)))
+                            .map(|(f, val)| {
+                                format!("{}: {}", f.name, format_vm_value(&val.load(), vm))
+                            })
                             .collect();
                         format!("{}{{ {} }}", class.name, fields.join(", "))
                     } else {
@@ -5102,7 +5104,7 @@ fn format_vm_value(value: &bex_vm_types::Value, vm: &bex_vm::BexVm) -> String {
                 Object::Closure(c) => format!("<closure captures={}>", c.captures.len()),
                 Object::BoundMethod(_) => "<bound_method>".to_string(),
                 Object::HostClosure(_) => "<host_closure>".to_string(),
-                Object::Cell(c) => format!("<cell {}>", format_vm_value(&c.value, vm)),
+                Object::Cell(c) => format!("<cell {}>", format_vm_value(&c.load(), vm)),
                 Object::Uint8Array(bytes) => format!("<uint8array len={}>", bytes.len()),
                 Object::RustData(_) => "<rust_data>".to_string(),
                 #[cfg(feature = "heap_debug")]


### PR DESCRIPTION
## Summary

- add `AtomicValueSlot` and use it for `Instance.fields` and captured `Cell.value`
- update VM field/cell access, GC tracing/fixup, conversion, JSON/deep-copy, debugger, and generated accessors to load/store through the slot API
- route array/map mutable access through shared heap access before taking the container lock, avoiding stale `get_object_mut` aliasing around locked containers
- add spawn race smoke tests for captured locals and class fields

## Safety scope

This is a crash-safety / Rust data-race fix. Racing slot and container accesses should no longer tear `Value`s, corrupt container internals, or crash the runtime through VM aliasing issues.

This does **not** make compound user operations atomic. Examples like `value += 1`, `obj.field += 1`, `arr[i] = arr[i] + 1`, and `map["x"] = map["x"] + 1` can still lose updates because the VM still executes them as separate load/compute/store steps.

## Benchmarks

Baseline before atomic slots:

```text
vm_closure_call_50k mean/median: 5.973 ms / 5.987 ms
vm_field_access_50k mean/median: 4.942 ms / 4.947 ms
```

After atomic slots:

```text
vm_closure_call_50k mean/median: 6.079 ms / 6.077 ms  (+1.8% / +1.5%)
vm_field_access_50k mean/median: 4.990 ms / 4.979 ms  (+1.0% / +0.6%)
```

## Validation

- `cargo fmt`
- `cargo clippy` via commit hook
- `cargo test -p baml_tests --test spawn_array_race`
- `cargo test -p baml_tests --test byte_strings`
- `cargo test -p bex_heap`
- `cargo test -p bex_vm`
- `cargo check -p tools_onionskin`
- `cargo check --workspace`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added regression tests covering concurrent byte-array (Uint8Array) operations and shared-state races.

* **Bug Fixes**
  * Prevents crashes from concurrent array/map/byte-array mutations and shared captured-state races.
  * More robust equality and deep-copy behavior for byte-array objects.

* **Refactor**
  * Heap fields and containers moved to synchronized, lock-guarded accessors and atomic slots for stronger concurrency safety and correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->