### PR TITLE
Add host_dispatch stub to promptfiddle LSP worker

### DIFF
--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -596,6 +596,7 @@ self.onmessage = async (event: MessageEvent) => {
           notification = mapsToRecordsDeep(notification);
           onPlaygroundNotification(notification);
         },
+        host_dispatch: () => {},
       },
       vfs.wasmVfs,
     );


### PR DESCRIPTION
## Summary
- The `bridge_wasm` callbacks bundle now requires a `host_dispatch` field (the JS-side dispatcher for BAML→host callable invocations). Promptfiddle's LSP worker wasn't updated, breaking the Vercel deploy with a tsc error.
- Promptfiddle runs pure BAML — it never registers host callables via `registerHostCallable` — so the dispatch path is unreachable. A no-op stub satisfies the type contract.

## Test plan
- [ ] Vercel deploy on this branch goes green
- [ ] Local `pnpm --filter app-promptfiddle run build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved runtime initialization process with enhanced host dispatch handling capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->