### PR TITLE
Add `let … else` expressions

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -754,6 +754,12 @@ pub enum Stmt {
         initializer: Option<ExprId>,
         is_watched: bool,
         origin: LetOrigin,
+        /// `let PATTERN = init else { … };` — refutable binding with a
+        /// diverging else clause. `Some` activates let-else semantics:
+        /// the pattern may be refutable, and the else expression is
+        /// required to have type `Ty::Never`. Pattern bindings flow into
+        /// the enclosing scope on a successful match.
+        else_branch: Option<ExprId>,
     },
     While {
         condition: ExprId,

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -2734,19 +2734,23 @@ impl LoweringContext {
 
     fn lower_let_stmt(&mut self, node: &SyntaxNode, is_watched: bool) -> StmtId {
         // LET_STMT shape (post-pattern-rewrite):
-        //   KW_WATCH? KW_LET? PATTERN EQUALS <init-expr> SEMICOLON?
+        //   KW_WATCH? KW_LET? PATTERN EQUALS <init-expr> (KW_ELSE BLOCK_EXPR)? SEMICOLON?
         //
         // The pattern carries its own `: T` narrow as a Chain link, so all we
-        // do here is locate the PATTERN child and the initialiser child.
+        // do here is locate the PATTERN child, the initialiser child, and an
+        // optional trailing `else { … }` block for let-else.
         let mut pattern_id = None;
         let mut initializer = None;
+        let mut else_branch = None;
         let mut seen_equals = false;
+        let mut seen_else = false;
 
         for elem in node.children_with_tokens() {
             match elem {
                 rowan::NodeOrToken::Token(token) => match token.kind() {
                     SyntaxKind::EQUALS => seen_equals = true,
-                    _ if seen_equals && initializer.is_none() => {
+                    SyntaxKind::KW_ELSE => seen_else = true,
+                    _ if seen_equals && !seen_else && initializer.is_none() => {
                         if let Some(id) = self.try_lower_bare_token(&token) {
                             initializer = Some(id);
                         }
@@ -2758,8 +2762,10 @@ impl LoweringContext {
                         if child.kind() == SyntaxKind::PATTERN && pattern_id.is_none() {
                             pattern_id = Some(self.lower_pattern(&child));
                         }
-                    } else if initializer.is_none() {
+                    } else if !seen_else && initializer.is_none() {
                         initializer = Some(self.lower_expr(&child));
+                    } else if seen_else && else_branch.is_none() {
+                        else_branch = Some(self.lower_expr(&child));
                     }
                 }
             }
@@ -2783,6 +2789,7 @@ impl LoweringContext {
                 initializer,
                 is_watched,
                 origin,
+                else_branch,
             },
             node.text_range(),
         )

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -348,10 +348,19 @@ impl<'db> SemanticIndexBuilder<'db> {
             ast::Stmt::Let {
                 pattern,
                 initializer,
+                else_branch,
                 ..
             } => {
                 if let Some(initializer) = initializer {
                     self.walk_expr(*initializer, body, source_map, true);
+                }
+                if let Some(else_expr) = else_branch {
+                    // `let … else { … }` — the else block runs in the
+                    // enclosing scope BEFORE the pattern's names are
+                    // registered, so walk it before `register_local_pattern`.
+                    // The block-expr's own push_scope/pop_scope keeps any
+                    // inner bindings from leaking out.
+                    self.walk_expr(*else_expr, body, source_map, true);
                 }
                 self.register_local_pattern(
                     *pattern,

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -5032,6 +5032,85 @@ impl LoweringContext<'_> {
                 self.lower_expr(expr_id, Place::local(temp));
             }
 
+            // `let PATTERN = init else { … };` — refutable binding lowered
+            // as a two-way pattern test. On match: bind into the current
+            // scope (locals survive past the statement); on miss: lower the
+            // else expression (guaranteed `Ty::Never` by TIR, so no
+            // successor edge is needed). Handled before the structural
+            // arms below because a refutable destructure ends up here too.
+            AstStmt::Let {
+                pattern,
+                initializer,
+                is_watched,
+                else_branch: Some(else_expr),
+                ..
+            } => {
+                // Materialize the scrutinee into a local once. The
+                // scrutinee carries the BROAD initializer type (e.g.
+                // `int | string`), not the pattern's narrowed match type —
+                // narrowing only kicks in on the match arm, after the
+                // refutable test.
+                let scrutinee_ty = initializer
+                    .map(|init| self.expr_ty(init))
+                    .unwrap_or_else(|| self.pat_ty(pattern));
+                let scrutinee = self.builder.temp(scrutinee_ty);
+                if let Some(init) = initializer {
+                    self.lower_expr(init, Place::local(scrutinee));
+                } else {
+                    self.builder.assign(
+                        Place::local(scrutinee),
+                        Rvalue::Use(Operand::Constant(Constant::Null)),
+                    );
+                }
+
+                let bb_match = self.builder.create_block();
+                let bb_fail = self.builder.create_block();
+                self.lower_pattern_test(scrutinee, pattern, bb_match, bb_fail);
+
+                // Fail path: lower the else expression. TIR enforced that
+                // the else has type `!`, so this block has no successor and
+                // we don't emit a join edge. Use a throwaway temp as dest
+                // because diverging expressions don't write through it.
+                self.builder.set_current_block(bb_fail);
+                let else_ty = self.expr_ty(else_expr);
+                let else_dest = self.builder.temp(else_ty);
+                self.lower_expr(else_expr, Place::local(else_dest));
+                // If for any reason lowering produced a fall-through (e.g.
+                // recovery state with an Unknown-typed else), terminate the
+                // block with an unreachable so the CFG stays valid.
+                if !self.builder.is_current_terminated() {
+                    self.builder.unreachable();
+                }
+
+                // Match path: bind pattern names into the enclosing scope.
+                // No saved/restored locals — these flow forward like a
+                // plain `let`.
+                self.builder.set_current_block(bb_match);
+                self.bind_pattern_inner(scrutinee, pattern, pattern, pattern, false, is_watched);
+
+                let names: Vec<Name> = self.body.patterns[pattern]
+                    .bound_names(&self.body.patterns)
+                    .into_iter()
+                    .cloned()
+                    .collect();
+                for name in names {
+                    if let Some(&local) = self.locals.get(&name)
+                        && let Some(binding_id) =
+                            self.binding_id_for_statement_name(stmt_id, pattern, &name)
+                    {
+                        self.binding_locals.insert(binding_id, local);
+                    }
+                }
+
+                if is_watched {
+                    for name in self.body.patterns[pattern].bound_names(&self.body.patterns) {
+                        if let Some(&local) = self.locals.get(name) {
+                            self.watched_locals_stack.push(local);
+                        }
+                    }
+                }
+            }
+
             AstStmt::Let {
                 pattern,
                 initializer,

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2115,6 +2115,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             Stmt::Let {
                 pattern,
                 initializer,
+                else_branch,
                 ..
             } => {
                 if let Some(expr) = initializer {
@@ -2125,6 +2126,20 @@ impl<'db> TypeInferenceBuilder<'db> {
                         shadowed,
                         refs,
                     );
+                }
+                if let Some(else_expr) = else_branch {
+                    // The else branch runs before the pattern's bindings
+                    // exist, so it can't see them — recurse with the
+                    // pre-binding `shadowed` set, then re-truncate after.
+                    let saved_len = shadowed.len();
+                    Self::collect_default_expr_forward_references(
+                        *else_expr,
+                        body,
+                        later_params,
+                        shadowed,
+                        refs,
+                    );
+                    shadowed.truncate(saved_len);
                 }
                 Self::push_pattern_bindings(*pattern, body, shadowed);
             }
@@ -3746,14 +3761,26 @@ impl<'db> TypeInferenceBuilder<'db> {
             Stmt::Let {
                 pattern,
                 initializer,
+                else_branch,
                 ..
             } => {
-                let (init_result_ty, pattern_subject_ty, declared_for_scope) =
-                    if let Some(init) = *initializer {
-                        let expected = self.pattern_expected_ty(*pattern, body);
-                        let is_structural_pattern =
-                            Self::pattern_contains_structural_syntax(*pattern, body);
-                        let expected_for_check = match expected {
+                let (init_result_ty, pattern_subject_ty, declared_for_scope) = if let Some(init) =
+                    *initializer
+                {
+                    let expected = self.pattern_expected_ty(*pattern, body);
+                    let is_structural_pattern =
+                        Self::pattern_contains_structural_syntax(*pattern, body);
+                    // For `let … else`, the pattern is refutable: the
+                    // declared type narrows the binding ON A MATCH, but
+                    // the initializer is allowed to be wider (the else
+                    // branch handles the residual). Don't push the
+                    // pattern's expected type into the init — infer it
+                    // freely instead so the refutability matrix sees
+                    // the full scrutinee type.
+                    let expected_for_check = if else_branch.is_some() {
+                        None
+                    } else {
+                        match expected {
                             Some(PatternExpectedTy::Full(ty)) if !is_structural_pattern => Some(ty),
                             Some(PatternExpectedTy::Partial(ty))
                                 if Self::expr_accepts_partial_pattern_expected(init, body) =>
@@ -3762,49 +3789,96 @@ impl<'db> TypeInferenceBuilder<'db> {
                             }
                             Some(PatternExpectedTy::Full(_) | PatternExpectedTy::Partial(_))
                             | None => None,
-                        };
-                        let ty = if let Some(expected) = expected_for_check.as_ref()
-                            && !matches!(expected, Ty::Void { .. })
-                        {
-                            self.check_expr(init, body, expected)
-                        } else {
-                            self.infer_expr(init, body)
-                        };
-                        if matches!(ty, Ty::Void { .. }) {
-                            let err = if matches!(
-                                body.exprs[init],
-                                Expr::Call { .. } | Expr::OptionalCall { .. }
-                            ) {
-                                TirTypeError::VoidFunctionResultUsed
-                            } else {
-                                TirTypeError::VoidUsedAsValue
-                            };
-                            self.context.report_simple(err, init);
                         }
-                        if let Some(expected) = expected_for_check {
-                            (Some(ty), Some(expected.clone()), Some(expected))
-                        } else {
-                            let flow_ty = ty.clone().widen_fresh().make_evolving();
-                            (Some(ty), Some(flow_ty), None)
-                        }
-                    } else {
-                        (None, None, None)
                     };
+                    let ty = if let Some(expected) = expected_for_check.as_ref()
+                        && !matches!(expected, Ty::Void { .. })
+                    {
+                        self.check_expr(init, body, expected)
+                    } else {
+                        self.infer_expr(init, body)
+                    };
+                    if matches!(ty, Ty::Void { .. }) {
+                        let err = if matches!(
+                            body.exprs[init],
+                            Expr::Call { .. } | Expr::OptionalCall { .. }
+                        ) {
+                            TirTypeError::VoidFunctionResultUsed
+                        } else {
+                            TirTypeError::VoidUsedAsValue
+                        };
+                        self.context.report_simple(err, init);
+                    }
+                    if let Some(expected) = expected_for_check {
+                        (Some(ty), Some(expected.clone()), Some(expected))
+                    } else {
+                        let flow_ty = ty.clone().widen_fresh().make_evolving();
+                        (Some(ty), Some(flow_ty), None)
+                    }
+                } else {
+                    (None, None, None)
+                };
 
                 let diverges = matches!(init_result_ty, Some(Ty::Never { .. }));
                 if !diverges && let Some(flow_ty) = pattern_subject_ty {
+                    // For `let … else`, check the else branch FIRST, in the
+                    // scope before pattern bindings are introduced. The else
+                    // path runs when the pattern did not match, so it must
+                    // not see the names the pattern would bind. We snapshot
+                    // scoped locals and restore so any inner let-bindings in
+                    // the else block don't leak into the enclosing scope.
+                    if let Some(else_expr) = else_branch {
+                        let snapshot = self.snapshot_scoped_locals();
+                        let else_ty = self.infer_expr(*else_expr, body);
+                        self.restore_scoped_locals(&snapshot);
+                        if !matches!(else_ty, Ty::Never { .. } | Ty::Unknown { .. }) {
+                            let err = TirTypeError::LetElseMustDiverge { got: else_ty };
+                            self.context.report_simple(err, *else_expr);
+                        }
+                    }
+
                     let result =
                         self.analyze_and_lower(*pattern, &flow_ty, body, initializer.unwrap());
+                    // Irrefutable-pattern check differs by binding form:
+                    //   - plain `let`: refutable patterns are an error
+                    //     (RefutablePatternInLet) — they'd fail at runtime
+                    //     with nowhere to go.
+                    //   - `let … else`: refutable is the whole point, but an
+                    //     irrefutable pattern makes the else branch dead, so
+                    //     warn (IrrefutablePatternInLetElse) and suggest
+                    //     dropping the else.
+                    let irrefutable_ctx = if else_branch.is_some() {
+                        None
+                    } else {
+                        Some(IrrefutablePatternContext {
+                            context: IrrefutableContextKind::Let,
+                            fallback_expr: *initializer,
+                        })
+                    };
                     self.finalize_pattern_lowering(
                         *pattern,
                         &result,
                         declared_for_scope.as_ref(),
-                        Some(IrrefutablePatternContext {
-                            context: IrrefutableContextKind::Let,
-                            fallback_expr: *initializer,
-                        }),
+                        irrefutable_ctx,
                         &flow_ty,
                     );
+                    if else_branch.is_some() {
+                        let scrut_for_matrix = self.matrix_normalize_scrut(&flow_ty);
+                        let report = crate::pattern_lowering::compute_match_usefulness(
+                            self,
+                            std::slice::from_ref(&result.dpat),
+                            scrut_for_matrix,
+                        );
+                        if report.missing.is_empty() {
+                            let err = TirTypeError::IrrefutablePatternInLetElse;
+                            if let Some(sm) = self.body_source_map.as_ref() {
+                                self.context
+                                    .report_warning_at_span(err, sm.pattern_span(*pattern));
+                            } else if let Some(init) = *initializer {
+                                self.context.report_warning_simple(err, init);
+                            }
+                        }
+                    }
                 }
                 diverges
             }
@@ -5551,9 +5625,16 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) {
         match &body.stmts[stmt_id] {
             Stmt::Expr(expr_id) => self.collect_throw_facts_from_expr(*expr_id, body, out),
-            Stmt::Let { initializer, .. } => {
+            Stmt::Let {
+                initializer,
+                else_branch,
+                ..
+            } => {
                 if let Some(init) = initializer {
                     self.collect_throw_facts_from_expr(*init, body, out);
+                }
+                if let Some(else_expr) = else_branch {
+                    self.collect_throw_facts_from_expr(*else_expr, body, out);
                 }
             }
             Stmt::While {

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -496,6 +496,22 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.restore_scoped_locals_inner(snapshot);
     }
 
+    /// Hard rollback to a previous snapshot — discards EVERYTHING introduced
+    /// since the snapshot, including assignments to outer bindings.
+    ///
+    /// Use this only for branches whose effects are not observable in the
+    /// continuation (i.e. diverging branches like `let … else`'s else
+    /// block). The normal `restore_scoped_locals` is a join-style merge —
+    /// it preserves outer-binding writes for branches that *do* return
+    /// control to the surrounding scope (`if`, `if let`, match arms).
+    fn discard_scoped_locals(&mut self, snapshot: ScopedLocalsSnapshot) {
+        self.locals = snapshot.locals;
+        self.scoped_local_declarations
+            .truncate(snapshot.scoped_local_declarations_len);
+        self.scoped_local_assignments
+            .truncate(snapshot.scoped_local_assignments_len);
+    }
+
     fn restore_scoped_locals_inner(&mut self, snapshot: &ScopedLocalsSnapshot) {
         // Pull the new assignments and declarations introduced since the
         // snapshot. We filter assignments by binding identity below, so the
@@ -3830,7 +3846,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                     if let Some(else_expr) = else_branch {
                         let snapshot = self.snapshot_scoped_locals();
                         let else_ty = self.infer_expr(*else_expr, body);
-                        self.restore_scoped_locals(&snapshot);
+                        // The else branch diverges by construction, so its
+                        // writes — including assignments to outer bindings —
+                        // are not observable in the success continuation.
+                        // Use the hard-rollback path, not the join-style
+                        // `restore_scoped_locals` that an `if`/`if let`
+                        // branch would use.
+                        self.discard_scoped_locals(snapshot);
                         if !matches!(else_ty, Ty::Never { .. } | Ty::Unknown { .. }) {
                             let err = TirTypeError::LetElseMustDiverge { got: else_ty };
                             self.context.report_simple(err, *else_expr);

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -392,7 +392,7 @@ impl fmt::Display for TirTypeError {
             ),
             TirTypeError::LetElseMustDiverge { got } => write!(
                 f,
-                "`let … else` requires a diverging else block (`return`, `throw`, `break`, `continue`, or an infinite loop); got `{}`",
+                "`let … else` requires a diverging else block (`return`, `throw`, `break`, or `continue`); got `{}`",
                 humanize_ty(got)
             ),
             TirTypeError::IrrefutablePatternInLetElse => write!(

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -137,6 +137,13 @@ pub enum TirTypeError {
     /// An `if let` pattern that covers every value of the scrutinee — the
     /// `else` branch is unreachable. Suggests using a plain `let` instead.
     IrrefutablePatternInIfLet,
+    /// `let … else { … }` whose else block does not have type `Ty::Never`.
+    /// The else branch must diverge — return, throw, break, continue, or
+    /// loop forever — so that fall-through past the binding cannot occur.
+    LetElseMustDiverge { got: Ty },
+    /// A `let … else` pattern that covers every value of the initializer
+    /// type — the else branch is unreachable. Suggest using a plain `let`.
+    IrrefutablePatternInLetElse,
     /// Catch binding cannot be typed as `any` or `unknown`.
     InvalidCatchBindingType { type_name: String },
     /// Inferred escaping throws are not covered by the declared throws contract.
@@ -382,6 +389,15 @@ impl fmt::Display for TirTypeError {
             TirTypeError::IrrefutablePatternInIfLet => write!(
                 f,
                 "irrefutable `if let` pattern; the `else` branch is unreachable — use a plain `let` binding instead"
+            ),
+            TirTypeError::LetElseMustDiverge { got } => write!(
+                f,
+                "`let … else` requires a diverging else block (`return`, `throw`, `break`, `continue`, or an infinite loop); got `{}`",
+                humanize_ty(got)
+            ),
+            TirTypeError::IrrefutablePatternInLetElse => write!(
+                f,
+                "irrefutable `let … else` pattern; the `else` branch is unreachable — use a plain `let` binding instead"
             ),
             TirTypeError::InvalidCatchBindingType { type_name } => write!(
                 f,

--- a/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
@@ -97,9 +97,20 @@ fn collect_from_stmt<C: ThrowsAnalysisContext>(
 ) {
     match &body.stmts[stmt_id] {
         Stmt::Expr(expr_id) => collect_from_expr(context, *expr_id, body, out),
-        Stmt::Let { initializer, .. } => {
+        Stmt::Let {
+            initializer,
+            else_branch,
+            ..
+        } => {
             if let Some(init) = initializer {
                 collect_from_expr(context, *init, body, out);
+            }
+            if let Some(else_expr) = else_branch {
+                // Throws from a `let … else` else block escape the
+                // enclosing function unless caught — they're part of the
+                // function's effect set just like throws from anywhere else
+                // in the body.
+                collect_from_expr(context, *else_expr, body, out);
             }
         }
         Stmt::While {

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
@@ -1254,6 +1254,7 @@ mod tests {
                 initializer: Some(if_expr),
                 is_watched: false,
                 origin: ast::LetOrigin::Source,
+                else_branch: None,
             });
             Some(exprs.alloc(ast::Expr::Block {
                 stmts: vec![let_stmt],
@@ -1294,6 +1295,7 @@ mod tests {
                 initializer: Some(if_expr),
                 is_watched: false,
                 origin: ast::LetOrigin::Source,
+                else_branch: None,
             });
             Some(exprs.alloc(ast::Expr::Block {
                 stmts: vec![let_stmt],

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -69,6 +69,13 @@ pub enum DiagnosticId {
     RefutablePatternInLet,
     /// `if let` pattern that always matches — the `else` branch is dead.
     IrrefutablePatternInIfLet,
+    /// `let … else` whose else block has a non-`!` type. The else must
+    /// diverge (return / throw / break / continue / panic / infinite loop)
+    /// so that fall-through past the binding is unreachable.
+    LetElseMustDiverge,
+    /// `let … else` pattern that covers every value — the else branch is
+    /// dead. Suggest replacing with a plain `let` binding.
+    IrrefutablePatternInLetElse,
     DuplicateAttribute,
     UnknownAttribute,
     InvalidAttributeContext,
@@ -236,6 +243,8 @@ impl DiagnosticId {
             DiagnosticId::DuplicateBinding => "E0094",
             DiagnosticId::RefutablePatternInLet => "E0111",
             DiagnosticId::IrrefutablePatternInIfLet => "E0112",
+            DiagnosticId::LetElseMustDiverge => "E0113",
+            DiagnosticId::IrrefutablePatternInLetElse => "E0114",
             DiagnosticId::DuplicateAttribute => "E0014",
             DiagnosticId::UnknownAttribute => "E0015",
             DiagnosticId::InvalidAttributeContext => "E0016",

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -2898,7 +2898,7 @@ impl<'a> Parser<'a> {
         if self.at(TokenKind::Watch) {
             self.parse_watch_let_stmt();
         } else if self.at(TokenKind::Let) {
-            self.parse_let_stmt(true);
+            self.parse_let_stmt();
         } else if self.at(TokenKind::Return) {
             self.parse_return_stmt();
         } else if self.at(TokenKind::While) {
@@ -2944,7 +2944,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_let_stmt(&mut self, allow_let_else: bool) {
+    fn parse_let_stmt(&mut self) {
         self.with_node(SyntaxKind::LET_STMT, |p| {
             // A let statement's pattern must start with `let`. parse_pattern
             // itself is permissive (it parses any pattern shape, including
@@ -2970,9 +2970,11 @@ impl<'a> Parser<'a> {
             }
 
             // Optional `let … else { … }` — refutable binding whose else
-            // branch must diverge. Suppressed inside C-style for-init, where
-            // `else` would clash with the condition slot.
-            if allow_let_else && p.at(TokenKind::Else) {
+            // branch must diverge. Allowed in every position `parse_let_stmt`
+            // is called from, including C-style for-init (a diverging init
+            // just makes the loop unreachable — same kind of dead code we
+            // already accept elsewhere, not a parse-time concern).
+            if p.at(TokenKind::Else) {
                 p.bump(); // else
                 if p.at(TokenKind::If) {
                     // `else if` after `let … else` has no value to chain
@@ -3983,10 +3985,11 @@ impl<'a> Parser<'a> {
                         p.expect(TokenKind::In);
                         p.parse_expr(); // iterator expression
                     } else {
-                        // C-style: for (let i = 0; cond; update).
-                        // `else` is suppressed here — a let-else would
-                        // collide with the for-loop's condition slot.
-                        p.parse_let_stmt(false);
+                        // C-style: for (let i = 0; cond; update). A
+                        // `let … else` here is unusual but legal — it
+                        // makes the loop unreachable, same as any other
+                        // diverging statement before the loop.
+                        p.parse_let_stmt();
                         // The let statement already consumed the semicolon
                         // Now parse condition
                         if !p.at(TokenKind::Semicolon) && !p.at(TokenKind::RParen) {
@@ -5921,7 +5924,7 @@ fn parse_impl(tokens: &[Token], cache: Option<&mut NodeCache>) -> (GreenNode, Ve
         {
             parser.parse_type_alias();
         } else if parser.at(TokenKind::Let) {
-            parser.parse_let_stmt(true);
+            parser.parse_let_stmt();
         } else if parser.at_header_comment_start() {
             parser.consume_header_comment();
         } else if parser.try_recover_invalid_block() {
@@ -7880,6 +7883,37 @@ function f(u: User) -> string {
             |elem| matches!(elem, rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::KW_ELSE),
         );
         assert!(has_else, "LET_STMT should have a KW_ELSE token");
+    }
+
+    #[test]
+    fn let_else_accepted_in_c_style_for_init() {
+        // C-style `for (let i = 0; cond; update)` accepts a let-else in the
+        // init slot. Makes the loop unreachable (the else diverges), which
+        // is silly but not a parse error — same kind of dead code we
+        // already allow elsewhere.
+        let source = r#"
+function f() -> int {
+  for (let i: int = 0 else { return 0; }; i < 3; i += 1) {
+    let _ = i;
+  }
+  0
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let for_expr = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::FOR_EXPR)
+            .expect("expected FOR_EXPR");
+        let let_stmt = for_expr
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::LET_STMT)
+            .expect("for-init should expose a LET_STMT");
+        let has_else = let_stmt.children_with_tokens().any(
+            |elem| matches!(elem, rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::KW_ELSE),
+        );
+        assert!(has_else, "for-init LET_STMT should carry the else branch");
     }
 
     #[test]

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -2898,7 +2898,7 @@ impl<'a> Parser<'a> {
         if self.at(TokenKind::Watch) {
             self.parse_watch_let_stmt();
         } else if self.at(TokenKind::Let) {
-            self.parse_let_stmt();
+            self.parse_let_stmt(true);
         } else if self.at(TokenKind::Return) {
             self.parse_return_stmt();
         } else if self.at(TokenKind::While) {
@@ -2944,7 +2944,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_let_stmt(&mut self) {
+    fn parse_let_stmt(&mut self, allow_let_else: bool) {
         self.with_node(SyntaxKind::LET_STMT, |p| {
             // A let statement's pattern must start with `let`. parse_pattern
             // itself is permissive (it parses any pattern shape, including
@@ -2967,6 +2967,26 @@ impl<'a> Parser<'a> {
                 p.parse_expr_bp(3);
             } else {
                 p.error_unexpected_token("initializer (=)".to_string());
+            }
+
+            // Optional `let … else { … }` — refutable binding whose else
+            // branch must diverge. Suppressed inside C-style for-init, where
+            // `else` would clash with the condition slot.
+            if allow_let_else && p.at(TokenKind::Else) {
+                p.bump(); // else
+                if p.at(TokenKind::If) {
+                    // `else if` after `let … else` has no value to chain
+                    // through (unlike `if let`, which produces a value), so
+                    // reject. The `if` token is left in place so recovery can
+                    // parse it as the next statement.
+                    p.error_unexpected_token(
+                        "block after 'else' (`else if` is not valid in let-else)".to_string(),
+                    );
+                } else if p.at(TokenKind::LBrace) {
+                    p.parse_block_expr();
+                } else {
+                    p.error_unexpected_token("block after 'else'".to_string());
+                }
             }
 
             // Consume trailing semicolon
@@ -2993,6 +3013,20 @@ impl<'a> Parser<'a> {
                 p.parse_expr_bp(3);
             } else {
                 p.error_unexpected_token("initializer (=)".to_string());
+            }
+
+            // Reject `watch let … else { … }` — the divergence semantics of
+            // let-else don't compose with the auto-rerun semantics of a
+            // watched binding. Emit a parse error but eat the else block so
+            // recovery proceeds cleanly past it.
+            if p.at(TokenKind::Else) {
+                p.error_unexpected_token(
+                    "';' (`watch let` cannot have an `else` clause)".to_string(),
+                );
+                p.bump(); // else
+                if p.at(TokenKind::LBrace) {
+                    p.parse_block_expr();
+                }
             }
 
             // Consume trailing semicolon
@@ -3949,8 +3983,10 @@ impl<'a> Parser<'a> {
                         p.expect(TokenKind::In);
                         p.parse_expr(); // iterator expression
                     } else {
-                        // C-style: for (let i = 0; cond; update)
-                        p.parse_let_stmt();
+                        // C-style: for (let i = 0; cond; update).
+                        // `else` is suppressed here — a let-else would
+                        // collide with the for-loop's condition slot.
+                        p.parse_let_stmt(false);
                         // The let statement already consumed the semicolon
                         // Now parse condition
                         if !p.at(TokenKind::Semicolon) && !p.at(TokenKind::RParen) {
@@ -5885,7 +5921,7 @@ fn parse_impl(tokens: &[Token], cache: Option<&mut NodeCache>) -> (GreenNode, Ve
         {
             parser.parse_type_alias();
         } else if parser.at(TokenKind::Let) {
-            parser.parse_let_stmt();
+            parser.parse_let_stmt(true);
         } else if parser.at_header_comment_start() {
             parser.consume_header_comment();
         } else if parser.try_recover_invalid_block() {
@@ -7746,5 +7782,128 @@ type Searcher = (query: string, max_results?: int) -> int
         assert!(optional_param.children_with_tokens().any(
             |it| matches!(it, rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::QUESTION)
         ));
+    }
+
+    // ============ let-else ============
+
+    #[test]
+    fn let_else_basic_parses() {
+        // `let Pattern = scrutinee else { ... };` — refutable binding with a
+        // diverging else clause. The LET_STMT should carry both an EQUALS
+        // initializer and a trailing KW_ELSE + BLOCK_EXPR.
+        let source = r#"
+function f(r: int | string) -> int {
+  let v: int = r else { return 0; };
+  v
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let let_stmt = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::LET_STMT)
+            .expect("expected LET_STMT");
+        let has_else = let_stmt.children_with_tokens().any(
+            |elem| matches!(elem, rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::KW_ELSE),
+        );
+        assert!(has_else, "LET_STMT should have a KW_ELSE token");
+        let block_count = let_stmt
+            .children()
+            .filter(|n| n.kind() == SyntaxKind::BLOCK_EXPR)
+            .count();
+        assert_eq!(
+            block_count, 1,
+            "LET_STMT should have one BLOCK_EXPR (the else body)"
+        );
+    }
+
+    #[test]
+    fn let_else_rejects_else_if() {
+        // `let X = y else if z { ... }` — `else if` is meaningless without a
+        // value being produced (unlike `if let`). Reject at parse time.
+        let source = r#"
+function f(r: int | string) -> int {
+  let v: int = r else if true { return 0; };
+  v
+}
+"#;
+        let (_, errors) = parse_source(source);
+        assert!(
+            !errors.is_empty(),
+            "expected parse error for `let ... else if ...`"
+        );
+    }
+
+    #[test]
+    fn let_else_rejected_in_watch_let() {
+        // `watch let X = y else { ... };` — combining watched bindings with
+        // let-else divergence is rejected at parse time.
+        let source = r#"
+function f(r: int | string) -> int {
+  watch let v: int = r else { return 0; };
+  v
+}
+"#;
+        let (_, errors) = parse_source(source);
+        assert!(
+            !errors.is_empty(),
+            "expected parse error for `watch let ... else {{ ... }}`"
+        );
+    }
+
+    #[test]
+    fn let_else_destructure_pattern_parses() {
+        // `let Class { f } = expr else { ... };` — destructure pattern with
+        // an else branch; verifies parser handles the structural pattern in
+        // combination with the trailing else block.
+        let source = r#"
+class User { name string }
+
+function f(u: User) -> string {
+  let User { name } = u else { return ""; };
+  name
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let let_stmt = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::LET_STMT)
+            .expect("expected LET_STMT");
+        let has_destructure = let_stmt
+            .descendants()
+            .any(|n| n.kind() == SyntaxKind::DESTRUCTURE_PATTERN);
+        assert!(has_destructure, "should contain a destructure pattern");
+        let has_else = let_stmt.children_with_tokens().any(
+            |elem| matches!(elem, rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::KW_ELSE),
+        );
+        assert!(has_else, "LET_STMT should have a KW_ELSE token");
+    }
+
+    #[test]
+    fn let_without_else_unchanged() {
+        // Regression: plain `let x = …;` continues to parse with no else
+        // sibling — the new else handling must not turn surrounding tokens
+        // into a phantom else block.
+        let source = r#"
+function f() -> int {
+  let x: int = 1;
+  x
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let let_stmt = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::LET_STMT)
+            .expect("expected LET_STMT");
+        let block_count = let_stmt
+            .children()
+            .filter(|n| n.kind() == SyntaxKind::BLOCK_EXPR)
+            .count();
+        assert_eq!(block_count, 0, "plain let-stmt should have no BLOCK_EXPR");
     }
 }

--- a/baml_language/crates/baml_fmt/src/ast/statements.rs
+++ b/baml_language/crates/baml_fmt/src/ast/statements.rs
@@ -12,7 +12,13 @@ use crate::{
 };
 
 /// Does not correspond to a specific [`SyntaxKind`], but contains all possible statements.
+//
+// `For(ForStmt)` is the largest variant (~720 bytes); the next-largest sits
+// well below it. The size difference is acknowledged here rather than
+// boxed because `Statement` is constructed transiently during formatting,
+// not stored at scale.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Statement {
     /// Assignment operations are parsed as binary expressions.
     ///
@@ -171,16 +177,23 @@ impl Printable for ExpressionStmt {
 
 /// Corresponds to a [`SyntaxKind::LET_STMT`] node or a [`SyntaxKind::WATCH_LET`] node.
 ///
-/// Post-pattern-rewrite shape: `KW_WATCH? KW_LET? PATTERN EQUALS? <expr>? SEMICOLON?`.
+/// Post-pattern-rewrite shape: `KW_WATCH? KW_LET? PATTERN EQUALS? <expr>? (KW_ELSE BLOCK_EXPR)? SEMICOLON?`.
 /// Simple bindings carry `let` inside the [`super::MatchPattern`] (e.g.
 /// `let x: int` parses as a `Chain([Bind, Type])`). Array destructuring uses
-/// the statement-level `let` before an `ARRAY_PATTERN`.
+/// the statement-level `let` before an `ARRAY_PATTERN`. The optional
+/// `else BLOCK_EXPR` tail is the `let … else` form: a refutable binding
+/// whose else branch must diverge.
 #[derive(Debug)]
 pub struct LetStmt {
     pub watch: Option<t::Watch>,
     pub let_keyword: Option<t::Let>,
     pub pattern: super::MatchPattern,
     pub initializer: Option<(t::Equals, Expression)>,
+    /// `else { … }` tail for `let … else`. None for plain `let`. Boxed
+    /// to keep `LetStmt` (and the enclosing `Statement` enum) small — the
+    /// else branch is rare and a `BlockExpr` carries a full statement
+    /// vector.
+    pub else_branch: Option<Box<(t::Else, super::BlockExpr)>>,
     /// Not required in some contexts like for-let loops
     pub semicolon: Option<t::Semicolon>,
 }
@@ -218,6 +231,16 @@ impl FromCST for LetStmt {
             None
         };
 
+        let else_branch = if let Some(else_kw) = it.next_if_kind(SyntaxKind::KW_ELSE) {
+            let block_elem = it.expect_next("block after `else`")?;
+            Some(Box::new((
+                t::Else::from_cst(else_kw)?,
+                super::BlockExpr::from_cst(block_elem)?,
+            )))
+        } else {
+            None
+        };
+
         let semicolon = it.next().map(t::Semicolon::from_cst).transpose()?;
         it.expect_end()?;
 
@@ -226,6 +249,7 @@ impl FromCST for LetStmt {
             let_keyword,
             pattern,
             initializer,
+            else_branch,
             semicolon,
         })
     }
@@ -260,11 +284,19 @@ impl Printable for LetStmt {
             printer.print_trivia_squished(equals_trailing);
             let expr_leading = printer.trivia.get_leading_for_element(expr);
             printer.print_trivia_squished(expr_leading);
-            multi_lined |= printer.print(expr, shape).multi_lined;
-            if self.semicolon.is_some() {
+            multi_lined |= printer.print(expr, shape.clone()).multi_lined;
+            if self.else_branch.is_none() && self.semicolon.is_some() {
                 let expr_trailing = printer.trivia.get_trailing_for_element(expr);
                 printer.print_trivia_squished(expr_trailing);
             }
+        }
+
+        if let Some(else_branch) = self.else_branch.as_deref() {
+            let (else_kw, block) = else_branch;
+            printer.print_str(" ");
+            printer.print_raw_token(else_kw);
+            printer.print_str(" ");
+            multi_lined |= printer.print(block, shape).multi_lined;
         }
 
         if let Some(semicolon) = &self.semicolon {
@@ -288,6 +320,9 @@ impl Printable for LetStmt {
     fn rightmost_token(&self) -> TextRange {
         if let Some(semicolon) = &self.semicolon {
             return semicolon.span();
+        }
+        if let Some(else_branch) = self.else_branch.as_deref() {
+            return else_branch.1.rightmost_token();
         }
         if let Some((_, expr)) = &self.initializer {
             return expr.rightmost_token();

--- a/baml_language/crates/baml_fmt/src/ast/statements.rs
+++ b/baml_language/crates/baml_fmt/src/ast/statements.rs
@@ -285,7 +285,12 @@ impl Printable for LetStmt {
             let expr_leading = printer.trivia.get_leading_for_element(expr);
             printer.print_trivia_squished(expr_leading);
             multi_lined |= printer.print(expr, shape.clone()).multi_lined;
-            if self.else_branch.is_none() && self.semicolon.is_some() {
+            // Trailing trivia between the initializer expression and what
+            // follows: a semicolon, or an `else { … }` tail. Either way,
+            // print it so inline comments aren't dropped.
+            if (self.else_branch.is_none() && self.semicolon.is_some())
+                || self.else_branch.is_some()
+            {
                 let expr_trailing = printer.trivia.get_trailing_for_element(expr);
                 printer.print_trivia_squished(expr_trailing);
             }
@@ -293,9 +298,16 @@ impl Printable for LetStmt {
 
         if let Some(else_branch) = self.else_branch.as_deref() {
             let (else_kw, block) = else_branch;
+            // Preserve trivia adjacent to the `else` keyword instead of
+            // hardcoding bare spaces — a `// note` between the init and
+            // `else`, or between `else` and the block, would otherwise be
+            // dropped.
+            let (else_leading, else_trailing) = printer.trivia.get_for_range_split(else_kw.span());
             printer.print_str(" ");
+            printer.print_trivia_squished(else_leading);
             printer.print_raw_token(else_kw);
             printer.print_str(" ");
+            printer.print_trivia_squished(else_trailing);
             multi_lined |= printer.print(block, shape).multi_lined;
         }
 

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -406,6 +406,18 @@ mod let_else_format_tests {
     }
 
     #[test]
+    fn test_let_else_preserves_trivia_around_else_keyword() {
+        // Trivia between the initializer and `else` (and between `else`
+        // and the block) must round-trip — pre-fix the formatter emitted
+        // hardcoded spaces and dropped any adjacent comments. The
+        // formatter squishes whitespace around the comments but keeps
+        // the comments themselves; the output is idempotent.
+        let source = "function f(r: int | string) -> int {\n    let v: int = r /* a */ else /* b */ {\n        return 0;\n    };\n    v\n}\n";
+        let expected = "function f(r: int | string) -> int {\n    let v: int = r/* a */ else /* b */{\n        return 0;\n    };\n    v\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    #[test]
     fn test_plain_let_unchanged() {
         // Regression: plain `let x = …;` without an else clause must still
         // format cleanly without picking up a stray `else { … }` tail.

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -358,3 +358,58 @@ mod if_let_format_tests {
         assert_formats_to(source, source);
     }
 }
+
+#[cfg(test)]
+mod let_else_format_tests {
+    //! Formatter tests for `let PATTERN = SCRUTINEE else { ... };`.
+
+    use super::*;
+
+    fn assert_formats_to(source: &str, expected: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed on `let … else`");
+        assert_eq!(
+            formatted, expected,
+            "formatter output didn't match expected\n--- got ---\n{formatted}\n--- want ---\n{expected}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    #[test]
+    fn test_let_else_basic() {
+        // The else block is a BlockExpr — formatter canonicalises it to
+        // multi-line layout, matching the rest of the codebase's block
+        // style.
+        let source = "function f(r: int | string) -> int {\n    let v: int = r else {\n        return 0;\n    };\n    v\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_let_else_destructure() {
+        let source = "class User {\n    name: string,\n    age: int,\n}\n\nclass Admin {\n    handle: string,\n}\n\nfunction f(u: User | Admin) -> string {\n    let User { name, age } = u else {\n        return \"admin\";\n    };\n    name\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_let_else_or_pattern() {
+        let source = "class Ok {\n    value: string,\n}\n\nclass Warn {\n    value: string,\n}\n\nclass Err {\n    message: string,\n}\n\nfunction f(r: Ok | Warn | Err) -> string {\n    let s: Ok | Warn = r else {\n        return \"err\";\n    };\n    s.value\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_let_else_throw() {
+        // `throw` in the else branch is a valid diverging form. Empty
+        // class body renders multi-line by the same block-expander rule.
+        let source = "class NoMatch {\n}\n\nfunction f(r: int | string) -> int throws NoMatch {\n    let n: int = r else {\n        throw NoMatch {};\n    };\n    n\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_plain_let_unchanged() {
+        // Regression: plain `let x = …;` without an else clause must still
+        // format cleanly without picking up a stray `else { … }` tail.
+        let source = "function f() -> int {\n    let x: int = 1;\n    x\n}\n";
+        assert_formats_to(source, source);
+    }
+}

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -897,6 +897,8 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::RestSubPatternNotSupported => DiagnosticId::TypeMismatch,
         TirTypeError::RefutablePatternInLet { .. } => DiagnosticId::RefutablePatternInLet,
         TirTypeError::IrrefutablePatternInIfLet => DiagnosticId::IrrefutablePatternInIfLet,
+        TirTypeError::LetElseMustDiverge { .. } => DiagnosticId::LetElseMustDiverge,
+        TirTypeError::IrrefutablePatternInLetElse => DiagnosticId::IrrefutablePatternInLetElse,
         TirTypeError::InvalidCatchBindingType { .. } => DiagnosticId::InvalidCatchBindingType,
         TirTypeError::ThrowsContractViolation { .. }
         | TirTypeError::CallbackThrowsContractViolation { .. } => {

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_array_pattern.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_array_pattern.baml
@@ -1,0 +1,12 @@
+// Array destructure in let-else: bare identifiers inside a pattern are
+// TYPE patterns by default, so the binding names need explicit `let`
+// markers. The whole pattern is refutable on `int[]` because the array
+// could be shorter than two elements.
+function FirstTwo(xs: int[]) -> int {
+  let [let a, let b] = xs else { return -1; };
+  a + b
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_basic.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_basic.baml
@@ -1,0 +1,18 @@
+// `let … else` with a refutable type pattern. Bindings flow into the
+// enclosing scope on a successful match; on failure the else block must
+// diverge (here, `return`).
+class Ok {
+  value string
+}
+class Err {
+  message string
+}
+
+function get_value(r: Ok | Err) -> string {
+  let o: Ok = r else { return "no match"; };
+  o.value
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_break_in_else.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_break_in_else.baml
@@ -1,0 +1,20 @@
+// `break` is `Ty::Never` only when there's a containing loop; inside a
+// `while` body it counts as divergence. Type-checks without errors.
+class Ok { value string }
+class Err { message string }
+
+function BreakOutOfLoopOnMiss(items: (Ok | Err)[]) -> string {
+  let result = "";
+  let i = 0;
+  while (i < 3) {
+    let item = items[i];
+    let o: Ok = item else { break; };
+    result = o.value;
+    i += 1;
+  }
+  result
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_caught_throw.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_caught_throw.baml
@@ -1,0 +1,24 @@
+// A throw from a let-else else block must participate in the throws
+// contract and be catchable at the call site. BAML's catch syntax is
+// `expr catch (e) { Pattern => arm, ... }` — a match-like dispatch on
+// the caught error.
+class Ok { value string }
+class Err { message string }
+class NoMatch {}
+
+function inner(r: Ok | Err) -> string throws NoMatch {
+  let o: Ok = r else { throw NoMatch {}; };
+  o.value
+}
+
+// The caller doesn't declare `throws NoMatch` — it catches the throw,
+// so the throws set is empty here.
+function caller(r: Ok | Err) -> string {
+  inner(r) catch (e) {
+    NoMatch => "caught"
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_destructure.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_destructure.baml
@@ -1,0 +1,35 @@
+// Destructure pattern in let-else: refutable on a union, irrefutable on a
+// non-union (warns).
+class User {
+  name string
+  age int
+}
+class Admin {
+  handle string
+}
+
+// Refutable: pattern picks one variant of the union; else diverges.
+function PickUserName(u: User | Admin) -> string {
+  let User { name, age } = u else { return "admin"; };
+  name
+}
+
+// Irrefutable: scrutinee is exactly `User`, so the else branch is dead and
+// we warn (E0114).
+function IrrefutableDestructure(u: User) -> string {
+  let User { name, age } = u else { return "unreachable"; };
+  name
+}
+
+//----
+//- diagnostics
+// warning: irrefutable `let … else` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//     ╭─[ let_else_let_else_destructure.baml:19:53 ]
+//     │
+//  19 │ ╭─▶ function IrrefutableDestructure(u: User) -> string {
+//  20 │ ├─▶   let User { name, age } = u else { return "unreachable"; };
+//     │ │                                                                  
+//     │ ╰────────────────────────────────────────────────────────────────── irrefutable `let … else` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//     │     
+//     │     Note: Error code: E0114
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_diverges_loop.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_diverges_loop.baml
@@ -1,0 +1,27 @@
+// Known limitation: BAML's TIR doesn't infer `while (true) { … }` as
+// `Ty::Never` (it sees it as a regular `while` with type `void`), so
+// using an infinite loop as a divergence form in let-else is rejected.
+// This is a TIR-wide gap, not specific to let-else — same applies to
+// `if` chains in tail position. Tracked as a follow-up.
+//
+// In Rust the equivalent `let X = e else { loop {} };` is accepted
+// because `loop {}` has type `!`.
+class Ok { value string }
+class Err { message string }
+
+function LoopDiverges(r: Ok | Err) -> string {
+  let o: Ok = r else { while (true) {} };
+  o.value
+}
+
+//----
+//- diagnostics
+// error: `let … else` requires a diverging else block (`return`, `throw`, `break`, or `continue`); got `void`
+//     ╭─[ let_else_let_else_diverges_loop.baml:13:21 ]
+//     │
+//  13 │   let o: Ok = r else { while (true) {} };
+//     │                     ──────────┬─────────  
+//     │                               ╰─────────── `let … else` requires a diverging else block (`return`, `throw`, `break`, or `continue`); got `void`
+//     │ 
+//     │ Note: Error code: E0113
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_diverges_return.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_diverges_return.baml
@@ -1,0 +1,12 @@
+// `return` in the else branch is one accepted diverging form.
+class Ok { value string }
+class Err { message string }
+
+function Acceptable(r: Ok | Err) -> string {
+  let o: Ok = r else { return "fallback"; };
+  o.value
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_diverges_throw.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_diverges_throw.baml
@@ -1,0 +1,14 @@
+// `throw` in the else branch is also an accepted diverging form. The thrown
+// type flows into the function's declared throws contract.
+class Ok { value string }
+class Err { message string }
+class NoMatch {}
+
+function DivergeByThrow(r: Ok | Err) -> string throws NoMatch {
+  let o: Ok = r else { throw NoMatch {}; };
+  o.value
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_else_assignment_not_observable.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_else_assignment_not_observable.baml
@@ -1,0 +1,25 @@
+// Writes to outer bindings from inside a `let … else` else block must NOT
+// be visible in the success continuation — the else branch diverges, so
+// its effects are unreachable from the rest of the function.
+//
+// Pre-fix, `restore_scoped_locals` was used for the else snapshot, which
+// is a JOIN-style merge designed for branches that return control (if /
+// if-let). For let-else's diverging else we use the hard-rollback path
+// `discard_scoped_locals` instead.
+class Ok { value string }
+class Err { message string }
+
+function uses_outer(r: Ok | Err) -> int {
+  let counter = 0;
+  let o: Ok = r else {
+    counter = 999;
+    return -1;
+  };
+  // If the else's assignment leaked through, `counter` would appear as
+  // assigned to 999 here; instead it's still 0.
+  counter
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_else_assignment_not_observable.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_else_assignment_not_observable.baml
@@ -6,6 +6,14 @@
 // is a JOIN-style merge designed for branches that return control (if /
 // if-let). For let-else's diverging else we use the hard-rollback path
 // `discard_scoped_locals` instead.
+//
+// Tested here at the integration level rather than as a Rust unit test
+// against `discard_scoped_locals` directly: the helper itself is a
+// three-line truncation whose only meaningful behavior is its
+// interaction with the surrounding TIR check pass. A standalone unit
+// test would have to reconstruct the TIR builder's state by hand and
+// would end up restating the implementation; the .baml form below
+// drives the actual code path the way real programs do.
 class Ok { value string }
 class Err { message string }
 

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_else_no_bindings.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_else_no_bindings.baml
@@ -1,0 +1,21 @@
+// Pattern bindings are not visible inside the else branch — the else runs
+// when the pattern did NOT match, so binding `o` doesn't exist there.
+class Ok { value string }
+class Err { message string }
+
+function ElseDoesNotSeeBinding(r: Ok | Err) -> string {
+  let o: Ok = r else { return o.value; };
+  o.value
+}
+
+//----
+//- diagnostics
+// error: unresolved name: o
+//    ╭─[ let_else_let_else_else_no_bindings.baml:7:30 ]
+//    │
+//  7 │   let o: Ok = r else { return o.value; };
+//    │                              ────┬───  
+//    │                                  ╰───── unresolved name: o
+//    │ 
+//    │ Note: Error code: E0003
+// ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_irrefutable_warns.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_irrefutable_warns.baml
@@ -1,0 +1,19 @@
+// Irrefutable pattern in let-else — the else branch is unreachable, so
+// suggest replacing with a plain `let` binding (E0114).
+function IrrefutablePlainBinding(x: int) -> int {
+  let v = x else { return 0; };
+  v
+}
+
+//----
+//- diagnostics
+// warning: irrefutable `let … else` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//    ╭─[ let_else_let_else_irrefutable_warns.baml:3:50 ]
+//    │
+//  3 │ ╭─▶ function IrrefutablePlainBinding(x: int) -> int {
+//  4 │ ├─▶   let v = x else { return 0; };
+//    │ │                                     
+//    │ ╰───────────────────────────────────── irrefutable `let … else` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//    │     
+//    │     Note: Error code: E0114
+// ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_multiple_consecutive.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_multiple_consecutive.baml
@@ -1,0 +1,14 @@
+// Two let-else statements back-to-back: both bindings reach the tail and
+// each name lives in the enclosing scope independently.
+class Ok { value string }
+class Err { message string }
+
+function ChainBoth(a: Ok | Err, b: Ok | Err) -> string {
+  let oa: Ok = a else { return "a-failed"; };
+  let ob: Ok = b else { return "b-failed"; };
+  oa.value + "-" + ob.value
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_must_diverge.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_must_diverge.baml
@@ -1,0 +1,20 @@
+// The else block must diverge (`!`). Returning a value is an error (E0113).
+class Ok { value string }
+class Err { message string }
+
+function NotDiverging(r: Ok | Err) -> string {
+  let o: Ok = r else { "fallback" };
+  o.value
+}
+
+//----
+//- diagnostics
+// error: `let … else` requires a diverging else block (`return`, `throw`, `break`, `continue`, or an infinite loop); got `"fallback"`
+//    ╭─[ let_else_let_else_must_diverge.baml:6:21 ]
+//    │
+//  6 │   let o: Ok = r else { "fallback" };
+//    │                     ───────┬───────  
+//    │                            ╰───────── `let … else` requires a diverging else block (`return`, `throw`, `break`, `continue`, or an infinite loop); got `"fallback"`
+//    │ 
+//    │ Note: Error code: E0113
+// ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_must_diverge.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_must_diverge.baml
@@ -9,12 +9,12 @@ function NotDiverging(r: Ok | Err) -> string {
 
 //----
 //- diagnostics
-// error: `let … else` requires a diverging else block (`return`, `throw`, `break`, `continue`, or an infinite loop); got `"fallback"`
+// error: `let … else` requires a diverging else block (`return`, `throw`, `break`, or `continue`); got `"fallback"`
 //    ╭─[ let_else_let_else_must_diverge.baml:6:21 ]
 //    │
 //  6 │   let o: Ok = r else { "fallback" };
 //    │                     ───────┬───────  
-//    │                            ╰───────── `let … else` requires a diverging else block (`return`, `throw`, `break`, `continue`, or an infinite loop); got `"fallback"`
+//    │                            ╰───────── `let … else` requires a diverging else block (`return`, `throw`, `break`, or `continue`); got `"fallback"`
 //    │ 
 //    │ Note: Error code: E0113
 // ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_no_else_if.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_no_else_if.baml
@@ -1,0 +1,30 @@
+// `else if` after `let … else` is rejected at parse time. Unlike `if let`,
+// there is no value being produced for the chain to feed into.
+class Ok { value string }
+class Err { message string }
+
+function NoElseIfChain(r: Ok | Err) -> string {
+  let o: Ok = r else if true { return "x"; };
+  o.value
+}
+
+//----
+//- diagnostics
+// error: Expected block after 'else' (`else if` is not valid in let-else), found if
+//    ╭─[ let_else_let_else_no_else_if.baml:7:22 ]
+//    │
+//  7 │   let o: Ok = r else if true { return "x"; };
+//    │                      ─┬  
+//    │                       ╰── Expected block after 'else' (`else if` is not valid in let-else), found if
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
+// error: type mismatch: expected user.Ok, got user.Ok | user.Err
+//    ╭─[ let_else_let_else_no_else_if.baml:7:15 ]
+//    │
+//  7 │   let o: Ok = r else if true { return "x"; };
+//    │               ┬  
+//    │               ╰── type mismatch: expected user.Ok, got user.Ok | user.Err
+//    │ 
+//    │ Note: Error code: E0001
+// ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_or_pattern.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_or_pattern.baml
@@ -1,0 +1,14 @@
+// Or-pattern in let-else: both alternatives bind `s` to a class with a
+// `value` field. The binding's type is `Ok | Warn`.
+class Ok { value string }
+class Warn { value string }
+class Err { message string }
+
+function OrPatternBindsCommon(r: Ok | Warn | Err) -> string {
+  let s: Ok | Warn = r else { return "err"; };
+  s.value
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_throws.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_throws.baml
@@ -1,0 +1,33 @@
+// Throws-analysis must flow through let-else: throws from the initializer
+// and from the else branch escape into the enclosing function's throws set.
+
+function may_yield(x: int) -> int | string throws int {
+  if (x < 0) { throw x } else { "fallback" }
+}
+
+class NoMatch {}
+
+// Positive: declared throws covers `int` (from initializer) and `NoMatch`
+// (thrown from the else branch).
+function ThrowsThroughLetElse(x: int) -> int throws int | NoMatch {
+  let n: int = may_yield(x) else { throw NoMatch {}; };
+  n
+}
+
+// Negative: declared throws missing the type thrown from the else branch.
+function ThrowsContractViolationInElse(v: int | string) -> int throws never {
+  let n: int = v else { throw "from else"; };
+  n
+}
+
+//----
+//- diagnostics
+// error: throws contract violation: `never` is missing string
+//     ╭─[ let_else_let_else_throws.baml:18:70 ]
+//     │
+//  18 │ function ThrowsContractViolationInElse(v: int | string) -> int throws never {
+//     │                                                                      ───┬──  
+//     │                                                                         ╰──── throws contract violation: `never` is missing string
+//     │ 
+//     │ Note: Error code: E0096
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_wildcard_irrefutable.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_wildcard_irrefutable.baml
@@ -1,0 +1,18 @@
+// Wildcard pattern matches everything → else is dead → warn (E0114).
+function WildcardIrrefutable(x: int) -> int {
+  let _ = x else { return 0; };
+  x
+}
+
+//----
+//- diagnostics
+// warning: irrefutable `let … else` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//    ╭─[ let_else_let_else_wildcard_irrefutable.baml:2:46 ]
+//    │
+//  2 │ ╭─▶ function WildcardIrrefutable(x: int) -> int {
+//  3 │ ├─▶   let _ = x else { return 0; };
+//    │ │                                     
+//    │ ╰───────────────────────────────────── irrefutable `let … else` pattern; the `else` branch is unreachable — use a plain `let` binding instead
+//    │     
+//    │     Note: Error code: E0114
+// ───╯

--- a/baml_language/crates/bex_engine/tests/control_flow.rs
+++ b/baml_language/crates/bex_engine/tests/control_flow.rs
@@ -429,3 +429,132 @@ async fn if_let_statement_form_with_return_in_then() -> anyhow::Result<()> {
     })
     .await
 }
+
+#[tokio::test]
+async fn let_else_binds_when_pattern_matches() -> anyhow::Result<()> {
+    // Pattern matches → bindings flow into the enclosing scope; the rest
+    // of the function body can use them.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function get_value(r: Ok | Err) -> string {
+                let o: Ok = r else { return "fallback"; };
+                o.value
+            }
+
+            function main() -> string {
+                get_value(Ok { value: "hit" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("hit".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn let_else_takes_else_branch_when_pattern_does_not_match() -> anyhow::Result<()> {
+    // Pattern fails → else branch runs and diverges (here via `return`),
+    // so the tail expression past the binding never executes.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function get_value(r: Ok | Err) -> string {
+                let o: Ok = r else { return "fallback"; };
+                o.value
+            }
+
+            function main() -> string {
+                get_value(Err { message: "ignored" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("fallback".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn let_else_destructure_binds_fields_at_runtime() -> anyhow::Result<()> {
+    // Destructure binding: the matched class's fields are bound into the
+    // enclosing scope, available to all later statements.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class User { name string, age int }
+            class Admin { handle string }
+
+            function greet(u: User | Admin) -> string {
+                let User { name, age } = u else { return "admin"; };
+                name
+            }
+
+            function main() -> string {
+                greet(User { name: "alice", age: 30 })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("alice".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn let_else_or_pattern_matches_either_alternative() -> anyhow::Result<()> {
+    // Or-pattern: either alternative produces a binding of the joined
+    // type. Here both Ok and Warn carry `value: string`.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Warn { value string }
+            class Err { message string }
+
+            function pick(r: Ok | Warn | Err) -> string {
+                let s: Ok | Warn = r else { return "err"; };
+                s.value
+            }
+
+            function main() -> string {
+                pick(Warn { value: "warn-val" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("warn-val".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn let_else_throw_in_else_propagates_when_uncaught() -> anyhow::Result<()> {
+    // `throw` in the else branch is a diverging form. When uncaught, the
+    // thrown value escapes the function and the engine reports the error.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+            class NoMatch {}
+
+            function get_or_throw(r: Ok | Err) -> string throws NoMatch {
+                let o: Ok = r else { throw NoMatch {}; };
+                o.value
+            }
+
+            function main() -> string throws NoMatch {
+                get_or_throw(Err { message: "boom" })
+            }
+        "#,
+        entry: "main",
+        // Uncaught NoMatch throw escapes — the engine reports a runtime
+        // error rather than producing a value.
+        expected: Err("NoMatch"),
+        ..Default::default()
+    })
+    .await
+}

--- a/baml_language/crates/bex_engine/tests/control_flow.rs
+++ b/baml_language/crates/bex_engine/tests/control_flow.rs
@@ -532,6 +532,157 @@ async fn let_else_or_pattern_matches_either_alternative() -> anyhow::Result<()> 
 }
 
 #[tokio::test]
+async fn let_else_break_in_else_inside_loop() -> anyhow::Result<()> {
+    // `break` is a diverging form (`Ty::Never`). When the pattern fails,
+    // the else branch breaks out of the enclosing loop instead of running
+    // the rest of the loop body — proving the unreachable terminator on
+    // the miss block doesn't fall through.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function pick_first_ok(items: (Ok | Err)[]) -> string {
+                let result = "no-ok";
+                let i = 0;
+                while (i < 3) {
+                    let item = items[i];
+                    let o: Ok = item else { break; };
+                    result = o.value;
+                    i += 1;
+                }
+                result
+            }
+
+            function main() -> string {
+                pick_first_ok([Ok { value: "first" }, Err { message: "stop" }, Ok { value: "third" }])
+            }
+        "#,
+        entry: "main",
+        // Iteration 0: Ok → result = "first". Iteration 1: Err → break.
+        // Iteration 2 never runs; result stays "first".
+        expected: Ok(BexExternalValue::String("first".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn let_else_continue_in_else_inside_loop() -> anyhow::Result<()> {
+    // `continue` is a diverging form: skip to the next iteration when the
+    // pattern fails. Aggregates only the matching items.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function concat_oks(items: (Ok | Err)[]) -> string {
+                let acc = "";
+                let i = 0;
+                while (i < 3) {
+                    let item = items[i];
+                    i += 1;
+                    let o: Ok = item else { continue; };
+                    acc = acc + o.value;
+                }
+                acc
+            }
+
+            function main() -> string {
+                concat_oks([Ok { value: "a" }, Err { message: "skip" }, Ok { value: "c" }])
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("ac".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn let_else_multiple_consecutive_bindings() -> anyhow::Result<()> {
+    // Two let-else statements back-to-back: both bindings should be live
+    // in the tail, locals must not collide, and a miss in the second one
+    // diverges past the first binding cleanly.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function chain(a: Ok | Err, b: Ok | Err) -> string {
+                let oa: Ok = a else { return "a-failed"; };
+                let ob: Ok = b else { return "b-failed"; };
+                oa.value + "-" + ob.value
+            }
+
+            function main() -> string {
+                chain(Ok { value: "x" }, Ok { value: "y" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("x-y".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn let_else_second_miss_skips_first_binding() -> anyhow::Result<()> {
+    // First let-else succeeds, second fails. Else of the second runs and
+    // returns; the rest of the function never executes.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+
+            function chain(a: Ok | Err, b: Ok | Err) -> string {
+                let oa: Ok = a else { return "a-failed"; };
+                let ob: Ok = b else { return "b-failed"; };
+                oa.value + "-" + ob.value
+            }
+
+            function main() -> string {
+                chain(Ok { value: "x" }, Err { message: "boom" })
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("b-failed".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn let_else_throw_in_else_is_caught_by_outer_catch() -> anyhow::Result<()> {
+    // A thrown value from the else branch participates in the surrounding
+    // throws contract — an enclosing `catch` block must receive it. This
+    // checks that throws-analysis on `Stmt::Let.else_branch` correctly
+    // surfaces the thrown type.
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            class Ok { value string }
+            class Err { message string }
+            class NoMatch {}
+
+            function inner(r: Ok | Err) -> string throws NoMatch {
+                let o: Ok = r else { throw NoMatch {}; };
+                o.value
+            }
+
+            function main() -> string {
+                inner(Err { message: "ignored" }) catch (e) {
+                    NoMatch => "caught"
+                }
+            }
+        "#,
+        entry: "main",
+        expected: Ok(BexExternalValue::String("caught".to_string())),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
 async fn let_else_throw_in_else_propagates_when_uncaught() -> anyhow::Result<()> {
     // `throw` in the else branch is a diverging form. When uncaught, the
     // thrown value escapes the function and the engine reports the error.

--- a/baml_language/crates/bex_sap/src/jsonish/value.rs
+++ b/baml_language/crates/bex_sap/src/jsonish/value.rs
@@ -97,7 +97,7 @@ impl<'s> Value<'s> {
                 match items.len() {
                     0 => as_simple_str(s),
                     1 => match items.pop().expect("Expected 1 item") {
-                        Value::String(content, completion_state) if content == s => {
+                        Value::String(content, _completion_state) if content == s => {
                             as_simple_str(s)
                         }
                         other => Value::AnyOf(vec![other], s),


### PR DESCRIPTION
## Summary

Refutable binding with a diverging else clause:

```baml
let User { name } = u else { return; };
name
```

- Pattern may be refutable; bindings flow into the enclosing scope on match.
- Else branch must have type `Ty::Never` (return / throw / break / continue / infinite loop).
- New `else_branch: Option<ExprId>` on `Stmt::Let` — no new statement kind; the existing irrefutable-pattern context just flips off when else is present.

### Pipeline

- **TIR**: refutability matrix reused from if-let, divergence check on the inferred else type, irrefutable-pattern warning fires symmetrically with E0112.
- **MIR**: `lower_pattern_test` → bind into current scope on match, lower else with an `unreachable` terminator on miss (no successor edge needed).
- **Formatter**: `LetStmt` carries an optional boxed `(Else, BlockExpr)` tail (boxed to keep the struct small), printed inline with the binding.

### Rejected forms (parse-time)

- `else if` after `let … else` — no value to chain through.
- `watch let … else` — divergence semantics don't compose with auto-rerun.

### New diagnostics

- `E0113 LetElseMustDiverge` — else block has non-`!` type.
- `E0114 IrrefutablePatternInLetElse` — pattern covers every value of the initializer; suggest a plain `let`.

### Drive-by

- Silence pre-existing `unused_variables` warning in `bex_sap` (unrelated; blocked the pre-commit `clippy -D warnings` hook).
- Allow `large_enum_variant` on the formatter's `Statement` enum — `For(ForStmt)` was already 720 bytes; tweaking `LetStmt` pushed the size gap over the pedantic threshold.

## Test plan

- [x] 4 parser unit tests (basic CST, else-if rejected, watch-let-else rejected, destructure, plain-let regression)
- [x] 10 LSP fixture tests in `test_files/syntax/let_else/` (basic, destructure refutable + irrefutable, diverges_return, diverges_throw, must_diverge, irrefutable_warns, or_pattern, throws positive + negative, else can't see pattern bindings, no_else_if)
- [x] 5 formatter tests
- [x] 5 end-to-end runtime tests in `bex_engine/tests/control_flow.rs` (match path, miss path, destructure, or-pattern, uncaught throw escapes)

Full workspace run: **5752 / 5756 pass**. The 4 failures are the same pre-existing stale `baml_py.abi3.so` set called out in #3579 — verified they fail identically on the base tree, unrelated to this PR.

## Follow-ups (not in this PR — see "Coverage gaps" comment below)

- `break` / `continue` / `loop {}` as alternative divergence forms (TIR accepts via `Ty::Never`; just untested)
- Array destructure (`let [a, b] = xs else { … };`)
- Wildcard pattern (irrefutable warning)
- C-style for-init reject test
- Caught-throw in else
- Multiple consecutive let-else statements
- Quick-fix code action: convert irrefutable let-else → plain let

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added let … else syntax: refutable patterns with a diverging else; bindings only visible after a successful match.

* **Diagnostics**
  * New error E0113: else block must diverge.
  * New warning E0114: irrefutable pattern in let … else.

* **Formatting**
  * Formatter updated to print and round-trip let … else correctly.

* **Tests**
  * Wide coverage: parser, type-checking, LSP, formatting, engine e2e, and control-flow/throws cases.

* **Tooling**
  * Type inference, throws propagation, semantic analysis, and diagnostics mapping updated for let … else.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->