### PR TITLE
Fix multi-host-call harness in testing

### DIFF
--- a/baml_language/crates/bex_engine/tests/host_value_callable.rs
+++ b/baml_language/crates/bex_engine/tests/host_value_callable.rs
@@ -68,12 +68,22 @@ type Behaviour = Arc<dyn Fn(Vec<BamlOutboundValue>) -> FakeReturn + Send + Sync>
 static BEHAVIOUR_TABLE: OnceLock<Mutex<HashMap<u64, Behaviour>>> = OnceLock::new();
 static NEXT_KEY: AtomicU64 = AtomicU64::new(1);
 static DISPATCH_REGISTERED: OnceLock<()> = OnceLock::new();
-/// Channel sender used by [`FakeReturn::NeverComplete`] to publish the
-/// dispatched `call_id` back to the test that armed the hung-host behaviour.
-static PENDING_CALL_ID: OnceLock<Mutex<Option<std::sync::mpsc::Sender<u32>>>> = OnceLock::new();
+/// Per-`host_value_key` channel senders used by [`FakeReturn::NeverComplete`]
+/// to publish the dispatched `call_id` back to the test that armed the
+/// hung-host behaviour. Keyed by `host_value_key` (rather than a single shared
+/// slot) because the whole test binary runs in one process under libtest: a
+/// single slot would let concurrently-running `NeverComplete` tests clobber
+/// each other's sender — dropping it so `recv` sees `Disconnected` — or
+/// cross-route a `call_id` into the wrong test's channel.
+static PENDING_CALL_ID: OnceLock<Mutex<HashMap<u64, std::sync::mpsc::Sender<u32>>>> =
+    OnceLock::new();
 
 fn table() -> &'static Mutex<HashMap<u64, Behaviour>> {
     BEHAVIOUR_TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn pending_call_ids() -> &'static Mutex<HashMap<u64, std::sync::mpsc::Sender<u32>>> {
+    PENDING_CALL_ID.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 fn next_host_key() -> u64 {
@@ -145,12 +155,13 @@ extern "C" fn global_dispatch(host_value_key: u64, call_id: u32, args: *const u8
             complete_with_test_error(call_id, &class_name, &message);
         }
         FakeReturn::NeverComplete => {
-            // Model a hung host: publish the call_id and return without
-            // completing. The engine's sysop future stays pending until the
-            // BAML call is cancelled, at which point the future (and its
-            // InflightGuard) is dropped, evicting the table entry.
+            // Model a hung host: publish the call_id (routed to the test that
+            // armed *this* key) and return without completing. The engine's
+            // sysop future stays pending until the BAML call is cancelled, at
+            // which point the future (and its InflightGuard) is dropped,
+            // evicting the table entry.
             if let Some(slot) = PENDING_CALL_ID.get() {
-                if let Some(tx) = slot.lock().unwrap().as_ref() {
+                if let Some(tx) = slot.lock().unwrap().get(&host_value_key) {
                     let _ = tx.send(call_id);
                 }
             }
@@ -597,11 +608,10 @@ async fn host_callable_cancel_evicts_in_flight_entry() {
     // Wire a channel so the hung-host behaviour can publish the dispatched
     // call_id back to us.
     let (tx, rx) = std::sync::mpsc::channel::<u32>();
-    let slot = PENDING_CALL_ID.get_or_init(|| Mutex::new(None));
-    *slot.lock().unwrap() = Some(tx);
 
     // Behaviour: never complete — model a hung host.
     let arc = register_host_callable(|_items| FakeReturn::NeverComplete);
+    pending_call_ids().lock().unwrap().insert(arc.key, tx);
 
     let snapshot = compile_for_engine(source);
     let engine = Arc::new(
@@ -660,7 +670,7 @@ async fn host_callable_cancel_evicts_in_flight_entry() {
     );
 
     // Tidy up the global channel slot so it does not dangle into other tests.
-    *slot.lock().unwrap() = None;
+    pending_call_ids().lock().unwrap().remove(&arc.key);
     drop(arc);
 }
 
@@ -806,11 +816,10 @@ async fn host_call_ret_ty_survives_gc_during_await() {
 
     // Publish the dispatched call_id so the test controls GC-vs-completion order.
     let (tx, rx) = std::sync::mpsc::channel::<u32>();
-    let slot = PENDING_CALL_ID.get_or_init(|| Mutex::new(None));
-    *slot.lock().unwrap() = Some(tx);
 
     // Park the host call (don't complete) so we can run a GC during the await.
     let arc = register_host_callable(|_items| FakeReturn::NeverComplete);
+    pending_call_ids().lock().unwrap().insert(arc.key, tx);
 
     let snapshot = compile_for_engine(source);
     let engine = Arc::new(
@@ -865,7 +874,7 @@ async fn host_call_ret_ty_survives_gc_during_await() {
     let result = call.await.expect("join call task");
     assert_host_callable_throw(&result);
 
-    *slot.lock().unwrap() = None;
+    pending_call_ids().lock().unwrap().remove(&arc.key);
     drop(arc);
 }
 


### PR DESCRIPTION
We had a special harness but it only had one slot for host calls. This broke when running tests in parallel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for host value callable end-to-end tests to prevent interference when multiple concurrent test scenarios run simultaneously.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->