### PR TITLE
feat(spawn): spawn options — `with baml.spawn.options(...)`, CancelToken, detach, TaskGroup (BEP-034)

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1737,6 +1737,8 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_spawn/spawn.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_spawn/spawn.baml
@@ -54,10 +54,12 @@ class CancelToken {
   }
 }
 
-/// Assemble a `SpawnConfig` for a `spawn ... with` clause. In v1 only `cancel`
-/// is honored at runtime; `group` is accepted for forward compatibility and
-/// wired in a follow-up. (`detach` lands alongside its runtime support.)
+/// Assemble a `SpawnConfig` for a `spawn ... with` clause. `cancel` links a
+/// cancel token into the spawn's effective token; `detach = true` opts the
+/// spawn out of the parent→child cancel cascade and routes its unhandled
+/// errors to the root task instead of the spawner. (`group` is accepted for
+/// forward compatibility and wired in a follow-up.)
 //baml:mut_vm
-function options(group: TaskGroup? = null, cancel: CancelToken? = null) -> SpawnConfig {
+function options(group: TaskGroup? = null, cancel: CancelToken? = null, detach: bool? = null) -> SpawnConfig {
   $rust_function
 }

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_spawn/spawn.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_spawn/spawn.baml
@@ -1,0 +1,63 @@
+/// BEP-034 — spawn options (`spawn ... with baml.spawn.options(...)`).
+///
+/// This namespace holds the values a `spawn` can be configured with: a
+/// `CancelToken` for cooperative cancellation, a `TaskGroup` for rate
+/// limiting, and the `detach` flag. They are assembled by `options(...)`
+/// into an opaque `SpawnConfig` that the `with` clause hands to the runtime.
+
+/// Opaque configuration produced by `baml.spawn.options(...)` and consumed by
+/// a `spawn ... with` clause. Carries the (optional) cancel token, group, and
+/// detach flag. Not meaningfully constructible any other way.
+class SpawnConfig {
+  _handle $rust_type
+}
+
+/// Caps how many spawned tasks run concurrently. Rate-limiting behavior lands
+/// in a follow-up; the class is declared now so `options(group = ...)`
+/// type-checks and the surface stays stable.
+class TaskGroup {
+  _handle $rust_type
+}
+
+/// A cooperative, one-shot cancellation handle backed by a runtime
+/// cancellation token. Passing one via `options(cancel = ...)` links it into a
+/// spawned task's effective token: once fired, the task's next `await` throws
+/// `baml.panics.Cancelled`. Once cancelled, a token stays cancelled forever.
+class CancelToken {
+  _handle $rust_type
+
+  /// Create a fresh, un-cancelled token.
+  //baml:mut_vm
+  function new() -> CancelToken {
+    $rust_function
+  }
+
+  /// A new token that fires when ANY of `tokens` fires. Cancelling the
+  /// returned token does not propagate back to the inputs (one-directional),
+  /// so token composition cannot form cycles.
+  //baml:mut_vm
+  function any(tokens: CancelToken[]) -> CancelToken {
+    $rust_function
+  }
+
+  /// Request cancellation. Returns `1` if this call transitioned the token
+  /// from un-cancelled to cancelled, `0` if it was already cancelled.
+  //baml:vm
+  function cancel(self) -> int {
+    $rust_function
+  }
+
+  /// `true` if this token has been cancelled.
+  //baml:vm
+  function is_cancelled(self) -> bool {
+    $rust_function
+  }
+}
+
+/// Assemble a `SpawnConfig` for a `spawn ... with` clause. In v1 only `cancel`
+/// is honored at runtime; `group` is accepted for forward compatibility and
+/// wired in a follow-up. (`detach` lands alongside its runtime support.)
+//baml:mut_vm
+function options(group: TaskGroup? = null, cancel: CancelToken? = null) -> SpawnConfig {
+  $rust_function
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_spawn/spawn.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_spawn/spawn.baml
@@ -12,11 +12,58 @@ class SpawnConfig {
   _handle $rust_type
 }
 
-/// Caps how many spawned tasks run concurrently. Rate-limiting behavior lands
-/// in a follow-up; the class is declared now so `options(group = ...)`
-/// type-checks and the surface stays stable.
+/// Caps how many spawns referencing it run concurrently. Excess spawns queue
+/// FIFO and start as earlier ones settle; the `spawn` still returns its
+/// `Future` immediately, so queueing is invisible. Two spawns share a limit iff
+/// they reference the same `TaskGroup` value — there is no global registry.
 class TaskGroup {
   _handle $rust_type
+
+  /// Create a group capping concurrency at `limit`. `name` is an optional
+  /// debug label (no semantic meaning).
+  //baml:mut_vm
+  function new(limit: int, name: string? = null) -> TaskGroup {
+    $rust_function
+  }
+
+  /// Fire the cancel tokens of the group's members. `pending` selects queued
+  /// members, `active` selects running ones (both default `true`). Returns the
+  /// number signalled. The group stays usable afterward.
+  //baml:vm
+  function cancel(self, pending: bool? = true, active: bool? = true) -> int {
+    $rust_function
+  }
+
+  /// Change the concurrency cap. Increasing admits queued members up to the new
+  /// cap immediately; decreasing never preempts running members; `0` pauses.
+  //baml:vm
+  function set_limit(self, limit: int) -> void {
+    $rust_function
+  }
+
+  /// The current concurrency cap.
+  //baml:vm
+  function limit(self) -> int {
+    $rust_function
+  }
+
+  /// The optional debug name.
+  //baml:vm
+  function name(self) -> string? {
+    $rust_function
+  }
+
+  /// Instantaneous count of running members.
+  //baml:vm
+  function active_count(self) -> int {
+    $rust_function
+  }
+
+  /// Instantaneous count of queued members.
+  //baml:vm
+  function queued_count(self) -> int {
+    $rust_function
+  }
 }
 
 /// A cooperative, one-shot cancellation handle backed by a runtime

--- a/baml_language/crates/baml_builtins2/src/lib.rs
+++ b/baml_language/crates/baml_builtins2/src/lib.rs
@@ -111,6 +111,7 @@ pub const ALL: &[BuiltinFile] = &[
     builtin!("baml", "ns_llm/llm.baml"),
     builtin!("baml", "ns_stream/stream.baml"),
     builtin!("baml", "ns_future/future.baml"),
+    builtin!("baml", "ns_spawn/spawn.baml"),
     builtin!("baml", "ns_host/host.baml"),
     // --- reflect package (standalone, accessible as `reflect.type_of(...)`) ---
     builtin!("reflect", "reflect.baml"),

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -1410,8 +1410,11 @@ fn extraction_expr(
                 extraction_expr("other", inner, false, needs_owned, arraymap_needs_owned);
             // Bind `other` so `.is_null()` (Value method) resolves through
             // the `&Value` without triggering `clippy::needless_borrow`.
+            // An omitted optional argument arrives as the `OmittedArg`
+            // sentinel; treat it the same as an explicit `null` (→ `None`) so
+            // the inner extraction (e.g. `as_bool`) never runs on it.
             format!(
-                "{{ let other = {val}; if other.is_null() {{ None }} else {{ Some({inner_expr}) }} }}"
+                "{{ let other = {val}; if other.is_null() || other.is_omitted() {{ None }} else {{ Some({inner_expr}) }} }}"
             )
         }
         BamlType::Uint8Array => {

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -639,13 +639,17 @@ pub enum Expr {
     Throw {
         value: ExprId,
     },
-    /// BEP-034 `spawn name_expr? { body }`. The body is always a block
-    /// expression that runs on a freshly-spawned green thread; the
-    /// optional `name` is any expression that evaluates to a string and
+    /// BEP-034 `spawn name_expr? (with expr (, expr)*)? { body }`. The body is
+    /// always a block expression that runs on a freshly-spawned green thread;
+    /// the optional `name` is any expression that evaluates to a string and
     /// surfaces in debug / stack traces.
     Spawn {
         /// Optional human-readable label for the spawn.
         name: Option<ExprId>,
+        /// BEP-034 spawn options: the `with expr (, expr)*` clause. Each entry
+        /// is an arbitrary expression; in v1 TIR requires exactly one, a call
+        /// to `baml.spawn.options(...)`. Empty when there is no `with` clause.
+        with_exprs: Vec<ExprId>,
         /// Body of the spawn (`{...}`) — always an `Expr::Block` after
         /// CST lowering.
         body: ExprId,

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -32,11 +32,16 @@ pub struct EnvVarRef {
 /// Returns true if `kind` can serve as an identifier token in expression position.
 ///
 /// The parser allows `KW_CLIENT` (and `WORD`) inside `PATH_EXPR` / `FIELD_ACCESS_EXPR`
-/// nodes when `client` is used as a variable or field name. This must match
-/// exactly what `parse_path_or_ident` accepts; adding a new keyword there
-/// requires adding it here too.
+/// nodes when `client` is used as a variable or field name. It likewise allows
+/// `KW_SPAWN` / `KW_AWAIT` as path segments (e.g. the `baml.spawn` namespace),
+/// since they are unambiguous after a `.`. This must match exactly what
+/// `parse_path_or_ident` accepts; adding a new keyword there requires adding it
+/// here too.
 fn is_ident_token(kind: SyntaxKind) -> bool {
-    kind == SyntaxKind::WORD || kind == SyntaxKind::KW_CLIENT
+    matches!(
+        kind,
+        SyntaxKind::WORD | SyntaxKind::KW_CLIENT | SyntaxKind::KW_SPAWN | SyntaxKind::KW_AWAIT
+    )
 }
 
 /// Locate the `GENERIC_ARGS` node that should be treated as the *call-site*
@@ -682,10 +687,25 @@ impl LoweringContext {
         use baml_compiler_syntax::ast as cst_ast;
 
         let mut name: Option<ExprId> = None;
+        let mut with_exprs: Vec<ExprId> = Vec::new();
         let mut body_lambda: Option<ExprId> = None;
+        // The CST is flat: `KW_SPAWN [name expr] [KW_WITH expr (COMMA expr)*]
+        // BLOCK_EXPR`. We walk children-with-tokens so the `KW_WITH` token is
+        // visible; everything after it (other than the body) is a `with` expr.
+        let mut seen_with = false;
 
-        for child in node.children() {
-            if child.kind() == SyntaxKind::BLOCK_EXPR {
+        for child in node.children_with_tokens() {
+            let kind = child.kind();
+            if kind == SyntaxKind::KW_WITH {
+                seen_with = true;
+                continue;
+            }
+            // Only expression nodes matter past here; skip `KW_SPAWN`, commas,
+            // and trivia tokens.
+            let Some(child) = child.as_node() else {
+                continue;
+            };
+            if kind == SyntaxKind::BLOCK_EXPR {
                 // Synthesize a 0-arg lambda whose body is this block —
                 // mirroring `lower_lambda_expr` so the existing
                 // capture / scope / MIR plumbing applies unchanged.
@@ -717,13 +737,22 @@ impl LoweringContext {
                     body_lambda =
                         Some(self.alloc_expr(Expr::Lambda(Box::new(fd)), child.text_range()));
                 }
+            } else if seen_with {
+                with_exprs.push(self.lower_expr(child));
             } else if name.is_none() {
-                name = Some(self.lower_expr(&child));
+                name = Some(self.lower_expr(child));
             }
         }
 
         let body = body_lambda.unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.text_range()));
-        self.alloc_expr(Expr::Spawn { name, body }, node.text_range())
+        self.alloc_expr(
+            Expr::Spawn {
+                name,
+                with_exprs,
+                body,
+            },
+            node.text_range(),
+        )
     }
 
     /// Lower `await expr`. The CST shape is `AWAIT_EXPR [ KW_AWAIT

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -860,11 +860,15 @@ fn collect_uses_in_terminator(
         Terminator::Spawn {
             closure,
             name,
+            config,
             future,
             ..
         } => {
             collect_uses_in_operand(closure, block, StatementRef::Terminator, def_use);
             collect_uses_in_operand(name, block, StatementRef::Terminator, def_use);
+            if let Some(config) = config {
+                collect_uses_in_operand(config, block, StatementRef::Terminator, def_use);
+            }
             if let Place::Local(local) = future {
                 if let Some(du) = def_use.get_mut(local) {
                     du.def = Some(DefLocation {

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -1856,13 +1856,18 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             Terminator::Spawn {
                 closure,
                 name,
+                config,
                 future,
                 resume,
             } => {
-                // Push closure then name. The runtime `OpCode::Spawn`
-                // pops them in reverse: name first, then closure.
+                // Push closure, name, then config. The runtime `OpCode::Spawn`
+                // pops them in reverse: config first, then name, then closure.
+                // Config is null when there is no `with` clause, so a fixed
+                // three values are always pushed (BEP-034 spawn options).
                 self.emit_operand_pull(closure);
                 self.emit_operand_pull(name);
+                let null_config = Operand::Constant(Constant::Null);
+                self.emit_operand_pull(config.as_ref().unwrap_or(&null_config));
                 self.emit(Instruction::Spawn);
                 self.emit_store_place(future);
                 self.emit_jump_unless_fallthrough(*resume);

--- a/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
@@ -581,6 +581,7 @@ fn simulate_terminator_stack(
         Terminator::Spawn {
             closure,
             name,
+            config,
             future,
             ..
         } => {
@@ -596,7 +597,14 @@ fn simulate_terminator_stack(
             if pull_semantics::walk_operand_pull(&mut sink, name).is_err() {
                 return false;
             }
-            if !sim.pop_n(2) {
+            // Config operand is pushed last (null when there is no `with`
+            // clause). Mirror `emit`: always push three, pop three.
+            let null_config = Operand::Constant(Constant::Null);
+            let config_op = config.as_ref().unwrap_or(&null_config);
+            if pull_semantics::walk_operand_pull(&mut sink, config_op).is_err() {
+                return false;
+            }
+            if !sim.pop_n(3) {
                 return false;
             }
             sim.push();

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -516,10 +516,14 @@ impl<'db> SemanticIndexBuilder<'db> {
             }
             ast::Expr::Spawn {
                 name,
+                with_exprs,
                 body: spawn_body,
             } => {
                 if let Some(name) = name {
                     self.walk_expr(*name, body, source_map, true);
+                }
+                for with_expr in with_exprs {
+                    self.walk_expr(*with_expr, body, source_map, true);
                 }
                 self.walk_expr(*spawn_body, body, source_map, true);
             }

--- a/baml_language/crates/baml_compiler2_mir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/builder.rs
@@ -418,6 +418,7 @@ impl MirBuilder {
         &mut self,
         closure: Operand,
         name: Operand,
+        config: Option<Operand>,
         future: Place,
         resume: BlockId,
     ) {
@@ -428,6 +429,7 @@ impl MirBuilder {
         self.set_terminator(Terminator::Spawn {
             closure,
             name,
+            config,
             future,
             resume,
         });

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -408,6 +408,11 @@ pub enum Terminator {
         closure: Operand,
         /// Optional name expression (string or null).
         name: Operand,
+        /// Optional `baml.spawn.options(...)` config value from a `with`
+        /// clause (BEP-034 spawn options). `None` when there is no `with`
+        /// clause; the engine reads the config's `cancel` (and later
+        /// `group`/`detach`) to derive the spawn's effective cancel token.
+        config: Option<Operand>,
         /// Where to store the resulting Future handle.
         future: Place,
         /// Block to resume after the spawn schedules.

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -2430,8 +2430,12 @@ impl LoweringContext<'_> {
                 self.emit_panic_call("parse error", expr_id);
             }
 
-            AstExpr::Spawn { name, body } => {
-                self.lower_spawn(expr_id, name, body, dest);
+            AstExpr::Spawn {
+                name,
+                with_exprs,
+                body,
+            } => {
+                self.lower_spawn(expr_id, name, &with_exprs, body, dest);
             }
 
             AstExpr::Await { future } => {
@@ -2442,14 +2446,17 @@ impl LoweringContext<'_> {
         self.builder.current_source_span = prev_span;
     }
 
-    /// Lower `spawn name? { body }` into:
+    /// Lower `spawn name? with? { body }` into:
     ///   1. A `MakeClosure` for the body wrapped as a 0-arg lambda.
     ///   2. A name temp (string operand or null constant).
-    ///   3. A `Terminator::Spawn` writing the resulting Future handle.
+    ///   3. An optional config operand from the `with baml.spawn.options(...)`
+    ///      clause (BEP-034 spawn options).
+    ///   4. A `Terminator::Spawn` writing the resulting Future handle.
     fn lower_spawn(
         &mut self,
         expr_id: AstExprId,
         name: Option<AstExprId>,
+        with_exprs: &[AstExprId],
         body: AstExprId,
         dest: Place,
     ) {
@@ -2470,6 +2477,13 @@ impl LoweringContext<'_> {
             None => Operand::Constant(Constant::Null),
         };
 
+        // Lower the optional `with` config (BEP-034 spawn options). In v1
+        // the only useful form is a single `baml.spawn.options(...)` call,
+        // which yields a `SpawnConfig` value; lower the first one into the
+        // config operand. (Additional `with` expressions are type-checked in
+        // TIR but ignored at runtime until the full middleware design lands.)
+        let config_op = with_exprs.first().map(|&cfg| self.lower_to_operand(cfg));
+
         // Allocate the future temp. Phase C uses a defaulted `Null` type
         // for the future local; the TIR-tracked value/error types flow
         // through to runtime via the surrounding context. A follow-up
@@ -2482,7 +2496,7 @@ impl LoweringContext<'_> {
 
         let resume = self.builder.create_block();
         self.builder
-            .spawn(closure_op, name_op, future_place.clone(), resume);
+            .spawn(closure_op, name_op, config_op, future_place.clone(), resume);
         self.builder.set_current_block(resume);
         // The result of `spawn` is the Future handle.
         self.builder

--- a/baml_language/crates/baml_compiler2_mir/src/optimize.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize.rs
@@ -436,11 +436,15 @@ fn collect_place_index_locals(body: &MirFunctionBody) -> HashSet<Local> {
                 Terminator::Spawn {
                     closure,
                     name,
+                    config,
                     future,
                     ..
                 } => {
                     scan_operand(closure, &mut set);
                     scan_operand(name, &mut set);
+                    if let Some(config) = config {
+                        scan_operand(config, &mut set);
+                    }
                     scan_place(future, &mut set);
                 }
                 Terminator::Branch { condition, .. } => scan_operand(condition, &mut set),
@@ -673,11 +677,15 @@ fn count_in_terminator(term: &Terminator, uses: &mut [usize]) {
         Terminator::Spawn {
             closure,
             name,
+            config,
             future,
             ..
         } => {
             count_in_operand(closure, uses);
             count_in_operand(name, uses);
+            if let Some(config) = config {
+                count_in_operand(config, uses);
+            }
             count_dest_place(future, uses);
         }
         Terminator::Await {
@@ -948,9 +956,17 @@ fn apply_subst_to_terminator(term: &mut Terminator, subst: &HashMap<Local, Opera
                 apply_subst_to_operand(arg, subst);
             }
         }
-        Terminator::Spawn { closure, name, .. } => {
+        Terminator::Spawn {
+            closure,
+            name,
+            config,
+            ..
+        } => {
             apply_subst_to_operand(closure, subst);
             apply_subst_to_operand(name, subst);
+            if let Some(config) = config {
+                apply_subst_to_operand(config, subst);
+            }
         }
         Terminator::Throw { value } | Terminator::ThrowIfPanic { value, .. } => {
             apply_subst_to_operand(value, subst);
@@ -1194,11 +1210,15 @@ fn rewrite_locals_in_terminator(term: &mut Terminator, map: &[Option<Local>]) {
         Terminator::Spawn {
             closure,
             name,
+            config,
             future,
             ..
         } => {
             remap_operand(closure, map);
             remap_operand(name, map);
+            if let Some(config) = config {
+                remap_operand(config, map);
+            }
             remap_place(future, map);
         }
         Terminator::Await {
@@ -1405,11 +1425,15 @@ fn verify_mir(body: &MirFunctionBody, name: &crate::ItemRef) {
                 Terminator::Spawn {
                     closure,
                     name,
+                    config,
                     future,
                     ..
                 } => {
                     check_operand(closure, &blk);
                     check_operand(name, &blk);
+                    if let Some(config) = config {
+                        check_operand(config, &blk);
+                    }
                     check_place(future, &blk);
                 }
                 Terminator::Await {

--- a/baml_language/crates/baml_compiler2_mir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/pretty.rs
@@ -313,6 +313,7 @@ fn write_terminator(f: &mut impl Write, term: &Terminator) -> fmt::Result {
         Terminator::Spawn {
             closure,
             name,
+            config,
             future,
             resume,
         } => {
@@ -320,6 +321,10 @@ fn write_terminator(f: &mut impl Write, term: &Terminator) -> fmt::Result {
             write_operand(f, closure)?;
             write!(f, " name=")?;
             write_operand(f, name)?;
+            if let Some(config) = config {
+                write!(f, " config=")?;
+                write_operand(f, config)?;
+            }
             write!(f, " -> {resume};")
         }
         Terminator::Await {

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -3213,15 +3213,31 @@ impl<'db> TypeInferenceBuilder<'db> {
                     let _ = self.infer_expr(*name_id, body);
                 }
                 // Spawn options: type-check each `with` expression — it is
-                // evaluated eagerly in the spawning function. In v1 the only
-                // useful form is a single `baml.spawn.options(...)` call
-                // producing a `SpawnConfig`, which MIR lowers into the spawn's
-                // config operand.
-                // TODO(spawn-options PR4): reject `with` expressions that are
-                // not a `baml.spawn.options(...)` call, and forbid more than
-                // one config.
-                for with_id in with_exprs {
-                    let _ = self.infer_expr(*with_id, body);
+                // evaluated eagerly in the spawning function. v1 accepts a
+                // single config producing a `baml.spawn.SpawnConfig` (i.e. a
+                // `baml.spawn.options(...)` call, or a variable bound to one).
+                for (idx, with_id) in with_exprs.iter().enumerate() {
+                    let cfg_ty = self.infer_expr(*with_id, body);
+                    if idx >= 1 {
+                        self.context
+                            .report_simple(TirTypeError::SpawnWithTooManyConfigs, *with_id);
+                        continue;
+                    }
+                    let is_spawn_config = matches!(
+                        &cfg_ty,
+                        Ty::Class(qn, _, _)
+                            if qn.package().as_str() == "baml"
+                                && qn.namespace().len() == 1
+                                && qn.namespace()[0].as_str() == "spawn"
+                                && qn.name().as_str() == "SpawnConfig"
+                    );
+                    // Don't double-report on an expression that already failed
+                    // to type-check.
+                    let unresolved = matches!(cfg_ty, Ty::Unknown { .. } | Ty::Error { .. });
+                    if !is_spawn_config && !unresolved {
+                        self.context
+                            .report_simple(TirTypeError::SpawnWithMustBeSpawnConfig, *with_id);
+                    }
                 }
                 let lambda_ty = self.infer_expr(*spawn_body, body);
                 let value_ty = match &lambda_ty {

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2084,11 +2084,21 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             Expr::Spawn {
                 name,
+                with_exprs,
                 body: spawn_body,
             } => {
                 if let Some(name_id) = name {
                     Self::collect_default_expr_forward_references(
                         *name_id,
+                        body,
+                        later_params,
+                        shadowed,
+                        refs,
+                    );
+                }
+                for with_id in with_exprs {
+                    Self::collect_default_expr_forward_references(
+                        *with_id,
                         body,
                         later_params,
                         shadowed,
@@ -3190,9 +3200,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             Expr::Spawn {
                 name,
+                with_exprs,
                 body: spawn_body,
             } => {
-                // BEP-034: `spawn name? { body } : Future<T, E>` where
+                // BEP-034: `spawn name? with? { body } : Future<T, E>` where
                 // `body` has type `T throws E`. After AST lowering the
                 // body is wrapped in a synthetic 0-arg lambda; we infer
                 // the lambda's type, peel out its return as `T`, and
@@ -3200,6 +3211,17 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // `infer_lambda_body`) as `E`.
                 if let Some(name_id) = name {
                     let _ = self.infer_expr(*name_id, body);
+                }
+                // Spawn options: type-check each `with` expression — it is
+                // evaluated eagerly in the spawning function. In v1 the only
+                // useful form is a single `baml.spawn.options(...)` call
+                // producing a `SpawnConfig`, which MIR lowers into the spawn's
+                // config operand.
+                // TODO(spawn-options PR4): reject `with` expressions that are
+                // not a `baml.spawn.options(...)` call, and forbid more than
+                // one config.
+                for with_id in with_exprs {
+                    let _ = self.infer_expr(*with_id, body);
                 }
                 let lambda_ty = self.infer_expr(*spawn_body, body);
                 let value_ty = match &lambda_ty {
@@ -5622,15 +5644,20 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             Expr::Spawn {
                 name,
+                with_exprs,
                 body: spawn_body,
             } => {
                 // Spawn-body throws do NOT escape the spawning function
                 // — they are captured into the resulting `Future<T, E>`'s
                 // E parameter and only re-thrown at an `await` site. The
-                // name expression itself can throw, so walk it; do not
-                // walk spawn_body.
+                // name and `with` expressions are evaluated eagerly in the
+                // spawning function, so their throws DO escape — walk them;
+                // do not walk spawn_body.
                 if let Some(name_id) = name {
                     self.collect_throw_facts_from_expr(*name_id, body, out);
+                }
+                for with_id in with_exprs {
+                    self.collect_throw_facts_from_expr(*with_id, body, out);
                 }
                 let _ = spawn_body;
             }

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -53,6 +53,12 @@ pub enum TirTypeError {
     /// The return value of a void-returning function was used where a value
     /// is required — assigned to a variable, passed as an argument, etc.
     VoidFunctionResultUsed,
+    /// A `spawn ... with` clause expression is not a `baml.spawn.options(...)`
+    /// config (BEP-034 spawn options; v1 accepts only that).
+    SpawnWithMustBeSpawnConfig,
+    /// A `spawn ... with` clause had more than one config expression (v1
+    /// accepts a single `baml.spawn.options(...)`).
+    SpawnWithTooManyConfigs,
     /// Expression is not callable (e.g. `42(1)` or `Foo(1)` where Foo is a class).
     NotCallable { ty: Ty },
     /// Expression is not iterable (e.g. `for let i in 42 { ... }` where 42 is an int).
@@ -259,6 +265,18 @@ impl fmt::Display for TirTypeError {
             }
             TirTypeError::VoidFunctionResultUsed => {
                 write!(f, "cannot use return value of a void function")
+            }
+            TirTypeError::SpawnWithMustBeSpawnConfig => {
+                write!(
+                    f,
+                    "`spawn ... with` accepts only a `baml.spawn.options(...)` configuration"
+                )
+            }
+            TirTypeError::SpawnWithTooManyConfigs => {
+                write!(
+                    f,
+                    "`spawn ... with` accepts a single `baml.spawn.options(...)` configuration"
+                )
             }
             TirTypeError::NotCallable { ty } => {
                 write!(

--- a/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
@@ -288,15 +288,20 @@ fn collect_from_expr<C: ThrowsAnalysisContext>(
         }
         Expr::Spawn {
             name,
+            with_exprs,
             body: spawn_body,
         } => {
             // Throws from a spawned body do NOT escape the spawning
             // function — they are captured into the resulting
             // `Future<T, E>`'s E parameter and only re-thrown at an
-            // `await` site. The name expression itself can throw, so
-            // walk it; do not walk spawn_body.
+            // `await` site. The name and `with` expressions are evaluated
+            // eagerly in the spawning function, so their throws DO escape —
+            // walk them; do not walk spawn_body.
             if let Some(name_id) = name {
                 collect_from_expr(context, *name_id, body, out);
+            }
+            for with_id in with_exprs {
+                collect_from_expr(context, *with_id, body, out);
             }
             let _ = spawn_body;
         }

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -4512,23 +4512,42 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse `spawn name_expr? { body }`. The name expression is optional
-    /// and is parsed until we see `{` (v1 has no `with` clause). The body
-    /// is always a brace-delimited block.
+    /// Parse `spawn name_expr? (with expr (, expr)*)? { body }`. The name
+    /// expression is optional and is parsed until we see `with` or `{`. The
+    /// optional `with` clause (BEP-034 spawn options) is a comma-separated
+    /// list of expressions; in v1 the only accepted form is a single
+    /// `baml.spawn.options(...)` call, enforced later in TIR. The body is
+    /// always a brace-delimited block.
     fn parse_spawn_expr(&mut self) {
         self.with_node(SyntaxKind::SPAWN_EXPR, |p| {
             p.bump(); // `spawn`
             // Optional name expression: anything that can lead an
-            // expression and is not `{`. We parse the name with a binding
-            // power of 0 (no infix beyond what naturally terminates at
-            // `{`), then the brace-block.
-            if !p.at(TokenKind::LBrace) {
+            // expression and is not `{` or `with`. We parse the name with a
+            // binding power of 1 (`with` is a bare Word with no infix binding
+            // power, so the name naturally terminates before it), then the
+            // optional `with` clause, then the brace-block.
+            if !p.at(TokenKind::LBrace) && !p.at_contextual_kw("with") {
                 // Suppress object-literal postfix so the body brace
                 // isn't consumed as a struct constructor — without
                 // this, `spawn nm { y: 1 }` parses `nm { y: 1 }` as
                 // an OBJECT_LITERAL and the body is missing.
                 p.suppress_object_literal_depth += 1;
                 p.parse_expr_bp(1);
+                p.suppress_object_literal_depth -= 1;
+            }
+            // Optional `with expr (, expr)*` clause. Suppress object literals
+            // for the same reason as the name: keep the body brace available.
+            if p.at_contextual_kw("with") {
+                p.bump_contextual_with();
+                p.suppress_object_literal_depth += 1;
+                p.parse_expr_bp(1);
+                while p.eat(TokenKind::Comma) {
+                    // Tolerate a trailing comma before the body brace.
+                    if p.at(TokenKind::LBrace) {
+                        break;
+                    }
+                    p.parse_expr_bp(1);
+                }
                 p.suppress_object_literal_depth -= 1;
             }
             if p.at(TokenKind::LBrace) {
@@ -5067,7 +5086,17 @@ impl<'a> Parser<'a> {
             return;
         }
 
-        let segment = |k: TokenKind| matches!(k, TokenKind::Word | TokenKind::Client);
+        // `spawn` / `await` are reserved keywords but are valid as path
+        // segments after a `.` (e.g. the `baml.spawn` namespace). They are
+        // unambiguous in segment position — a leading `spawn`/`await` is
+        // handled before this point. `is_ident_token` in
+        // `baml_compiler2_ast::lower_expr_body` must mirror this set.
+        let segment = |k: TokenKind| {
+            matches!(
+                k,
+                TokenKind::Word | TokenKind::Client | TokenKind::Spawn | TokenKind::Await
+            )
+        };
 
         // Check if this looks like a path (ident.client followed by dot and another ident)
         if self.peek(1).map(|t| t.kind) == Some(TokenKind::Dot)
@@ -5079,7 +5108,7 @@ impl<'a> Parser<'a> {
 
                 // Parse remaining segments
                 while p.eat(TokenKind::Dot) {
-                    if p.at(TokenKind::Word) || p.at(TokenKind::Client) {
+                    if p.current().map(|t| segment(t.kind)).unwrap_or(false) {
                         p.bump(); // Next segment
                     } else {
                         p.error_unexpected_token("path segment after '.'".to_string());

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -873,6 +873,8 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::DeadCode { .. } => DiagnosticId::TypeMismatch,
         TirTypeError::VoidUsedAsValue => DiagnosticId::TypeMismatch,
         TirTypeError::VoidFunctionResultUsed => DiagnosticId::TypeMismatch,
+        TirTypeError::SpawnWithMustBeSpawnConfig => DiagnosticId::TypeMismatch,
+        TirTypeError::SpawnWithTooManyConfigs => DiagnosticId::TypeMismatch,
         TirTypeError::NotCallable { .. } => DiagnosticId::NotCallable,
         TirTypeError::NotIterable { .. } => DiagnosticId::NotCallable,
         TirTypeError::NotIndexable { .. } => DiagnosticId::NotIndexable,

--- a/baml_language/crates/baml_tests/baml_src/ns_cancel_token/cancel_token.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_cancel_token/cancel_token.baml
@@ -48,3 +48,15 @@ function token_is_cancelled_reflects_cancel() -> bool[] {
 test "token_is_cancelled_reflects_cancel" {
     assert.is_true(baml.deep_equals(token_is_cancelled_reflects_cancel(), [false, true]))
 }
+
+// `detach = true` opts out of the parent cascade but must not break normal
+// completion (its survival/cascade-independence is verified by construction in
+// the engine: a detached spawn gets a fresh effective token).
+function detached_spawn_completes() -> int {
+    let f = spawn with baml.spawn.options(detach = true) { 42 };
+    await f
+}
+
+test "detached_spawn_completes" {
+    assert.is_true(baml.deep_equals(detached_spawn_completes(), 42))
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_cancel_token/cancel_token.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_cancel_token/cancel_token.baml
@@ -1,0 +1,50 @@
+// BEP-034 spawn options — `spawn ... with baml.spawn.options(cancel = tok)`.
+//
+// Helpers are top-level functions (test-block locals hit the known
+// local-boxing VM bug; see ns_cancel_cascade/cancel_cascade.baml).
+//
+// Only deterministic, `await`-based assertions live here: a CancelToken fires
+// the spawn's effective token via an async watcher, so reading `f.state()`
+// immediately after `tok.cancel()` would race the watcher. `await` blocks
+// until the future settles, so its outcome is deterministic.
+
+// Awaiting a token-cancelled spawn re-throws `Cancelled`, which is catchable.
+function await_token_cancelled_catches() -> int {
+    let tok = baml.spawn.CancelToken.new();
+    let f = spawn with baml.spawn.options(cancel = tok) {
+        baml.sys.sleep(60000);
+        42
+    };
+    let _ = tok.cancel();
+    (await f) catch (e) { baml.panics.Cancelled => 0 }
+}
+
+test "await_token_cancelled_catches" {
+    assert.is_true(baml.deep_equals(await_token_cancelled_catches(), 0))
+}
+
+// An un-fired token leaves the spawn to complete normally — the option must
+// not perturb the happy path.
+function uncancelled_token_completes() -> int {
+    let tok = baml.spawn.CancelToken.new();
+    let f = spawn with baml.spawn.options(cancel = tok) { 42 };
+    await f
+}
+
+test "uncancelled_token_completes" {
+    assert.is_true(baml.deep_equals(uncancelled_token_completes(), 42))
+}
+
+// `CancelToken.cancel()` is synchronous on the token, so `is_cancelled()`
+// observes the transition immediately (no future / watcher involved).
+function token_is_cancelled_reflects_cancel() -> bool[] {
+    let tok = baml.spawn.CancelToken.new();
+    let before = tok.is_cancelled();
+    let _ = tok.cancel();
+    let after = tok.is_cancelled();
+    [before, after]
+}
+
+test "token_is_cancelled_reflects_cancel" {
+    assert.is_true(baml.deep_equals(token_is_cancelled_reflects_cancel(), [false, true]))
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_task_group/task_group.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_task_group/task_group.baml
@@ -1,0 +1,64 @@
+// BEP-034 spawn options — `TaskGroup` rate limiting via
+// `spawn ... with baml.spawn.options(group = g)`.
+//
+// Deterministic tests only: a `TaskGroup` member is registered synchronously
+// at `spawn`, so `active_count`/`queued_count` read right after spawning are
+// exact, and `await`/`catch` outcomes don't depend on scheduler timing.
+
+// The cap is enforced at admission: four members into a `limit = 2` group
+// leave exactly two active and two queued (bodies not yet polled). `g.cancel()`
+// tears the parked sleeps down.
+function caps_active_and_queues_rest() -> int {
+    let g = baml.spawn.TaskGroup.new(2);
+    let a = spawn with baml.spawn.options(group = g) { baml.sys.sleep(5000); 1 };
+    let b = spawn with baml.spawn.options(group = g) { baml.sys.sleep(5000); 1 };
+    let c = spawn with baml.spawn.options(group = g) { baml.sys.sleep(5000); 1 };
+    let d = spawn with baml.spawn.options(group = g) { baml.sys.sleep(5000); 1 };
+    let snapshot = g.active_count() * 100 + g.queued_count();
+    let _ = g.cancel();
+    snapshot
+}
+
+test "caps_active_and_queues_rest" {
+    assert.is_true(baml.deep_equals(caps_active_and_queues_rest(), 202))
+}
+
+// More spawns than the limit all complete — the queued ones start as slots free.
+function queues_excess_and_all_complete() -> int {
+    let g = baml.spawn.TaskGroup.new(2);
+    let a = spawn with baml.spawn.options(group = g) { 1 };
+    let b = spawn with baml.spawn.options(group = g) { 1 };
+    let c = spawn with baml.spawn.options(group = g) { 1 };
+    let d = spawn with baml.spawn.options(group = g) { 1 };
+    let e = spawn with baml.spawn.options(group = g) { 1 };
+    (await a) + (await b) + (await c) + (await d) + (await e)
+}
+
+test "queues_excess_and_all_complete" {
+    assert.is_true(baml.deep_equals(queues_excess_and_all_complete(), 5))
+}
+
+// `group.cancel()` fires its members' tokens; awaiting a cancelled member
+// re-throws `Cancelled`, which is catchable.
+function group_cancel_cancels_member() -> int {
+    let g = baml.spawn.TaskGroup.new(5);
+    let f = spawn with baml.spawn.options(group = g) { baml.sys.sleep(10000); 42 };
+    let _ = g.cancel();
+    (await f) catch (e) { baml.panics.Cancelled => 0 }
+}
+
+test "group_cancel_cancels_member" {
+    assert.is_true(baml.deep_equals(group_cancel_cancels_member(), 0))
+}
+
+// `limit()` / `set_limit()` round-trip.
+function set_limit_updates_limit() -> int {
+    let g = baml.spawn.TaskGroup.new(3);
+    let before = g.limit();
+    g.set_limit(7);
+    before + g.limit()
+}
+
+test "set_limit_updates_limit" {
+    assert.is_true(baml.deep_equals(set_limit_updates_limit(), 10))
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -165,6 +165,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -162,6 +162,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/arrays.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/arrays.snap
@@ -1,448 +1,448 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function arrays.$init_test_35(registry: testing.TestCollector) -> null {
+function arrays.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "array_literal"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_assign_to_variable"
-    make_closure .<lambda($init_test_35, 1)>, 0
+    make_closure .<lambda($init_test_36, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_push"
-    make_closure .<lambda($init_test_35, 2)>, 0
+    make_closure .<lambda($init_test_36, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_simple_double"
-    make_closure .<lambda($init_test_35, 3)>, 0
+    make_closure .<lambda($init_test_36, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_empty_array"
-    make_closure .<lambda($init_test_35, 5)>, 0
+    make_closure .<lambda($init_test_36, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_single_element"
-    make_closure .<lambda($init_test_35, 7)>, 0
+    make_closure .<lambda($init_test_36, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_closure_captures_multiple_variables"
-    make_closure .<lambda($init_test_35, 9)>, 0
+    make_closure .<lambda($init_test_36, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_callback_throws"
-    make_closure .<lambda($init_test_35, 11)>, 0
+    make_closure .<lambda($init_test_36, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_callback_in_catch_base_keeps_parameter_scope"
-    make_closure .<lambda($init_test_35, 13)>, 0
+    make_closure .<lambda($init_test_36, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_string_elements"
-    make_closure .<lambda($init_test_35, 15)>, 0
+    make_closure .<lambda($init_test_36, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_clear_non_empty"
-    make_closure .<lambda($init_test_35, 17)>, 0
+    make_closure .<lambda($init_test_36, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_clear_already_empty_is_noop"
-    make_closure .<lambda($init_test_35, 18)>, 0
+    make_closure .<lambda($init_test_36, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_clear_returns_array_after"
-    make_closure .<lambda($init_test_35, 19)>, 0
+    make_closure .<lambda($init_test_36, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_shift_returns_first_element"
-    make_closure .<lambda($init_test_35, 20)>, 0
+    make_closure .<lambda($init_test_36, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_shift_modifies_array_in_place"
-    make_closure .<lambda($init_test_35, 21)>, 0
+    make_closure .<lambda($init_test_36, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_shift_empty_returns_null"
-    make_closure .<lambda($init_test_35, 22)>, 0
+    make_closure .<lambda($init_test_36, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_shift_repeated_drains_array"
-    make_closure .<lambda($init_test_35, 23)>, 0
+    make_closure .<lambda($init_test_36, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_unshift_returns_new_length"
-    make_closure .<lambda($init_test_35, 24)>, 0
+    make_closure .<lambda($init_test_36, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_unshift_inserts_at_front"
-    make_closure .<lambda($init_test_35, 25)>, 0
+    make_closure .<lambda($init_test_36, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_unshift_empty_array"
-    make_closure .<lambda($init_test_35, 26)>, 0
+    make_closure .<lambda($init_test_36, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_in_middle"
-    make_closure .<lambda($init_test_35, 27)>, 0
+    make_closure .<lambda($init_test_36, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_at_zero"
-    make_closure .<lambda($init_test_35, 28)>, 0
+    make_closure .<lambda($init_test_36, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_at_length_appends"
-    make_closure .<lambda($init_test_35, 29)>, 0
+    make_closure .<lambda($init_test_36, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_returns_new_length"
-    make_closure .<lambda($init_test_35, 30)>, 0
+    make_closure .<lambda($init_test_36, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_empty_array_at_zero"
-    make_closure .<lambda($init_test_35, 31)>, 0
+    make_closure .<lambda($init_test_36, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_negative_throws"
-    make_closure .<lambda($init_test_35, 32)>, 0
+    make_closure .<lambda($init_test_36, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_past_length_throws"
-    make_closure .<lambda($init_test_35, 33)>, 0
+    make_closure .<lambda($init_test_36, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_replaces_range"
-    make_closure .<lambda($init_test_35, 34)>, 0
+    make_closure .<lambda($init_test_36, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_pure_insertion"
-    make_closure .<lambda($init_test_35, 35)>, 0
+    make_closure .<lambda($init_test_36, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_pure_removal"
-    make_closure .<lambda($init_test_35, 36)>, 0
+    make_closure .<lambda($init_test_36, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_count_clamped_to_length"
-    make_closure .<lambda($init_test_35, 37)>, 0
+    make_closure .<lambda($init_test_36, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_at_length_appends"
-    make_closure .<lambda($init_test_35, 38)>, 0
+    make_closure .<lambda($init_test_36, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_replace_with_longer"
-    make_closure .<lambda($init_test_35, 39)>, 0
+    make_closure .<lambda($init_test_36, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_negative_start_throws"
-    make_closure .<lambda($init_test_35, 40)>, 0
+    make_closure .<lambda($init_test_36, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_start_past_length_throws"
-    make_closure .<lambda($init_test_35, 41)>, 0
+    make_closure .<lambda($init_test_36, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_negative_count_throws"
-    make_closure .<lambda($init_test_35, 42)>, 0
+    make_closure .<lambda($init_test_36, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_finds_match"
-    make_closure .<lambda($init_test_35, 43)>, 0
+    make_closure .<lambda($init_test_36, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_no_match"
-    make_closure .<lambda($init_test_35, 45)>, 0
+    make_closure .<lambda($init_test_36, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_empty_is_false"
-    make_closure .<lambda($init_test_35, 47)>, 0
+    make_closure .<lambda($init_test_36, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_short_circuits"
-    make_closure .<lambda($init_test_35, 49)>, 0
+    make_closure .<lambda($init_test_36, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_propagates_error"
-    make_closure .<lambda($init_test_35, 51)>, 0
+    make_closure .<lambda($init_test_36, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_all_match"
-    make_closure .<lambda($init_test_35, 53)>, 0
+    make_closure .<lambda($init_test_36, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_one_fails"
-    make_closure .<lambda($init_test_35, 55)>, 0
+    make_closure .<lambda($init_test_36, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_empty_is_true"
-    make_closure .<lambda($init_test_35, 57)>, 0
+    make_closure .<lambda($init_test_36, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_short_circuits_on_false"
-    make_closure .<lambda($init_test_35, 59)>, 0
+    make_closure .<lambda($init_test_36, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_returns_first_match"
-    make_closure .<lambda($init_test_35, 61)>, 0
+    make_closure .<lambda($init_test_36, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_returns_null_when_no_match"
-    make_closure .<lambda($init_test_35, 63)>, 0
+    make_closure .<lambda($init_test_36, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_empty_is_null"
-    make_closure .<lambda($init_test_35, 65)>, 0
+    make_closure .<lambda($init_test_36, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_index_returns_first_index"
-    make_closure .<lambda($init_test_35, 67)>, 0
+    make_closure .<lambda($init_test_36, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_index_returns_null_when_no_match"
-    make_closure .<lambda($init_test_35, 69)>, 0
+    make_closure .<lambda($init_test_36, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_short_circuits"
-    make_closure .<lambda($init_test_35, 71)>, 0
+    make_closure .<lambda($init_test_36, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_returns_last_match"
-    make_closure .<lambda($init_test_35, 73)>, 0
+    make_closure .<lambda($init_test_36, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_returns_null_when_no_match"
-    make_closure .<lambda($init_test_35, 75)>, 0
+    make_closure .<lambda($init_test_36, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_index_returns_last_index"
-    make_closure .<lambda($init_test_35, 77)>, 0
+    make_closure .<lambda($init_test_36, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_iterates_back_to_front"
-    make_closure .<lambda($init_test_35, 79)>, 0
+    make_closure .<lambda($init_test_36, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_empty_is_null"
-    make_closure .<lambda($init_test_35, 81)>, 0
+    make_closure .<lambda($init_test_36, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_includes_present"
-    make_closure .<lambda($init_test_35, 83)>, 0
+    make_closure .<lambda($init_test_36, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_includes_absent"
-    make_closure .<lambda($init_test_35, 84)>, 0
+    make_closure .<lambda($init_test_36, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_includes_empty"
-    make_closure .<lambda($init_test_35, 85)>, 0
+    make_closure .<lambda($init_test_36, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_includes_strings"
-    make_closure .<lambda($init_test_35, 86)>, 0
+    make_closure .<lambda($init_test_36, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_index_of_present"
-    make_closure .<lambda($init_test_35, 87)>, 0
+    make_closure .<lambda($init_test_36, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_index_of_first_match"
-    make_closure .<lambda($init_test_35, 88)>, 0
+    make_closure .<lambda($init_test_36, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_index_of_absent"
-    make_closure .<lambda($init_test_35, 89)>, 0
+    make_closure .<lambda($init_test_36, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_last_index_of_returns_last_match"
-    make_closure .<lambda($init_test_35, 90)>, 0
+    make_closure .<lambda($init_test_36, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_last_index_of_absent"
-    make_closure .<lambda($init_test_35, 91)>, 0
+    make_closure .<lambda($init_test_36, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_sum"
-    make_closure .<lambda($init_test_35, 92)>, 0
+    make_closure .<lambda($init_test_36, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_with_nonzero_initial"
-    make_closure .<lambda($init_test_35, 94)>, 0
+    make_closure .<lambda($init_test_36, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_empty_returns_initial"
-    make_closure .<lambda($init_test_35, 96)>, 0
+    make_closure .<lambda($init_test_36, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_visits_every_element"
-    make_closure .<lambda($init_test_35, 98)>, 0
+    make_closure .<lambda($init_test_36, 98)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_concat_strings"
-    make_closure .<lambda($init_test_35, 100)>, 0
+    make_closure .<lambda($init_test_36, 100)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_doubles_each_element"
-    make_closure .<lambda($init_test_35, 102)>, 0
+    make_closure .<lambda($init_test_36, 102)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_with_empty_inner_arrays"
-    make_closure .<lambda($init_test_35, 104)>, 0
+    make_closure .<lambda($init_test_36, 104)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_empty_input"
-    make_closure .<lambda($init_test_35, 106)>, 0
+    make_closure .<lambda($init_test_36, 106)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_uneven_inner_lengths"
-    make_closure .<lambda($init_test_35, 108)>, 0
+    make_closure .<lambda($init_test_36, 108)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/assignments.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/assignments.snap
@@ -1,130 +1,130 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function assignments.$init_test_36(registry: testing.TestCollector) -> null {
+function assignments.$init_test_37(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "block_expr"
-    make_closure .<lambda($init_test_36, 0)>, 0
+    make_closure .<lambda($init_test_37, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mutable_var_in_function"
-    make_closure .<lambda($init_test_36, 1)>, 0
+    make_closure .<lambda($init_test_37, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mutable_param"
-    make_closure .<lambda($init_test_36, 2)>, 0
+    make_closure .<lambda($init_test_37, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "virtual_cross_block_soundness"
-    make_closure .<lambda($init_test_36, 3)>, 0
+    make_closure .<lambda($init_test_37, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "virtual_cross_block_param_mutation_soundness"
-    make_closure .<lambda($init_test_36, 4)>, 0
+    make_closure .<lambda($init_test_37, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "copy_of_mutable_param_soundness"
-    make_closure .<lambda($init_test_36, 5)>, 0
+    make_closure .<lambda($init_test_37, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "virtual_cross_block_transitive_param_mutation_soundness"
-    make_closure .<lambda($init_test_36, 6)>, 0
+    make_closure .<lambda($init_test_37, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment_add_assign"
-    make_closure .<lambda($init_test_36, 7)>, 0
+    make_closure .<lambda($init_test_37, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment_sub_assign"
-    make_closure .<lambda($init_test_36, 8)>, 0
+    make_closure .<lambda($init_test_37, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment_mul_assign"
-    make_closure .<lambda($init_test_36, 9)>, 0
+    make_closure .<lambda($init_test_37, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment_div_assign"
-    make_closure .<lambda($init_test_36, 10)>, 0
+    make_closure .<lambda($init_test_37, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment_mod_assign"
-    make_closure .<lambda($init_test_36, 11)>, 0
+    make_closure .<lambda($init_test_37, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment_simple"
-    make_closure .<lambda($init_test_36, 12)>, 0
+    make_closure .<lambda($init_test_37, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment_multiple_ops"
-    make_closure .<lambda($init_test_36, 13)>, 0
+    make_closure .<lambda($init_test_37, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_field_assignment_simple"
-    make_closure .<lambda($init_test_36, 14)>, 0
+    make_closure .<lambda($init_test_37, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_field_assignment_compound"
-    make_closure .<lambda($init_test_36, 15)>, 0
+    make_closure .<lambda($init_test_37, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment_object_field"
-    make_closure .<lambda($init_test_36, 16)>, 0
+    make_closure .<lambda($init_test_37, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_element_field_assignment"
-    make_closure .<lambda($init_test_36, 17)>, 0
+    make_closure .<lambda($init_test_37, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "method_call_field_assignment_with_copy"
-    make_closure .<lambda($init_test_36, 18)>, 0
+    make_closure .<lambda($init_test_37, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "virtual_multiple_defs_preserve_side_effects"
-    make_closure .<lambda($init_test_36, 19)>, 0
+    make_closure .<lambda($init_test_37, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "parenthesized_assignment_in_expr_position_is_bug"
-    make_closure .<lambda($init_test_36, 20)>, 0
+    make_closure .<lambda($init_test_37, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/bigints.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/bigints.snap
@@ -1,676 +1,676 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function bigints.$init_test_37(registry: testing.TestCollector) -> null {
+function bigints.$init_test_38(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "test_bigint_compound_assign_int_add"
-    make_closure .<lambda($init_test_37, 0)>, 0
+    make_closure .<lambda($init_test_38, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_compound_assign_int_mul"
-    make_closure .<lambda($init_test_37, 1)>, 0
+    make_closure .<lambda($init_test_38, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_compound_assign_int_nonliteral_rhs"
-    make_closure .<lambda($init_test_37, 2)>, 0
+    make_closure .<lambda($init_test_38, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_generic_fn_explicit_type_arg"
-    make_closure .<lambda($init_test_37, 3)>, 0
+    make_closure .<lambda($init_test_38, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_generic_method_class_type_arg"
-    make_closure .<lambda($init_test_37, 4)>, 0
+    make_closure .<lambda($init_test_38, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_generic_cmp_eq_int_true"
-    make_closure .<lambda($init_test_37, 5)>, 0
+    make_closure .<lambda($init_test_38, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_generic_cmp_eq_int_false"
-    make_closure .<lambda($init_test_37, 6)>, 0
+    make_closure .<lambda($init_test_38, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_generic_cmp_ordering"
-    make_closure .<lambda($init_test_37, 7)>, 0
+    make_closure .<lambda($init_test_38, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_generic_cmp_bigint_bigint"
-    make_closure .<lambda($init_test_37, 8)>, 0
+    make_closure .<lambda($init_test_38, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_constant_fold_add_narrows_to_literal_type"
-    make_closure .<lambda($init_test_37, 9)>, 0
+    make_closure .<lambda($init_test_38, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_constant_fold_mul_narrows"
-    make_closure .<lambda($init_test_37, 10)>, 0
+    make_closure .<lambda($init_test_38, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_constant_fold_comparison_to_bool"
-    make_closure .<lambda($init_test_37, 11)>, 0
+    make_closure .<lambda($init_test_38, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_constant_fold_negative_shift_refused"
-    make_closure .<lambda($init_test_37, 12)>, 0
+    make_closure .<lambda($init_test_38, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_compound_assign_int_in_lambda"
-    make_closure .<lambda($init_test_37, 13)>, 0
+    make_closure .<lambda($init_test_38, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_literal_small"
-    make_closure .<lambda($init_test_37, 14)>, 0
+    make_closure .<lambda($init_test_38, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_literal_large"
-    make_closure .<lambda($init_test_37, 15)>, 0
+    make_closure .<lambda($init_test_38, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_literal_negative"
-    make_closure .<lambda($init_test_37, 16)>, 0
+    make_closure .<lambda($init_test_38, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_literal_zero"
-    make_closure .<lambda($init_test_37, 17)>, 0
+    make_closure .<lambda($init_test_38, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_literal_let_binding"
-    make_closure .<lambda($init_test_37, 18)>, 0
+    make_closure .<lambda($init_test_38, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_parse_small"
-    make_closure .<lambda($init_test_37, 19)>, 0
+    make_closure .<lambda($init_test_38, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_parse_large"
-    make_closure .<lambda($init_test_37, 20)>, 0
+    make_closure .<lambda($init_test_38, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_parse_negative"
-    make_closure .<lambda($init_test_37, 21)>, 0
+    make_closure .<lambda($init_test_38, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_parse_zero"
-    make_closure .<lambda($init_test_37, 22)>, 0
+    make_closure .<lambda($init_test_38, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_parse_invalid_throws"
-    make_closure .<lambda($init_test_37, 23)>, 0
+    make_closure .<lambda($init_test_38, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_parse_empty_throws"
-    make_closure .<lambda($init_test_37, 24)>, 0
+    make_closure .<lambda($init_test_38, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_abs_positive"
-    make_closure .<lambda($init_test_37, 25)>, 0
+    make_closure .<lambda($init_test_38, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_abs_negative"
-    make_closure .<lambda($init_test_37, 26)>, 0
+    make_closure .<lambda($init_test_38, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_abs_zero"
-    make_closure .<lambda($init_test_37, 27)>, 0
+    make_closure .<lambda($init_test_38, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_abs_large_negative"
-    make_closure .<lambda($init_test_37, 28)>, 0
+    make_closure .<lambda($init_test_38, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_min_self_smaller"
-    make_closure .<lambda($init_test_37, 29)>, 0
+    make_closure .<lambda($init_test_38, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_min_other_smaller"
-    make_closure .<lambda($init_test_37, 30)>, 0
+    make_closure .<lambda($init_test_38, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_min_equal"
-    make_closure .<lambda($init_test_37, 31)>, 0
+    make_closure .<lambda($init_test_38, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_min_negative"
-    make_closure .<lambda($init_test_37, 32)>, 0
+    make_closure .<lambda($init_test_38, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_max_self_larger"
-    make_closure .<lambda($init_test_37, 33)>, 0
+    make_closure .<lambda($init_test_38, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_max_other_larger"
-    make_closure .<lambda($init_test_37, 34)>, 0
+    make_closure .<lambda($init_test_38, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_max_equal"
-    make_closure .<lambda($init_test_37, 35)>, 0
+    make_closure .<lambda($init_test_38, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_clamp_in_range"
-    make_closure .<lambda($init_test_37, 36)>, 0
+    make_closure .<lambda($init_test_38, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_clamp_below_min"
-    make_closure .<lambda($init_test_37, 37)>, 0
+    make_closure .<lambda($init_test_38, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_clamp_above_max"
-    make_closure .<lambda($init_test_37, 38)>, 0
+    make_closure .<lambda($init_test_38, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_clamp_at_min"
-    make_closure .<lambda($init_test_37, 39)>, 0
+    make_closure .<lambda($init_test_38, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_clamp_at_max"
-    make_closure .<lambda($init_test_37, 40)>, 0
+    make_closure .<lambda($init_test_38, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_isqrt_perfect_square"
-    make_closure .<lambda($init_test_37, 41)>, 0
+    make_closure .<lambda($init_test_38, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_isqrt_non_perfect_square"
-    make_closure .<lambda($init_test_37, 42)>, 0
+    make_closure .<lambda($init_test_38, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_isqrt_zero"
-    make_closure .<lambda($init_test_37, 43)>, 0
+    make_closure .<lambda($init_test_38, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_isqrt_one"
-    make_closure .<lambda($init_test_37, 44)>, 0
+    make_closure .<lambda($init_test_38, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_isqrt_negative_throws"
-    make_closure .<lambda($init_test_37, 45)>, 0
+    make_closure .<lambda($init_test_38, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_pow_basic"
-    make_closure .<lambda($init_test_37, 46)>, 0
+    make_closure .<lambda($init_test_38, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_pow_zero_exp"
-    make_closure .<lambda($init_test_37, 47)>, 0
+    make_closure .<lambda($init_test_38, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_pow_zero_base_zero_exp"
-    make_closure .<lambda($init_test_37, 48)>, 0
+    make_closure .<lambda($init_test_38, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_pow_negative_base"
-    make_closure .<lambda($init_test_37, 49)>, 0
+    make_closure .<lambda($init_test_38, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_pow_negative_exp_returns_zero"
-    make_closure .<lambda($init_test_37, 50)>, 0
+    make_closure .<lambda($init_test_38, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_pow_large"
-    make_closure .<lambda($init_test_37, 51)>, 0
+    make_closure .<lambda($init_test_38, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_ilog_base10"
-    make_closure .<lambda($init_test_37, 52)>, 0
+    make_closure .<lambda($init_test_38, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_ilog_base2"
-    make_closure .<lambda($init_test_37, 53)>, 0
+    make_closure .<lambda($init_test_38, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_ilog_one_returns_zero"
-    make_closure .<lambda($init_test_37, 54)>, 0
+    make_closure .<lambda($init_test_38, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_ilog_zero_throws"
-    make_closure .<lambda($init_test_37, 55)>, 0
+    make_closure .<lambda($init_test_38, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_ilog_negative_throws"
-    make_closure .<lambda($init_test_37, 56)>, 0
+    make_closure .<lambda($init_test_38, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_ilog_base_one_throws"
-    make_closure .<lambda($init_test_37, 57)>, 0
+    make_closure .<lambda($init_test_38, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_random_single_element_range"
-    make_closure .<lambda($init_test_37, 58)>, 0
+    make_closure .<lambda($init_test_38, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_random_in_range"
-    make_closure .<lambda($init_test_37, 59)>, 0
+    make_closure .<lambda($init_test_38, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_random_empty_range_throws"
-    make_closure .<lambda($init_test_37, 60)>, 0
+    make_closure .<lambda($init_test_38, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bigint_random_lower_greater_throws"
-    make_closure .<lambda($init_test_37, 61)>, 0
+    make_closure .<lambda($init_test_38, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_eq_same_alloc"
-    make_closure .<lambda($init_test_37, 62)>, 0
+    make_closure .<lambda($init_test_38, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_eq_distinct_allocs"
-    make_closure .<lambda($init_test_37, 63)>, 0
+    make_closure .<lambda($init_test_38, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_ordering_lt"
-    make_closure .<lambda($init_test_37, 64)>, 0
+    make_closure .<lambda($init_test_38, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_ordering_gt_eq"
-    make_closure .<lambda($init_test_37, 65)>, 0
+    make_closure .<lambda($init_test_38, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_ordering_ne"
-    make_closure .<lambda($init_test_37, 66)>, 0
+    make_closure .<lambda($init_test_38, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_ordering_large"
-    make_closure .<lambda($init_test_37, 67)>, 0
+    make_closure .<lambda($init_test_38, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_arithmetic_add"
-    make_closure .<lambda($init_test_37, 68)>, 0
+    make_closure .<lambda($init_test_38, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_arithmetic_sub"
-    make_closure .<lambda($init_test_37, 69)>, 0
+    make_closure .<lambda($init_test_38, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_arithmetic_mul"
-    make_closure .<lambda($init_test_37, 70)>, 0
+    make_closure .<lambda($init_test_38, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_arithmetic_div"
-    make_closure .<lambda($init_test_37, 71)>, 0
+    make_closure .<lambda($init_test_38, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_arithmetic_mod"
-    make_closure .<lambda($init_test_37, 72)>, 0
+    make_closure .<lambda($init_test_38, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_bitwise_and"
-    make_closure .<lambda($init_test_37, 73)>, 0
+    make_closure .<lambda($init_test_38, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_bitwise_or"
-    make_closure .<lambda($init_test_37, 74)>, 0
+    make_closure .<lambda($init_test_38, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_bitwise_xor"
-    make_closure .<lambda($init_test_37, 75)>, 0
+    make_closure .<lambda($init_test_38, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_bitwise_shl"
-    make_closure .<lambda($init_test_37, 76)>, 0
+    make_closure .<lambda($init_test_38, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_bitwise_shr"
-    make_closure .<lambda($init_test_37, 77)>, 0
+    make_closure .<lambda($init_test_38, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_bitwise_negative"
-    make_closure .<lambda($init_test_37, 78)>, 0
+    make_closure .<lambda($init_test_38, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_div_by_zero"
-    make_closure .<lambda($init_test_37, 79)>, 0
+    make_closure .<lambda($init_test_38, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_mod_by_zero"
-    make_closure .<lambda($init_test_37, 80)>, 0
+    make_closure .<lambda($init_test_38, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_arithmetic_huge"
-    make_closure .<lambda($init_test_37, 81)>, 0
+    make_closure .<lambda($init_test_38, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_add_left"
-    make_closure .<lambda($init_test_37, 82)>, 0
+    make_closure .<lambda($init_test_38, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_add_right"
-    make_closure .<lambda($init_test_37, 83)>, 0
+    make_closure .<lambda($init_test_38, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_mul"
-    make_closure .<lambda($init_test_37, 84)>, 0
+    make_closure .<lambda($init_test_38, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_shl"
-    make_closure .<lambda($init_test_37, 85)>, 0
+    make_closure .<lambda($init_test_38, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_bitand_neg_one_with_mask"
-    make_closure .<lambda($init_test_37, 86)>, 0
+    make_closure .<lambda($init_test_38, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_bitor"
-    make_closure .<lambda($init_test_37, 87)>, 0
+    make_closure .<lambda($init_test_38, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_bitxor"
-    make_closure .<lambda($init_test_37, 88)>, 0
+    make_closure .<lambda($init_test_38, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_shr"
-    make_closure .<lambda($init_test_37, 89)>, 0
+    make_closure .<lambda($init_test_38, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_comparison_gt"
-    make_closure .<lambda($init_test_37, 90)>, 0
+    make_closure .<lambda($init_test_38, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_int_mixed_comparison_eq"
-    make_closure .<lambda($init_test_37, 91)>, 0
+    make_closure .<lambda($init_test_38, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_alloc_failure"
-    make_closure .<lambda($init_test_37, 92)>, 0
+    make_closure .<lambda($init_test_38, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_shl_alloc_failure"
-    make_closure .<lambda($init_test_37, 93)>, 0
+    make_closure .<lambda($init_test_38, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_shl_negative_shift"
-    make_closure .<lambda($init_test_37, 94)>, 0
+    make_closure .<lambda($init_test_38, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_shr_negative_shift"
-    make_closure .<lambda($init_test_37, 95)>, 0
+    make_closure .<lambda($init_test_38, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_mul_pre_flight_alloc_failure"
-    make_closure .<lambda($init_test_37, 96)>, 0
+    make_closure .<lambda($init_test_38, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_normal_works"
-    make_closure .<lambda($init_test_37, 97)>, 0
+    make_closure .<lambda($init_test_38, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_neg_exp_one"
-    make_closure .<lambda($init_test_37, 98)>, 0
+    make_closure .<lambda($init_test_38, 98)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_neg_exp_neg_one"
-    make_closure .<lambda($init_test_37, 99)>, 0
+    make_closure .<lambda($init_test_38, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_neg_exp_zero_base"
-    make_closure .<lambda($init_test_37, 100)>, 0
+    make_closure .<lambda($init_test_38, 100)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_zero_zero"
-    make_closure .<lambda($init_test_37, 101)>, 0
+    make_closure .<lambda($init_test_38, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_one_huge_exponent"
-    make_closure .<lambda($init_test_37, 102)>, 0
+    make_closure .<lambda($init_test_38, 102)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_neg_one_huge_even"
-    make_closure .<lambda($init_test_37, 103)>, 0
+    make_closure .<lambda($init_test_38, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_neg_one_huge_odd"
-    make_closure .<lambda($init_test_37, 104)>, 0
+    make_closure .<lambda($init_test_38, 104)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_pow_zero_huge_exponent"
-    make_closure .<lambda($init_test_37, 105)>, 0
+    make_closure .<lambda($init_test_38, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_ilog_base_two"
-    make_closure .<lambda($init_test_37, 106)>, 0
+    make_closure .<lambda($init_test_38, 106)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_ilog_base_ten"
-    make_closure .<lambda($init_test_37, 107)>, 0
+    make_closure .<lambda($init_test_38, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_ilog_large_input"
-    make_closure .<lambda($init_test_37, 108)>, 0
+    make_closure .<lambda($init_test_38, 108)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_ilog_floor"
-    make_closure .<lambda($init_test_37, 109)>, 0
+    make_closure .<lambda($init_test_38, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_to_json_returns_string"
-    make_closure .<lambda($init_test_37, 110)>, 0
+    make_closure .<lambda($init_test_38, 110)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "test_bigint_to_json_large"
-    make_closure .<lambda($init_test_37, 111)>, 0
+    make_closure .<lambda($init_test_38, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/builtins.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/builtins.snap
@@ -1,28 +1,28 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function builtins.$init_test_38(registry: testing.TestCollector) -> null {
+function builtins.$init_test_39(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "builtin_method_call"
-    make_closure .<lambda($init_test_38, 0)>, 0
+    make_closure .<lambda($init_test_39, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bind_method_call"
-    make_closure .<lambda($init_test_38, 1)>, 0
+    make_closure .<lambda($init_test_39, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "any_value_to_string"
-    make_closure .<lambda($init_test_38, 2)>, 0
+    make_closure .<lambda($init_test_39, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_to_string_preserves_decimal"
-    make_closure .<lambda($init_test_38, 3)>, 0
+    make_closure .<lambda($init_test_39, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/byte_strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/byte_strings.snap
@@ -1,166 +1,166 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function byte_strings.$init_test_39(registry: testing.TestCollector) -> null {
+function byte_strings.$init_test_40(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "literal_basic"
-    make_closure .<lambda($init_test_39, 0)>, 0
+    make_closure .<lambda($init_test_40, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "literal_empty"
-    make_closure .<lambda($init_test_39, 1)>, 0
+    make_closure .<lambda($init_test_40, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "literal_hex_escapes"
-    make_closure .<lambda($init_test_39, 2)>, 0
+    make_closure .<lambda($init_test_40, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "literal_standard_escapes"
-    make_closure .<lambda($init_test_39, 3)>, 0
+    make_closure .<lambda($init_test_40, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "literal_mixed_ascii_and_hex"
-    make_closure .<lambda($init_test_39, 4)>, 0
+    make_closure .<lambda($init_test_40, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "length_basic"
-    make_closure .<lambda($init_test_39, 5)>, 0
+    make_closure .<lambda($init_test_40, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "length_empty"
-    make_closure .<lambda($init_test_39, 6)>, 0
+    make_closure .<lambda($init_test_40, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "at_valid_index"
-    make_closure .<lambda($init_test_39, 7)>, 0
+    make_closure .<lambda($init_test_40, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "at_out_of_bounds"
-    make_closure .<lambda($init_test_39, 8)>, 0
+    make_closure .<lambda($init_test_40, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "at_negative_index"
-    make_closure .<lambda($init_test_39, 9)>, 0
+    make_closure .<lambda($init_test_40, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "zeroes_basic"
-    make_closure .<lambda($init_test_39, 10)>, 0
+    make_closure .<lambda($init_test_40, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "index_read"
-    make_closure .<lambda($init_test_39, 11)>, 0
+    make_closure .<lambda($init_test_40, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "index_write"
-    make_closure .<lambda($init_test_39, 12)>, 0
+    make_closure .<lambda($init_test_40, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "index_write_out_of_range"
-    make_closure .<lambda($init_test_39, 13)>, 0
+    make_closure .<lambda($init_test_40, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "index_out_of_bounds"
-    make_closure .<lambda($init_test_39, 14)>, 0
+    make_closure .<lambda($init_test_40, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "index_negative"
-    make_closure .<lambda($init_test_39, 15)>, 0
+    make_closure .<lambda($init_test_40, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "return_uint8array"
-    make_closure .<lambda($init_test_39, 16)>, 0
+    make_closure .<lambda($init_test_40, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "equality_same_content"
-    make_closure .<lambda($init_test_39, 17)>, 0
+    make_closure .<lambda($init_test_40, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "equality_different_content"
-    make_closure .<lambda($init_test_39, 18)>, 0
+    make_closure .<lambda($init_test_40, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "equality_empty"
-    make_closure .<lambda($init_test_39, 19)>, 0
+    make_closure .<lambda($init_test_40, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "equality_different_lengths"
-    make_closure .<lambda($init_test_39, 20)>, 0
+    make_closure .<lambda($init_test_40, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "equality_different_lengths_reversed"
-    make_closure .<lambda($init_test_39, 21)>, 0
+    make_closure .<lambda($init_test_40, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "inequality_same"
-    make_closure .<lambda($init_test_39, 22)>, 0
+    make_closure .<lambda($init_test_40, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "inequality_different"
-    make_closure .<lambda($init_test_39, 23)>, 0
+    make_closure .<lambda($init_test_40, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "b_as_identifier"
-    make_closure .<lambda($init_test_39, 24)>, 0
+    make_closure .<lambda($init_test_40, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "literal_as_call_argument"
-    make_closure .<lambda($init_test_39, 25)>, 0
+    make_closure .<lambda($init_test_40, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "index_read_direct"
-    make_closure .<lambda($init_test_39, 26)>, 0
+    make_closure .<lambda($init_test_40, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function cancel_cascade.$init_test_40(registry: testing.TestCollector) -> null {
+function cancel_cascade.$init_test_41(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "cancel_from_handle_then_await_catches_cancelled"
-    make_closure .<lambda($init_test_40, 0)>, 0
+    make_closure .<lambda($init_test_41, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "cancelled_child_future_state_is_cancelled"
-    make_closure .<lambda($init_test_40, 1)>, 0
+    make_closure .<lambda($init_test_41, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -26,6 +26,7 @@ function cancel_cascade.boom_io() -> int {
 
 function cancel_cascade.cancel_from_handle_then_await_catches_cancelled() -> int {
     make_closure .<lambda(cancel_from_handle_then_await_catches_cancelled, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3
@@ -58,12 +59,14 @@ function cancel_cascade.cancelled_child_future_state_is_cancelled() -> baml.futu
     store_var ?1
     make_closure .<lambda(cancelled_child_future_state_is_cancelled, 0)>, 0
     load_const null
+    load_const null
     spawn
     store_var _3
     load_var _3
     store_deref ?1
     load_var slow
     make_closure .<lambda(cancelled_child_future_state_is_cancelled, 1)>, 1
+    load_const null
     load_const null
     spawn
     store_var _6

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_token.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_token.snap
@@ -20,6 +20,12 @@ function cancel_token.$init_test_42(registry: testing.TestCollector) -> null {
     load_const null
     call testing.TestCollector.register_test
     pop 1
+    load_var registry
+    load_const "detached_spawn_completes"
+    make_closure .<lambda($init_test_42, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
     load_const null
     return
 }
@@ -29,6 +35,7 @@ function cancel_token.await_token_cancelled_catches() -> int {
     store_var tok
     load_const <omitted>
     load_var tok
+    load_const <omitted>
     call baml.spawn.options
     store_var _4
     make_closure .<lambda(await_token_cancelled_catches, 0)>, 0
@@ -58,6 +65,22 @@ function cancel_token.await_token_cancelled_catches() -> int {
     return
 }
 
+function cancel_token.detached_spawn_completes() -> int {
+    load_const <omitted>
+    load_const <omitted>
+    load_const true
+    call baml.spawn.options
+    store_var _3
+    make_closure .<lambda(detached_spawn_completes, 0)>, 0
+    load_const null
+    load_var _3
+    spawn
+    store_var _4
+    load_var _4
+    await
+    return
+}
+
 function cancel_token.token_is_cancelled_reflects_cancel() -> bool[] {
     call baml.spawn.CancelToken.new
     store_var tok
@@ -81,6 +104,7 @@ function cancel_token.uncancelled_token_completes() -> int {
     store_var tok
     load_const <omitted>
     load_var tok
+    load_const <omitted>
     call baml.spawn.options
     store_var _4
     make_closure .<lambda(uncancelled_token_completes, 0)>, 0

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_token.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_token.snap
@@ -1,0 +1,94 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function cancel_token.$init_test_42(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "await_token_cancelled_catches"
+    make_closure .<lambda($init_test_42, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "uncancelled_token_completes"
+    make_closure .<lambda($init_test_42, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "token_is_cancelled_reflects_cancel"
+    make_closure .<lambda($init_test_42, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_const null
+    return
+}
+
+function cancel_token.await_token_cancelled_catches() -> int {
+    call baml.spawn.CancelToken.new
+    store_var tok
+    load_const <omitted>
+    load_var tok
+    call baml.spawn.options
+    store_var _4
+    make_closure .<lambda(await_token_cancelled_catches, 0)>, 0
+    load_const null
+    load_var _4
+    spawn
+    store_var _6
+    load_var tok
+    call baml.spawn.CancelToken.cancel
+    pop 1
+    load_var _6
+    await
+    jump L2
+    load_var e
+    is_type baml.panics.Cancelled
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    throw
+
+  L1:
+    load_const 0
+
+  L2:
+    return
+}
+
+function cancel_token.token_is_cancelled_reflects_cancel() -> bool[] {
+    call baml.spawn.CancelToken.new
+    store_var tok
+    load_var tok
+    call baml.spawn.CancelToken.is_cancelled
+    store_var before
+    load_var tok
+    call baml.spawn.CancelToken.cancel
+    pop 1
+    load_var tok
+    call baml.spawn.CancelToken.is_cancelled
+    store_var after
+    load_var before
+    load_var after
+    alloc_array 2
+    return
+}
+
+function cancel_token.uncancelled_token_completes() -> int {
+    call baml.spawn.CancelToken.new
+    store_var tok
+    load_const <omitted>
+    load_var tok
+    call baml.spawn.options
+    store_var _4
+    make_closure .<lambda(uncancelled_token_completes, 0)>, 0
+    load_const null
+    load_var _4
+    spawn
+    store_var _6
+    load_var _6
+    await
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/class_type_args_at_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/class_type_args_at_runtime.snap
@@ -1,64 +1,64 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function class_type_args_at_runtime.$init_test_41(registry: testing.TestCollector) -> null {
+function class_type_args_at_runtime.$init_test_43(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "method_sees_class_type_arg_int"
-    make_closure .<lambda($init_test_41, 0)>, 0
+    make_closure .<lambda($init_test_43, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "method_sees_class_type_arg_string"
-    make_closure .<lambda($init_test_41, 1)>, 0
+    make_closure .<lambda($init_test_43, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "method_sees_composite_class_type_arg"
-    make_closure .<lambda($init_test_41, 2)>, 0
+    make_closure .<lambda($init_test_43, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_dispatch_generic_class_int"
-    make_closure .<lambda($init_test_41, 3)>, 0
+    make_closure .<lambda($init_test_43, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_dispatch_generic_class_string"
-    make_closure .<lambda($init_test_41, 4)>, 0
+    make_closure .<lambda($init_test_43, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_type_parametric_class_same_args"
-    make_closure .<lambda($init_test_41, 5)>, 0
+    make_closure .<lambda($init_test_43, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_type_parametric_class_different_args"
-    make_closure .<lambda($init_test_41, 6)>, 0
+    make_closure .<lambda($init_test_43, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_type_bare_class_still_matches"
-    make_closure .<lambda($init_test_41, 7)>, 0
+    make_closure .<lambda($init_test_43, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "closure_inside_method_captures_class_type_arg"
-    make_closure .<lambda($init_test_41, 8)>, 0
+    make_closure .<lambda($init_test_43, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "closure_inside_method_survives_gc"
-    make_closure .<lambda($init_test_41, 9)>, 0
+    make_closure .<lambda($init_test_43, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/classes.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/classes.snap
@@ -1,118 +1,118 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function classes.$init_test_42(registry: testing.TestCollector) -> null {
+function classes.$init_test_44(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "class_constructor"
-    make_closure .<lambda($init_test_42, 0)>, 0
+    make_closure .<lambda($init_test_44, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_constructor_return_directly"
-    make_closure .<lambda($init_test_42, 1)>, 0
+    make_closure .<lambda($init_test_44, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "constructor_with_preceding_variables"
-    make_closure .<lambda($init_test_42, 2)>, 0
+    make_closure .<lambda($init_test_44, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_construction_dead_store"
-    make_closure .<lambda($init_test_42, 3)>, 0
+    make_closure .<lambda($init_test_44, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_construction_field_access"
-    make_closure .<lambda($init_test_42, 4)>, 0
+    make_closure .<lambda($init_test_44, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_construction_inner_field_access"
-    make_closure .<lambda($init_test_42, 5)>, 0
+    make_closure .<lambda($init_test_44, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_field_read"
-    make_closure .<lambda($init_test_42, 6)>, 0
+    make_closure .<lambda($init_test_44, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_field_read_separate_construction"
-    make_closure .<lambda($init_test_42, 7)>, 0
+    make_closure .<lambda($init_test_44, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_constructor_with_preceding_variables"
-    make_closure .<lambda($init_test_42, 8)>, 0
+    make_closure .<lambda($init_test_44, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "spread_before_named_fields"
-    make_closure .<lambda($init_test_42, 9)>, 0
+    make_closure .<lambda($init_test_44, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "spread_after_named_fields"
-    make_closure .<lambda($init_test_42, 10)>, 0
+    make_closure .<lambda($init_test_44, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multiple_spreads"
-    make_closure .<lambda($init_test_42, 11)>, 0
+    make_closure .<lambda($init_test_44, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "spread_does_not_break_locals"
-    make_closure .<lambda($init_test_42, 12)>, 0
+    make_closure .<lambda($init_test_44, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_assignment"
-    make_closure .<lambda($init_test_42, 13)>, 0
+    make_closure .<lambda($init_test_44, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_compound_assignment"
-    make_closure .<lambda($init_test_42, 14)>, 0
+    make_closure .<lambda($init_test_44, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_field_assignment"
-    make_closure .<lambda($init_test_42, 15)>, 0
+    make_closure .<lambda($init_test_44, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_field_compound_assignment"
-    make_closure .<lambda($init_test_42, 16)>, 0
+    make_closure .<lambda($init_test_44, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "method_call"
-    make_closure .<lambda($init_test_42, 17)>, 0
+    make_closure .<lambda($init_test_44, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mutable_self_method"
-    make_closure .<lambda($init_test_42, 18)>, 0
+    make_closure .<lambda($init_test_44, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
@@ -1,64 +1,64 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function closures.$init_test_43(registry: testing.TestCollector) -> null {
+function closures.$init_test_45(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "bound_formatter_mapper"
-    make_closure .<lambda($init_test_43, 0)>, 0
+    make_closure .<lambda($init_test_45, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "unbound_in_map"
-    make_closure .<lambda($init_test_43, 1)>, 0
+    make_closure .<lambda($init_test_45, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bound_validator_mapped"
-    make_closure .<lambda($init_test_43, 2)>, 0
+    make_closure .<lambda($init_test_45, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mutation_after_bind"
-    make_closure .<lambda($init_test_43, 3)>, 0
+    make_closure .<lambda($init_test_45, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "repeated_bound_calls"
-    make_closure .<lambda($init_test_43, 4)>, 0
+    make_closure .<lambda($init_test_45, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "field_chain_bind"
-    make_closure .<lambda($init_test_43, 5)>, 0
+    make_closure .<lambda($init_test_45, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "strategy_swap"
-    make_closure .<lambda($init_test_43, 6)>, 0
+    make_closure .<lambda($init_test_45, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_unwrap"
-    make_closure .<lambda($init_test_43, 7)>, 0
+    make_closure .<lambda($init_test_45, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bound_in_lambda"
-    make_closure .<lambda($init_test_43, 8)>, 0
+    make_closure .<lambda($init_test_45, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bound_throwing_method_reference_catches_error"
-    make_closure .<lambda($init_test_43, 9)>, 0
+    make_closure .<lambda($init_test_45, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/deep_copy.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/deep_copy.snap
@@ -1,100 +1,100 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function deep_copy.$init_test_44(registry: testing.TestCollector) -> null {
+function deep_copy.$init_test_46(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "deep_copy_object"
-    make_closure .<lambda($init_test_44, 0)>, 0
+    make_closure .<lambda($init_test_46, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_copy_independence"
-    make_closure .<lambda($init_test_44, 1)>, 0
+    make_closure .<lambda($init_test_46, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_copy_nested_arrays_in_class"
-    make_closure .<lambda($init_test_44, 2)>, 0
+    make_closure .<lambda($init_test_46, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_copy_map_in_class"
-    make_closure .<lambda($init_test_44, 3)>, 0
+    make_closure .<lambda($init_test_46, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_copy_complex_nested_structure"
-    make_closure .<lambda($init_test_44, 4)>, 0
+    make_closure .<lambda($init_test_46, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_copy_circular_reference"
-    make_closure .<lambda($init_test_44, 5)>, 0
+    make_closure .<lambda($init_test_46, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_primitives"
-    make_closure .<lambda($init_test_44, 6)>, 0
+    make_closure .<lambda($init_test_46, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_different_primitives"
-    make_closure .<lambda($init_test_44, 7)>, 0
+    make_closure .<lambda($init_test_46, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_simple_objects"
-    make_closure .<lambda($init_test_44, 8)>, 0
+    make_closure .<lambda($init_test_46, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_different_objects"
-    make_closure .<lambda($init_test_44, 9)>, 0
+    make_closure .<lambda($init_test_46, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_nested_objects"
-    make_closure .<lambda($init_test_44, 10)>, 0
+    make_closure .<lambda($init_test_46, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_nested_objects_different"
-    make_closure .<lambda($init_test_44, 11)>, 0
+    make_closure .<lambda($init_test_46, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_with_arrays"
-    make_closure .<lambda($init_test_44, 12)>, 0
+    make_closure .<lambda($init_test_46, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_with_maps"
-    make_closure .<lambda($init_test_44, 13)>, 0
+    make_closure .<lambda($init_test_46, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_same_reference"
-    make_closure .<lambda($init_test_44, 14)>, 0
+    make_closure .<lambda($init_test_46, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_circular_structure"
-    make_closure .<lambda($init_test_44, 15)>, 0
+    make_closure .<lambda($init_test_46, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/enums.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/enums.snap
@@ -1,22 +1,22 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function enums.$init_test_45(registry: testing.TestCollector) -> null {
+function enums.$init_test_47(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "return_enum_variant"
-    make_closure .<lambda($init_test_45, 0)>, 0
+    make_closure .<lambda($init_test_47, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_enum_variant"
-    make_closure .<lambda($init_test_45, 1)>, 0
+    make_closure .<lambda($init_test_47, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "pass_enum_variant_to_function"
-    make_closure .<lambda($init_test_45, 2)>, 0
+    make_closure .<lambda($init_test_47, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/env.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/env.snap
@@ -1,22 +1,22 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function env.$init_test_46(registry: testing.TestCollector) -> null {
+function env.$init_test_48(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "env_get_or_panic_missing_var"
-    make_closure .<lambda($init_test_46, 0)>, 0
+    make_closure .<lambda($init_test_48, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "env_get_missing_var_returns_null"
-    make_closure .<lambda($init_test_46, 1)>, 0
+    make_closure .<lambda($init_test_48, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "env_sugar_missing_var"
-    make_closure .<lambda($init_test_46, 2)>, 0
+    make_closure .<lambda($init_test_48, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/exceptions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/exceptions.snap
@@ -1,526 +1,526 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function exceptions.$init_test_48(registry: testing.TestCollector) -> null {
+function exceptions.$init_test_50(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "catch_literal_string_match"
-    make_closure .<lambda($init_test_48, 0)>, 0
+    make_closure .<lambda($init_test_50, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_literal_string_no_match_falls_to_wildcard"
-    make_closure .<lambda($init_test_48, 1)>, 0
+    make_closure .<lambda($init_test_50, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_literal_int_match"
-    make_closure .<lambda($init_test_48, 2)>, 0
+    make_closure .<lambda($init_test_50, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_multiple_literals_dispatch"
-    make_closure .<lambda($init_test_48, 3)>, 0
+    make_closure .<lambda($init_test_50, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "typed_binding_string"
-    make_closure .<lambda($init_test_48, 4)>, 0
+    make_closure .<lambda($init_test_50, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "typed_binding_int"
-    make_closure .<lambda($init_test_48, 5)>, 0
+    make_closure .<lambda($init_test_50, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "typed_binding_dispatch_string_vs_int"
-    make_closure .<lambda($init_test_48, 6)>, 0
+    make_closure .<lambda($init_test_50, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "typed_binding_dispatch_int_vs_string"
-    make_closure .<lambda($init_test_48, 7)>, 0
+    make_closure .<lambda($init_test_50, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "typed_binding_plus_wildcard"
-    make_closure .<lambda($init_test_48, 8)>, 0
+    make_closure .<lambda($init_test_50, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_binding_string_access_value"
-    make_closure .<lambda($init_test_48, 9)>, 0
+    make_closure .<lambda($init_test_50, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_binding_int_access_value"
-    make_closure .<lambda($init_test_48, 10)>, 0
+    make_closure .<lambda($init_test_50, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_user_class_single_arm"
-    make_closure .<lambda($init_test_48, 11)>, 0
+    make_closure .<lambda($init_test_50, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_two_user_classes_dispatch_first"
-    make_closure .<lambda($init_test_48, 12)>, 0
+    make_closure .<lambda($init_test_50, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_two_user_classes_dispatch_second"
-    make_closure .<lambda($init_test_48, 13)>, 0
+    make_closure .<lambda($init_test_50, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_user_class_plus_wildcard"
-    make_closure .<lambda($init_test_48, 14)>, 0
+    make_closure .<lambda($init_test_50, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_three_user_classes_plus_wildcard"
-    make_closure .<lambda($init_test_48, 15)>, 0
+    make_closure .<lambda($init_test_50, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_class_binding_access_field"
-    make_closure .<lambda($init_test_48, 16)>, 0
+    make_closure .<lambda($init_test_50, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_class_binding_dispatch_access_fields"
-    make_closure .<lambda($init_test_48, 17)>, 0
+    make_closure .<lambda($init_test_50, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bare_class_single_arm"
-    make_closure .<lambda($init_test_48, 18)>, 0
+    make_closure .<lambda($init_test_50, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bare_class_dispatch_first"
-    make_closure .<lambda($init_test_48, 19)>, 0
+    make_closure .<lambda($init_test_50, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bare_class_dispatch_second"
-    make_closure .<lambda($init_test_48, 20)>, 0
+    make_closure .<lambda($init_test_50, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bare_class_plus_wildcard"
-    make_closure .<lambda($init_test_48, 21)>, 0
+    make_closure .<lambda($init_test_50, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bare_class_plus_wildcard_wildcard_fires"
-    make_closure .<lambda($init_test_48, 22)>, 0
+    make_closure .<lambda($init_test_50, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "unhandled_throw_string"
-    make_closure .<lambda($init_test_48, 23)>, 0
+    make_closure .<lambda($init_test_50, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "unhandled_throw_int"
-    make_closure .<lambda($init_test_48, 24)>, 0
+    make_closure .<lambda($init_test_50, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_division_by_zero"
-    make_closure .<lambda($init_test_48, 25)>, 0
+    make_closure .<lambda($init_test_50, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_index_out_of_bounds"
-    make_closure .<lambda($init_test_48, 26)>, 0
+    make_closure .<lambda($init_test_50, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_map_key_not_found"
-    make_closure .<lambda($init_test_48, 27)>, 0
+    make_closure .<lambda($init_test_50, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_negative_index_as_index_out_of_bounds"
-    make_closure .<lambda($init_test_48, 28)>, 0
+    make_closure .<lambda($init_test_50, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_panic_binding_division_by_zero_field"
-    make_closure .<lambda($init_test_48, 29)>, 0
+    make_closure .<lambda($init_test_50, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_panic_binding_index_out_of_bounds_fields"
-    make_closure .<lambda($init_test_48, 30)>, 0
+    make_closure .<lambda($init_test_50, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_panic_binding_index_out_of_bounds_length"
-    make_closure .<lambda($init_test_48, 31)>, 0
+    make_closure .<lambda($init_test_50, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_panic_binding_map_key_not_found_field"
-    make_closure .<lambda($init_test_48, 32)>, 0
+    make_closure .<lambda($init_test_50, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "wildcard_skips_division_by_zero"
-    make_closure .<lambda($init_test_48, 33)>, 0
+    make_closure .<lambda($init_test_50, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "wildcard_skips_index_out_of_bounds"
-    make_closure .<lambda($init_test_48, 34)>, 0
+    make_closure .<lambda($init_test_50, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "panic_arm_plus_wildcard_panic_fires"
-    make_closure .<lambda($init_test_48, 35)>, 0
+    make_closure .<lambda($init_test_50, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "panic_arm_plus_wildcard_user_error_fires"
-    make_closure .<lambda($init_test_48, 36)>, 0
+    make_closure .<lambda($init_test_50, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "panic_arm_plus_wildcard_no_error"
-    make_closure .<lambda($init_test_48, 37)>, 0
+    make_closure .<lambda($init_test_50, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "user_class_plus_panic_plus_wildcard_class_fires"
-    make_closure .<lambda($init_test_48, 38)>, 0
+    make_closure .<lambda($init_test_50, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "user_class_plus_panic_plus_wildcard_panic_fires"
-    make_closure .<lambda($init_test_48, 39)>, 0
+    make_closure .<lambda($init_test_50, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "user_class_plus_panic_plus_wildcard_string_fires"
-    make_closure .<lambda($init_test_48, 40)>, 0
+    make_closure .<lambda($init_test_50, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_arm_plus_wildcard_panic_fires"
-    make_closure .<lambda($init_test_48, 41)>, 0
+    make_closure .<lambda($init_test_50, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_arm_plus_wildcard_user_error_fires"
-    make_closure .<lambda($init_test_48, 42)>, 0
+    make_closure .<lambda($init_test_50, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_arm_plus_wildcard_fallback_error_fires"
-    make_closure .<lambda($init_test_48, 43)>, 0
+    make_closure .<lambda($init_test_50, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_arm_plus_wildcard_other_panic_propagates"
-    make_closure .<lambda($init_test_48, 44)>, 0
+    make_closure .<lambda($init_test_50, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_alias_plus_wildcard_handles_both_domains"
-    make_closure .<lambda($init_test_48, 45)>, 0
+    make_closure .<lambda($init_test_50, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_alias_plus_wildcard_error_fires"
-    make_closure .<lambda($init_test_48, 46)>, 0
+    make_closure .<lambda($init_test_50, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_no_wildcard_panic_fires"
-    make_closure .<lambda($init_test_48, 47)>, 0
+    make_closure .<lambda($init_test_50, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_no_wildcard_error_fires"
-    make_closure .<lambda($init_test_48, 48)>, 0
+    make_closure .<lambda($init_test_50, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_no_wildcard_unmatched_rethrows"
-    make_closure .<lambda($init_test_48, 49)>, 0
+    make_closure .<lambda($init_test_50, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_union_no_wildcard_unmatched_panic_rethrows"
-    make_closure .<lambda($init_test_48, 50)>, 0
+    make_closure .<lambda($init_test_50, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "panic_union_plus_wildcard_division_fires"
-    make_closure .<lambda($init_test_48, 51)>, 0
+    make_closure .<lambda($init_test_50, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "panic_union_plus_wildcard_index_fires"
-    make_closure .<lambda($init_test_48, 52)>, 0
+    make_closure .<lambda($init_test_50, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "panic_union_plus_wildcard_error_falls_to_wildcard"
-    make_closure .<lambda($init_test_48, 53)>, 0
+    make_closure .<lambda($init_test_50, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "four_arms_division_by_zero_fires"
-    make_closure .<lambda($init_test_48, 54)>, 0
+    make_closure .<lambda($init_test_50, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "four_arms_index_out_of_bounds_fires"
-    make_closure .<lambda($init_test_48, 55)>, 0
+    make_closure .<lambda($init_test_50, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "four_arms_user_class_fires"
-    make_closure .<lambda($init_test_48, 56)>, 0
+    make_closure .<lambda($init_test_50, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "four_arms_wildcard_fires"
-    make_closure .<lambda($init_test_48, 57)>, 0
+    make_closure .<lambda($init_test_50, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "four_arms_no_error"
-    make_closure .<lambda($init_test_48, 58)>, 0
+    make_closure .<lambda($init_test_50, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "uncaught_division_by_zero"
-    make_closure .<lambda($init_test_48, 59)>, 0
+    make_closure .<lambda($init_test_50, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "uncaught_index_out_of_bounds"
-    make_closure .<lambda($init_test_48, 60)>, 0
+    make_closure .<lambda($init_test_50, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "wrong_panic_pattern_propagates"
-    make_closure .<lambda($init_test_48, 61)>, 0
+    make_closure .<lambda($init_test_50, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "same_frame_division_caught"
-    make_closure .<lambda($init_test_48, 62)>, 0
+    make_closure .<lambda($init_test_50, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "same_frame_index_out_of_bounds_caught"
-    make_closure .<lambda($init_test_48, 63)>, 0
+    make_closure .<lambda($init_test_50, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "panic_alias_catches_any_panic"
-    make_closure .<lambda($init_test_48, 64)>, 0
+    make_closure .<lambda($init_test_50, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "panic_alias_plus_wildcard_dispatch"
-    make_closure .<lambda($init_test_48, 65)>, 0
+    make_closure .<lambda($init_test_50, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_inner_catches_outer_does_not_fire"
-    make_closure .<lambda($init_test_48, 66)>, 0
+    make_closure .<lambda($init_test_50, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_inner_catches_panic_outer_catches_rethrow"
-    make_closure .<lambda($init_test_48, 67)>, 0
+    make_closure .<lambda($init_test_50, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rethrow_propagates_to_outer"
-    make_closure .<lambda($init_test_48, 68)>, 0
+    make_closure .<lambda($init_test_50, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "sequential_catches_both_recover"
-    make_closure .<lambda($init_test_48, 69)>, 0
+    make_closure .<lambda($init_test_50, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "inline_throw_catch"
-    make_closure .<lambda($init_test_48, 70)>, 0
+    make_closure .<lambda($init_test_50, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "throw_in_match_arm_propagates"
-    make_closure .<lambda($init_test_48, 71)>, 0
+    make_closure .<lambda($init_test_50, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "caught_panic_has_accessible_fields"
-    make_closure .<lambda($init_test_48, 72)>, 0
+    make_closure .<lambda($init_test_50, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_four_primitive_type_arms"
-    make_closure .<lambda($init_test_48, 73)>, 0
+    make_closure .<lambda($init_test_50, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_four_typed_arms_plus_bind_jump_table_rethrows_panic"
-    make_closure .<lambda($init_test_48, 74)>, 0
+    make_closure .<lambda($init_test_50, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_four_primitive_wildcard_on_float"
-    make_closure .<lambda($init_test_48, 75)>, 0
+    make_closure .<lambda($init_test_50, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_three_type_arms_bool_throw"
-    make_closure .<lambda($init_test_48, 76)>, 0
+    make_closure .<lambda($init_test_50, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_four_user_classes_instanceof_chain"
-    make_closure .<lambda($init_test_48, 77)>, 0
+    make_closure .<lambda($init_test_50, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_four_literal_arms"
-    make_closure .<lambda($init_test_48, 78)>, 0
+    make_closure .<lambda($init_test_50, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_mixed_named_and_anonymous_bindings"
-    make_closure .<lambda($init_test_48, 79)>, 0
+    make_closure .<lambda($init_test_50, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_four_typed_arms_jump_table"
-    make_closure .<lambda($init_test_48, 80)>, 0
+    make_closure .<lambda($init_test_50, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_four_typed_arms_plus_wildcard_jump_table"
-    make_closure .<lambda($init_test_48, 81)>, 0
+    make_closure .<lambda($init_test_50, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_two_typed_arms_sequential_chain"
-    make_closure .<lambda($init_test_48, 82)>, 0
+    make_closure .<lambda($init_test_50, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_mixed_literal_and_typed_no_switch"
-    make_closure .<lambda($init_test_48, 83)>, 0
+    make_closure .<lambda($init_test_50, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_without_stack_trace_still_works"
-    make_closure .<lambda($init_test_48, 84)>, 0
+    make_closure .<lambda($init_test_50, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "named_wrapper_value_catches_callback_throw"
-    make_closure .<lambda($init_test_48, 85)>, 0
+    make_closure .<lambda($init_test_50, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_four_typed_arms_plus_bind_chain_rethrows_panic"
-    make_closure .<lambda($init_test_48, 86)>, 0
+    make_closure .<lambda($init_test_50, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/floats.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/floats.snap
@@ -1,856 +1,856 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function floats.$init_test_49(registry: testing.TestCollector) -> null {
+function floats.$init_test_51(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "float_is_nan_true"
-    make_closure .<lambda($init_test_49, 0)>, 0
+    make_closure .<lambda($init_test_51, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_nan_false_for_zero"
-    make_closure .<lambda($init_test_49, 1)>, 0
+    make_closure .<lambda($init_test_51, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_nan_false_for_finite"
-    make_closure .<lambda($init_test_49, 2)>, 0
+    make_closure .<lambda($init_test_51, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_nan_false_for_infinity"
-    make_closure .<lambda($init_test_49, 3)>, 0
+    make_closure .<lambda($init_test_51, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_infinite_true_positive"
-    make_closure .<lambda($init_test_49, 4)>, 0
+    make_closure .<lambda($init_test_51, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_infinite_true_negative"
-    make_closure .<lambda($init_test_49, 5)>, 0
+    make_closure .<lambda($init_test_51, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_infinite_false_for_large_finite"
-    make_closure .<lambda($init_test_49, 6)>, 0
+    make_closure .<lambda($init_test_51, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_infinite_false_for_nan"
-    make_closure .<lambda($init_test_49, 7)>, 0
+    make_closure .<lambda($init_test_51, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_finite_true_for_zero"
-    make_closure .<lambda($init_test_49, 8)>, 0
+    make_closure .<lambda($init_test_51, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_finite_true_for_normal"
-    make_closure .<lambda($init_test_49, 9)>, 0
+    make_closure .<lambda($init_test_51, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_finite_true_for_negative_zero"
-    make_closure .<lambda($init_test_49, 10)>, 0
+    make_closure .<lambda($init_test_51, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_finite_false_for_nan"
-    make_closure .<lambda($init_test_49, 11)>, 0
+    make_closure .<lambda($init_test_51, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_finite_false_for_infinity"
-    make_closure .<lambda($init_test_49, 12)>, 0
+    make_closure .<lambda($init_test_51, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_is_finite_false_for_negative_infinity"
-    make_closure .<lambda($init_test_49, 13)>, 0
+    make_closure .<lambda($init_test_51, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_pi_value"
-    make_closure .<lambda($init_test_49, 14)>, 0
+    make_closure .<lambda($init_test_51, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_e_value"
-    make_closure .<lambda($init_test_49, 15)>, 0
+    make_closure .<lambda($init_test_51, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_golden_ratio_value"
-    make_closure .<lambda($init_test_49, 16)>, 0
+    make_closure .<lambda($init_test_51, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_nan_is_a_nan"
-    make_closure .<lambda($init_test_49, 17)>, 0
+    make_closure .<lambda($init_test_51, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_inf_is_positive_infinity"
-    make_closure .<lambda($init_test_49, 18)>, 0
+    make_closure .<lambda($init_test_51, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_inf_is_positive_not_negative"
-    make_closure .<lambda($init_test_49, 19)>, 0
+    make_closure .<lambda($init_test_51, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_negative_inf_via_unary_minus"
-    make_closure .<lambda($init_test_49, 20)>, 0
+    make_closure .<lambda($init_test_51, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_negative_inf_is_negative"
-    make_closure .<lambda($init_test_49, 21)>, 0
+    make_closure .<lambda($init_test_51, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_abs_negative"
-    make_closure .<lambda($init_test_49, 22)>, 0
+    make_closure .<lambda($init_test_51, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_abs_positive"
-    make_closure .<lambda($init_test_49, 23)>, 0
+    make_closure .<lambda($init_test_51, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_abs_nan_is_nan"
-    make_closure .<lambda($init_test_49, 24)>, 0
+    make_closure .<lambda($init_test_51, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_abs_inf_is_inf"
-    make_closure .<lambda($init_test_49, 25)>, 0
+    make_closure .<lambda($init_test_51, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_abs_inf_becomes_positive"
-    make_closure .<lambda($init_test_49, 26)>, 0
+    make_closure .<lambda($init_test_51, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_min_basic"
-    make_closure .<lambda($init_test_49, 27)>, 0
+    make_closure .<lambda($init_test_51, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_min_with_nan_suppresses_nan"
-    make_closure .<lambda($init_test_49, 28)>, 0
+    make_closure .<lambda($init_test_51, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_min_nan_receiver_suppresses_nan"
-    make_closure .<lambda($init_test_49, 29)>, 0
+    make_closure .<lambda($init_test_51, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_min_both_nan_is_nan"
-    make_closure .<lambda($init_test_49, 30)>, 0
+    make_closure .<lambda($init_test_51, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_max_basic"
-    make_closure .<lambda($init_test_49, 31)>, 0
+    make_closure .<lambda($init_test_51, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_max_with_nan_suppresses_nan"
-    make_closure .<lambda($init_test_49, 32)>, 0
+    make_closure .<lambda($init_test_51, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_max_nan_receiver_suppresses_nan"
-    make_closure .<lambda($init_test_49, 33)>, 0
+    make_closure .<lambda($init_test_51, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_clamp_in_range"
-    make_closure .<lambda($init_test_49, 34)>, 0
+    make_closure .<lambda($init_test_51, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_clamp_below"
-    make_closure .<lambda($init_test_49, 35)>, 0
+    make_closure .<lambda($init_test_51, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_clamp_above"
-    make_closure .<lambda($init_test_49, 36)>, 0
+    make_closure .<lambda($init_test_51, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_floor_positive_fraction"
-    make_closure .<lambda($init_test_49, 37)>, 0
+    make_closure .<lambda($init_test_51, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_floor_negative_fraction"
-    make_closure .<lambda($init_test_49, 38)>, 0
+    make_closure .<lambda($init_test_51, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_floor_integer_unchanged"
-    make_closure .<lambda($init_test_49, 39)>, 0
+    make_closure .<lambda($init_test_51, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_ceil_positive_fraction"
-    make_closure .<lambda($init_test_49, 40)>, 0
+    make_closure .<lambda($init_test_51, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_ceil_negative_fraction"
-    make_closure .<lambda($init_test_49, 41)>, 0
+    make_closure .<lambda($init_test_51, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_round_half_up"
-    make_closure .<lambda($init_test_49, 42)>, 0
+    make_closure .<lambda($init_test_51, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_round_negative_half_away_from_zero"
-    make_closure .<lambda($init_test_49, 43)>, 0
+    make_closure .<lambda($init_test_51, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_round_below_half"
-    make_closure .<lambda($init_test_49, 44)>, 0
+    make_closure .<lambda($init_test_51, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_round_above_half"
-    make_closure .<lambda($init_test_49, 45)>, 0
+    make_closure .<lambda($init_test_51, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_round_two_point_five_is_three"
-    make_closure .<lambda($init_test_49, 46)>, 0
+    make_closure .<lambda($init_test_51, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_round_negative_two_point_five_is_neg_three"
-    make_closure .<lambda($init_test_49, 47)>, 0
+    make_closure .<lambda($init_test_51, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_trunc_positive"
-    make_closure .<lambda($init_test_49, 48)>, 0
+    make_closure .<lambda($init_test_51, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_trunc_negative"
-    make_closure .<lambda($init_test_49, 49)>, 0
+    make_closure .<lambda($init_test_51, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_fract_positive"
-    make_closure .<lambda($init_test_49, 50)>, 0
+    make_closure .<lambda($init_test_51, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_fract_negative"
-    make_closure .<lambda($init_test_49, 51)>, 0
+    make_closure .<lambda($init_test_51, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_fract_integer_is_zero"
-    make_closure .<lambda($init_test_49, 52)>, 0
+    make_closure .<lambda($init_test_51, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_floor_nan_propagates"
-    make_closure .<lambda($init_test_49, 53)>, 0
+    make_closure .<lambda($init_test_51, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_ifloor_positive"
-    make_closure .<lambda($init_test_49, 54)>, 0
+    make_closure .<lambda($init_test_51, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_ifloor_negative"
-    make_closure .<lambda($init_test_49, 55)>, 0
+    make_closure .<lambda($init_test_51, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iceil_positive"
-    make_closure .<lambda($init_test_49, 56)>, 0
+    make_closure .<lambda($init_test_51, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iceil_negative"
-    make_closure .<lambda($init_test_49, 57)>, 0
+    make_closure .<lambda($init_test_51, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iround_half_up"
-    make_closure .<lambda($init_test_49, 58)>, 0
+    make_closure .<lambda($init_test_51, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iround_negative_half"
-    make_closure .<lambda($init_test_49, 59)>, 0
+    make_closure .<lambda($init_test_51, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iround_below_half"
-    make_closure .<lambda($init_test_49, 60)>, 0
+    make_closure .<lambda($init_test_51, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_itrunc_positive"
-    make_closure .<lambda($init_test_49, 61)>, 0
+    make_closure .<lambda($init_test_51, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_itrunc_negative"
-    make_closure .<lambda($init_test_49, 62)>, 0
+    make_closure .<lambda($init_test_51, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iround_at_i63_min_is_ok"
-    make_closure .<lambda($init_test_49, 63)>, 0
+    make_closure .<lambda($init_test_51, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iround_too_large_throws"
-    make_closure .<lambda($init_test_49, 64)>, 0
+    make_closure .<lambda($init_test_51, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iround_too_small_throws"
-    make_closure .<lambda($init_test_49, 65)>, 0
+    make_closure .<lambda($init_test_51, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_itrunc_nan_throws"
-    make_closure .<lambda($init_test_49, 66)>, 0
+    make_closure .<lambda($init_test_51, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_itrunc_inf_throws"
-    make_closure .<lambda($init_test_49, 67)>, 0
+    make_closure .<lambda($init_test_51, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iround_nan_throws"
-    make_closure .<lambda($init_test_49, 68)>, 0
+    make_closure .<lambda($init_test_51, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iround_inf_throws"
-    make_closure .<lambda($init_test_49, 69)>, 0
+    make_closure .<lambda($init_test_51, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_ifloor_nan_throws"
-    make_closure .<lambda($init_test_49, 70)>, 0
+    make_closure .<lambda($init_test_51, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_ifloor_inf_throws"
-    make_closure .<lambda($init_test_49, 71)>, 0
+    make_closure .<lambda($init_test_51, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_ifloor_neg_inf_throws"
-    make_closure .<lambda($init_test_49, 72)>, 0
+    make_closure .<lambda($init_test_51, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iceil_nan_throws"
-    make_closure .<lambda($init_test_49, 73)>, 0
+    make_closure .<lambda($init_test_51, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_iceil_inf_throws"
-    make_closure .<lambda($init_test_49, 74)>, 0
+    make_closure .<lambda($init_test_51, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_sqrt_basic_4"
-    make_closure .<lambda($init_test_49, 75)>, 0
+    make_closure .<lambda($init_test_51, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_sqrt_basic_2"
-    make_closure .<lambda($init_test_49, 76)>, 0
+    make_closure .<lambda($init_test_51, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_sqrt_zero"
-    make_closure .<lambda($init_test_49, 77)>, 0
+    make_closure .<lambda($init_test_51, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_sqrt_negative_is_nan"
-    make_closure .<lambda($init_test_49, 78)>, 0
+    make_closure .<lambda($init_test_51, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_pow_integer"
-    make_closure .<lambda($init_test_49, 79)>, 0
+    make_closure .<lambda($init_test_51, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_pow_negative_exp"
-    make_closure .<lambda($init_test_49, 80)>, 0
+    make_closure .<lambda($init_test_51, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_pow_fractional_exp"
-    make_closure .<lambda($init_test_49, 81)>, 0
+    make_closure .<lambda($init_test_51, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_pow_negative_base_fractional_is_nan"
-    make_closure .<lambda($init_test_49, 82)>, 0
+    make_closure .<lambda($init_test_51, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_pow_one_to_nan_is_one"
-    make_closure .<lambda($init_test_49, 83)>, 0
+    make_closure .<lambda($init_test_51, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_pow_nan_to_zero_is_one"
-    make_closure .<lambda($init_test_49, 84)>, 0
+    make_closure .<lambda($init_test_51, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_pow_nan_to_one_is_nan"
-    make_closure .<lambda($init_test_49, 85)>, 0
+    make_closure .<lambda($init_test_51, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_log_base_10"
-    make_closure .<lambda($init_test_49, 86)>, 0
+    make_closure .<lambda($init_test_51, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_log_base_2"
-    make_closure .<lambda($init_test_49, 87)>, 0
+    make_closure .<lambda($init_test_51, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_log_negative_self_is_nan"
-    make_closure .<lambda($init_test_49, 88)>, 0
+    make_closure .<lambda($init_test_51, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_hypot_345"
-    make_closure .<lambda($init_test_49, 89)>, 0
+    make_closure .<lambda($init_test_51, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_hypot_zero"
-    make_closure .<lambda($init_test_49, 90)>, 0
+    make_closure .<lambda($init_test_51, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_sin_zero"
-    make_closure .<lambda($init_test_49, 91)>, 0
+    make_closure .<lambda($init_test_51, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_sin_pi_is_zero"
-    make_closure .<lambda($init_test_49, 92)>, 0
+    make_closure .<lambda($init_test_51, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_sin_half_pi_is_one"
-    make_closure .<lambda($init_test_49, 93)>, 0
+    make_closure .<lambda($init_test_51, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_cos_zero_is_one"
-    make_closure .<lambda($init_test_49, 94)>, 0
+    make_closure .<lambda($init_test_51, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_cos_pi_is_neg_one"
-    make_closure .<lambda($init_test_49, 95)>, 0
+    make_closure .<lambda($init_test_51, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_tan_zero"
-    make_closure .<lambda($init_test_49, 96)>, 0
+    make_closure .<lambda($init_test_51, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_tan_pi_quarter_is_one"
-    make_closure .<lambda($init_test_49, 97)>, 0
+    make_closure .<lambda($init_test_51, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_asin_one_is_half_pi"
-    make_closure .<lambda($init_test_49, 98)>, 0
+    make_closure .<lambda($init_test_51, 98)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_asin_out_of_range_is_nan"
-    make_closure .<lambda($init_test_49, 99)>, 0
+    make_closure .<lambda($init_test_51, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_acos_zero_is_half_pi"
-    make_closure .<lambda($init_test_49, 100)>, 0
+    make_closure .<lambda($init_test_51, 100)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_acos_out_of_range_is_nan"
-    make_closure .<lambda($init_test_49, 101)>, 0
+    make_closure .<lambda($init_test_51, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_atan_one_is_quarter_pi"
-    make_closure .<lambda($init_test_49, 102)>, 0
+    make_closure .<lambda($init_test_51, 102)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_atan2_one_one_is_quarter_pi"
-    make_closure .<lambda($init_test_49, 103)>, 0
+    make_closure .<lambda($init_test_51, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_atan2_one_zero_is_half_pi"
-    make_closure .<lambda($init_test_49, 104)>, 0
+    make_closure .<lambda($init_test_51, 104)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_atan2_zero_neg_one_is_pi"
-    make_closure .<lambda($init_test_49, 105)>, 0
+    make_closure .<lambda($init_test_51, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_sinh_zero"
-    make_closure .<lambda($init_test_49, 106)>, 0
+    make_closure .<lambda($init_test_51, 106)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_cosh_zero_is_one"
-    make_closure .<lambda($init_test_49, 107)>, 0
+    make_closure .<lambda($init_test_51, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_tanh_large_input_approaches_one"
-    make_closure .<lambda($init_test_49, 108)>, 0
+    make_closure .<lambda($init_test_51, 108)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_asinh_zero"
-    make_closure .<lambda($init_test_49, 109)>, 0
+    make_closure .<lambda($init_test_51, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_acosh_one_is_zero"
-    make_closure .<lambda($init_test_49, 110)>, 0
+    make_closure .<lambda($init_test_51, 110)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_acosh_below_one_is_nan"
-    make_closure .<lambda($init_test_49, 111)>, 0
+    make_closure .<lambda($init_test_51, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_atanh_zero"
-    make_closure .<lambda($init_test_49, 112)>, 0
+    make_closure .<lambda($init_test_51, 112)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_atanh_out_of_range_is_nan"
-    make_closure .<lambda($init_test_49, 113)>, 0
+    make_closure .<lambda($init_test_51, 113)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_to_radians_180_is_pi"
-    make_closure .<lambda($init_test_49, 114)>, 0
+    make_closure .<lambda($init_test_51, 114)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_to_radians_zero"
-    make_closure .<lambda($init_test_49, 115)>, 0
+    make_closure .<lambda($init_test_51, 115)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_to_degrees_pi_is_180"
-    make_closure .<lambda($init_test_49, 116)>, 0
+    make_closure .<lambda($init_test_51, 116)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_to_radians_round_trip"
-    make_closure .<lambda($init_test_49, 117)>, 0
+    make_closure .<lambda($init_test_51, 117)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_decimal"
-    make_closure .<lambda($init_test_49, 118)>, 0
+    make_closure .<lambda($init_test_51, 118)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_negative"
-    make_closure .<lambda($init_test_49, 119)>, 0
+    make_closure .<lambda($init_test_51, 119)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_explicit_plus"
-    make_closure .<lambda($init_test_49, 120)>, 0
+    make_closure .<lambda($init_test_51, 120)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_integer"
-    make_closure .<lambda($init_test_49, 121)>, 0
+    make_closure .<lambda($init_test_51, 121)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_zero"
-    make_closure .<lambda($init_test_49, 122)>, 0
+    make_closure .<lambda($init_test_51, 122)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_scientific_lowercase"
-    make_closure .<lambda($init_test_49, 123)>, 0
+    make_closure .<lambda($init_test_51, 123)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_scientific_uppercase_negative_exp"
-    make_closure .<lambda($init_test_49, 124)>, 0
+    make_closure .<lambda($init_test_51, 124)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_inf"
-    make_closure .<lambda($init_test_49, 125)>, 0
+    make_closure .<lambda($init_test_51, 125)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_inf_is_positive"
-    make_closure .<lambda($init_test_49, 126)>, 0
+    make_closure .<lambda($init_test_51, 126)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_infinity_word"
-    make_closure .<lambda($init_test_49, 127)>, 0
+    make_closure .<lambda($init_test_51, 127)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_infinity_word_is_positive"
-    make_closure .<lambda($init_test_49, 128)>, 0
+    make_closure .<lambda($init_test_51, 128)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_negative_inf"
-    make_closure .<lambda($init_test_49, 129)>, 0
+    make_closure .<lambda($init_test_51, 129)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_negative_inf_is_negative"
-    make_closure .<lambda($init_test_49, 130)>, 0
+    make_closure .<lambda($init_test_51, 130)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_nan_lowercase"
-    make_closure .<lambda($init_test_49, 131)>, 0
+    make_closure .<lambda($init_test_51, 131)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_nan_mixed_case"
-    make_closure .<lambda($init_test_49, 132)>, 0
+    make_closure .<lambda($init_test_51, 132)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_empty_throws"
-    make_closure .<lambda($init_test_49, 133)>, 0
+    make_closure .<lambda($init_test_51, 133)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_alpha_throws"
-    make_closure .<lambda($init_test_49, 134)>, 0
+    make_closure .<lambda($init_test_51, 134)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_trailing_garbage_throws"
-    make_closure .<lambda($init_test_49, 135)>, 0
+    make_closure .<lambda($init_test_51, 135)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_whitespace_throws"
-    make_closure .<lambda($init_test_49, 136)>, 0
+    make_closure .<lambda($init_test_51, 136)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_just_sign_throws"
-    make_closure .<lambda($init_test_49, 137)>, 0
+    make_closure .<lambda($init_test_51, 137)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_parse_round_trip_in_arithmetic"
-    make_closure .<lambda($init_test_49, 138)>, 0
+    make_closure .<lambda($init_test_51, 138)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_random_returns_a_float"
-    make_closure .<lambda($init_test_49, 139)>, 0
+    make_closure .<lambda($init_test_51, 139)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_random_in_unit_interval_and_covers_both_halves"
-    make_closure .<lambda($init_test_49, 140)>, 0
+    make_closure .<lambda($init_test_51, 140)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_random_distinct_values"
-    make_closure .<lambda($init_test_49, 141)>, 0
+    make_closure .<lambda($init_test_51, 141)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
@@ -1,64 +1,64 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function for_loops.$init_test_50(registry: testing.TestCollector) -> null {
+function for_loops.$init_test_52(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "for_loop_sum"
-    make_closure .<lambda($init_test_50, 0)>, 0
+    make_closure .<lambda($init_test_52, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_loop_with_break"
-    make_closure .<lambda($init_test_50, 1)>, 0
+    make_closure .<lambda($init_test_52, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_loop_with_continue"
-    make_closure .<lambda($init_test_50, 2)>, 0
+    make_closure .<lambda($init_test_52, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_loop_nested"
-    make_closure .<lambda($init_test_50, 3)>, 0
+    make_closure .<lambda($init_test_52, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "c_for_sum_to_ten"
-    make_closure .<lambda($init_test_50, 4)>, 0
+    make_closure .<lambda($init_test_52, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_loop_over_let_variable"
-    make_closure .<lambda($init_test_50, 5)>, 0
+    make_closure .<lambda($init_test_52, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_loop_over_let_variable_no_parens"
-    make_closure .<lambda($init_test_50, 6)>, 0
+    make_closure .<lambda($init_test_52, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_loop_final_if_without_semicolon_can_return"
-    make_closure .<lambda($init_test_50, 7)>, 0
+    make_closure .<lambda($init_test_52, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_loop_final_if_else_without_semicolon_can_mutate"
-    make_closure .<lambda($init_test_50, 8)>, 0
+    make_closure .<lambda($init_test_52, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_for_loop_final_if_without_semicolon_can_return"
-    make_closure .<lambda($init_test_50, 9)>, 0
+    make_closure .<lambda($init_test_52, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
@@ -1,202 +1,202 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function fs.$init_test_51(registry: testing.TestCollector) -> null {
+function fs.$init_test_53(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "fs_open_and_read"
-    make_closure .<lambda($init_test_51, 0)>, 0
+    make_closure .<lambda($init_test_53, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_open_and_read_bytes"
-    make_closure .<lambda($init_test_51, 1)>, 0
+    make_closure .<lambda($init_test_53, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_write_string"
-    make_closure .<lambda($init_test_51, 2)>, 0
+    make_closure .<lambda($init_test_53, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_write_bytes"
-    make_closure .<lambda($init_test_51, 3)>, 0
+    make_closure .<lambda($init_test_53, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_write_creates_parent_dirs"
-    make_closure .<lambda($init_test_51, 4)>, 0
+    make_closure .<lambda($init_test_53, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_write_overwrites_existing"
-    make_closure .<lambda($init_test_51, 5)>, 0
+    make_closure .<lambda($init_test_53, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_roundtrip_write_and_read"
-    make_closure .<lambda($init_test_51, 6)>, 0
+    make_closure .<lambda($init_test_53, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_file_rw_seek_and_read"
-    make_closure .<lambda($init_test_51, 7)>, 0
+    make_closure .<lambda($init_test_53, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_file_rw_write_and_read_back"
-    make_closure .<lambda($init_test_51, 8)>, 0
+    make_closure .<lambda($init_test_53, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_file_rw_write_bytes"
-    make_closure .<lambda($init_test_51, 9)>, 0
+    make_closure .<lambda($init_test_53, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_exists_returns_true"
-    make_closure .<lambda($init_test_51, 10)>, 0
+    make_closure .<lambda($init_test_53, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_exists_returns_false"
-    make_closure .<lambda($init_test_51, 11)>, 0
+    make_closure .<lambda($init_test_53, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_remove_deletes_file"
-    make_closure .<lambda($init_test_51, 12)>, 0
+    make_closure .<lambda($init_test_53, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_size_returns_length"
-    make_closure .<lambda($init_test_51, 13)>, 0
+    make_closure .<lambda($init_test_53, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_file_read_n_bytes"
-    make_closure .<lambda($init_test_51, 14)>, 0
+    make_closure .<lambda($init_test_53, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_file_read_truncates_at_eof"
-    make_closure .<lambda($init_test_51, 15)>, 0
+    make_closure .<lambda($init_test_53, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_file_read_bytes_n"
-    make_closure .<lambda($init_test_51, 16)>, 0
+    make_closure .<lambda($init_test_53, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_file_read_advances_cursor"
-    make_closure .<lambda($init_test_51, 17)>, 0
+    make_closure .<lambda($init_test_53, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_open_append_creates_and_appends"
-    make_closure .<lambda($init_test_51, 18)>, 0
+    make_closure .<lambda($init_test_53, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_open_append_creates_missing_file"
-    make_closure .<lambda($init_test_51, 19)>, 0
+    make_closure .<lambda($init_test_53, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_open_append_plus_can_read"
-    make_closure .<lambda($init_test_51, 20)>, 0
+    make_closure .<lambda($init_test_53, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_file_close_is_idempotent"
-    make_closure .<lambda($init_test_51, 21)>, 0
+    make_closure .<lambda($init_test_53, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_read_returns_contents"
-    make_closure .<lambda($init_test_51, 22)>, 0
+    make_closure .<lambda($init_test_53, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_open_w_truncates_existing"
-    make_closure .<lambda($init_test_51, 23)>, 0
+    make_closure .<lambda($init_test_53, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_open_w_creates_missing_file"
-    make_closure .<lambda($init_test_51, 24)>, 0
+    make_closure .<lambda($init_test_53, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_open_w_plus_reads_after_write"
-    make_closure .<lambda($init_test_51, 25)>, 0
+    make_closure .<lambda($init_test_53, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_open_w_creates_parent_dirs"
-    make_closure .<lambda($init_test_51, 26)>, 0
+    make_closure .<lambda($init_test_53, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_read_dir_returns_entries"
-    make_closure .<lambda($init_test_51, 27)>, 0
+    make_closure .<lambda($init_test_53, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_read_dir_type_flags"
-    make_closure .<lambda($init_test_51, 28)>, 0
+    make_closure .<lambda($init_test_53, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_read_dir_empty_dir"
-    make_closure .<lambda($init_test_51, 29)>, 0
+    make_closure .<lambda($init_test_53, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_mkdir_creates_directory"
-    make_closure .<lambda($init_test_51, 30)>, 0
+    make_closure .<lambda($init_test_53, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_mkdir_recursive_creates_parents"
-    make_closure .<lambda($init_test_51, 31)>, 0
+    make_closure .<lambda($init_test_53, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fs_mkdir_recursive_is_idempotent"
-    make_closure .<lambda($init_test_51, 32)>, 0
+    make_closure .<lambda($init_test_53, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/functions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/functions.snap
@@ -1,76 +1,76 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function functions.$init_test_52(registry: testing.TestCollector) -> null {
+function functions.$init_test_54(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "return_literal_int"
-    make_closure .<lambda($init_test_52, 0)>, 0
+    make_closure .<lambda($init_test_54, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "return_literal_bool"
-    make_closure .<lambda($init_test_52, 1)>, 0
+    make_closure .<lambda($init_test_54, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "return_literal_string"
-    make_closure .<lambda($init_test_52, 2)>, 0
+    make_closure .<lambda($init_test_54, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "return_function_call"
-    make_closure .<lambda($init_test_52, 3)>, 0
+    make_closure .<lambda($init_test_54, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "call_function_assign_to_variable"
-    make_closure .<lambda($init_test_52, 4)>, 0
+    make_closure .<lambda($init_test_54, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mutable_variables"
-    make_closure .<lambda($init_test_52, 5)>, 0
+    make_closure .<lambda($init_test_54, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "call_with_arguments"
-    make_closure .<lambda($init_test_52, 6)>, 0
+    make_closure .<lambda($init_test_54, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "unused_variable_does_not_affect_result"
-    make_closure .<lambda($init_test_52, 7)>, 0
+    make_closure .<lambda($init_test_54, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "early_return"
-    make_closure .<lambda($init_test_52, 8)>, 0
+    make_closure .<lambda($init_test_54, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "early_return_from_nested_scopes"
-    make_closure .<lambda($init_test_52, 9)>, 0
+    make_closure .<lambda($init_test_54, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "recursion"
-    make_closure .<lambda($init_test_52, 10)>, 0
+    make_closure .<lambda($init_test_54, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "function_as_value"
-    make_closure .<lambda($init_test_52, 11)>, 0
+    make_closure .<lambda($init_test_54, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
@@ -1,28 +1,28 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function future_methods.$init_test_53(registry: testing.TestCollector) -> null {
+function future_methods.$init_test_55(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "methods_after_successful_settle"
-    make_closure .<lambda($init_test_53, 0)>, 0
+    make_closure .<lambda($init_test_55, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "methods_on_pending_future"
-    make_closure .<lambda($init_test_53, 1)>, 0
+    make_closure .<lambda($init_test_55, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "methods_after_cancel"
-    make_closure .<lambda($init_test_53, 2)>, 0
+    make_closure .<lambda($init_test_55, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "methods_on_errored_future"
-    make_closure .<lambda($init_test_53, 3)>, 0
+    make_closure .<lambda($init_test_55, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -39,6 +39,7 @@ function future_methods.fail_io() -> int {
 function future_methods.methods_after_cancel() -> baml.future.FutureState {
     make_closure .<lambda(methods_after_cancel, 0)>, 0
     load_const null
+    load_const null
     spawn
     store_var _3
     load_var _3
@@ -52,6 +53,7 @@ function future_methods.methods_after_cancel() -> baml.future.FutureState {
 
 function future_methods.methods_after_successful_settle() -> bool[] {
     make_closure .<lambda(methods_after_successful_settle, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3
@@ -75,6 +77,7 @@ function future_methods.methods_after_successful_settle() -> bool[] {
 
 function future_methods.methods_on_errored_future() -> baml.future.FutureState {
     make_closure .<lambda(methods_on_errored_future, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3
@@ -100,6 +103,7 @@ function future_methods.methods_on_errored_future() -> baml.future.FutureState {
 
 function future_methods.methods_on_pending_future() -> baml.future.FutureState {
     make_closure .<lambda(methods_on_pending_future, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/glob.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/glob.snap
@@ -1,166 +1,166 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function glob.$init_test_54(registry: testing.TestCollector) -> null {
+function glob.$init_test_56(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "glob_matches_basic"
-    make_closure .<lambda($init_test_54, 0)>, 0
+    make_closure .<lambda($init_test_56, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_no_match"
-    make_closure .<lambda($init_test_54, 1)>, 0
+    make_closure .<lambda($init_test_56, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_recursive_wildcard"
-    make_closure .<lambda($init_test_54, 2)>, 0
+    make_closure .<lambda($init_test_56, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_question_mark"
-    make_closure .<lambda($init_test_54, 3)>, 0
+    make_closure .<lambda($init_test_56, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_question_mark_no_match"
-    make_closure .<lambda($init_test_54, 4)>, 0
+    make_closure .<lambda($init_test_56, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_bracket_character_class"
-    make_closure .<lambda($init_test_54, 5)>, 0
+    make_closure .<lambda($init_test_56, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_bracket_range"
-    make_closure .<lambda($init_test_54, 6)>, 0
+    make_closure .<lambda($init_test_56, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_negated_bracket"
-    make_closure .<lambda($init_test_54, 7)>, 0
+    make_closure .<lambda($init_test_56, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_alternation"
-    make_closure .<lambda($init_test_54, 8)>, 0
+    make_closure .<lambda($init_test_56, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_matches_negated_pattern"
-    make_closure .<lambda($init_test_54, 9)>, 0
+    make_closure .<lambda($init_test_56, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_finds_txt_files_length"
-    make_closure .<lambda($init_test_54, 10)>, 0
+    make_closure .<lambda($init_test_56, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_finds_txt_files_has_a"
-    make_closure .<lambda($init_test_54, 11)>, 0
+    make_closure .<lambda($init_test_56, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_finds_txt_files_has_b"
-    make_closure .<lambda($init_test_54, 12)>, 0
+    make_closure .<lambda($init_test_56, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_returns_empty_for_no_match"
-    make_closure .<lambda($init_test_54, 13)>, 0
+    make_closure .<lambda($init_test_56, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_only_files_by_default_length"
-    make_closure .<lambda($init_test_54, 14)>, 0
+    make_closure .<lambda($init_test_56, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_only_files_by_default_has_file"
-    make_closure .<lambda($init_test_54, 15)>, 0
+    make_closure .<lambda($init_test_56, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_options_include_dot_absolute_and_directories"
-    make_closure .<lambda($init_test_54, 16)>, 0
+    make_closure .<lambda($init_test_56, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_matches_dot_slash_pattern_length"
-    make_closure .<lambda($init_test_54, 17)>, 0
+    make_closure .<lambda($init_test_56, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_matches_dot_slash_pattern_has_file"
-    make_closure .<lambda($init_test_54, 18)>, 0
+    make_closure .<lambda($init_test_56, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_matches_absolute_pattern"
-    make_closure .<lambda($init_test_54, 19)>, 0
+    make_closure .<lambda($init_test_56, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_dot_pattern_matches_only_dot_files_length"
-    make_closure .<lambda($init_test_54, 20)>, 0
+    make_closure .<lambda($init_test_56, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_dot_pattern_matches_only_dot_files_has_hidden"
-    make_closure .<lambda($init_test_54, 21)>, 0
+    make_closure .<lambda($init_test_56, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_default_prunes_dot_directories_length"
-    make_closure .<lambda($init_test_54, 22)>, 0
+    make_closure .<lambda($init_test_56, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_default_prunes_dot_directories_has_visible"
-    make_closure .<lambda($init_test_54, 23)>, 0
+    make_closure .<lambda($init_test_56, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_follows_symlinked_directory_when_enabled"
-    make_closure .<lambda($init_test_54, 24)>, 0
+    make_closure .<lambda($init_test_56, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_skips_broken_symlinks_by_default_length"
-    make_closure .<lambda($init_test_54, 25)>, 0
+    make_closure .<lambda($init_test_56, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "glob_scan_skips_broken_symlinks_by_default_has_real"
-    make_closure .<lambda($init_test_54, 26)>, 0
+    make_closure .<lambda($init_test_56, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/if_else.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/if_else.snap
@@ -1,196 +1,196 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function if_else.$init_test_55(registry: testing.TestCollector) -> null {
+function if_else.$init_test_57(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "if_else_true_branch"
-    make_closure .<lambda($init_test_55, 0)>, 0
+    make_closure .<lambda($init_test_57, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_false_branch"
-    make_closure .<lambda($init_test_55, 1)>, 0
+    make_closure .<lambda($init_test_57, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_comparison"
-    make_closure .<lambda($init_test_55, 2)>, 0
+    make_closure .<lambda($init_test_57, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_equality"
-    make_closure .<lambda($init_test_55, 3)>, 0
+    make_closure .<lambda($init_test_57, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_assign_to_variable"
-    make_closure .<lambda($init_test_55, 4)>, 0
+    make_closure .<lambda($init_test_57, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_with_local_in_branches"
-    make_closure .<lambda($init_test_55, 5)>, 0
+    make_closure .<lambda($init_test_57, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_with_parameter"
-    make_closure .<lambda($init_test_55, 6)>, 0
+    make_closure .<lambda($init_test_57, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_return_expr_with_locals"
-    make_closure .<lambda($init_test_55, 7)>, 0
+    make_closure .<lambda($init_test_57, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_assignment_with_param"
-    make_closure .<lambda($init_test_55, 8)>, 0
+    make_closure .<lambda($init_test_57, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_assignment_with_locals"
-    make_closure .<lambda($init_test_55, 9)>, 0
+    make_closure .<lambda($init_test_57, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_nested"
-    make_closure .<lambda($init_test_55, 10)>, 0
+    make_closure .<lambda($init_test_57, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "else_if_chain"
-    make_closure .<lambda($init_test_55, 11)>, 0
+    make_closure .<lambda($init_test_57, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "else_if_with_comparisons"
-    make_closure .<lambda($init_test_55, 12)>, 0
+    make_closure .<lambda($init_test_57, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "else_if_with_parameter"
-    make_closure .<lambda($init_test_55, 13)>, 0
+    make_closure .<lambda($init_test_57, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "else_if_assignment"
-    make_closure .<lambda($init_test_55, 14)>, 0
+    make_closure .<lambda($init_test_57, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "else_if_return_expr_with_locals"
-    make_closure .<lambda($init_test_55, 15)>, 0
+    make_closure .<lambda($init_test_57, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "else_if_assignment_with_locals"
-    make_closure .<lambda($init_test_55, 16)>, 0
+    make_closure .<lambda($init_test_57, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_function_call_in_branch"
-    make_closure .<lambda($init_test_55, 17)>, 0
+    make_closure .<lambda($init_test_57, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_arithmetic_condition"
-    make_closure .<lambda($init_test_55, 18)>, 0
+    make_closure .<lambda($init_test_57, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_logical_and"
-    make_closure .<lambda($init_test_55, 19)>, 0
+    make_closure .<lambda($init_test_57, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_logical_or"
-    make_closure .<lambda($init_test_55, 20)>, 0
+    make_closure .<lambda($init_test_57, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_in_arithmetic"
-    make_closure .<lambda($init_test_55, 21)>, 0
+    make_closure .<lambda($init_test_57, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_as_function_arg"
-    make_closure .<lambda($init_test_55, 22)>, 0
+    make_closure .<lambda($init_test_57, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_assigned_then_passed_to_call"
-    make_closure .<lambda($init_test_55, 23)>, 0
+    make_closure .<lambda($init_test_57, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "parenthesized_if_else_in_arithmetic"
-    make_closure .<lambda($init_test_55, 24)>, 0
+    make_closure .<lambda($init_test_57, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "chained_if_else_in_arithmetic"
-    make_closure .<lambda($init_test_55, 25)>, 0
+    make_closure .<lambda($init_test_57, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_without_else"
-    make_closure .<lambda($init_test_55, 26)>, 0
+    make_closure .<lambda($init_test_57, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_without_else_with_local"
-    make_closure .<lambda($init_test_55, 27)>, 0
+    make_closure .<lambda($init_test_57, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "consecutive_if_without_else"
-    make_closure .<lambda($init_test_55, 28)>, 0
+    make_closure .<lambda($init_test_57, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "block_expression"
-    make_closure .<lambda($init_test_55, 29)>, 0
+    make_closure .<lambda($init_test_57, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "if_else_statement"
-    make_closure .<lambda($init_test_55, 30)>, 0
+    make_closure .<lambda($init_test_57, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_block_with_if"
-    make_closure .<lambda($init_test_55, 31)>, 0
+    make_closure .<lambda($init_test_57, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ints.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ints.snap
@@ -1,556 +1,556 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function ints.$init_test_56(registry: testing.TestCollector) -> null {
+function ints.$init_test_58(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "int_abs_positive"
-    make_closure .<lambda($init_test_56, 0)>, 0
+    make_closure .<lambda($init_test_58, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_abs_negative"
-    make_closure .<lambda($init_test_56, 1)>, 0
+    make_closure .<lambda($init_test_58, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_abs_zero"
-    make_closure .<lambda($init_test_56, 2)>, 0
+    make_closure .<lambda($init_test_58, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_abs_min_value_throws"
-    make_closure .<lambda($init_test_56, 3)>, 0
+    make_closure .<lambda($init_test_58, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_abs_near_min_value_succeeds"
-    make_closure .<lambda($init_test_56, 4)>, 0
+    make_closure .<lambda($init_test_58, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_min_basic"
-    make_closure .<lambda($init_test_56, 5)>, 0
+    make_closure .<lambda($init_test_58, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_min_other_smaller"
-    make_closure .<lambda($init_test_56, 6)>, 0
+    make_closure .<lambda($init_test_58, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_min_equal"
-    make_closure .<lambda($init_test_56, 7)>, 0
+    make_closure .<lambda($init_test_58, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_min_negative"
-    make_closure .<lambda($init_test_56, 8)>, 0
+    make_closure .<lambda($init_test_58, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_max_basic"
-    make_closure .<lambda($init_test_56, 9)>, 0
+    make_closure .<lambda($init_test_58, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_max_other_smaller"
-    make_closure .<lambda($init_test_56, 10)>, 0
+    make_closure .<lambda($init_test_58, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_max_negative"
-    make_closure .<lambda($init_test_56, 11)>, 0
+    make_closure .<lambda($init_test_58, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_clamp_in_range"
-    make_closure .<lambda($init_test_56, 12)>, 0
+    make_closure .<lambda($init_test_58, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_clamp_below_min"
-    make_closure .<lambda($init_test_56, 13)>, 0
+    make_closure .<lambda($init_test_58, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_clamp_above_max"
-    make_closure .<lambda($init_test_56, 14)>, 0
+    make_closure .<lambda($init_test_58, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_clamp_at_min_boundary"
-    make_closure .<lambda($init_test_56, 15)>, 0
+    make_closure .<lambda($init_test_58, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_clamp_at_max_boundary"
-    make_closure .<lambda($init_test_56, 16)>, 0
+    make_closure .<lambda($init_test_58, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_max_value_returns_i63_max"
-    make_closure .<lambda($init_test_56, 17)>, 0
+    make_closure .<lambda($init_test_58, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_min_value_returns_i63_min"
-    make_closure .<lambda($init_test_56, 18)>, 0
+    make_closure .<lambda($init_test_58, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_max_min_inverse"
-    make_closure .<lambda($init_test_56, 19)>, 0
+    make_closure .<lambda($init_test_58, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_basic"
-    make_closure .<lambda($init_test_56, 20)>, 0
+    make_closure .<lambda($init_test_58, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_zero"
-    make_closure .<lambda($init_test_56, 21)>, 0
+    make_closure .<lambda($init_test_58, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_negative"
-    make_closure .<lambda($init_test_56, 22)>, 0
+    make_closure .<lambda($init_test_58, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_explicit_plus_sign"
-    make_closure .<lambda($init_test_56, 23)>, 0
+    make_closure .<lambda($init_test_58, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_max_value"
-    make_closure .<lambda($init_test_56, 24)>, 0
+    make_closure .<lambda($init_test_58, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_min_value"
-    make_closure .<lambda($init_test_56, 25)>, 0
+    make_closure .<lambda($init_test_58, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_leading_zeros_ok"
-    make_closure .<lambda($init_test_56, 26)>, 0
+    make_closure .<lambda($init_test_58, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_empty_throws"
-    make_closure .<lambda($init_test_56, 27)>, 0
+    make_closure .<lambda($init_test_58, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_non_digit_throws"
-    make_closure .<lambda($init_test_56, 28)>, 0
+    make_closure .<lambda($init_test_58, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_alpha_throws"
-    make_closure .<lambda($init_test_56, 29)>, 0
+    make_closure .<lambda($init_test_58, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_whitespace_throws"
-    make_closure .<lambda($init_test_56, 30)>, 0
+    make_closure .<lambda($init_test_58, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_overflow_throws"
-    make_closure .<lambda($init_test_56, 31)>, 0
+    make_closure .<lambda($init_test_58, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_underflow_throws"
-    make_closure .<lambda($init_test_56, 32)>, 0
+    make_closure .<lambda($init_test_58, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_just_sign_throws"
-    make_closure .<lambda($init_test_56, 33)>, 0
+    make_closure .<lambda($init_test_58, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_underscore_throws"
-    make_closure .<lambda($init_test_56, 34)>, 0
+    make_closure .<lambda($init_test_58, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_parse_round_trip_via_to_string"
-    make_closure .<lambda($init_test_56, 35)>, 0
+    make_closure .<lambda($init_test_58, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_random_in_range_and_covers_endpoints"
-    make_closure .<lambda($init_test_56, 36)>, 0
+    make_closure .<lambda($init_test_58, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_random_negative_range"
-    make_closure .<lambda($init_test_56, 37)>, 0
+    make_closure .<lambda($init_test_58, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_random_single_element_range"
-    make_closure .<lambda($init_test_56, 38)>, 0
+    make_closure .<lambda($init_test_58, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_random_full_range_returns_some_int"
-    make_closure .<lambda($init_test_56, 39)>, 0
+    make_closure .<lambda($init_test_58, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_random_distinct_values_in_wide_range"
-    make_closure .<lambda($init_test_56, 40)>, 0
+    make_closure .<lambda($init_test_58, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_random_lower_equals_upper_throws"
-    make_closure .<lambda($init_test_56, 41)>, 0
+    make_closure .<lambda($init_test_58, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_random_lower_greater_than_upper_throws"
-    make_closure .<lambda($init_test_56, 42)>, 0
+    make_closure .<lambda($init_test_58, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_isqrt_perfect_square"
-    make_closure .<lambda($init_test_56, 43)>, 0
+    make_closure .<lambda($init_test_58, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_isqrt_non_square_rounds_down"
-    make_closure .<lambda($init_test_56, 44)>, 0
+    make_closure .<lambda($init_test_58, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_isqrt_zero"
-    make_closure .<lambda($init_test_56, 45)>, 0
+    make_closure .<lambda($init_test_58, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_isqrt_one"
-    make_closure .<lambda($init_test_56, 46)>, 0
+    make_closure .<lambda($init_test_58, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_isqrt_large"
-    make_closure .<lambda($init_test_56, 47)>, 0
+    make_closure .<lambda($init_test_58, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_isqrt_max_value"
-    make_closure .<lambda($init_test_56, 48)>, 0
+    make_closure .<lambda($init_test_58, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_isqrt_negative_throws"
-    make_closure .<lambda($init_test_56, 49)>, 0
+    make_closure .<lambda($init_test_58, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_isqrt_min_value_throws"
-    make_closure .<lambda($init_test_56, 50)>, 0
+    make_closure .<lambda($init_test_58, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_basic"
-    make_closure .<lambda($init_test_56, 51)>, 0
+    make_closure .<lambda($init_test_58, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_zero_exponent"
-    make_closure .<lambda($init_test_56, 52)>, 0
+    make_closure .<lambda($init_test_58, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_zero_to_zero_is_one"
-    make_closure .<lambda($init_test_56, 53)>, 0
+    make_closure .<lambda($init_test_58, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_zero_to_positive_is_zero"
-    make_closure .<lambda($init_test_56, 54)>, 0
+    make_closure .<lambda($init_test_58, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_negative_exponent_returns_zero"
-    make_closure .<lambda($init_test_56, 55)>, 0
+    make_closure .<lambda($init_test_58, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_negative_base_odd_exp"
-    make_closure .<lambda($init_test_56, 56)>, 0
+    make_closure .<lambda($init_test_58, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_negative_base_even_exp"
-    make_closure .<lambda($init_test_56, 57)>, 0
+    make_closure .<lambda($init_test_58, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_one_anything"
-    make_closure .<lambda($init_test_56, 58)>, 0
+    make_closure .<lambda($init_test_58, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_negative_one_even"
-    make_closure .<lambda($init_test_56, 59)>, 0
+    make_closure .<lambda($init_test_58, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_negative_one_odd"
-    make_closure .<lambda($init_test_56, 60)>, 0
+    make_closure .<lambda($init_test_58, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_negative_one_huge_even_exp"
-    make_closure .<lambda($init_test_56, 61)>, 0
+    make_closure .<lambda($init_test_58, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_overflow_positive_saturates"
-    make_closure .<lambda($init_test_56, 62)>, 0
+    make_closure .<lambda($init_test_58, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_overflow_negative_odd_saturates_to_min"
-    make_closure .<lambda($init_test_56, 63)>, 0
+    make_closure .<lambda($init_test_58, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_pow_overflow_negative_even_saturates_to_max"
-    make_closure .<lambda($init_test_56, 64)>, 0
+    make_closure .<lambda($init_test_58, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_base_10"
-    make_closure .<lambda($init_test_56, 65)>, 0
+    make_closure .<lambda($init_test_58, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_base_2_power_of_two"
-    make_closure .<lambda($init_test_56, 66)>, 0
+    make_closure .<lambda($init_test_58, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_rounds_down"
-    make_closure .<lambda($init_test_56, 67)>, 0
+    make_closure .<lambda($init_test_58, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_one_is_zero"
-    make_closure .<lambda($init_test_56, 68)>, 0
+    make_closure .<lambda($init_test_58, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_self_zero_throws"
-    make_closure .<lambda($init_test_56, 69)>, 0
+    make_closure .<lambda($init_test_58, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_self_negative_throws"
-    make_closure .<lambda($init_test_56, 70)>, 0
+    make_closure .<lambda($init_test_58, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_base_one_throws"
-    make_closure .<lambda($init_test_56, 71)>, 0
+    make_closure .<lambda($init_test_58, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_base_zero_throws"
-    make_closure .<lambda($init_test_56, 72)>, 0
+    make_closure .<lambda($init_test_58, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_ilog_base_negative_throws"
-    make_closure .<lambda($init_test_56, 73)>, 0
+    make_closure .<lambda($init_test_58, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_leading_zeros_zero"
-    make_closure .<lambda($init_test_56, 74)>, 0
+    make_closure .<lambda($init_test_58, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_leading_zeros_one"
-    make_closure .<lambda($init_test_56, 75)>, 0
+    make_closure .<lambda($init_test_58, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_leading_zeros_negative_one_is_zero"
-    make_closure .<lambda($init_test_56, 76)>, 0
+    make_closure .<lambda($init_test_58, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_leading_zeros_large_power_of_two"
-    make_closure .<lambda($init_test_56, 77)>, 0
+    make_closure .<lambda($init_test_58, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_leading_ones_zero"
-    make_closure .<lambda($init_test_56, 78)>, 0
+    make_closure .<lambda($init_test_58, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_leading_ones_negative_one"
-    make_closure .<lambda($init_test_56, 79)>, 0
+    make_closure .<lambda($init_test_58, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_trailing_zeros_zero"
-    make_closure .<lambda($init_test_56, 80)>, 0
+    make_closure .<lambda($init_test_58, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_trailing_zeros_one"
-    make_closure .<lambda($init_test_56, 81)>, 0
+    make_closure .<lambda($init_test_58, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_trailing_zeros_eight"
-    make_closure .<lambda($init_test_56, 82)>, 0
+    make_closure .<lambda($init_test_58, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_trailing_ones_zero"
-    make_closure .<lambda($init_test_56, 83)>, 0
+    make_closure .<lambda($init_test_58, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_trailing_ones_seven"
-    make_closure .<lambda($init_test_56, 84)>, 0
+    make_closure .<lambda($init_test_58, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_trailing_ones_negative_one"
-    make_closure .<lambda($init_test_56, 85)>, 0
+    make_closure .<lambda($init_test_58, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_count_zeros_of_zero"
-    make_closure .<lambda($init_test_56, 86)>, 0
+    make_closure .<lambda($init_test_58, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_count_zeros_of_negative_one"
-    make_closure .<lambda($init_test_56, 87)>, 0
+    make_closure .<lambda($init_test_58, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_count_ones_of_zero"
-    make_closure .<lambda($init_test_56, 88)>, 0
+    make_closure .<lambda($init_test_58, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_count_ones_of_seven"
-    make_closure .<lambda($init_test_56, 89)>, 0
+    make_closure .<lambda($init_test_58, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_count_ones_of_negative_one"
-    make_closure .<lambda($init_test_56, 90)>, 0
+    make_closure .<lambda($init_test_58, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_count_zeros_plus_count_ones_equals_64"
-    make_closure .<lambda($init_test_56, 91)>, 0
+    make_closure .<lambda($init_test_58, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/is_operator.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/is_operator.snap
@@ -1,364 +1,364 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function is_operator.$init_test_57(registry: testing.TestCollector) -> null {
+function is_operator.$init_test_59(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "is_type_match_true"
-    make_closure .<lambda($init_test_57, 0)>, 0
+    make_closure .<lambda($init_test_59, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_type_match_false"
-    make_closure .<lambda($init_test_57, 1)>, 0
+    make_closure .<lambda($init_test_59, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_pattern_disjoint_from_scrutinee_type_returns_false"
-    make_closure .<lambda($init_test_57, 2)>, 0
+    make_closure .<lambda($init_test_59, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_with_not"
-    make_closure .<lambda($init_test_57, 3)>, 0
+    make_closure .<lambda($init_test_59, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_null_pattern_on_null"
-    make_closure .<lambda($init_test_57, 4)>, 0
+    make_closure .<lambda($init_test_59, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_null_pattern_on_non_null"
-    make_closure .<lambda($init_test_57, 5)>, 0
+    make_closure .<lambda($init_test_59, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_wildcard_pattern_is_always_true"
-    make_closure .<lambda($init_test_57, 6)>, 0
+    make_closure .<lambda($init_test_59, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_wildcard_on_null_is_true"
-    make_closure .<lambda($init_test_57, 7)>, 0
+    make_closure .<lambda($init_test_59, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_string_literal_pattern_match"
-    make_closure .<lambda($init_test_57, 8)>, 0
+    make_closure .<lambda($init_test_59, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_string_literal_pattern_mismatch"
-    make_closure .<lambda($init_test_57, 9)>, 0
+    make_closure .<lambda($init_test_59, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_bool_literal_pattern_true"
-    make_closure .<lambda($init_test_57, 10)>, 0
+    make_closure .<lambda($init_test_59, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_bool_literal_pattern_false"
-    make_closure .<lambda($init_test_57, 11)>, 0
+    make_closure .<lambda($init_test_59, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_int_literal_pattern_zero"
-    make_closure .<lambda($init_test_57, 12)>, 0
+    make_closure .<lambda($init_test_59, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_int_literal_pattern_mismatch"
-    make_closure .<lambda($init_test_57, 13)>, 0
+    make_closure .<lambda($init_test_59, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_enum_variant_pattern_match"
-    make_closure .<lambda($init_test_57, 14)>, 0
+    make_closure .<lambda($init_test_59, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_enum_variant_pattern_mismatch"
-    make_closure .<lambda($init_test_57, 15)>, 0
+    make_closure .<lambda($init_test_59, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_class_destructure_pattern_match"
-    make_closure .<lambda($init_test_57, 16)>, 0
+    make_closure .<lambda($init_test_59, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_array_type_pattern"
-    make_closure .<lambda($init_test_57, 17)>, 0
+    make_closure .<lambda($init_test_59, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_array_type_pattern_mismatch"
-    make_closure .<lambda($init_test_57, 18)>, 0
+    make_closure .<lambda($init_test_59, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_or_pattern"
-    make_closure .<lambda($init_test_57, 19)>, 0
+    make_closure .<lambda($init_test_59, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_or_pattern_first_alternative"
-    make_closure .<lambda($init_test_57, 20)>, 0
+    make_closure .<lambda($init_test_59, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_or_pattern_none_match"
-    make_closure .<lambda($init_test_57, 21)>, 0
+    make_closure .<lambda($init_test_59, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_or_pattern_with_literals"
-    make_closure .<lambda($init_test_57, 22)>, 0
+    make_closure .<lambda($init_test_59, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_or_pattern_parenthesised_alternatives"
-    make_closure .<lambda($init_test_57, 23)>, 0
+    make_closure .<lambda($init_test_59, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_bare_binding_pattern_matches"
-    make_closure .<lambda($init_test_57, 24)>, 0
+    make_closure .<lambda($init_test_59, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_typed_binding_pattern_matches"
-    make_closure .<lambda($init_test_57, 25)>, 0
+    make_closure .<lambda($init_test_59, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_typed_binding_pattern_mismatch"
-    make_closure .<lambda($init_test_57, 26)>, 0
+    make_closure .<lambda($init_test_59, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_with_call_scrutinee"
-    make_closure .<lambda($init_test_57, 27)>, 0
+    make_closure .<lambda($init_test_59, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_with_field_access_scrutinee"
-    make_closure .<lambda($init_test_57, 28)>, 0
+    make_closure .<lambda($init_test_59, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_with_optional_chain_scrutinee"
-    make_closure .<lambda($init_test_57, 29)>, 0
+    make_closure .<lambda($init_test_59, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_with_parenthesised_arithmetic_scrutinee"
-    make_closure .<lambda($init_test_57, 30)>, 0
+    make_closure .<lambda($init_test_59, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_chained_with_and"
-    make_closure .<lambda($init_test_57, 31)>, 0
+    make_closure .<lambda($init_test_59, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_chained_with_or"
-    make_closure .<lambda($init_test_57, 32)>, 0
+    make_closure .<lambda($init_test_59, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_compared_with_eq_binds_tighter"
-    make_closure .<lambda($init_test_57, 33)>, 0
+    make_closure .<lambda($init_test_59, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_chained_on_itself"
-    make_closure .<lambda($init_test_57, 34)>, 0
+    make_closure .<lambda($init_test_59, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_chained_on_itself_without_parens_is_left_associative"
-    make_closure .<lambda($init_test_57, 35)>, 0
+    make_closure .<lambda($init_test_59, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_chained_on_itself_without_parens_negative_outer"
-    make_closure .<lambda($init_test_57, 36)>, 0
+    make_closure .<lambda($init_test_59, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_in_if_condition"
-    make_closure .<lambda($init_test_57, 37)>, 0
+    make_closure .<lambda($init_test_59, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_inside_array_literal"
-    make_closure .<lambda($init_test_57, 38)>, 0
+    make_closure .<lambda($init_test_59, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_inside_lambda_body"
-    make_closure .<lambda($init_test_57, 39)>, 0
+    make_closure .<lambda($init_test_59, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_as_return_value"
-    make_closure .<lambda($init_test_57, 40)>, 0
+    make_closure .<lambda($init_test_59, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_in_match_guard"
-    make_closure .<lambda($init_test_57, 41)>, 0
+    make_closure .<lambda($init_test_59, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_in_let_initializer"
-    make_closure .<lambda($init_test_57, 42)>, 0
+    make_closure .<lambda($init_test_59, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_inside_while_condition"
-    make_closure .<lambda($init_test_57, 43)>, 0
+    make_closure .<lambda($init_test_59, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_evaluates_scrutinee_exactly_once"
-    make_closure .<lambda($init_test_57, 44)>, 0
+    make_closure .<lambda($init_test_59, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_then_branch_picks_pattern_type"
-    make_closure .<lambda($init_test_57, 45)>, 0
+    make_closure .<lambda($init_test_59, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_then_branch_picks_or_pattern_type"
-    make_closure .<lambda($init_test_57, 46)>, 0
+    make_closure .<lambda($init_test_59, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_else_branch_runs_for_non_matching_value"
-    make_closure .<lambda($init_test_57, 47)>, 0
+    make_closure .<lambda($init_test_59, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_else_branch_subtracts_matched_type"
-    make_closure .<lambda($init_test_57, 48)>, 0
+    make_closure .<lambda($init_test_59, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_else_branch_subtracts_or_pattern"
-    make_closure .<lambda($init_test_57, 49)>, 0
+    make_closure .<lambda($init_test_59, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_else_branch_with_class_types"
-    make_closure .<lambda($init_test_57, 50)>, 0
+    make_closure .<lambda($init_test_59, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_else_branch_with_literal_pattern_keeps_original"
-    make_closure .<lambda($init_test_57, 51)>, 0
+    make_closure .<lambda($init_test_59, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_negation_subtracts_in_then_branch"
-    make_closure .<lambda($init_test_57, 52)>, 0
+    make_closure .<lambda($init_test_59, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_through_negation"
-    make_closure .<lambda($init_test_57, 53)>, 0
+    make_closure .<lambda($init_test_59, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_works_on_function_parameter"
-    make_closure .<lambda($init_test_57, 54)>, 0
+    make_closure .<lambda($init_test_59, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_picks_class_type_in_then_branch"
-    make_closure .<lambda($init_test_57, 55)>, 0
+    make_closure .<lambda($init_test_59, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_persists_across_multiple_uses_in_then"
-    make_closure .<lambda($init_test_57, 56)>, 0
+    make_closure .<lambda($init_test_59, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_skipped_for_non_path_scrutinee"
-    make_closure .<lambda($init_test_57, 57)>, 0
+    make_closure .<lambda($init_test_59, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "narrowing_with_early_return"
-    make_closure .<lambda($init_test_57, 58)>, 0
+    make_closure .<lambda($init_test_59, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "is_chained_negation_and_or"
-    make_closure .<lambda($init_test_57, 59)>, 0
+    make_closure .<lambda($init_test_59, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_alias.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_alias.snap
@@ -1,46 +1,46 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function json_alias.$init_test_58(registry: testing.TestCollector) -> null {
+function json_alias.$init_test_60(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "field_of_type_json_lowers_cleanly"
-    make_closure .<lambda($init_test_58, 0)>, 0
+    make_closure .<lambda($init_test_60, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_json_null"
-    make_closure .<lambda($init_test_58, 1)>, 0
+    make_closure .<lambda($init_test_60, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_json_int"
-    make_closure .<lambda($init_test_58, 2)>, 0
+    make_closure .<lambda($init_test_60, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_json_string"
-    make_closure .<lambda($init_test_58, 3)>, 0
+    make_closure .<lambda($init_test_60, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_json_array"
-    make_closure .<lambda($init_test_58, 4)>, 0
+    make_closure .<lambda($init_test_60, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_json_map"
-    make_closure .<lambda($init_test_58, 5)>, 0
+    make_closure .<lambda($init_test_60, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_json_arms_exhaustive"
-    make_closure .<lambda($init_test_58, 6)>, 0
+    make_closure .<lambda($init_test_60, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_auto_derive.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_auto_derive.snap
@@ -1,256 +1,256 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function json_auto_derive.$init_test_59(registry: testing.TestCollector) -> null {
+function json_auto_derive.$init_test_61(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "simple_class_to_json_roundtrip"
-    make_closure .<lambda($init_test_59, 0)>, 0
+    make_closure .<lambda($init_test_61, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "user_to_json_override_suppresses_auto_derive"
-    make_closure .<lambda($init_test_59, 1)>, 0
+    make_closure .<lambda($init_test_61, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_to_json_resolves_and_executes"
-    make_closure .<lambda($init_test_59, 2)>, 0
+    make_closure .<lambda($init_test_61, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_to_json_resolves_and_executes"
-    make_closure .<lambda($init_test_59, 3)>, 0
+    make_closure .<lambda($init_test_61, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bool_to_json_resolves_and_executes"
-    make_closure .<lambda($init_test_59, 4)>, 0
+    make_closure .<lambda($init_test_61, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "null_to_json_resolves_and_executes"
-    make_closure .<lambda($init_test_59, 5)>, 0
+    make_closure .<lambda($init_test_61, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_of_int_to_json_returns_json_array"
-    make_closure .<lambda($init_test_59, 6)>, 0
+    make_closure .<lambda($init_test_61, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_of_class_to_json_honors_override"
-    make_closure .<lambda($init_test_59, 7)>, 0
+    make_closure .<lambda($init_test_61, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_of_int_to_json_returns_json_map"
-    make_closure .<lambda($init_test_59, 8)>, 0
+    make_closure .<lambda($init_test_61, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "typevar_to_json_compiles_in_generic_class"
-    make_closure .<lambda($init_test_59, 9)>, 0
+    make_closure .<lambda($init_test_61, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "primitive_field_to_json"
-    make_closure .<lambda($init_test_59, 10)>, 0
+    make_closure .<lambda($init_test_61, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_of_primitive_to_json"
-    make_closure .<lambda($init_test_59, 11)>, 0
+    make_closure .<lambda($init_test_61, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_class_override_honored_direct"
-    make_closure .<lambda($init_test_59, 12)>, 0
+    make_closure .<lambda($init_test_61, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_class_override_honored_in_array"
-    make_closure .<lambda($init_test_59, 13)>, 0
+    make_closure .<lambda($init_test_61, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_class_override_honored_in_map"
-    make_closure .<lambda($init_test_59, 14)>, 0
+    make_closure .<lambda($init_test_61, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "recursive_class_to_json"
-    make_closure .<lambda($init_test_59, 15)>, 0
+    make_closure .<lambda($init_test_61, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_to_json_concrete"
-    make_closure .<lambda($init_test_59, 16)>, 0
+    make_closure .<lambda($init_test_61, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_to_json_array_typearg"
-    make_closure .<lambda($init_test_59, 17)>, 0
+    make_closure .<lambda($init_test_61, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_honors_override_through_typevar"
-    make_closure .<lambda($init_test_59, 18)>, 0
+    make_closure .<lambda($init_test_61, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_with_optional_typevar_field"
-    make_closure .<lambda($init_test_59, 19)>, 0
+    make_closure .<lambda($init_test_61, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_with_optional_typevar_field_null"
-    make_closure .<lambda($init_test_59, 20)>, 0
+    make_closure .<lambda($init_test_61, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_with_optional_typevar_field_honors_override"
-    make_closure .<lambda($init_test_59, 21)>, 0
+    make_closure .<lambda($init_test_61, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "primitive_field_from_json"
-    make_closure .<lambda($init_test_59, 22)>, 0
+    make_closure .<lambda($init_test_61, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_of_primitive_from_json"
-    make_closure .<lambda($init_test_59, 23)>, 0
+    make_closure .<lambda($init_test_61, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_class_override_honored_direct_from_json"
-    make_closure .<lambda($init_test_59, 24)>, 0
+    make_closure .<lambda($init_test_61, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_class_override_honored_in_array_from_json"
-    make_closure .<lambda($init_test_59, 25)>, 0
+    make_closure .<lambda($init_test_61, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_class_override_honored_in_map_from_json"
-    make_closure .<lambda($init_test_59, 26)>, 0
+    make_closure .<lambda($init_test_61, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "recursive_class_from_json"
-    make_closure .<lambda($init_test_59, 27)>, 0
+    make_closure .<lambda($init_test_61, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_from_json_concrete"
-    make_closure .<lambda($init_test_59, 28)>, 0
+    make_closure .<lambda($init_test_61, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_honors_override_through_typevar_from_json"
-    make_closure .<lambda($init_test_59, 29)>, 0
+    make_closure .<lambda($init_test_61, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_class_override_honored_from_json_non_null"
-    make_closure .<lambda($init_test_59, 30)>, 0
+    make_closure .<lambda($init_test_61, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_class_override_honored_from_json_null"
-    make_closure .<lambda($init_test_59, 31)>, 0
+    make_closure .<lambda($init_test_61, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_primitive_field_from_json"
-    make_closure .<lambda($init_test_59, 32)>, 0
+    make_closure .<lambda($init_test_61, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_of_primitive_from_json"
-    make_closure .<lambda($init_test_59, 33)>, 0
+    make_closure .<lambda($init_test_61, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "top_level_from_json_call_concrete_class"
-    make_closure .<lambda($init_test_59, 34)>, 0
+    make_closure .<lambda($init_test_61, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "top_level_from_json_call_primitive"
-    make_closure .<lambda($init_test_59, 35)>, 0
+    make_closure .<lambda($init_test_61, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "independent_synthesis_only_from_json_defined"
-    make_closure .<lambda($init_test_59, 36)>, 0
+    make_closure .<lambda($init_test_61, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "independent_synthesis_only_to_json_defined"
-    make_closure .<lambda($init_test_59, 37)>, 0
+    make_closure .<lambda($init_test_61, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "round_trip_with_overrides_both_directions"
-    make_closure .<lambda($init_test_59, 38)>, 0
+    make_closure .<lambda($init_test_61, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "alias_chain_dispatch_to_json"
-    make_closure .<lambda($init_test_59, 39)>, 0
+    make_closure .<lambda($init_test_61, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "alias_chain_dispatch_from_json"
-    make_closure .<lambda($init_test_59, 40)>, 0
+    make_closure .<lambda($init_test_61, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "from_json_wrapper_body_fallback"
-    make_closure .<lambda($init_test_59, 41)>, 0
+    make_closure .<lambda($init_test_61, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_parse_stringify.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_parse_stringify.snap
@@ -1,52 +1,52 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function json_parse_stringify.$init_test_60(registry: testing.TestCollector) -> null {
+function json_parse_stringify.$init_test_62(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "parse_array_of_ints"
-    make_closure .<lambda($init_test_60, 0)>, 0
+    make_closure .<lambda($init_test_62, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "parse_then_match_array"
-    make_closure .<lambda($init_test_60, 1)>, 0
+    make_closure .<lambda($init_test_62, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "roundtrip_stringify_parse"
-    make_closure .<lambda($init_test_60, 2)>, 0
+    make_closure .<lambda($init_test_62, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "parse_int_disambiguation"
-    make_closure .<lambda($init_test_60, 3)>, 0
+    make_closure .<lambda($init_test_62, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "parse_float_disambiguation"
-    make_closure .<lambda($init_test_60, 4)>, 0
+    make_closure .<lambda($init_test_62, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "parse_throws_on_garbage"
-    make_closure .<lambda($init_test_60, 5)>, 0
+    make_closure .<lambda($init_test_62, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "stringify_pretty_multiline"
-    make_closure .<lambda($init_test_60, 6)>, 0
+    make_closure .<lambda($init_test_62, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "roundtrip_nested_object"
-    make_closure .<lambda($init_test_60, 7)>, 0
+    make_closure .<lambda($init_test_62, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_to_from_string.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_to_from_string.snap
@@ -1,166 +1,166 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function json_to_from_string.$init_test_61(registry: testing.TestCollector) -> null {
+function json_to_from_string.$init_test_63(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "to_string_simple_class"
-    make_closure .<lambda($init_test_61, 0)>, 0
+    make_closure .<lambda($init_test_63, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "from_string_simple_class"
-    make_closure .<lambda($init_test_61, 1)>, 0
+    make_closure .<lambda($init_test_63, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "roundtrip_simple"
-    make_closure .<lambda($init_test_61, 2)>, 0
+    make_closure .<lambda($init_test_63, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "composite_generic_roundtrip"
-    make_closure .<lambda($init_test_61, 3)>, 0
+    make_closure .<lambda($init_test_63, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_forwarding_user"
-    make_closure .<lambda($init_test_61, 4)>, 0
+    make_closure .<lambda($init_test_63, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_forwarding_composite"
-    make_closure .<lambda($init_test_61, 5)>, 0
+    make_closure .<lambda($init_test_63, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "three_level_forwarding"
-    make_closure .<lambda($init_test_61, 6)>, 0
+    make_closure .<lambda($init_test_63, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "closure_captures_type_arg"
-    make_closure .<lambda($init_test_61, 7)>, 0
+    make_closure .<lambda($init_test_63, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "enum_variant_to_string"
-    make_closure .<lambda($init_test_61, 8)>, 0
+    make_closure .<lambda($init_test_63, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "enum_variant_from_string"
-    make_closure .<lambda($init_test_61, 9)>, 0
+    make_closure .<lambda($init_test_63, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_field_present"
-    make_closure .<lambda($init_test_61, 10)>, 0
+    make_closure .<lambda($init_test_63, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_field_null"
-    make_closure .<lambda($init_test_61, 11)>, 0
+    make_closure .<lambda($init_test_63, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_field_decode_missing"
-    make_closure .<lambda($init_test_61, 12)>, 0
+    make_closure .<lambda($init_test_63, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "recursive_class_roundtrip"
-    make_closure .<lambda($init_test_61, 13)>, 0
+    make_closure .<lambda($init_test_63, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "parse_throws_on_bad_json"
-    make_closure .<lambda($init_test_61, 14)>, 0
+    make_closure .<lambda($init_test_63, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "decode_throws_on_missing_field"
-    make_closure .<lambda($init_test_61, 15)>, 0
+    make_closure .<lambda($init_test_63, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "serialize_throws_uint8array"
-    make_closure .<lambda($init_test_61, 16)>, 0
+    make_closure .<lambda($init_test_63, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "decode_error_path_points_at_missing_field"
-    make_closure .<lambda($init_test_61, 17)>, 0
+    make_closure .<lambda($init_test_63, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "enum_variant_roundtrip"
-    make_closure .<lambda($init_test_61, 18)>, 0
+    make_closure .<lambda($init_test_63, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "media_field_to_string"
-    make_closure .<lambda($init_test_61, 19)>, 0
+    make_closure .<lambda($init_test_63, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "media_field_roundtrip"
-    make_closure .<lambda($init_test_61, 20)>, 0
+    make_closure .<lambda($init_test_63, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "alias_field_uses_raw_name_in_json"
-    make_closure .<lambda($init_test_61, 21)>, 0
+    make_closure .<lambda($init_test_63, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "alias_field_decodes_raw_name"
-    make_closure .<lambda($init_test_61, 22)>, 0
+    make_closure .<lambda($init_test_63, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "skip_field_still_emitted_in_json"
-    make_closure .<lambda($init_test_61, 23)>, 0
+    make_closure .<lambda($init_test_63, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "from_string_json_passthrough_int"
-    make_closure .<lambda($init_test_61, 24)>, 0
+    make_closure .<lambda($init_test_63, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "from_string_json_passthrough_object"
-    make_closure .<lambda($init_test_61, 25)>, 0
+    make_closure .<lambda($init_test_63, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "to_string_json_passthrough"
-    make_closure .<lambda($init_test_61, 26)>, 0
+    make_closure .<lambda($init_test_63, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -1,172 +1,172 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function lambdas.$init_test_62(registry: testing.TestCollector) -> null {
+function lambdas.$init_test_64(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "iife_single_param_returns_correct_value"
-    make_closure .<lambda($init_test_62, 0)>, 0
+    make_closure .<lambda($init_test_64, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "zero_param_lambda_returns_constant"
-    make_closure .<lambda($init_test_62, 1)>, 0
+    make_closure .<lambda($init_test_64, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multi_param_lambda_returns_sum"
-    make_closure .<lambda($init_test_62, 2)>, 0
+    make_closure .<lambda($init_test_64, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "annotated_lambda_doubles_value"
-    make_closure .<lambda($init_test_62, 3)>, 0
+    make_closure .<lambda($init_test_64, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "inferred_return_type_lambda"
-    make_closure .<lambda($init_test_62, 4)>, 0
+    make_closure .<lambda($init_test_64, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "lambda_captures_local_variable"
-    make_closure .<lambda($init_test_62, 5)>, 0
+    make_closure .<lambda($init_test_64, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "lambda_captures_function_parameter"
-    make_closure .<lambda($init_test_62, 6)>, 0
+    make_closure .<lambda($init_test_64, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "lambda_captures_multiple_variables"
-    make_closure .<lambda($init_test_62, 7)>, 0
+    make_closure .<lambda($init_test_64, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shared_cell_mutation_counter"
-    make_closure .<lambda($init_test_62, 8)>, 0
+    make_closure .<lambda($init_test_64, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_lambda_transitive_capture"
-    make_closure .<lambda($init_test_62, 9)>, 0
+    make_closure .<lambda($init_test_64, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "iife_returns_closure_counter"
-    make_closure .<lambda($init_test_62, 10)>, 0
+    make_closure .<lambda($init_test_64, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "closure_in_map_with_captured_offset"
-    make_closure .<lambda($init_test_62, 11)>, 0
+    make_closure .<lambda($init_test_64, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multiple_closures_share_cell"
-    make_closure .<lambda($init_test_62, 12)>, 0
+    make_closure .<lambda($init_test_64, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multiple_closures_share_cell_deep_copy"
-    make_closure .<lambda($init_test_62, 13)>, 0
+    make_closure .<lambda($init_test_64, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "explicit_throwing_lambda_catches_error"
-    make_closure .<lambda($init_test_62, 14)>, 0
+    make_closure .<lambda($init_test_64, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "lambda_inside_catch_base_keeps_parameter_scope"
-    make_closure .<lambda($init_test_62, 15)>, 0
+    make_closure .<lambda($init_test_64, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_nesting_three_levels"
-    make_closure .<lambda($init_test_62, 16)>, 0
+    make_closure .<lambda($init_test_64, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "lambda_captures_loop_variable_accumulation"
-    make_closure .<lambda($init_test_62, 17)>, 0
+    make_closure .<lambda($init_test_64, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_e_method_resolution_different_types"
-    make_closure .<lambda($init_test_62, 18)>, 0
+    make_closure .<lambda($init_test_64, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_f_shadowing_capture_correct_binding"
-    make_closure .<lambda($init_test_62, 19)>, 0
+    make_closure .<lambda($init_test_64, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_f_shadowing_capture_independent_cells"
-    make_closure .<lambda($init_test_62, 20)>, 0
+    make_closure .<lambda($init_test_64, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_a_capture_read_after_mutation"
-    make_closure .<lambda($init_test_62, 21)>, 0
+    make_closure .<lambda($init_test_64, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_a_interleaved_capture_reads_writes"
-    make_closure .<lambda($init_test_62, 22)>, 0
+    make_closure .<lambda($init_test_64, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_d_capture_as_call_destination"
-    make_closure .<lambda($init_test_62, 23)>, 0
+    make_closure .<lambda($init_test_64, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_b_captured_variable_mutation_visible"
-    make_closure .<lambda($init_test_62, 24)>, 0
+    make_closure .<lambda($init_test_64, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_b_watch_let_captured_by_lambda"
-    make_closure .<lambda($init_test_62, 25)>, 0
+    make_closure .<lambda($init_test_64, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "issue_b_watch_let_mutated_by_parent_and_lambda"
-    make_closure .<lambda($init_test_62, 26)>, 0
+    make_closure .<lambda($init_test_64, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "lambda_param_shadows_annotated_outer_local"
-    make_closure .<lambda($init_test_62, 27)>, 0
+    make_closure .<lambda($init_test_64, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
@@ -1,106 +1,106 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function lexical_scoping.$init_test_63(registry: testing.TestCollector) -> null {
+function lexical_scoping.$init_test_65(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "same_scope_shadow"
-    make_closure .<lambda($init_test_63, 0)>, 0
+    make_closure .<lambda($init_test_65, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "outer_restored"
-    make_closure .<lambda($init_test_63, 1)>, 0
+    make_closure .<lambda($init_test_65, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "initializer_uses_previous"
-    make_closure .<lambda($init_test_63, 2)>, 0
+    make_closure .<lambda($init_test_65, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shadow_param"
-    make_closure .<lambda($init_test_63, 3)>, 0
+    make_closure .<lambda($init_test_65, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_loop_restores_outer"
-    make_closure .<lambda($init_test_63, 4)>, 0
+    make_closure .<lambda($init_test_65, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_outer_restored"
-    make_closure .<lambda($init_test_63, 5)>, 0
+    make_closure .<lambda($init_test_65, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "capture_before_after_shadow"
-    make_closure .<lambda($init_test_63, 6)>, 0
+    make_closure .<lambda($init_test_65, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rule1_while_no_leakage"
-    make_closure .<lambda($init_test_63, 7)>, 0
+    make_closure .<lambda($init_test_65, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rule1_while_observed_inner_shadow"
-    make_closure .<lambda($init_test_63, 8)>, 0
+    make_closure .<lambda($init_test_65, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rule2_block_outer_mutation_escapes"
-    make_closure .<lambda($init_test_63, 9)>, 0
+    make_closure .<lambda($init_test_65, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rule2_for_outer_mutation_escapes"
-    make_closure .<lambda($init_test_63, 10)>, 0
+    make_closure .<lambda($init_test_65, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rule3_block_shadow_then_assign_inner_does_not_escape"
-    make_closure .<lambda($init_test_63, 11)>, 0
+    make_closure .<lambda($init_test_65, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rule2_pre_shadow_mutation_escapes_post_shadow_does_not"
-    make_closure .<lambda($init_test_63, 12)>, 0
+    make_closure .<lambda($init_test_65, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "declared_type_restored_across_scope"
-    make_closure .<lambda($init_test_63, 13)>, 0
+    make_closure .<lambda($init_test_65, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "lambdas_capture_match_and_catch_pattern_bindings"
-    make_closure .<lambda($init_test_63, 14)>, 0
+    make_closure .<lambda($init_test_65, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_and_catch_pattern_bindings_restore_outer_locals"
-    make_closure .<lambda($init_test_63, 15)>, 0
+    make_closure .<lambda($init_test_65, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multi_clause_catch_uses_clause_local_binding"
-    make_closure .<lambda($init_test_63, 16)>, 0
+    make_closure .<lambda($init_test_65, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/maps.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/maps.snap
@@ -1,160 +1,160 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function maps.$init_test_64(registry: testing.TestCollector) -> null {
+function maps.$init_test_66(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "len"
-    make_closure .<lambda($init_test_64, 0)>, 0
+    make_closure .<lambda($init_test_66, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_set_first_insert_returns_null"
-    make_closure .<lambda($init_test_64, 1)>, 0
+    make_closure .<lambda($init_test_66, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_set_replace_returns_previous"
-    make_closure .<lambda($init_test_64, 2)>, 0
+    make_closure .<lambda($init_test_66, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_set_then_get_reads_latest"
-    make_closure .<lambda($init_test_64, 3)>, 0
+    make_closure .<lambda($init_test_66, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_set_grows_length"
-    make_closure .<lambda($init_test_64, 4)>, 0
+    make_closure .<lambda($init_test_66, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_set_replace_preserves_length"
-    make_closure .<lambda($init_test_64, 5)>, 0
+    make_closure .<lambda($init_test_66, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_delete_returns_previous"
-    make_closure .<lambda($init_test_64, 6)>, 0
+    make_closure .<lambda($init_test_66, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_delete_absent_returns_null"
-    make_closure .<lambda($init_test_64, 7)>, 0
+    make_closure .<lambda($init_test_66, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_delete_already_deleted_returns_null"
-    make_closure .<lambda($init_test_64, 8)>, 0
+    make_closure .<lambda($init_test_66, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_delete_shrinks_length"
-    make_closure .<lambda($init_test_64, 9)>, 0
+    make_closure .<lambda($init_test_66, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_delete_does_not_affect_other_keys"
-    make_closure .<lambda($init_test_64, 10)>, 0
+    make_closure .<lambda($init_test_66, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_get_or_insert_inserts_when_absent"
-    make_closure .<lambda($init_test_64, 11)>, 0
+    make_closure .<lambda($init_test_66, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_get_or_insert_returns_existing_when_present"
-    make_closure .<lambda($init_test_64, 12)>, 0
+    make_closure .<lambda($init_test_66, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_get_or_insert_does_not_overwrite"
-    make_closure .<lambda($init_test_64, 13)>, 0
+    make_closure .<lambda($init_test_66, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_get_or_insert_persists_inserted_value"
-    make_closure .<lambda($init_test_64, 14)>, 0
+    make_closure .<lambda($init_test_66, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_get_or_insert_grows_length_only_when_absent"
-    make_closure .<lambda($init_test_64, 15)>, 0
+    make_closure .<lambda($init_test_66, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_clear_removes_all"
-    make_closure .<lambda($init_test_64, 16)>, 0
+    make_closure .<lambda($init_test_66, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_clear_already_empty_is_noop"
-    make_closure .<lambda($init_test_64, 17)>, 0
+    make_closure .<lambda($init_test_66, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_clear_then_reuse"
-    make_closure .<lambda($init_test_64, 18)>, 0
+    make_closure .<lambda($init_test_66, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_clear_makes_get_return_null"
-    make_closure .<lambda($init_test_64, 19)>, 0
+    make_closure .<lambda($init_test_66, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_has_after_delete_is_false"
-    make_closure .<lambda($init_test_64, 20)>, 0
+    make_closure .<lambda($init_test_66, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_has_after_get_or_insert_is_true"
-    make_closure .<lambda($init_test_64, 21)>, 0
+    make_closure .<lambda($init_test_66, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "create_and_access"
-    make_closure .<lambda($init_test_64, 22)>, 0
+    make_closure .<lambda($init_test_66, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "access_no_key"
-    make_closure .<lambda($init_test_64, 23)>, 0
+    make_closure .<lambda($init_test_66, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "contains"
-    make_closure .<lambda($init_test_64, 24)>, 0
+    make_closure .<lambda($init_test_66, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "modify"
-    make_closure .<lambda($init_test_64, 25)>, 0
+    make_closure .<lambda($init_test_66, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/match_basics.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/match_basics.snap
@@ -1,244 +1,244 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function match_basics.$init_test_65(registry: testing.TestCollector) -> null {
+function match_basics.$init_test_67(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "match_catch_all_underscore"
-    make_closure .<lambda($init_test_65, 0)>, 0
+    make_closure .<lambda($init_test_67, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_catch_all_named_binding"
-    make_closure .<lambda($init_test_65, 1)>, 0
+    make_closure .<lambda($init_test_67, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_catch_all_with_variable"
-    make_closure .<lambda($init_test_65, 2)>, 0
+    make_closure .<lambda($init_test_67, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_literal_int_first_arm"
-    make_closure .<lambda($init_test_65, 3)>, 0
+    make_closure .<lambda($init_test_67, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_literal_int_second_arm"
-    make_closure .<lambda($init_test_65, 4)>, 0
+    make_closure .<lambda($init_test_67, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_literal_int_fallback"
-    make_closure .<lambda($init_test_65, 5)>, 0
+    make_closure .<lambda($init_test_67, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_literal_int_single_arm"
-    make_closure .<lambda($init_test_65, 6)>, 0
+    make_closure .<lambda($init_test_67, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_literal_null"
-    make_closure .<lambda($init_test_65, 7)>, 0
+    make_closure .<lambda($init_test_67, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_literal_bool_true"
-    make_closure .<lambda($init_test_65, 8)>, 0
+    make_closure .<lambda($init_test_67, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_literal_bool_false"
-    make_closure .<lambda($init_test_65, 9)>, 0
+    make_closure .<lambda($init_test_67, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_literal_bool_exhaustive_constant"
-    make_closure .<lambda($init_test_65, 10)>, 0
+    make_closure .<lambda($init_test_67, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_union_literal_first"
-    make_closure .<lambda($init_test_65, 11)>, 0
+    make_closure .<lambda($init_test_67, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_union_literal_second"
-    make_closure .<lambda($init_test_65, 12)>, 0
+    make_closure .<lambda($init_test_67, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_union_large"
-    make_closure .<lambda($init_test_65, 13)>, 0
+    make_closure .<lambda($init_test_67, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_union_client_error"
-    make_closure .<lambda($init_test_65, 14)>, 0
+    make_closure .<lambda($init_test_67, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_union_with_duplicates"
-    make_closure .<lambda($init_test_65, 15)>, 0
+    make_closure .<lambda($init_test_67, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_as_expression_in_arithmetic"
-    make_closure .<lambda($init_test_65, 16)>, 0
+    make_closure .<lambda($init_test_67, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_nested"
-    make_closure .<lambda($init_test_65, 17)>, 0
+    make_closure .<lambda($init_test_67, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_string_literal_first_arm"
-    make_closure .<lambda($init_test_65, 18)>, 0
+    make_closure .<lambda($init_test_67, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_string_literal_second_arm"
-    make_closure .<lambda($init_test_65, 19)>, 0
+    make_closure .<lambda($init_test_67, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_string_literal_fallback"
-    make_closure .<lambda($init_test_65, 20)>, 0
+    make_closure .<lambda($init_test_67, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_string_four_arms"
-    make_closure .<lambda($init_test_65, 21)>, 0
+    make_closure .<lambda($init_test_67, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_string_literal_with_typed_fallback"
-    make_closure .<lambda($init_test_65, 22)>, 0
+    make_closure .<lambda($init_test_67, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_catch_all_binding_with_int_patterns"
-    make_closure .<lambda($init_test_65, 23)>, 0
+    make_closure .<lambda($init_test_67, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_negative_int_with_variable"
-    make_closure .<lambda($init_test_65, 24)>, 0
+    make_closure .<lambda($init_test_67, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_negative_int_first_arm"
-    make_closure .<lambda($init_test_65, 25)>, 0
+    make_closure .<lambda($init_test_67, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_three_levels_nested"
-    make_closure .<lambda($init_test_65, 26)>, 0
+    make_closure .<lambda($init_test_67, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_three_levels_nested_middle"
-    make_closure .<lambda($init_test_65, 27)>, 0
+    make_closure .<lambda($init_test_67, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_optional_null_pattern"
-    make_closure .<lambda($init_test_65, 28)>, 0
+    make_closure .<lambda($init_test_67, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_optional_value_pattern"
-    make_closure .<lambda($init_test_65, 29)>, 0
+    make_closure .<lambda($init_test_67, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_optional_with_literal_and_typed"
-    make_closure .<lambda($init_test_65, 30)>, 0
+    make_closure .<lambda($init_test_67, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_arithmetic_scrutinee"
-    make_closure .<lambda($init_test_65, 31)>, 0
+    make_closure .<lambda($init_test_67, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_function_call_scrutinee"
-    make_closure .<lambda($init_test_65, 32)>, 0
+    make_closure .<lambda($init_test_67, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_computed_discriminant"
-    make_closure .<lambda($init_test_65, 33)>, 0
+    make_closure .<lambda($init_test_67, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_in_loop"
-    make_closure .<lambda($init_test_65, 34)>, 0
+    make_closure .<lambda($init_test_67, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_dense_with_catch_all_via_call"
-    make_closure .<lambda($init_test_65, 35)>, 0
+    make_closure .<lambda($init_test_67, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_mixed_instanceof_and_literal"
-    make_closure .<lambda($init_test_65, 36)>, 0
+    make_closure .<lambda($init_test_67, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_bool_variable_exhaustive"
-    make_closure .<lambda($init_test_65, 37)>, 0
+    make_closure .<lambda($init_test_67, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_wildcard_bool_is_exhaustive"
-    make_closure .<lambda($init_test_65, 38)>, 0
+    make_closure .<lambda($init_test_67, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_string_many_arms"
-    make_closure .<lambda($init_test_65, 39)>, 0
+    make_closure .<lambda($init_test_67, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/match_optimization.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/match_optimization.snap
@@ -1,214 +1,214 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function match_optimization.$init_test_66(registry: testing.TestCollector) -> null {
+function match_optimization.$init_test_68(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "match_jump_table_first_arm"
-    make_closure .<lambda($init_test_66, 0)>, 0
+    make_closure .<lambda($init_test_68, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_middle_arm"
-    make_closure .<lambda($init_test_66, 1)>, 0
+    make_closure .<lambda($init_test_68, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_last_arm"
-    make_closure .<lambda($init_test_66, 2)>, 0
+    make_closure .<lambda($init_test_68, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_fallback"
-    make_closure .<lambda($init_test_66, 3)>, 0
+    make_closure .<lambda($init_test_68, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_negative_fallback"
-    make_closure .<lambda($init_test_66, 4)>, 0
+    make_closure .<lambda($init_test_68, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_with_holes_miss"
-    make_closure .<lambda($init_test_66, 5)>, 0
+    make_closure .<lambda($init_test_68, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_with_holes_hit"
-    make_closure .<lambda($init_test_66, 6)>, 0
+    make_closure .<lambda($init_test_68, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_offset_values"
-    make_closure .<lambda($init_test_66, 7)>, 0
+    make_closure .<lambda($init_test_68, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_large"
-    make_closure .<lambda($init_test_66, 8)>, 0
+    make_closure .<lambda($init_test_68, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_jump_table_dense_four_arms_param"
-    make_closure .<lambda($init_test_66, 9)>, 0
+    make_closure .<lambda($init_test_68, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_first_arm"
-    make_closure .<lambda($init_test_66, 10)>, 0
+    make_closure .<lambda($init_test_68, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_middle_arm"
-    make_closure .<lambda($init_test_66, 11)>, 0
+    make_closure .<lambda($init_test_68, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_last_arm"
-    make_closure .<lambda($init_test_66, 12)>, 0
+    make_closure .<lambda($init_test_68, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_fallback"
-    make_closure .<lambda($init_test_66, 13)>, 0
+    make_closure .<lambda($init_test_68, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_very_sparse"
-    make_closure .<lambda($init_test_66, 14)>, 0
+    make_closure .<lambda($init_test_68, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_large_values"
-    make_closure .<lambda($init_test_66, 15)>, 0
+    make_closure .<lambda($init_test_68, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_sparse_four_arms_param"
-    make_closure .<lambda($init_test_66, 16)>, 0
+    make_closure .<lambda($init_test_68, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_if_else_chain_three_arms"
-    make_closure .<lambda($init_test_66, 17)>, 0
+    make_closure .<lambda($init_test_68, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_density_exactly_50_percent"
-    make_closure .<lambda($init_test_66, 18)>, 0
+    make_closure .<lambda($init_test_68, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_density_below_50_percent"
-    make_closure .<lambda($init_test_66, 19)>, 0
+    make_closure .<lambda($init_test_68, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_density_above_50_percent"
-    make_closure .<lambda($init_test_66, 20)>, 0
+    make_closure .<lambda($init_test_68, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_large_range_dense"
-    make_closure .<lambda($init_test_66, 21)>, 0
+    make_closure .<lambda($init_test_68, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_large_range_sparse"
-    make_closure .<lambda($init_test_66, 22)>, 0
+    make_closure .<lambda($init_test_68, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_zero_in_range"
-    make_closure .<lambda($init_test_66, 23)>, 0
+    make_closure .<lambda($init_test_68, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_negative_jump_table"
-    make_closure .<lambda($init_test_66, 24)>, 0
+    make_closure .<lambda($init_test_68, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_negative_jump_table_fallback"
-    make_closure .<lambda($init_test_66, 25)>, 0
+    make_closure .<lambda($init_test_68, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_spanning_zero_jump_table"
-    make_closure .<lambda($init_test_66, 26)>, 0
+    make_closure .<lambda($init_test_68, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_spanning_zero_negative_hit"
-    make_closure .<lambda($init_test_66, 27)>, 0
+    make_closure .<lambda($init_test_68, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_negative_sparse"
-    make_closure .<lambda($init_test_66, 28)>, 0
+    make_closure .<lambda($init_test_68, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_spanning_zero_sparse"
-    make_closure .<lambda($init_test_66, 29)>, 0
+    make_closure .<lambda($init_test_68, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_union_aggregated_jump_table"
-    make_closure .<lambda($init_test_66, 30)>, 0
+    make_closure .<lambda($init_test_68, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_range_at_limit_uses_jump_table"
-    make_closure .<lambda($init_test_66, 31)>, 0
+    make_closure .<lambda($init_test_68, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_range_exceeds_limit_uses_binary_search"
-    make_closure .<lambda($init_test_66, 32)>, 0
+    make_closure .<lambda($init_test_68, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_large_jump_table"
-    make_closure .<lambda($init_test_66, 33)>, 0
+    make_closure .<lambda($init_test_68, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_binary_search_eight_arms"
-    make_closure .<lambda($init_test_66, 34)>, 0
+    make_closure .<lambda($init_test_68, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/match_types.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/match_types.snap
@@ -1,190 +1,190 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function match_types.$init_test_67(registry: testing.TestCollector) -> null {
+function match_types.$init_test_69(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "match_typed_pattern_second_arm"
-    make_closure .<lambda($init_test_67, 0)>, 0
+    make_closure .<lambda($init_test_69, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_typed_pattern_with_field_access"
-    make_closure .<lambda($init_test_67, 1)>, 0
+    make_closure .<lambda($init_test_69, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_typed_discard_patterns_typetag_switch_path"
-    make_closure .<lambda($init_test_67, 2)>, 0
+    make_closure .<lambda($init_test_69, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_guard_true"
-    make_closure .<lambda($init_test_67, 3)>, 0
+    make_closure .<lambda($init_test_69, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_guard_fallthrough"
-    make_closure .<lambda($init_test_67, 4)>, 0
+    make_closure .<lambda($init_test_69, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_guard_all_fail"
-    make_closure .<lambda($init_test_67, 5)>, 0
+    make_closure .<lambda($init_test_69, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_guarded_int_literal_guard_true"
-    make_closure .<lambda($init_test_67, 6)>, 0
+    make_closure .<lambda($init_test_69, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_guarded_int_literal_guard_false"
-    make_closure .<lambda($init_test_67, 7)>, 0
+    make_closure .<lambda($init_test_69, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_all_arms_guarded_all_fail"
-    make_closure .<lambda($init_test_67, 8)>, 0
+    make_closure .<lambda($init_test_69, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_mixed_literal_typed_guard"
-    make_closure .<lambda($init_test_67, 9)>, 0
+    make_closure .<lambda($init_test_69, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_mixed_literal_typed_guard_fallthrough"
-    make_closure .<lambda($init_test_67, 10)>, 0
+    make_closure .<lambda($init_test_69, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_guard_on_typed_pattern_field_access"
-    make_closure .<lambda($init_test_67, 11)>, 0
+    make_closure .<lambda($init_test_69, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_guard_on_typed_pattern_field_access_fails"
-    make_closure .<lambda($init_test_67, 12)>, 0
+    make_closure .<lambda($init_test_69, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_enum_variant_first"
-    make_closure .<lambda($init_test_67, 13)>, 0
+    make_closure .<lambda($init_test_69, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_enum_variant_last"
-    make_closure .<lambda($init_test_67, 14)>, 0
+    make_closure .<lambda($init_test_69, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_enum_variant_with_wildcard"
-    make_closure .<lambda($init_test_67, 15)>, 0
+    make_closure .<lambda($init_test_69, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_enum_variant_with_wildcard_matched"
-    make_closure .<lambda($init_test_67, 16)>, 0
+    make_closure .<lambda($init_test_69, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_enum_four_variants_jump_table"
-    make_closure .<lambda($init_test_67, 17)>, 0
+    make_closure .<lambda($init_test_69, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_types_exhaustive_first"
-    make_closure .<lambda($init_test_67, 18)>, 0
+    make_closure .<lambda($init_test_69, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_types_exhaustive_last"
-    make_closure .<lambda($init_test_67, 19)>, 0
+    make_closure .<lambda($init_test_69, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_types_non_exhaustive_wildcard"
-    make_closure .<lambda($init_test_67, 20)>, 0
+    make_closure .<lambda($init_test_69, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_types_non_exhaustive_matched"
-    make_closure .<lambda($init_test_67, 21)>, 0
+    make_closure .<lambda($init_test_69, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_union_type_four_patterns_type_tag"
-    make_closure .<lambda($init_test_67, 22)>, 0
+    make_closure .<lambda($init_test_69, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_multiple_typed_patterns_with_guards"
-    make_closure .<lambda($init_test_67, 23)>, 0
+    make_closure .<lambda($init_test_69, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_type_tag_jump_table"
-    make_closure .<lambda($init_test_67, 24)>, 0
+    make_closure .<lambda($init_test_69, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_type_is_type_chain"
-    make_closure .<lambda($init_test_67, 25)>, 0
+    make_closure .<lambda($init_test_69, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_mixed_class_primitive_type_tag_switch"
-    make_closure .<lambda($init_test_67, 26)>, 0
+    make_closure .<lambda($init_test_69, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_sparse_class_type_tag_perfect_hash"
-    make_closure .<lambda($init_test_67, 27)>, 0
+    make_closure .<lambda($init_test_69, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_null_in_type_tag_jump_table"
-    make_closure .<lambda($init_test_67, 28)>, 0
+    make_closure .<lambda($init_test_69, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_null_with_class_types_type_tag"
-    make_closure .<lambda($init_test_67, 29)>, 0
+    make_closure .<lambda($init_test_69, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_dense_class_still_uses_direct_jump_table"
-    make_closure .<lambda($init_test_67, 30)>, 0
+    make_closure .<lambda($init_test_69, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/null_handling.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/null_handling.snap
@@ -1,64 +1,64 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function null_handling.$init_test_68(registry: testing.TestCollector) -> null {
+function null_handling.$init_test_70(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "safe_assign_null_skips"
-    make_closure .<lambda($init_test_68, 0)>, 0
+    make_closure .<lambda($init_test_70, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "safe_assign_non_null_writes"
-    make_closure .<lambda($init_test_68, 1)>, 0
+    make_closure .<lambda($init_test_70, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "compound_assign_null_skips"
-    make_closure .<lambda($init_test_68, 2)>, 0
+    make_closure .<lambda($init_test_70, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "compound_assign_non_null_increments"
-    make_closure .<lambda($init_test_68, 3)>, 0
+    make_closure .<lambda($init_test_70, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "safe_assign_index_null_skips"
-    make_closure .<lambda($init_test_68, 4)>, 0
+    make_closure .<lambda($init_test_70, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "safe_assign_index_non_null_writes"
-    make_closure .<lambda($init_test_68, 5)>, 0
+    make_closure .<lambda($init_test_70, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "null_coalesce_lazy_rhs_skips_side_effects"
-    make_closure .<lambda($init_test_68, 6)>, 0
+    make_closure .<lambda($init_test_70, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "null_coalesce_null_lhs_evaluates_rhs"
-    make_closure .<lambda($init_test_68, 7)>, 0
+    make_closure .<lambda($init_test_70, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "combined_compound_assign_rhs_null_uses_fallback"
-    make_closure .<lambda($init_test_68, 8)>, 0
+    make_closure .<lambda($init_test_70, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "combined_compound_assign_lhs_null_skips"
-    make_closure .<lambda($init_test_68, 9)>, 0
+    make_closure .<lambda($init_test_70, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/operators.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/operators.snap
@@ -1,220 +1,220 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function operators.$init_test_69(registry: testing.TestCollector) -> null {
+function operators.$init_test_71(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "add"
-    make_closure .<lambda($init_test_69, 0)>, 0
+    make_closure .<lambda($init_test_71, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "subtract"
-    make_closure .<lambda($init_test_69, 1)>, 0
+    make_closure .<lambda($init_test_71, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multiply"
-    make_closure .<lambda($init_test_69, 2)>, 0
+    make_closure .<lambda($init_test_71, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "divide"
-    make_closure .<lambda($init_test_69, 3)>, 0
+    make_closure .<lambda($init_test_71, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "modulo"
-    make_closure .<lambda($init_test_69, 4)>, 0
+    make_closure .<lambda($init_test_71, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bitwise_and"
-    make_closure .<lambda($init_test_69, 5)>, 0
+    make_closure .<lambda($init_test_71, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bitwise_or"
-    make_closure .<lambda($init_test_69, 6)>, 0
+    make_closure .<lambda($init_test_71, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bitwise_xor"
-    make_closure .<lambda($init_test_69, 7)>, 0
+    make_closure .<lambda($init_test_71, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shift_left"
-    make_closure .<lambda($init_test_69, 8)>, 0
+    make_closure .<lambda($init_test_71, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shift_right"
-    make_closure .<lambda($init_test_69, 9)>, 0
+    make_closure .<lambda($init_test_71, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "unary_negate"
-    make_closure .<lambda($init_test_69, 10)>, 0
+    make_closure .<lambda($init_test_71, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "unary_not"
-    make_closure .<lambda($init_test_69, 11)>, 0
+    make_closure .<lambda($init_test_71, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "negative_int_in_let"
-    make_closure .<lambda($init_test_69, 12)>, 0
+    make_closure .<lambda($init_test_71, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "negative_int_arithmetic"
-    make_closure .<lambda($init_test_69, 13)>, 0
+    make_closure .<lambda($init_test_71, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "negative_int_comparison"
-    make_closure .<lambda($init_test_69, 14)>, 0
+    make_closure .<lambda($init_test_71, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "negative_float_in_let"
-    make_closure .<lambda($init_test_69, 15)>, 0
+    make_closure .<lambda($init_test_71, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "double_negation"
-    make_closure .<lambda($init_test_69, 16)>, 0
+    make_closure .<lambda($init_test_71, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "double_negation_variable"
-    make_closure .<lambda($init_test_69, 17)>, 0
+    make_closure .<lambda($init_test_71, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "equal"
-    make_closure .<lambda($init_test_69, 18)>, 0
+    make_closure .<lambda($init_test_71, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "not_equal"
-    make_closure .<lambda($init_test_69, 19)>, 0
+    make_closure .<lambda($init_test_71, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "greater_than"
-    make_closure .<lambda($init_test_69, 20)>, 0
+    make_closure .<lambda($init_test_71, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "greater_than_or_equal"
-    make_closure .<lambda($init_test_69, 21)>, 0
+    make_closure .<lambda($init_test_71, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "less_than"
-    make_closure .<lambda($init_test_69, 22)>, 0
+    make_closure .<lambda($init_test_71, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "less_than_or_equal"
-    make_closure .<lambda($init_test_69, 23)>, 0
+    make_closure .<lambda($init_test_71, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "logical_and"
-    make_closure .<lambda($init_test_69, 24)>, 0
+    make_closure .<lambda($init_test_71, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "logical_or"
-    make_closure .<lambda($init_test_69, 25)>, 0
+    make_closure .<lambda($init_test_71, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "short_circuit_and"
-    make_closure .<lambda($init_test_69, 26)>, 0
+    make_closure .<lambda($init_test_71, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "short_circuit_or"
-    make_closure .<lambda($init_test_69, 27)>, 0
+    make_closure .<lambda($init_test_71, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_add"
-    make_closure .<lambda($init_test_69, 28)>, 0
+    make_closure .<lambda($init_test_71, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_subtract"
-    make_closure .<lambda($init_test_69, 29)>, 0
+    make_closure .<lambda($init_test_71, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_multiply"
-    make_closure .<lambda($init_test_69, 30)>, 0
+    make_closure .<lambda($init_test_71, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_divide"
-    make_closure .<lambda($init_test_69, 31)>, 0
+    make_closure .<lambda($init_test_71, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_modulo"
-    make_closure .<lambda($init_test_69, 32)>, 0
+    make_closure .<lambda($init_test_71, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_bitwise_and"
-    make_closure .<lambda($init_test_69, 33)>, 0
+    make_closure .<lambda($init_test_71, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_bitwise_or"
-    make_closure .<lambda($init_test_69, 34)>, 0
+    make_closure .<lambda($init_test_71, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "assign_bitwise_xor"
-    make_closure .<lambda($init_test_69, 35)>, 0
+    make_closure .<lambda($init_test_71, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/optional_function_parameters.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/optional_function_parameters.snap
@@ -1,40 +1,40 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function optional_function_parameters.$init_test_70(registry: testing.TestCollector) -> null {
+function optional_function_parameters.$init_test_72(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "source_defaults_named_overrides_and_required_by_name"
-    make_closure .<lambda($init_test_70, 0)>, 0
+    make_closure .<lambda($init_test_72, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mutable_default_array_is_fresh_per_call"
-    make_closure .<lambda($init_test_70, 1)>, 0
+    make_closure .<lambda($init_test_72, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_dropping_adapter_uses_defaults_for_hidden_params"
-    make_closure .<lambda($init_test_70, 2)>, 0
+    make_closure .<lambda($init_test_72, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "default_named_call_args_do_not_reuse_body_call_metadata"
-    make_closure .<lambda($init_test_70, 3)>, 0
+    make_closure .<lambda($init_test_72, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "host_call_omitted_default_returns_default"
-    make_closure .<lambda($init_test_70, 4)>, 0
+    make_closure .<lambda($init_test_72, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "host_call_explicit_null_returns_1"
-    make_closure .<lambda($init_test_70, 5)>, 0
+    make_closure .<lambda($init_test_72, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -1,580 +1,580 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function patterns_new_runtime.$init_test_72(registry: testing.TestCollector) -> null {
+function patterns_new_runtime.$init_test_74(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "let_or_of_same_binding"
-    make_closure .<lambda($init_test_72, 0)>, 0
+    make_closure .<lambda($init_test_74, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_or_of_six_same_bindings"
-    make_closure .<lambda($init_test_72, 1)>, 0
+    make_closure .<lambda($init_test_74, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_of_bare_bindings_uses_value"
-    make_closure .<lambda($init_test_72, 2)>, 0
+    make_closure .<lambda($init_test_74, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_of_chain_narrows_uses_value"
-    make_closure .<lambda($init_test_72, 3)>, 0
+    make_closure .<lambda($init_test_74, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_chain_of_bindings_aliases_scrutinee"
-    make_closure .<lambda($init_test_72, 4)>, 0
+    make_closure .<lambda($init_test_74, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_chain_trailing_binding_after_array_type_aliases_value"
-    make_closure .<lambda($init_test_72, 5)>, 0
+    make_closure .<lambda($init_test_74, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_chain_binding_used_in_guard"
-    make_closure .<lambda($init_test_72, 6)>, 0
+    make_closure .<lambda($init_test_74, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_let_chain_of_bindings"
-    make_closure .<lambda($init_test_72, 7)>, 0
+    make_closure .<lambda($init_test_74, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_let_chain_trailing_binding_after_type_aliases_iteration_value"
-    make_closure .<lambda($init_test_72, 8)>, 0
+    make_closure .<lambda($init_test_74, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_let_chain_alias_capture_per_iteration"
-    make_closure .<lambda($init_test_72, 9)>, 0
+    make_closure .<lambda($init_test_74, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_let_or_of_same_binding"
-    make_closure .<lambda($init_test_72, 10)>, 0
+    make_closure .<lambda($init_test_74, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_let_or_of_six_same_bindings"
-    make_closure .<lambda($init_test_72, 11)>, 0
+    make_closure .<lambda($init_test_74, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_array_destructure_rest_sums_rows"
-    make_closure .<lambda($init_test_72, 12)>, 0
+    make_closure .<lambda($init_test_74, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_array_destructure_rest_capture_gets_fresh_cell_per_iteration"
-    make_closure .<lambda($init_test_72, 13)>, 0
+    make_closure .<lambda($init_test_74, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_array_destructure_inside_class_destructure_sums_fields"
-    make_closure .<lambda($init_test_72, 14)>, 0
+    make_closure .<lambda($init_test_74, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "catch_or_of_same_typed_binding"
-    make_closure .<lambda($init_test_72, 15)>, 0
+    make_closure .<lambda($init_test_74, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_wildcard_discards_value"
-    make_closure .<lambda($init_test_72, 16)>, 0
+    make_closure .<lambda($init_test_74, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_bind_with_type_ascription"
-    make_closure .<lambda($init_test_72, 17)>, 0
+    make_closure .<lambda($init_test_74, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_dispatches_int_callback"
-    make_closure .<lambda($init_test_72, 18)>, 0
+    make_closure .<lambda($init_test_74, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_dispatches_string_callback"
-    make_closure .<lambda($init_test_72, 20)>, 0
+    make_closure .<lambda($init_test_74, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_of_chain_bindings_swapped"
-    make_closure .<lambda($init_test_72, 22)>, 0
+    make_closure .<lambda($init_test_74, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "chain_second_binding_capture_after_reassign"
-    make_closure .<lambda($init_test_72, 23)>, 0
+    make_closure .<lambda($init_test_74, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_class_destructure_binds_shorthand_and_ignores_omitted_fields"
-    make_closure .<lambda($init_test_72, 24)>, 0
+    make_closure .<lambda($init_test_74, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_class_destructure_renames_field_binding"
-    make_closure .<lambda($init_test_72, 25)>, 0
+    make_closure .<lambda($init_test_74, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_class_destructure_nested_class"
-    make_closure .<lambda($init_test_72, 26)>, 0
+    make_closure .<lambda($init_test_74, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_nested_same_field_names_are_ok_with_distinct_bindings"
-    make_closure .<lambda($init_test_72, 27)>, 0
+    make_closure .<lambda($init_test_74, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_generic_class_destructure_substitutes_field_types"
-    make_closure .<lambda($init_test_72, 28)>, 0
+    make_closure .<lambda($init_test_74, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "empty_generic_class_destructure_uses_contextual_type"
-    make_closure .<lambda($init_test_72, 29)>, 0
+    make_closure .<lambda($init_test_74, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_generic_class_type_patterns_distinguish_type_args"
-    make_closure .<lambda($init_test_72, 30)>, 0
+    make_closure .<lambda($init_test_74, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_generic_class_destructure_union_tests_substituted_field_type"
-    make_closure .<lambda($init_test_72, 31)>, 0
+    make_closure .<lambda($init_test_74, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "generic_class_destructure_backfills_through_wrapped_flow_types"
-    make_closure .<lambda($init_test_72, 32)>, 0
+    make_closure .<lambda($init_test_74, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "empty_generic_class_destructure_covers_union_of_same_class_instantiations"
-    make_closure .<lambda($init_test_72, 33)>, 0
+    make_closure .<lambda($init_test_74, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_generic_class_destructure_substitutes_through_nested_fields"
-    make_closure .<lambda($init_test_72, 34)>, 0
+    make_closure .<lambda($init_test_74, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_destructure_tests_field_literal_and_falls_through"
-    make_closure .<lambda($init_test_72, 35)>, 0
+    make_closure .<lambda($init_test_74, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_destructure_tests_union_field_type"
-    make_closure .<lambda($init_test_72, 36)>, 0
+    make_closure .<lambda($init_test_74, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_top_level_class_destructure_tests_union_scrutinee"
-    make_closure .<lambda($init_test_72, 37)>, 0
+    make_closure .<lambda($init_test_74, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_class_destructure_same_binding_name_compatible_types"
-    make_closure .<lambda($init_test_72, 38)>, 0
+    make_closure .<lambda($init_test_74, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_class_destructure_same_binding_name_different_depths"
-    make_closure .<lambda($init_test_72, 39)>, 0
+    make_closure .<lambda($init_test_74, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_empty_and_prefix_rest"
-    make_closure .<lambda($init_test_72, 40)>, 0
+    make_closure .<lambda($init_test_74, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_exact_length"
-    make_closure .<lambda($init_test_72, 41)>, 0
+    make_closure .<lambda($init_test_74, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_binds_rest_copy"
-    make_closure .<lambda($init_test_72, 42)>, 0
+    make_closure .<lambda($init_test_74, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_suffix_rest"
-    make_closure .<lambda($init_test_72, 43)>, 0
+    make_closure .<lambda($init_test_74, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_array_destructure_binds_whole_rest"
-    make_closure .<lambda($init_test_72, 44)>, 0
+    make_closure .<lambda($init_test_74, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_array_destructure_nested_rest_only_is_irrefutable"
-    make_closure .<lambda($init_test_72, 45)>, 0
+    make_closure .<lambda($init_test_74, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_entire_alphabet_of_bindings"
-    make_closure .<lambda($init_test_72, 46)>, 0
+    make_closure .<lambda($init_test_74, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_binding_from_class_field_or_nested_array_position"
-    make_closure .<lambda($init_test_72, 47)>, 0
+    make_closure .<lambda($init_test_74, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_wildcard_inside_chained_binding_type_array_pattern"
-    make_closure .<lambda($init_test_72, 48)>, 0
+    make_closure .<lambda($init_test_74, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_shadows_outer_local_only_inside_arm"
-    make_closure .<lambda($init_test_72, 49)>, 0
+    make_closure .<lambda($init_test_74, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_array_destructure_nested_rest_only_is_irrefutable"
-    make_closure .<lambda($init_test_72, 50)>, 0
+    make_closure .<lambda($init_test_74, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_literal_and_type_element_patterns"
-    make_closure .<lambda($init_test_72, 51)>, 0
+    make_closure .<lambda($init_test_74, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_or_patterns_share_bindings"
-    make_closure .<lambda($init_test_72, 52)>, 0
+    make_closure .<lambda($init_test_74, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_or_patterns_nested_arrays_share_bindings"
-    make_closure .<lambda($init_test_72, 53)>, 0
+    make_closure .<lambda($init_test_74, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_nested_array_binding_projects_inner_element"
-    make_closure .<lambda($init_test_72, 54)>, 0
+    make_closure .<lambda($init_test_74, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_or_patterns_nested_class_array_fields"
-    make_closure .<lambda($init_test_72, 55)>, 0
+    make_closure .<lambda($init_test_74, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_outer_chain_applies_to_whole_array"
-    make_closure .<lambda($init_test_72, 56)>, 0
+    make_closure .<lambda($init_test_74, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_alternating_class_array_five_levels_or_flipped_traversal"
-    make_closure .<lambda($init_test_72, 57)>, 0
+    make_closure .<lambda($init_test_74, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_four_alternates_same_name_different_paths"
-    make_closure .<lambda($init_test_72, 58)>, 0
+    make_closure .<lambda($init_test_74, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_deep_class_array_or_picks_deep_cell"
-    make_closure .<lambda($init_test_72, 59)>, 0
+    make_closure .<lambda($init_test_74, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_2d_array_vs_class_with_2d_field"
-    make_closure .<lambda($init_test_72, 60)>, 0
+    make_closure .<lambda($init_test_74, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_two_prefix_rest_suffix_binding"
-    make_closure .<lambda($init_test_72, 61)>, 0
+    make_closure .<lambda($init_test_74, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_prefix_rest_two_suffix_bindings"
-    make_closure .<lambda($init_test_72, 62)>, 0
+    make_closure .<lambda($init_test_74, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_inside_class_destructure_empty_field"
-    make_closure .<lambda($init_test_72, 63)>, 0
+    make_closure .<lambda($init_test_74, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_with_class_elements"
-    make_closure .<lambda($init_test_72, 64)>, 0
+    make_closure .<lambda($init_test_74, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_wildcard_elements_and_rest"
-    make_closure .<lambda($init_test_72, 65)>, 0
+    make_closure .<lambda($init_test_74, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_wildcard_length_shapes"
-    make_closure .<lambda($init_test_72, 66)>, 0
+    make_closure .<lambda($init_test_74, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_wildcards_nested_in_class_fields"
-    make_closure .<lambda($init_test_72, 67)>, 0
+    make_closure .<lambda($init_test_74, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_destructure_wildcard_class_fields_and_rest"
-    make_closure .<lambda($init_test_72, 68)>, 0
+    make_closure .<lambda($init_test_74, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_array_destructure_rest_wildcard_is_irrefutable"
-    make_closure .<lambda($init_test_72, 69)>, 0
+    make_closure .<lambda($init_test_74, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_destructure_shorthand_field_same_name_as_class_binds_field"
-    make_closure .<lambda($init_test_72, 70)>, 0
+    make_closure .<lambda($init_test_74, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_destructure_binds_nested_field"
-    make_closure .<lambda($init_test_72, 71)>, 0
+    make_closure .<lambda($init_test_74, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_deep_class_destructure_binds_inner_field"
-    make_closure .<lambda($init_test_72, 72)>, 0
+    make_closure .<lambda($init_test_74, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_deep_class_destructure_falls_through_to_binding_arm"
-    make_closure .<lambda($init_test_72, 73)>, 0
+    make_closure .<lambda($init_test_74, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_deep_class_destructure_binds_when_second_alt_matches"
-    make_closure .<lambda($init_test_72, 74)>, 0
+    make_closure .<lambda($init_test_74, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_deep_class_destructure_sums_fields"
-    make_closure .<lambda($init_test_72, 75)>, 0
+    make_closure .<lambda($init_test_74, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_deep_class_destructure_capture_gets_fresh_cell_per_iteration"
-    make_closure .<lambda($init_test_72, 76)>, 0
+    make_closure .<lambda($init_test_74, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "let_class_destructure_binds_inner_zip"
-    make_closure .<lambda($init_test_72, 77)>, 0
+    make_closure .<lambda($init_test_74, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_destructure_binds_inner_zip"
-    make_closure .<lambda($init_test_72, 78)>, 0
+    make_closure .<lambda($init_test_74, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "for_class_destructure_binds_inner_zip"
-    make_closure .<lambda($init_test_72, 79)>, 0
+    make_closure .<lambda($init_test_74, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_field_pattern_should_refine_parent_union_scrutinee"
-    make_closure .<lambda($init_test_72, 80)>, 0
+    make_closure .<lambda($init_test_74, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_destructure_union_field_int_arm"
-    make_closure .<lambda($init_test_72, 81)>, 0
+    make_closure .<lambda($init_test_74, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_destructure_union_field_float_arm"
-    make_closure .<lambda($init_test_72, 82)>, 0
+    make_closure .<lambda($init_test_74, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_class_destructure_union_field_bool_arm"
-    make_closure .<lambda($init_test_72, 83)>, 0
+    make_closure .<lambda($init_test_74, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_array_element_pattern_should_refine_parent_union_scrutinee"
-    make_closure .<lambda($init_test_72, 84)>, 0
+    make_closure .<lambda($init_test_74, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_class_patterns_should_refine_parent_union_scrutinee"
-    make_closure .<lambda($init_test_72, 85)>, 0
+    make_closure .<lambda($init_test_74, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "match_or_array_patterns_should_refine_parent_union_scrutinee"
-    make_closure .<lambda($init_test_72, 86)>, 0
+    make_closure .<lambda($init_test_74, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_nested_class_optional_full_coverage_true_present"
-    make_closure .<lambda($init_test_72, 87)>, 0
+    make_closure .<lambda($init_test_74, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_nested_class_optional_full_coverage_false_null"
-    make_closure .<lambda($init_test_72, 88)>, 0
+    make_closure .<lambda($init_test_74, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_slice_prefix_dispatch"
-    make_closure .<lambda($init_test_72, 89)>, 0
+    make_closure .<lambda($init_test_74, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_slice_suffix_dispatch"
-    make_closure .<lambda($init_test_72, 90)>, 0
+    make_closure .<lambda($init_test_74, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_enum_full_variant_dispatch_north"
-    make_closure .<lambda($init_test_72, 91)>, 0
+    make_closure .<lambda($init_test_74, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_enum_full_variant_dispatch_west"
-    make_closure .<lambda($init_test_72, 92)>, 0
+    make_closure .<lambda($init_test_74, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_or_pattern_in_class_field_first_alt"
-    make_closure .<lambda($init_test_72, 93)>, 0
+    make_closure .<lambda($init_test_74, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_or_pattern_in_class_field_falls_to_wildcard"
-    make_closure .<lambda($init_test_72, 94)>, 0
+    make_closure .<lambda($init_test_74, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_optional_literal_or_arm_zero"
-    make_closure .<lambda($init_test_72, 95)>, 0
+    make_closure .<lambda($init_test_74, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_optional_literal_or_arm_null"
-    make_closure .<lambda($init_test_72, 96)>, 0
+    make_closure .<lambda($init_test_74, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "rustc_port_optional_literal_or_arm_other"
-    make_closure .<lambda($init_test_72, 97)>, 0
+    make_closure .<lambda($init_test_74, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of.snap
@@ -1,136 +1,136 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function reflect_type_of.$init_test_73(registry: testing.TestCollector) -> null {
+function reflect_type_of.$init_test_75(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "type_of_class_to_string"
-    make_closure .<lambda($init_test_73, 0)>, 0
+    make_closure .<lambda($init_test_75, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_int_to_string"
-    make_closure .<lambda($init_test_73, 1)>, 0
+    make_closure .<lambda($init_test_75, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_string_to_string"
-    make_closure .<lambda($init_test_73, 2)>, 0
+    make_closure .<lambda($init_test_75, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_bool_to_string"
-    make_closure .<lambda($init_test_73, 3)>, 0
+    make_closure .<lambda($init_test_75, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_array_to_string"
-    make_closure .<lambda($init_test_73, 4)>, 0
+    make_closure .<lambda($init_test_75, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_optional_to_string"
-    make_closure .<lambda($init_test_73, 5)>, 0
+    make_closure .<lambda($init_test_75, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_map_to_string"
-    make_closure .<lambda($init_test_73, 6)>, 0
+    make_closure .<lambda($init_test_75, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_generic_class_runs_without_crash"
-    make_closure .<lambda($init_test_73, 7)>, 0
+    make_closure .<lambda($init_test_75, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_generic_class_to_string_matches_source"
-    make_closure .<lambda($init_test_73, 8)>, 0
+    make_closure .<lambda($init_test_75, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_map_eq"
-    make_closure .<lambda($init_test_73, 9)>, 0
+    make_closure .<lambda($init_test_75, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_generic_class_eq"
-    make_closure .<lambda($init_test_73, 10)>, 0
+    make_closure .<lambda($init_test_75, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_generic_class_neq_different_arg"
-    make_closure .<lambda($init_test_73, 11)>, 0
+    make_closure .<lambda($init_test_75, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "wrap_in_container_to_string"
-    make_closure .<lambda($init_test_73, 12)>, 0
+    make_closure .<lambda($init_test_75, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_same_class_eq"
-    make_closure .<lambda($init_test_73, 13)>, 0
+    make_closure .<lambda($init_test_75, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_different_class_neq"
-    make_closure .<lambda($init_test_73, 14)>, 0
+    make_closure .<lambda($init_test_75, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_assign_and_compare"
-    make_closure .<lambda($init_test_73, 15)>, 0
+    make_closure .<lambda($init_test_75, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_enum_to_string"
-    make_closure .<lambda($init_test_73, 16)>, 0
+    make_closure .<lambda($init_test_75, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_enum_eq"
-    make_closure .<lambda($init_test_73, 17)>, 0
+    make_closure .<lambda($init_test_75, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_enum_neq_class"
-    make_closure .<lambda($init_test_73, 18)>, 0
+    make_closure .<lambda($init_test_75, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_union_eq"
-    make_closure .<lambda($init_test_73, 19)>, 0
+    make_closure .<lambda($init_test_75, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_union_neq_different_member"
-    make_closure .<lambda($init_test_73, 20)>, 0
+    make_closure .<lambda($init_test_75, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_to_string_works_as_map_key"
-    make_closure .<lambda($init_test_73, 21)>, 0
+    make_closure .<lambda($init_test_75, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of_generic.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of_generic.snap
@@ -1,118 +1,118 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function reflect_type_of_generic.$init_test_74(registry: testing.TestCollector) -> null {
+function reflect_type_of_generic.$init_test_76(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "describe_user_returns_user"
-    make_closure .<lambda($init_test_74, 0)>, 0
+    make_closure .<lambda($init_test_76, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "describe_int_returns_int"
-    make_closure .<lambda($init_test_74, 1)>, 0
+    make_closure .<lambda($init_test_76, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "describe_string_returns_string"
-    make_closure .<lambda($init_test_74, 2)>, 0
+    make_closure .<lambda($init_test_76, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_of_user_to_string"
-    make_closure .<lambda($init_test_74, 3)>, 0
+    make_closure .<lambda($init_test_76, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_of_int_to_string"
-    make_closure .<lambda($init_test_74, 4)>, 0
+    make_closure .<lambda($init_test_76, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "described_type_eq_concrete"
-    make_closure .<lambda($init_test_74, 5)>, 0
+    make_closure .<lambda($init_test_76, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "described_type_neq_different"
-    make_closure .<lambda($init_test_74, 6)>, 0
+    make_closure .<lambda($init_test_76, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "closure_captures_type_arg_user"
-    make_closure .<lambda($init_test_74, 7)>, 0
+    make_closure .<lambda($init_test_76, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "closure_captures_type_arg_int"
-    make_closure .<lambda($init_test_74, 8)>, 0
+    make_closure .<lambda($init_test_76, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fwd_user_eq_reflect_type_of_user"
-    make_closure .<lambda($init_test_74, 9)>, 0
+    make_closure .<lambda($init_test_76, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "fwd_int_neq_user"
-    make_closure .<lambda($init_test_74, 10)>, 0
+    make_closure .<lambda($init_test_76, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "three_level_forwarding_eq_concrete"
-    make_closure .<lambda($init_test_74, 11)>, 0
+    make_closure .<lambda($init_test_76, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "three_level_forwarding_to_string"
-    make_closure .<lambda($init_test_74, 12)>, 0
+    make_closure .<lambda($init_test_76, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "closure_captures_type_arg_array_of_user"
-    make_closure .<lambda($init_test_74, 13)>, 0
+    make_closure .<lambda($init_test_76, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "closure_captures_type_arg_optional_of_int"
-    make_closure .<lambda($init_test_74, 14)>, 0
+    make_closure .<lambda($init_test_76, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_depth3_path_in_method"
-    make_closure .<lambda($init_test_74, 15)>, 0
+    make_closure .<lambda($init_test_76, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_depth3_picks_inner_type_param"
-    make_closure .<lambda($init_test_74, 16)>, 0
+    make_closure .<lambda($init_test_76, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_self_field_method_depth3"
-    make_closure .<lambda($init_test_74, 17)>, 0
+    make_closure .<lambda($init_test_76, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "type_of_depth4_path_picks_prefix_class_args"
-    make_closure .<lambda($init_test_74, 18)>, 0
+    make_closure .<lambda($init_test_76, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/shell.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/shell.snap
@@ -1,46 +1,46 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function shell.$init_test_75(registry: testing.TestCollector) -> null {
+function shell.$init_test_77(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "shell_echo"
-    make_closure .<lambda($init_test_75, 0)>, 0
+    make_closure .<lambda($init_test_77, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shell_failing_command"
-    make_closure .<lambda($init_test_75, 1)>, 0
+    make_closure .<lambda($init_test_77, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shell_with_variable"
-    make_closure .<lambda($init_test_75, 2)>, 0
+    make_closure .<lambda($init_test_77, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shell_ok_method_success"
-    make_closure .<lambda($init_test_75, 3)>, 0
+    make_closure .<lambda($init_test_77, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shell_ok_method_failure"
-    make_closure .<lambda($init_test_75, 4)>, 0
+    make_closure .<lambda($init_test_77, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "shell_stdout_bytes"
-    make_closure .<lambda($init_test_75, 5)>, 0
+    make_closure .<lambda($init_test_77, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "exec_echo"
-    make_closure .<lambda($init_test_75, 6)>, 0
+    make_closure .<lambda($init_test_77, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/soundness.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/soundness.snap
@@ -1,58 +1,58 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function soundness.$init_test_76(registry: testing.TestCollector) -> null {
+function soundness.$init_test_78(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "call_result_immediate_right_operand_subtraction"
-    make_closure .<lambda($init_test_76, 0)>, 0
+    make_closure .<lambda($init_test_78, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "phi_like_right_operand_subtraction"
-    make_closure .<lambda($init_test_76, 1)>, 0
+    make_closure .<lambda($init_test_78, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "cross_block_field_mutation"
-    make_closure .<lambda($init_test_76, 2)>, 0
+    make_closure .<lambda($init_test_78, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "cross_block_let_mutation"
-    make_closure .<lambda($init_test_76, 3)>, 0
+    make_closure .<lambda($init_test_78, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "cross_block_let_mutation_false_branch"
-    make_closure .<lambda($init_test_76, 4)>, 0
+    make_closure .<lambda($init_test_78, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "cross_block_param_mutation"
-    make_closure .<lambda($init_test_76, 5)>, 0
+    make_closure .<lambda($init_test_78, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "copy_of_mutable_param"
-    make_closure .<lambda($init_test_76, 6)>, 0
+    make_closure .<lambda($init_test_78, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "transitive_param_copy_mutation"
-    make_closure .<lambda($init_test_76, 7)>, 0
+    make_closure .<lambda($init_test_78, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multiple_defs_preserve_side_effects"
-    make_closure .<lambda($init_test_76, 8)>, 0
+    make_closure .<lambda($init_test_78, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_basic.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_basic.snap
@@ -1,22 +1,22 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function spawn_basic.$init_test_77(registry: testing.TestCollector) -> null {
+function spawn_basic.$init_test_79(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "spawn_returning_int_literal"
-    make_closure .<lambda($init_test_77, 0)>, 0
+    make_closure .<lambda($init_test_79, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "spawn_returning_string"
-    make_closure .<lambda($init_test_77, 1)>, 0
+    make_closure .<lambda($init_test_79, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "spawn_with_name_literal"
-    make_closure .<lambda($init_test_77, 2)>, 0
+    make_closure .<lambda($init_test_79, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -26,6 +26,7 @@ function spawn_basic.$init_test_77(registry: testing.TestCollector) -> null {
 
 function spawn_basic.spawn_returning_int_literal() -> int {
     make_closure .<lambda(spawn_returning_int_literal, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3
@@ -37,6 +38,7 @@ function spawn_basic.spawn_returning_int_literal() -> int {
 function spawn_basic.spawn_returning_string() -> string {
     make_closure .<lambda(spawn_returning_string, 0)>, 0
     load_const null
+    load_const null
     spawn
     store_var _3
     load_var _3
@@ -47,6 +49,7 @@ function spawn_basic.spawn_returning_string() -> string {
 function spawn_basic.spawn_with_name_literal() -> int {
     make_closure .<lambda(spawn_with_name_literal, 0)>, 0
     load_const "answer"
+    load_const null
     spawn
     store_var _3
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_name_object.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_name_object.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function spawn_name_object.$init_test_78(registry: testing.TestCollector) -> null {
+function spawn_name_object.$init_test_80(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "spawn_name_then_struct_body_parses_correctly"
-    make_closure .<lambda($init_test_78, 0)>, 0
+    make_closure .<lambda($init_test_80, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "spawn_name_then_map_literal_body"
-    make_closure .<lambda($init_test_78, 1)>, 0
+    make_closure .<lambda($init_test_80, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -21,6 +21,7 @@ function spawn_name_object.$init_test_78(registry: testing.TestCollector) -> nul
 function spawn_name_object.spawn_name_then_map_literal_body_fn() -> int {
     make_closure .<lambda(spawn_name_then_map_literal_body_fn, 0)>, 0
     load_const null
+    load_const null
     spawn
     store_var _3
     load_var _3
@@ -30,6 +31,7 @@ function spawn_name_object.spawn_name_then_map_literal_body_fn() -> int {
 
 function spawn_name_object.spawn_name_then_struct_body_parses_correctly_fn() -> int {
     make_closure .<lambda(spawn_name_then_struct_body_parses_correctly_fn, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_semantics.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_semantics.snap
@@ -1,22 +1,22 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function spawn_semantics.$init_test_79(registry: testing.TestCollector) -> null {
+function spawn_semantics.$init_test_81(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "multiple_awaits_on_same_future_return_cached_value"
-    make_closure .<lambda($init_test_79, 0)>, 0
+    make_closure .<lambda($init_test_81, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "three_level_nested_spawn_sum"
-    make_closure .<lambda($init_test_79, 1)>, 0
+    make_closure .<lambda($init_test_81, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "function_can_return_future_typed_value"
-    make_closure .<lambda($init_test_79, 2)>, 0
+    make_closure .<lambda($init_test_81, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -43,6 +43,7 @@ function spawn_semantics.leaf() -> int {
 function spawn_semantics.mid() -> int {
     make_closure .<lambda(mid, 0)>, 0
     load_const null
+    load_const null
     spawn
     store_var _3
     load_var _3
@@ -54,6 +55,7 @@ function spawn_semantics.mid() -> int {
 
 function spawn_semantics.multiple_awaits_on_same_future_return_cached_value_fn() -> int {
     make_closure .<lambda(multiple_awaits_on_same_future_return_cached_value_fn, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3
@@ -78,6 +80,7 @@ function spawn_semantics.multiple_awaits_on_same_future_return_cached_value_fn()
 function spawn_semantics.spawn_child() -> future<int, null> {
     make_closure .<lambda(spawn_child, 0)>, 0
     load_const null
+    load_const null
     spawn
     store_var _2
     load_var _2
@@ -86,6 +89,7 @@ function spawn_semantics.spawn_child() -> future<int, null> {
 
 function spawn_semantics.three_level_nested_spawn_sum_fn() -> int {
     make_closure .<lambda(three_level_nested_spawn_sum_fn, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3
@@ -96,6 +100,7 @@ function spawn_semantics.three_level_nested_spawn_sum_fn() -> int {
 
 function spawn_semantics.top() -> int {
     make_closure .<lambda(top, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function spawn_throws.$init_test_80(registry: testing.TestCollector) -> null {
+function spawn_throws.$init_test_82(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "await_uncaught_bubbles_to_host"
-    make_closure .<lambda($init_test_80, 0)>, 0
+    make_closure .<lambda($init_test_82, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "await_rethrows_caught_by_user_catch"
-    make_closure .<lambda($init_test_80, 1)>, 0
+    make_closure .<lambda($init_test_82, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -20,6 +20,7 @@ function spawn_throws.$init_test_80(registry: testing.TestCollector) -> null {
 
 function spawn_throws.await_rethrows_caught_by_user_catch_fn() -> int {
     make_closure .<lambda(await_rethrows_caught_by_user_catch_fn, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3
@@ -44,6 +45,7 @@ function spawn_throws.await_rethrows_caught_by_user_catch_fn() -> int {
 
 function spawn_throws.await_uncaught_spawns_io_fn() -> int {
     make_closure .<lambda(await_uncaught_spawns_io_fn, 0)>, 0
+    load_const null
     load_const null
     spawn
     store_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/strings.snap
@@ -1,898 +1,898 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function strings.$init_test_81(registry: testing.TestCollector) -> null {
+function strings.$init_test_83(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "concat_strings"
-    make_closure .<lambda($init_test_81, 0)>, 0
+    make_closure .<lambda($init_test_83, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_equality_true"
-    make_closure .<lambda($init_test_81, 1)>, 0
+    make_closure .<lambda($init_test_83, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_equality_false"
-    make_closure .<lambda($init_test_81, 2)>, 0
+    make_closure .<lambda($init_test_83, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_not_equal_true"
-    make_closure .<lambda($init_test_81, 3)>, 0
+    make_closure .<lambda($init_test_83, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_less_than"
-    make_closure .<lambda($init_test_81, 4)>, 0
+    make_closure .<lambda($init_test_83, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_less_than_or_equal"
-    make_closure .<lambda($init_test_81, 5)>, 0
+    make_closure .<lambda($init_test_83, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_greater_than"
-    make_closure .<lambda($init_test_81, 6)>, 0
+    make_closure .<lambda($init_test_83, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_greater_than_or_equal"
-    make_closure .<lambda($init_test_81, 7)>, 0
+    make_closure .<lambda($init_test_83, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_length"
-    make_closure .<lambda($init_test_81, 8)>, 0
+    make_closure .<lambda($init_test_83, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_to_lower_case"
-    make_closure .<lambda($init_test_81, 9)>, 0
+    make_closure .<lambda($init_test_83, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_to_upper_case"
-    make_closure .<lambda($init_test_81, 10)>, 0
+    make_closure .<lambda($init_test_83, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_trim"
-    make_closure .<lambda($init_test_81, 11)>, 0
+    make_closure .<lambda($init_test_83, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_includes"
-    make_closure .<lambda($init_test_81, 12)>, 0
+    make_closure .<lambda($init_test_83, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_starts_with"
-    make_closure .<lambda($init_test_81, 13)>, 0
+    make_closure .<lambda($init_test_83, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_ends_with"
-    make_closure .<lambda($init_test_81, 14)>, 0
+    make_closure .<lambda($init_test_83, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_split"
-    make_closure .<lambda($init_test_81, 15)>, 0
+    make_closure .<lambda($init_test_83, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_substring"
-    make_closure .<lambda($init_test_81, 16)>, 0
+    make_closure .<lambda($init_test_83, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_substring_bounds"
-    make_closure .<lambda($init_test_81, 17)>, 0
+    make_closure .<lambda($init_test_83, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_length_is_bytes_for_non_ascii"
-    make_closure .<lambda($init_test_81, 18)>, 0
+    make_closure .<lambda($init_test_83, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_length_is_bytes_for_emoji"
-    make_closure .<lambda($init_test_81, 19)>, 0
+    make_closure .<lambda($init_test_83, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_substring_byte_indexed_keeps_multibyte_char"
-    make_closure .<lambda($init_test_81, 20)>, 0
+    make_closure .<lambda($init_test_83, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_substring_mid_codepoint_throws"
-    make_closure .<lambda($init_test_81, 21)>, 0
+    make_closure .<lambda($init_test_83, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_substring_negative_clamps_to_zero"
-    make_closure .<lambda($init_test_81, 22)>, 0
+    make_closure .<lambda($init_test_83, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_substring_empty_when_start_past_end"
-    make_closure .<lambda($init_test_81, 23)>, 0
+    make_closure .<lambda($init_test_83, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_at_byte_indexed_returns_multibyte_char"
-    make_closure .<lambda($init_test_81, 24)>, 0
+    make_closure .<lambda($init_test_83, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_at_byte_indexed_after_multibyte"
-    make_closure .<lambda($init_test_81, 25)>, 0
+    make_closure .<lambda($init_test_83, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_at_mid_codepoint_throws"
-    make_closure .<lambda($init_test_81, 26)>, 0
+    make_closure .<lambda($init_test_83, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_at_end_returns_empty"
-    make_closure .<lambda($init_test_81, 27)>, 0
+    make_closure .<lambda($init_test_83, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_at_past_end_throws"
-    make_closure .<lambda($init_test_81, 28)>, 0
+    make_closure .<lambda($init_test_83, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_at_negative_throws"
-    make_closure .<lambda($init_test_81, 29)>, 0
+    make_closure .<lambda($init_test_83, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_index_of_returns_byte_offset"
-    make_closure .<lambda($init_test_81, 30)>, 0
+    make_closure .<lambda($init_test_83, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_count_ascii"
-    make_closure .<lambda($init_test_81, 31)>, 0
+    make_closure .<lambda($init_test_83, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_count_multibyte"
-    make_closure .<lambda($init_test_81, 32)>, 0
+    make_closure .<lambda($init_test_83, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_count_emoji"
-    make_closure .<lambda($init_test_81, 33)>, 0
+    make_closure .<lambda($init_test_83, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_char_count_empty"
-    make_closure .<lambda($init_test_81, 34)>, 0
+    make_closure .<lambda($init_test_83, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_trim_start_removes_leading_only"
-    make_closure .<lambda($init_test_81, 35)>, 0
+    make_closure .<lambda($init_test_83, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_trim_end_removes_trailing_only"
-    make_closure .<lambda($init_test_81, 36)>, 0
+    make_closure .<lambda($init_test_83, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_trim_start_handles_newlines_and_tabs"
-    make_closure .<lambda($init_test_81, 37)>, 0
+    make_closure .<lambda($init_test_83, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_trim_end_no_whitespace_unchanged"
-    make_closure .<lambda($init_test_81, 38)>, 0
+    make_closure .<lambda($init_test_83, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_trim_start_empty"
-    make_closure .<lambda($init_test_81, 39)>, 0
+    make_closure .<lambda($init_test_83, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_lines_lf"
-    make_closure .<lambda($init_test_81, 40)>, 0
+    make_closure .<lambda($init_test_83, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_lines_crlf"
-    make_closure .<lambda($init_test_81, 41)>, 0
+    make_closure .<lambda($init_test_83, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_lines_trailing_newline_no_empty"
-    make_closure .<lambda($init_test_81, 42)>, 0
+    make_closure .<lambda($init_test_83, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_lines_empty_string"
-    make_closure .<lambda($init_test_81, 43)>, 0
+    make_closure .<lambda($init_test_83, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_lines_just_newline"
-    make_closure .<lambda($init_test_81, 44)>, 0
+    make_closure .<lambda($init_test_83, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_code_point_at_ascii"
-    make_closure .<lambda($init_test_81, 45)>, 0
+    make_closure .<lambda($init_test_83, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_code_point_at_multibyte"
-    make_closure .<lambda($init_test_81, 46)>, 0
+    make_closure .<lambda($init_test_83, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_code_point_at_emoji"
-    make_closure .<lambda($init_test_81, 47)>, 0
+    make_closure .<lambda($init_test_83, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_code_point_at_mid_codepoint_throws"
-    make_closure .<lambda($init_test_81, 48)>, 0
+    make_closure .<lambda($init_test_83, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_code_point_at_at_end_throws"
-    make_closure .<lambda($init_test_81, 49)>, 0
+    make_closure .<lambda($init_test_83, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_code_point_at_negative_throws"
-    make_closure .<lambda($init_test_81, 50)>, 0
+    make_closure .<lambda($init_test_83, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_to_utf8_ascii"
-    make_closure .<lambda($init_test_81, 51)>, 0
+    make_closure .<lambda($init_test_83, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_to_utf8_multibyte"
-    make_closure .<lambda($init_test_81, 52)>, 0
+    make_closure .<lambda($init_test_83, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_to_utf8_empty"
-    make_closure .<lambda($init_test_81, 53)>, 0
+    make_closure .<lambda($init_test_83, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_utf8_ascii_round_trip"
-    make_closure .<lambda($init_test_81, 54)>, 0
+    make_closure .<lambda($init_test_83, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_utf8_multibyte_round_trip"
-    make_closure .<lambda($init_test_81, 55)>, 0
+    make_closure .<lambda($init_test_83, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_utf8_invalid_throws"
-    make_closure .<lambda($init_test_81, 56)>, 0
+    make_closure .<lambda($init_test_83, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_utf8_empty"
-    make_closure .<lambda($init_test_81, 57)>, 0
+    make_closure .<lambda($init_test_83, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_code_points_ascii"
-    make_closure .<lambda($init_test_81, 58)>, 0
+    make_closure .<lambda($init_test_83, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_code_points_multibyte"
-    make_closure .<lambda($init_test_81, 59)>, 0
+    make_closure .<lambda($init_test_83, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_code_points_emoji"
-    make_closure .<lambda($init_test_81, 60)>, 0
+    make_closure .<lambda($init_test_83, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_code_points_empty"
-    make_closure .<lambda($init_test_81, 61)>, 0
+    make_closure .<lambda($init_test_83, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_code_points_negative_throws"
-    make_closure .<lambda($init_test_81, 62)>, 0
+    make_closure .<lambda($init_test_83, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_code_points_surrogate_throws"
-    make_closure .<lambda($init_test_81, 63)>, 0
+    make_closure .<lambda($init_test_83, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_from_code_points_too_large_throws"
-    make_closure .<lambda($init_test_81, 64)>, 0
+    make_closure .<lambda($init_test_83, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_numeric_ascii_digits"
-    make_closure .<lambda($init_test_81, 65)>, 0
+    make_closure .<lambda($init_test_83, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_numeric_unicode_roman"
-    make_closure .<lambda($init_test_81, 66)>, 0
+    make_closure .<lambda($init_test_83, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_numeric_mixed_false"
-    make_closure .<lambda($init_test_81, 67)>, 0
+    make_closure .<lambda($init_test_83, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_numeric_letters_false"
-    make_closure .<lambda($init_test_81, 68)>, 0
+    make_closure .<lambda($init_test_83, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_numeric_empty_true"
-    make_closure .<lambda($init_test_81, 69)>, 0
+    make_closure .<lambda($init_test_83, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphabetic_ascii"
-    make_closure .<lambda($init_test_81, 70)>, 0
+    make_closure .<lambda($init_test_83, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphabetic_accented"
-    make_closure .<lambda($init_test_81, 71)>, 0
+    make_closure .<lambda($init_test_83, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphabetic_cjk"
-    make_closure .<lambda($init_test_81, 72)>, 0
+    make_closure .<lambda($init_test_83, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphabetic_with_digit_false"
-    make_closure .<lambda($init_test_81, 73)>, 0
+    make_closure .<lambda($init_test_83, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphabetic_with_space_false"
-    make_closure .<lambda($init_test_81, 74)>, 0
+    make_closure .<lambda($init_test_83, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphabetic_empty_true"
-    make_closure .<lambda($init_test_81, 75)>, 0
+    make_closure .<lambda($init_test_83, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphanumeric_letters_and_digits"
-    make_closure .<lambda($init_test_81, 76)>, 0
+    make_closure .<lambda($init_test_83, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphanumeric_accented_with_digit"
-    make_closure .<lambda($init_test_81, 77)>, 0
+    make_closure .<lambda($init_test_83, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphanumeric_with_space_false"
-    make_closure .<lambda($init_test_81, 78)>, 0
+    make_closure .<lambda($init_test_83, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphanumeric_with_punct_false"
-    make_closure .<lambda($init_test_81, 79)>, 0
+    make_closure .<lambda($init_test_83, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_alphanumeric_empty_true"
-    make_closure .<lambda($init_test_81, 80)>, 0
+    make_closure .<lambda($init_test_83, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_uppercase_all_upper"
-    make_closure .<lambda($init_test_81, 81)>, 0
+    make_closure .<lambda($init_test_83, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_uppercase_mixed_false"
-    make_closure .<lambda($init_test_81, 82)>, 0
+    make_closure .<lambda($init_test_83, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_uppercase_digit_false"
-    make_closure .<lambda($init_test_81, 83)>, 0
+    make_closure .<lambda($init_test_83, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_uppercase_empty_true"
-    make_closure .<lambda($init_test_81, 84)>, 0
+    make_closure .<lambda($init_test_83, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_lowercase_all_lower"
-    make_closure .<lambda($init_test_81, 85)>, 0
+    make_closure .<lambda($init_test_83, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_lowercase_mixed_false"
-    make_closure .<lambda($init_test_81, 86)>, 0
+    make_closure .<lambda($init_test_83, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_lowercase_accented_lower"
-    make_closure .<lambda($init_test_81, 87)>, 0
+    make_closure .<lambda($init_test_83, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_lowercase_empty_true"
-    make_closure .<lambda($init_test_81, 88)>, 0
+    make_closure .<lambda($init_test_83, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_whitespace_spaces"
-    make_closure .<lambda($init_test_81, 89)>, 0
+    make_closure .<lambda($init_test_83, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_whitespace_mixed_ws"
-    make_closure .<lambda($init_test_81, 90)>, 0
+    make_closure .<lambda($init_test_83, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_whitespace_unicode_nbsp"
-    make_closure .<lambda($init_test_81, 91)>, 0
+    make_closure .<lambda($init_test_83, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_whitespace_with_letter_false"
-    make_closure .<lambda($init_test_81, 92)>, 0
+    make_closure .<lambda($init_test_83, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_whitespace_empty_true"
-    make_closure .<lambda($init_test_81, 93)>, 0
+    make_closure .<lambda($init_test_83, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_control_newline_tab"
-    make_closure .<lambda($init_test_81, 94)>, 0
+    make_closure .<lambda($init_test_83, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_control_letter_false"
-    make_closure .<lambda($init_test_81, 95)>, 0
+    make_closure .<lambda($init_test_83, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_control_empty_true"
-    make_closure .<lambda($init_test_81, 96)>, 0
+    make_closure .<lambda($init_test_83, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_graphic_letters"
-    make_closure .<lambda($init_test_81, 97)>, 0
+    make_closure .<lambda($init_test_83, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_graphic_accented"
-    make_closure .<lambda($init_test_81, 98)>, 0
+    make_closure .<lambda($init_test_83, 98)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_graphic_with_space_false"
-    make_closure .<lambda($init_test_81, 99)>, 0
+    make_closure .<lambda($init_test_83, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_graphic_with_newline_false"
-    make_closure .<lambda($init_test_81, 100)>, 0
+    make_closure .<lambda($init_test_83, 100)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_graphic_empty_true"
-    make_closure .<lambda($init_test_81, 101)>, 0
+    make_closure .<lambda($init_test_83, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_pure_ascii"
-    make_closure .<lambda($init_test_81, 102)>, 0
+    make_closure .<lambda($init_test_83, 102)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_with_accent_false"
-    make_closure .<lambda($init_test_81, 103)>, 0
+    make_closure .<lambda($init_test_83, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_with_emoji_false"
-    make_closure .<lambda($init_test_81, 104)>, 0
+    make_closure .<lambda($init_test_83, 104)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_control_chars"
-    make_closure .<lambda($init_test_81, 105)>, 0
+    make_closure .<lambda($init_test_83, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_empty_true"
-    make_closure .<lambda($init_test_81, 106)>, 0
+    make_closure .<lambda($init_test_83, 106)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_numeric_digits"
-    make_closure .<lambda($init_test_81, 107)>, 0
+    make_closure .<lambda($init_test_83, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_numeric_unicode_numeral_false"
-    make_closure .<lambda($init_test_81, 108)>, 0
+    make_closure .<lambda($init_test_83, 108)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_numeric_letter_false"
-    make_closure .<lambda($init_test_81, 109)>, 0
+    make_closure .<lambda($init_test_83, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_numeric_empty_true"
-    make_closure .<lambda($init_test_81, 110)>, 0
+    make_closure .<lambda($init_test_83, 110)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_alphabetic_letters"
-    make_closure .<lambda($init_test_81, 111)>, 0
+    make_closure .<lambda($init_test_83, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_alphabetic_accented_false"
-    make_closure .<lambda($init_test_81, 112)>, 0
+    make_closure .<lambda($init_test_83, 112)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_alphabetic_with_digit_false"
-    make_closure .<lambda($init_test_81, 113)>, 0
+    make_closure .<lambda($init_test_83, 113)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_alphabetic_empty_true"
-    make_closure .<lambda($init_test_81, 114)>, 0
+    make_closure .<lambda($init_test_83, 114)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_alphanumeric_basic"
-    make_closure .<lambda($init_test_81, 115)>, 0
+    make_closure .<lambda($init_test_83, 115)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_alphanumeric_accented_false"
-    make_closure .<lambda($init_test_81, 116)>, 0
+    make_closure .<lambda($init_test_83, 116)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_alphanumeric_with_space_false"
-    make_closure .<lambda($init_test_81, 117)>, 0
+    make_closure .<lambda($init_test_83, 117)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_alphanumeric_empty_true"
-    make_closure .<lambda($init_test_81, 118)>, 0
+    make_closure .<lambda($init_test_83, 118)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_uppercase_pure_upper"
-    make_closure .<lambda($init_test_81, 119)>, 0
+    make_closure .<lambda($init_test_83, 119)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_uppercase_mixed_false"
-    make_closure .<lambda($init_test_81, 120)>, 0
+    make_closure .<lambda($init_test_83, 120)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_uppercase_with_accent_false"
-    make_closure .<lambda($init_test_81, 121)>, 0
+    make_closure .<lambda($init_test_83, 121)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_uppercase_empty_true"
-    make_closure .<lambda($init_test_81, 122)>, 0
+    make_closure .<lambda($init_test_83, 122)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_lowercase_pure_lower"
-    make_closure .<lambda($init_test_81, 123)>, 0
+    make_closure .<lambda($init_test_83, 123)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_lowercase_mixed_false"
-    make_closure .<lambda($init_test_81, 124)>, 0
+    make_closure .<lambda($init_test_83, 124)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_lowercase_with_accent_false"
-    make_closure .<lambda($init_test_81, 125)>, 0
+    make_closure .<lambda($init_test_83, 125)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_lowercase_empty_true"
-    make_closure .<lambda($init_test_81, 126)>, 0
+    make_closure .<lambda($init_test_83, 126)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_whitespace_basic"
-    make_closure .<lambda($init_test_81, 127)>, 0
+    make_closure .<lambda($init_test_83, 127)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_whitespace_form_feed"
-    make_closure .<lambda($init_test_81, 128)>, 0
+    make_closure .<lambda($init_test_83, 128)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_whitespace_nbsp_false"
-    make_closure .<lambda($init_test_81, 129)>, 0
+    make_closure .<lambda($init_test_83, 129)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_whitespace_letter_false"
-    make_closure .<lambda($init_test_81, 130)>, 0
+    make_closure .<lambda($init_test_83, 130)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_whitespace_empty_true"
-    make_closure .<lambda($init_test_81, 131)>, 0
+    make_closure .<lambda($init_test_83, 131)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_control_low_range"
-    make_closure .<lambda($init_test_81, 132)>, 0
+    make_closure .<lambda($init_test_83, 132)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_control_del"
-    make_closure .<lambda($init_test_81, 133)>, 0
+    make_closure .<lambda($init_test_83, 133)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_control_letter_false"
-    make_closure .<lambda($init_test_81, 134)>, 0
+    make_closure .<lambda($init_test_83, 134)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_control_empty_true"
-    make_closure .<lambda($init_test_81, 135)>, 0
+    make_closure .<lambda($init_test_83, 135)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_graphic_letters"
-    make_closure .<lambda($init_test_81, 136)>, 0
+    make_closure .<lambda($init_test_83, 136)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_graphic_punctuation"
-    make_closure .<lambda($init_test_81, 137)>, 0
+    make_closure .<lambda($init_test_83, 137)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_graphic_space_false"
-    make_closure .<lambda($init_test_81, 138)>, 0
+    make_closure .<lambda($init_test_83, 138)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_graphic_control_false"
-    make_closure .<lambda($init_test_81, 139)>, 0
+    make_closure .<lambda($init_test_83, 139)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_graphic_accented_false"
-    make_closure .<lambda($init_test_81, 140)>, 0
+    make_closure .<lambda($init_test_83, 140)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_graphic_empty_true"
-    make_closure .<lambda($init_test_81, 141)>, 0
+    make_closure .<lambda($init_test_83, 141)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_hex_lower"
-    make_closure .<lambda($init_test_81, 142)>, 0
+    make_closure .<lambda($init_test_83, 142)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_hex_upper"
-    make_closure .<lambda($init_test_81, 143)>, 0
+    make_closure .<lambda($init_test_83, 143)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_hex_mixed_case_with_digits"
-    make_closure .<lambda($init_test_81, 144)>, 0
+    make_closure .<lambda($init_test_83, 144)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_hex_g_false"
-    make_closure .<lambda($init_test_81, 145)>, 0
+    make_closure .<lambda($init_test_83, 145)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_hex_x_prefix_false"
-    make_closure .<lambda($init_test_81, 146)>, 0
+    make_closure .<lambda($init_test_83, 146)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_is_ascii_hex_empty_true"
-    make_closure .<lambda($init_test_81, 147)>, 0
+    make_closure .<lambda($init_test_83, 147)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_replace"
-    make_closure .<lambda($init_test_81, 148)>, 0
+    make_closure .<lambda($init_test_83, 148)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/task_group.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/task_group.snap
@@ -1,0 +1,237 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function task_group.$init_test_84(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "caps_active_and_queues_rest"
+    make_closure .<lambda($init_test_84, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "queues_excess_and_all_complete"
+    make_closure .<lambda($init_test_84, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "group_cancel_cancels_member"
+    make_closure .<lambda($init_test_84, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "set_limit_updates_limit"
+    make_closure .<lambda($init_test_84, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_const null
+    return
+}
+
+function task_group.caps_active_and_queues_rest() -> int {
+    load_const 2
+    load_const <omitted>
+    call baml.spawn.TaskGroup.new
+    store_var g
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _3
+    make_closure .<lambda(caps_active_and_queues_rest, 0)>, 0
+    load_const null
+    load_var _3
+    spawn
+    pop 1
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _7
+    make_closure .<lambda(caps_active_and_queues_rest, 1)>, 0
+    load_const null
+    load_var _7
+    spawn
+    pop 1
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _11
+    make_closure .<lambda(caps_active_and_queues_rest, 2)>, 0
+    load_const null
+    load_var _11
+    spawn
+    pop 1
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _15
+    make_closure .<lambda(caps_active_and_queues_rest, 3)>, 0
+    load_const null
+    load_var _15
+    spawn
+    pop 1
+    load_var g
+    call baml.spawn.TaskGroup.active_count
+    store_var _20
+    load_var g
+    call baml.spawn.TaskGroup.queued_count
+    store_var _21
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.TaskGroup.cancel
+    pop 1
+    load_var _20
+    load_const 100
+    mul_int
+    load_var _21
+    add_int
+    return
+}
+
+function task_group.group_cancel_cancels_member() -> int {
+    load_const 5
+    load_const <omitted>
+    call baml.spawn.TaskGroup.new
+    store_var g
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _4
+    make_closure .<lambda(group_cancel_cancels_member, 0)>, 0
+    load_const null
+    load_var _4
+    spawn
+    store_var _6
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.TaskGroup.cancel
+    pop 1
+    load_var _6
+    await
+    jump L2
+    load_var e
+    is_type baml.panics.Cancelled
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    throw
+
+  L1:
+    load_const 0
+
+  L2:
+    return
+}
+
+function task_group.queues_excess_and_all_complete() -> int {
+    load_const 2
+    load_const <omitted>
+    call baml.spawn.TaskGroup.new
+    store_var g
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _4
+    make_closure .<lambda(queues_excess_and_all_complete, 0)>, 0
+    load_const null
+    load_var _4
+    spawn
+    store_var _6
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _9
+    make_closure .<lambda(queues_excess_and_all_complete, 1)>, 0
+    load_const null
+    load_var _9
+    spawn
+    store_var _11
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _14
+    make_closure .<lambda(queues_excess_and_all_complete, 2)>, 0
+    load_const null
+    load_var _14
+    spawn
+    store_var _16
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _19
+    make_closure .<lambda(queues_excess_and_all_complete, 3)>, 0
+    load_const null
+    load_var _19
+    spawn
+    store_var _21
+    load_var g
+    load_const <omitted>
+    load_const <omitted>
+    call baml.spawn.options
+    store_var _24
+    make_closure .<lambda(queues_excess_and_all_complete, 4)>, 0
+    load_const null
+    load_var _24
+    spawn
+    store_var _26
+    load_var _6
+    await
+    store_var _30
+    load_var _11
+    await
+    store_var _32
+    load_var _16
+    await
+    store_var _34
+    load_var _21
+    await
+    store_var _36
+    load_var _26
+    await
+    store_var _38
+    load_var _30
+    load_var _32
+    add_int
+    load_var _34
+    add_int
+    load_var _36
+    add_int
+    load_var _38
+    add_int
+    return
+}
+
+function task_group.set_limit_updates_limit() -> int {
+    load_const 3
+    load_const <omitted>
+    call baml.spawn.TaskGroup.new
+    store_var g
+    load_var g
+    call baml.spawn.TaskGroup.limit
+    store_var before
+    load_var g
+    load_const 7
+    call baml.spawn.TaskGroup.set_limit
+    pop 1
+    load_var g
+    call baml.spawn.TaskGroup.limit
+    store_var _5
+    load_var before
+    load_var _5
+    add_int
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
@@ -1,172 +1,172 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function type_error_repro.$init_test_82(registry: testing.TestCollector) -> null {
+function type_error_repro.$init_test_84(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "bytecode_1d_array_write_local"
-    make_closure .<lambda($init_test_82, 0)>, 0
+    make_closure .<lambda($init_test_84, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_1d_array_write_through_field"
-    make_closure .<lambda($init_test_82, 1)>, 0
+    make_closure .<lambda($init_test_84, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_1d_array_read_through_field"
-    make_closure .<lambda($init_test_82, 2)>, 0
+    make_closure .<lambda($init_test_84, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_2d_array_write_local"
-    make_closure .<lambda($init_test_82, 3)>, 0
+    make_closure .<lambda($init_test_84, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_2d_array_write_through_field"
-    make_closure .<lambda($init_test_82, 4)>, 0
+    make_closure .<lambda($init_test_84, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_map_write_through_field"
-    make_closure .<lambda($init_test_82, 5)>, 0
+    make_closure .<lambda($init_test_84, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_map_write_local"
-    make_closure .<lambda($init_test_82, 6)>, 0
+    make_closure .<lambda($init_test_84, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_non_self_param_array_write"
-    make_closure .<lambda($init_test_82, 7)>, 0
+    make_closure .<lambda($init_test_84, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_index_with_int_works"
-    make_closure .<lambda($init_test_82, 8)>, 0
+    make_closure .<lambda($init_test_84, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_through_function_call_as_index_works"
-    make_closure .<lambda($init_test_82, 9)>, 0
+    make_closure .<lambda($init_test_84, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_array_index_with_int_works"
-    make_closure .<lambda($init_test_82, 10)>, 0
+    make_closure .<lambda($init_test_84, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_element_assignment_2d_type_error"
-    make_closure .<lambda($init_test_82, 11)>, 0
+    make_closure .<lambda($init_test_84, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_element_assignment_1d"
-    make_closure .<lambda($init_test_82, 12)>, 0
+    make_closure .<lambda($init_test_84, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_array_read_works"
-    make_closure .<lambda($init_test_82, 13)>, 0
+    make_closure .<lambda($init_test_84, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_array_write_type_error"
-    make_closure .<lambda($init_test_82, 14)>, 0
+    make_closure .<lambda($init_test_84, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_array_read_with_variables"
-    make_closure .<lambda($init_test_82, 15)>, 0
+    make_closure .<lambda($init_test_84, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_array_write_with_variables"
-    make_closure .<lambda($init_test_82, 16)>, 0
+    make_closure .<lambda($init_test_84, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_write_with_variable_index"
-    make_closure .<lambda($init_test_82, 17)>, 0
+    make_closure .<lambda($init_test_84, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_1d_array_write_through_self"
-    make_closure .<lambda($init_test_82, 18)>, 0
+    make_closure .<lambda($init_test_84, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_2d_array_write_through_self_literals"
-    make_closure .<lambda($init_test_82, 19)>, 0
+    make_closure .<lambda($init_test_84, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_2d_array_write_minimal"
-    make_closure .<lambda($init_test_82, 20)>, 0
+    make_closure .<lambda($init_test_84, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_map_write_through_self"
-    make_closure .<lambda($init_test_82, 21)>, 0
+    make_closure .<lambda($init_test_84, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_write_local_variable"
-    make_closure .<lambda($init_test_82, 22)>, 0
+    make_closure .<lambda($init_test_84, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_nested_field_array_write"
-    make_closure .<lambda($init_test_82, 23)>, 0
+    make_closure .<lambda($init_test_84, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_map_then_array_write_through_self"
-    make_closure .<lambda($init_test_82, 24)>, 0
+    make_closure .<lambda($init_test_84, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_3d_array_write_through_self"
-    make_closure .<lambda($init_test_82, 25)>, 0
+    make_closure .<lambda($init_test_84, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_array_push_through_self"
-    make_closure .<lambda($init_test_82, 26)>, 0
+    make_closure .<lambda($init_test_84, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "non_self_param_array_write"
-    make_closure .<lambda($init_test_82, 27)>, 0
+    make_closure .<lambda($init_test_84, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
@@ -1,172 +1,172 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function type_error_repro.$init_test_84(registry: testing.TestCollector) -> null {
+function type_error_repro.$init_test_85(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "bytecode_1d_array_write_local"
-    make_closure .<lambda($init_test_84, 0)>, 0
+    make_closure .<lambda($init_test_85, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_1d_array_write_through_field"
-    make_closure .<lambda($init_test_84, 1)>, 0
+    make_closure .<lambda($init_test_85, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_1d_array_read_through_field"
-    make_closure .<lambda($init_test_84, 2)>, 0
+    make_closure .<lambda($init_test_85, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_2d_array_write_local"
-    make_closure .<lambda($init_test_84, 3)>, 0
+    make_closure .<lambda($init_test_85, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_2d_array_write_through_field"
-    make_closure .<lambda($init_test_84, 4)>, 0
+    make_closure .<lambda($init_test_85, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_map_write_through_field"
-    make_closure .<lambda($init_test_84, 5)>, 0
+    make_closure .<lambda($init_test_85, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_map_write_local"
-    make_closure .<lambda($init_test_84, 6)>, 0
+    make_closure .<lambda($init_test_85, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bytecode_non_self_param_array_write"
-    make_closure .<lambda($init_test_84, 7)>, 0
+    make_closure .<lambda($init_test_85, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_index_with_int_works"
-    make_closure .<lambda($init_test_84, 8)>, 0
+    make_closure .<lambda($init_test_85, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "int_through_function_call_as_index_works"
-    make_closure .<lambda($init_test_84, 9)>, 0
+    make_closure .<lambda($init_test_85, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_array_index_with_int_works"
-    make_closure .<lambda($init_test_84, 10)>, 0
+    make_closure .<lambda($init_test_85, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_element_assignment_2d_type_error"
-    make_closure .<lambda($init_test_84, 11)>, 0
+    make_closure .<lambda($init_test_85, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_element_assignment_1d"
-    make_closure .<lambda($init_test_84, 12)>, 0
+    make_closure .<lambda($init_test_85, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_array_read_works"
-    make_closure .<lambda($init_test_84, 13)>, 0
+    make_closure .<lambda($init_test_85, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_array_write_type_error"
-    make_closure .<lambda($init_test_84, 14)>, 0
+    make_closure .<lambda($init_test_85, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_array_read_with_variables"
-    make_closure .<lambda($init_test_84, 15)>, 0
+    make_closure .<lambda($init_test_85, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "nested_array_write_with_variables"
-    make_closure .<lambda($init_test_84, 16)>, 0
+    make_closure .<lambda($init_test_85, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_write_with_variable_index"
-    make_closure .<lambda($init_test_84, 17)>, 0
+    make_closure .<lambda($init_test_85, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_1d_array_write_through_self"
-    make_closure .<lambda($init_test_84, 18)>, 0
+    make_closure .<lambda($init_test_85, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_2d_array_write_through_self_literals"
-    make_closure .<lambda($init_test_84, 19)>, 0
+    make_closure .<lambda($init_test_85, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_2d_array_write_minimal"
-    make_closure .<lambda($init_test_84, 20)>, 0
+    make_closure .<lambda($init_test_85, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_map_write_through_self"
-    make_closure .<lambda($init_test_84, 21)>, 0
+    make_closure .<lambda($init_test_85, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_write_local_variable"
-    make_closure .<lambda($init_test_84, 22)>, 0
+    make_closure .<lambda($init_test_85, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_nested_field_array_write"
-    make_closure .<lambda($init_test_84, 23)>, 0
+    make_closure .<lambda($init_test_85, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_map_then_array_write_through_self"
-    make_closure .<lambda($init_test_84, 24)>, 0
+    make_closure .<lambda($init_test_85, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_3d_array_write_through_self"
-    make_closure .<lambda($init_test_84, 25)>, 0
+    make_closure .<lambda($init_test_85, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_method_array_push_through_self"
-    make_closure .<lambda($init_test_84, 26)>, 0
+    make_closure .<lambda($init_test_85, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "non_self_param_array_write"
-    make_closure .<lambda($init_test_84, 27)>, 0
+    make_closure .<lambda($init_test_85, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
@@ -1,40 +1,40 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function type_reflection.$init_test_85(registry: testing.TestCollector) -> null {
+function type_reflection.$init_test_86(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "eq_type_values_same"
-    make_closure .<lambda($init_test_85, 0)>, 0
+    make_closure .<lambda($init_test_86, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "eq_type_values_different"
-    make_closure .<lambda($init_test_85, 1)>, 0
+    make_closure .<lambda($init_test_86, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "neq_type_values_same"
-    make_closure .<lambda($init_test_85, 2)>, 0
+    make_closure .<lambda($init_test_86, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "neq_type_values_different"
-    make_closure .<lambda($init_test_85, 3)>, 0
+    make_closure .<lambda($init_test_86, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_type_values_same"
-    make_closure .<lambda($init_test_85, 4)>, 0
+    make_closure .<lambda($init_test_86, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_type_values_different"
-    make_closure .<lambda($init_test_85, 5)>, 0
+    make_closure .<lambda($init_test_86, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
@@ -1,40 +1,40 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function type_reflection.$init_test_83(registry: testing.TestCollector) -> null {
+function type_reflection.$init_test_85(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "eq_type_values_same"
-    make_closure .<lambda($init_test_83, 0)>, 0
+    make_closure .<lambda($init_test_85, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "eq_type_values_different"
-    make_closure .<lambda($init_test_83, 1)>, 0
+    make_closure .<lambda($init_test_85, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "neq_type_values_same"
-    make_closure .<lambda($init_test_83, 2)>, 0
+    make_closure .<lambda($init_test_85, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "neq_type_values_different"
-    make_closure .<lambda($init_test_83, 3)>, 0
+    make_closure .<lambda($init_test_85, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_type_values_same"
-    make_closure .<lambda($init_test_83, 4)>, 0
+    make_closure .<lambda($init_test_85, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "deep_equals_type_values_different"
-    make_closure .<lambda($init_test_83, 5)>, 0
+    make_closure .<lambda($init_test_85, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
@@ -1,64 +1,64 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function typed_inputs.$init_test_84(registry: testing.TestCollector) -> null {
+function typed_inputs.$init_test_86(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "int_input"
-    make_closure .<lambda($init_test_84, 0)>, 0
+    make_closure .<lambda($init_test_86, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_input"
-    make_closure .<lambda($init_test_84, 1)>, 0
+    make_closure .<lambda($init_test_86, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multiple_inputs"
-    make_closure .<lambda($init_test_84, 2)>, 0
+    make_closure .<lambda($init_test_86, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bool_input"
-    make_closure .<lambda($init_test_84, 3)>, 0
+    make_closure .<lambda($init_test_86, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_input"
-    make_closure .<lambda($init_test_84, 4)>, 0
+    make_closure .<lambda($init_test_86, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_input"
-    make_closure .<lambda($init_test_84, 5)>, 0
+    make_closure .<lambda($init_test_86, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_input"
-    make_closure .<lambda($init_test_84, 6)>, 0
+    make_closure .<lambda($init_test_86, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_input"
-    make_closure .<lambda($init_test_84, 7)>, 0
+    make_closure .<lambda($init_test_86, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "null_input"
-    make_closure .<lambda($init_test_84, 8)>, 0
+    make_closure .<lambda($init_test_86, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_types_inputs"
-    make_closure .<lambda($init_test_84, 9)>, 0
+    make_closure .<lambda($init_test_86, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
@@ -1,64 +1,64 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function typed_inputs.$init_test_86(registry: testing.TestCollector) -> null {
+function typed_inputs.$init_test_87(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "int_input"
-    make_closure .<lambda($init_test_86, 0)>, 0
+    make_closure .<lambda($init_test_87, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "string_input"
-    make_closure .<lambda($init_test_86, 1)>, 0
+    make_closure .<lambda($init_test_87, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "multiple_inputs"
-    make_closure .<lambda($init_test_86, 2)>, 0
+    make_closure .<lambda($init_test_87, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "bool_input"
-    make_closure .<lambda($init_test_86, 3)>, 0
+    make_closure .<lambda($init_test_87, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "float_input"
-    make_closure .<lambda($init_test_86, 4)>, 0
+    make_closure .<lambda($init_test_87, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_input"
-    make_closure .<lambda($init_test_86, 5)>, 0
+    make_closure .<lambda($init_test_87, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_input"
-    make_closure .<lambda($init_test_86, 6)>, 0
+    make_closure .<lambda($init_test_87, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_input"
-    make_closure .<lambda($init_test_86, 7)>, 0
+    make_closure .<lambda($init_test_87, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "null_input"
-    make_closure .<lambda($init_test_86, 8)>, 0
+    make_closure .<lambda($init_test_87, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "mixed_types_inputs"
-    make_closure .<lambda($init_test_86, 9)>, 0
+    make_closure .<lambda($init_test_87, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_outputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_outputs.snap
@@ -1,100 +1,100 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function typed_outputs.$init_test_85(registry: testing.TestCollector) -> null {
+function typed_outputs.$init_test_87(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "union_int_or_string_returns_int"
-    make_closure .<lambda($init_test_85, 0)>, 0
+    make_closure .<lambda($init_test_87, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_int_or_string_returns_string"
-    make_closure .<lambda($init_test_85, 1)>, 0
+    make_closure .<lambda($init_test_87, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_int_returns_value"
-    make_closure .<lambda($init_test_85, 2)>, 0
+    make_closure .<lambda($init_test_87, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_int_returns_null"
-    make_closure .<lambda($init_test_85, 3)>, 0
+    make_closure .<lambda($init_test_87, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_with_union_field"
-    make_closure .<lambda($init_test_85, 4)>, 0
+    make_closure .<lambda($init_test_87, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_of_classes_returns_success"
-    make_closure .<lambda($init_test_85, 5)>, 0
+    make_closure .<lambda($init_test_87, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_of_classes_returns_failure"
-    make_closure .<lambda($init_test_85, 6)>, 0
+    make_closure .<lambda($init_test_87, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_of_arrays"
-    make_closure .<lambda($init_test_85, 7)>, 0
+    make_closure .<lambda($init_test_87, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_of_unions"
-    make_closure .<lambda($init_test_85, 8)>, 0
+    make_closure .<lambda($init_test_87, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_class"
-    make_closure .<lambda($init_test_85, 9)>, 0
+    make_closure .<lambda($init_test_87, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_class_returns_null"
-    make_closure .<lambda($init_test_85, 10)>, 0
+    make_closure .<lambda($init_test_87, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_with_optional_field"
-    make_closure .<lambda($init_test_85, 11)>, 0
+    make_closure .<lambda($init_test_87, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_union_preserves_union_metadata"
-    make_closure .<lambda($init_test_85, 12)>, 0
+    make_closure .<lambda($init_test_87, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_union_returns_null"
-    make_closure .<lambda($init_test_85, 13)>, 0
+    make_closure .<lambda($init_test_87, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_with_union_values"
-    make_closure .<lambda($init_test_85, 14)>, 0
+    make_closure .<lambda($init_test_87, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_of_array_with_union_elements_or_string"
-    make_closure .<lambda($init_test_85, 15)>, 0
+    make_closure .<lambda($init_test_87, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_outputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_outputs.snap
@@ -1,100 +1,100 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function typed_outputs.$init_test_87(registry: testing.TestCollector) -> null {
+function typed_outputs.$init_test_88(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "union_int_or_string_returns_int"
-    make_closure .<lambda($init_test_87, 0)>, 0
+    make_closure .<lambda($init_test_88, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_int_or_string_returns_string"
-    make_closure .<lambda($init_test_87, 1)>, 0
+    make_closure .<lambda($init_test_88, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_int_returns_value"
-    make_closure .<lambda($init_test_87, 2)>, 0
+    make_closure .<lambda($init_test_88, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_int_returns_null"
-    make_closure .<lambda($init_test_87, 3)>, 0
+    make_closure .<lambda($init_test_88, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_with_union_field"
-    make_closure .<lambda($init_test_87, 4)>, 0
+    make_closure .<lambda($init_test_88, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_of_classes_returns_success"
-    make_closure .<lambda($init_test_87, 5)>, 0
+    make_closure .<lambda($init_test_88, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_of_classes_returns_failure"
-    make_closure .<lambda($init_test_87, 6)>, 0
+    make_closure .<lambda($init_test_88, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_of_arrays"
-    make_closure .<lambda($init_test_87, 7)>, 0
+    make_closure .<lambda($init_test_88, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_of_unions"
-    make_closure .<lambda($init_test_87, 8)>, 0
+    make_closure .<lambda($init_test_88, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_class"
-    make_closure .<lambda($init_test_87, 9)>, 0
+    make_closure .<lambda($init_test_88, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_class_returns_null"
-    make_closure .<lambda($init_test_87, 10)>, 0
+    make_closure .<lambda($init_test_88, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "class_with_optional_field"
-    make_closure .<lambda($init_test_87, 11)>, 0
+    make_closure .<lambda($init_test_88, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_union_preserves_union_metadata"
-    make_closure .<lambda($init_test_87, 12)>, 0
+    make_closure .<lambda($init_test_88, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "optional_union_returns_null"
-    make_closure .<lambda($init_test_87, 13)>, 0
+    make_closure .<lambda($init_test_88, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "map_with_union_values"
-    make_closure .<lambda($init_test_87, 14)>, 0
+    make_closure .<lambda($init_test_88, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "union_of_array_with_union_elements_or_string"
-    make_closure .<lambda($init_test_87, 15)>, 0
+    make_closure .<lambda($init_test_88, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
@@ -1,178 +1,178 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function watch.$init_test_88(registry: testing.TestCollector) -> null {
+function watch.$init_test_89(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "watch_primitive"
-    make_closure .<lambda($init_test_88, 0)>, 0
+    make_closure .<lambda($init_test_89, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_primitive_nested_scope"
-    make_closure .<lambda($init_test_88, 1)>, 0
+    make_closure .<lambda($init_test_89, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_class_destructure_initializes_and_unwatches_binding"
-    make_closure .<lambda($init_test_88, 2)>, 0
+    make_closure .<lambda($init_test_89, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_default_filter"
-    make_closure .<lambda($init_test_88, 3)>, 0
+    make_closure .<lambda($init_test_89, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_alias"
-    make_closure .<lambda($init_test_88, 4)>, 0
+    make_closure .<lambda($init_test_89, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_alias_nested_scope"
-    make_closure .<lambda($init_test_88, 5)>, 0
+    make_closure .<lambda($init_test_89, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_scope_exit"
-    make_closure .<lambda($init_test_88, 6)>, 0
+    make_closure .<lambda($init_test_89, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_break_unwatches"
-    make_closure .<lambda($init_test_88, 7)>, 0
+    make_closure .<lambda($init_test_89, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_continue_unwatches"
-    make_closure .<lambda($init_test_88, 8)>, 0
+    make_closure .<lambda($init_test_89, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_early_return_unwatches"
-    make_closure .<lambda($init_test_88, 9)>, 0
+    make_closure .<lambda($init_test_89, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_throw_unwatches"
-    make_closure .<lambda($init_test_88, 10)>, 0
+    make_closure .<lambda($init_test_89, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_for_throw_unwatches"
-    make_closure .<lambda($init_test_88, 11)>, 0
+    make_closure .<lambda($init_test_89, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_while_throw_unwatches"
-    make_closure .<lambda($init_test_88, 12)>, 0
+    make_closure .<lambda($init_test_89, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_match_arm_throw_unwatches"
-    make_closure .<lambda($init_test_88, 13)>, 0
+    make_closure .<lambda($init_test_89, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_catch_arm_throw_unwatches"
-    make_closure .<lambda($init_test_88, 14)>, 0
+    make_closure .<lambda($init_test_89, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_match_arm_fallthrough_unwatches"
-    make_closure .<lambda($init_test_88, 15)>, 0
+    make_closure .<lambda($init_test_89, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_switch_arm_fallthrough_unwatches"
-    make_closure .<lambda($init_test_88, 16)>, 0
+    make_closure .<lambda($init_test_89, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_catch_arm_fallthrough_unwatches"
-    make_closure .<lambda($init_test_88, 17)>, 0
+    make_closure .<lambda($init_test_89, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_function_call_modifications"
-    make_closure .<lambda($init_test_88, 18)>, 0
+    make_closure .<lambda($init_test_89, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_nested_object_added"
-    make_closure .<lambda($init_test_88, 19)>, 0
+    make_closure .<lambda($init_test_89, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_nested_object_removed"
-    make_closure .<lambda($init_test_88, 20)>, 0
+    make_closure .<lambda($init_test_89, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_cyclic_graph"
-    make_closure .<lambda($init_test_88, 21)>, 0
+    make_closure .<lambda($init_test_89, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "block_notification_basic"
-    make_closure .<lambda($init_test_88, 22)>, 0
+    make_closure .<lambda($init_test_89, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "block_notification_multiple"
-    make_closure .<lambda($init_test_88, 23)>, 0
+    make_closure .<lambda($init_test_89, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_header_before_if"
-    make_closure .<lambda($init_test_88, 24)>, 0
+    make_closure .<lambda($init_test_89, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_header_before_while"
-    make_closure .<lambda($init_test_88, 25)>, 0
+    make_closure .<lambda($init_test_89, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_standalone_header_no_viz_events"
-    make_closure .<lambda($init_test_88, 26)>, 0
+    make_closure .<lambda($init_test_89, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_multiple_headers_only_one_before_if"
-    make_closure .<lambda($init_test_88, 27)>, 0
+    make_closure .<lambda($init_test_89, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_if_without_header_no_viz"
-    make_closure .<lambda($init_test_88, 28)>, 0
+    make_closure .<lambda($init_test_89, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
@@ -1,178 +1,178 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function watch.$init_test_86(registry: testing.TestCollector) -> null {
+function watch.$init_test_88(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "watch_primitive"
-    make_closure .<lambda($init_test_86, 0)>, 0
+    make_closure .<lambda($init_test_88, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_primitive_nested_scope"
-    make_closure .<lambda($init_test_86, 1)>, 0
+    make_closure .<lambda($init_test_88, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_class_destructure_initializes_and_unwatches_binding"
-    make_closure .<lambda($init_test_86, 2)>, 0
+    make_closure .<lambda($init_test_88, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_default_filter"
-    make_closure .<lambda($init_test_86, 3)>, 0
+    make_closure .<lambda($init_test_88, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_alias"
-    make_closure .<lambda($init_test_86, 4)>, 0
+    make_closure .<lambda($init_test_88, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_alias_nested_scope"
-    make_closure .<lambda($init_test_86, 5)>, 0
+    make_closure .<lambda($init_test_88, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_scope_exit"
-    make_closure .<lambda($init_test_86, 6)>, 0
+    make_closure .<lambda($init_test_88, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_break_unwatches"
-    make_closure .<lambda($init_test_86, 7)>, 0
+    make_closure .<lambda($init_test_88, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_continue_unwatches"
-    make_closure .<lambda($init_test_86, 8)>, 0
+    make_closure .<lambda($init_test_88, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_early_return_unwatches"
-    make_closure .<lambda($init_test_86, 9)>, 0
+    make_closure .<lambda($init_test_88, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_throw_unwatches"
-    make_closure .<lambda($init_test_86, 10)>, 0
+    make_closure .<lambda($init_test_88, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_for_throw_unwatches"
-    make_closure .<lambda($init_test_86, 11)>, 0
+    make_closure .<lambda($init_test_88, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_while_throw_unwatches"
-    make_closure .<lambda($init_test_86, 12)>, 0
+    make_closure .<lambda($init_test_88, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_match_arm_throw_unwatches"
-    make_closure .<lambda($init_test_86, 13)>, 0
+    make_closure .<lambda($init_test_88, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_catch_arm_throw_unwatches"
-    make_closure .<lambda($init_test_86, 14)>, 0
+    make_closure .<lambda($init_test_88, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_match_arm_fallthrough_unwatches"
-    make_closure .<lambda($init_test_86, 15)>, 0
+    make_closure .<lambda($init_test_88, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_switch_arm_fallthrough_unwatches"
-    make_closure .<lambda($init_test_86, 16)>, 0
+    make_closure .<lambda($init_test_88, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_catch_arm_fallthrough_unwatches"
-    make_closure .<lambda($init_test_86, 17)>, 0
+    make_closure .<lambda($init_test_88, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_function_call_modifications"
-    make_closure .<lambda($init_test_86, 18)>, 0
+    make_closure .<lambda($init_test_88, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_nested_object_added"
-    make_closure .<lambda($init_test_86, 19)>, 0
+    make_closure .<lambda($init_test_88, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_nested_object_removed"
-    make_closure .<lambda($init_test_86, 20)>, 0
+    make_closure .<lambda($init_test_88, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "watch_cyclic_graph"
-    make_closure .<lambda($init_test_86, 21)>, 0
+    make_closure .<lambda($init_test_88, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "block_notification_basic"
-    make_closure .<lambda($init_test_86, 22)>, 0
+    make_closure .<lambda($init_test_88, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "block_notification_multiple"
-    make_closure .<lambda($init_test_86, 23)>, 0
+    make_closure .<lambda($init_test_88, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_header_before_if"
-    make_closure .<lambda($init_test_86, 24)>, 0
+    make_closure .<lambda($init_test_88, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_header_before_while"
-    make_closure .<lambda($init_test_86, 25)>, 0
+    make_closure .<lambda($init_test_88, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_standalone_header_no_viz_events"
-    make_closure .<lambda($init_test_86, 26)>, 0
+    make_closure .<lambda($init_test_88, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_multiple_headers_only_one_before_if"
-    make_closure .<lambda($init_test_86, 27)>, 0
+    make_closure .<lambda($init_test_88, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "viz_if_without_header_no_viz"
-    make_closure .<lambda($init_test_86, 28)>, 0
+    make_closure .<lambda($init_test_88, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/while_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/while_loops.snap
@@ -1,58 +1,58 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function while_loops.$init_test_87(registry: testing.TestCollector) -> null {
+function while_loops.$init_test_89(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "while_loop_gcd"
-    make_closure .<lambda($init_test_87, 0)>, 0
+    make_closure .<lambda($init_test_89, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "while_with_scope"
-    make_closure .<lambda($init_test_87, 1)>, 0
+    make_closure .<lambda($init_test_89, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "while_with_break"
-    make_closure .<lambda($init_test_87, 2)>, 0
+    make_closure .<lambda($init_test_89, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "break_factorial"
-    make_closure .<lambda($init_test_87, 3)>, 0
+    make_closure .<lambda($init_test_89, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "break_nested"
-    make_closure .<lambda($init_test_87, 4)>, 0
+    make_closure .<lambda($init_test_89, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "break_nested_with_variable_conditions"
-    make_closure .<lambda($init_test_87, 5)>, 0
+    make_closure .<lambda($init_test_89, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "while_with_conditional_break"
-    make_closure .<lambda($init_test_87, 6)>, 0
+    make_closure .<lambda($init_test_89, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "continue_factorial"
-    make_closure .<lambda($init_test_87, 7)>, 0
+    make_closure .<lambda($init_test_89, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "continue_nested"
-    make_closure .<lambda($init_test_87, 8)>, 0
+    make_closure .<lambda($init_test_89, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/while_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/while_loops.snap
@@ -1,58 +1,58 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
-function while_loops.$init_test_89(registry: testing.TestCollector) -> null {
+function while_loops.$init_test_90(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "while_loop_gcd"
-    make_closure .<lambda($init_test_89, 0)>, 0
+    make_closure .<lambda($init_test_90, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "while_with_scope"
-    make_closure .<lambda($init_test_89, 1)>, 0
+    make_closure .<lambda($init_test_90, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "while_with_break"
-    make_closure .<lambda($init_test_89, 2)>, 0
+    make_closure .<lambda($init_test_90, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "break_factorial"
-    make_closure .<lambda($init_test_89, 3)>, 0
+    make_closure .<lambda($init_test_90, 3)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "break_nested"
-    make_closure .<lambda($init_test_89, 4)>, 0
+    make_closure .<lambda($init_test_90, 4)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "break_nested_with_variable_conditions"
-    make_closure .<lambda($init_test_89, 5)>, 0
+    make_closure .<lambda($init_test_90, 5)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "while_with_conditional_break"
-    make_closure .<lambda($init_test_89, 6)>, 0
+    make_closure .<lambda($init_test_90, 6)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "continue_factorial"
-    make_closure .<lambda($init_test_89, 7)>, 0
+    make_closure .<lambda($init_test_90, 7)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "continue_nested"
-    make_closure .<lambda($init_test_89, 8)>, 0
+    make_closure .<lambda($init_test_90, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1025,6 +1025,40 @@ function baml.panics.to_json(self: ?) -> baml.json.json  [expr] {
   map { "message": self.message.to_json() }
 }
 
+--- <builtin>/baml/ns_spawn/spawn.baml ---
+class baml.spawn.CancelToken {
+  _handle: $rust_type
+}
+class baml.spawn.SpawnConfig {
+  _handle: $rust_type
+}
+class baml.spawn.TaskGroup {
+  _handle: $rust_type
+}
+function baml.spawn.any(tokens: baml.spawn.CancelToken[]) -> baml.spawn.CancelToken  [builtin]
+function baml.spawn.cancel(self: ?) -> int  [builtin]
+function baml.spawn.from_json(j: baml.json.json) -> baml.spawn.SpawnConfig  [expr] {
+  baml.json.from_string(baml.json.stringify(j))
+}
+function baml.spawn.from_json(j: baml.json.json) -> baml.spawn.CancelToken  [expr] {
+  baml.json.from_string(baml.json.stringify(j))
+}
+function baml.spawn.from_json(j: baml.json.json) -> baml.spawn.TaskGroup  [expr] {
+  baml.json.from_string(baml.json.stringify(j))
+}
+function baml.spawn.is_cancelled(self: ?) -> bool  [builtin]
+function baml.spawn.new() -> baml.spawn.CancelToken  [builtin]
+function baml.spawn.options(group: baml.spawn.TaskGroup? = null, cancel: baml.spawn.CancelToken? = null) -> baml.spawn.SpawnConfig  [builtin]
+function baml.spawn.to_json(self: ?) -> baml.json.json  [expr] {
+  baml.json.parse(baml.json.to_string(self))
+}
+function baml.spawn.to_json(self: ?) -> baml.json.json  [expr] {
+  baml.json.parse(baml.json.to_string(self))
+}
+function baml.spawn.to_json(self: ?) -> baml.json.json  [expr] {
+  baml.json.parse(baml.json.to_string(self))
+}
+
 --- <builtin>/baml/ns_stream/stream.baml ---
 class baml.stream.StreamFinished {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1035,20 +1035,27 @@ class baml.spawn.SpawnConfig {
 class baml.spawn.TaskGroup {
   _handle: $rust_type
 }
+function baml.spawn.active_count(self: ?) -> int  [builtin]
 function baml.spawn.any(tokens: baml.spawn.CancelToken[]) -> baml.spawn.CancelToken  [builtin]
+function baml.spawn.cancel(self: ?, pending: bool? = true, active: bool? = true) -> int  [builtin]
 function baml.spawn.cancel(self: ?) -> int  [builtin]
 function baml.spawn.from_json(j: baml.json.json) -> baml.spawn.SpawnConfig  [expr] {
-  baml.json.from_string(baml.json.stringify(j))
-}
-function baml.spawn.from_json(j: baml.json.json) -> baml.spawn.CancelToken  [expr] {
   baml.json.from_string(baml.json.stringify(j))
 }
 function baml.spawn.from_json(j: baml.json.json) -> baml.spawn.TaskGroup  [expr] {
   baml.json.from_string(baml.json.stringify(j))
 }
+function baml.spawn.from_json(j: baml.json.json) -> baml.spawn.CancelToken  [expr] {
+  baml.json.from_string(baml.json.stringify(j))
+}
 function baml.spawn.is_cancelled(self: ?) -> bool  [builtin]
+function baml.spawn.limit(self: ?) -> int  [builtin]
+function baml.spawn.name(self: ?) -> string?  [builtin]
 function baml.spawn.new() -> baml.spawn.CancelToken  [builtin]
+function baml.spawn.new(limit: int, name: string? = null) -> baml.spawn.TaskGroup  [builtin]
 function baml.spawn.options(group: baml.spawn.TaskGroup? = null, cancel: baml.spawn.CancelToken? = null, detach: bool? = null) -> baml.spawn.SpawnConfig  [builtin]
+function baml.spawn.queued_count(self: ?) -> int  [builtin]
+function baml.spawn.set_limit(self: ?, limit: int) -> void  [builtin]
 function baml.spawn.to_json(self: ?) -> baml.json.json  [expr] {
   baml.json.parse(baml.json.to_string(self))
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1048,7 +1048,7 @@ function baml.spawn.from_json(j: baml.json.json) -> baml.spawn.TaskGroup  [expr]
 }
 function baml.spawn.is_cancelled(self: ?) -> bool  [builtin]
 function baml.spawn.new() -> baml.spawn.CancelToken  [builtin]
-function baml.spawn.options(group: baml.spawn.TaskGroup? = null, cancel: baml.spawn.CancelToken? = null) -> baml.spawn.SpawnConfig  [builtin]
+function baml.spawn.options(group: baml.spawn.TaskGroup? = null, cancel: baml.spawn.CancelToken? = null, detach: bool? = null) -> baml.spawn.SpawnConfig  [builtin]
 function baml.spawn.to_json(self: ?) -> baml.json.json  [expr] {
   baml.json.parse(baml.json.to_string(self))
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -7091,7 +7091,11 @@ fn baml.panics.Unreachable.to_json(self: baml.panics.Unreachable) -> baml.json.j
     }
 }
 
+fn baml.spawn.TaskGroup.active_count = builtin(vm)
+
 fn baml.spawn.CancelToken.any = builtin(vm)
+
+fn baml.spawn.TaskGroup.cancel = builtin(vm)
 
 fn baml.spawn.CancelToken.cancel = builtin(vm)
 
@@ -7108,27 +7112,6 @@ fn baml.spawn.SpawnConfig.from_json(j: baml.json.json) -> baml.spawn.SpawnConfig
 
     bb1: {
         _3 = load_type(baml.spawn.SpawnConfig);
-        _0 = call const fn baml.json.from_string<copy _3>(copy _2) -> [bb2];
-    }
-
-    bb2: {
-        return;
-    }
-}
-
-fn baml.spawn.CancelToken.from_json(j: baml.json.json) -> baml.spawn.CancelToken {
-    // Locals:
-    let _0: baml.spawn.CancelToken // _0 // return
-    let _1: baml.json.json // j // param
-    let _2: string
-    let _3: type
-
-    bb0: {
-        _2 = call const fn baml.json.stringify(copy _1) -> [bb1];
-    }
-
-    bb1: {
-        _3 = load_type(baml.spawn.CancelToken);
         _0 = call const fn baml.json.from_string<copy _3>(copy _2) -> [bb2];
     }
 
@@ -7158,21 +7141,52 @@ fn baml.spawn.TaskGroup.from_json(j: baml.json.json) -> baml.spawn.TaskGroup {
     }
 }
 
-fn baml.spawn.CancelToken.is_cancelled = builtin(vm)
-
-fn baml.spawn.CancelToken.new = builtin(vm)
-
-fn baml.spawn.options = builtin(vm)
-
-fn baml.spawn.TaskGroup.to_json(self: baml.spawn.TaskGroup) -> baml.json.json {
+fn baml.spawn.CancelToken.from_json(j: baml.json.json) -> baml.spawn.CancelToken {
     // Locals:
-    let _0: baml.json.json // _0 // return
-    let _1: baml.spawn.TaskGroup // self // param
+    let _0: baml.spawn.CancelToken // _0 // return
+    let _1: baml.json.json // j // param
     let _2: string
     let _3: type
 
     bb0: {
-        _3 = load_type(baml.spawn.TaskGroup);
+        _2 = call const fn baml.json.stringify(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _3 = load_type(baml.spawn.CancelToken);
+        _0 = call const fn baml.json.from_string<copy _3>(copy _2) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.spawn.CancelToken.is_cancelled = builtin(vm)
+
+fn baml.spawn.TaskGroup.limit = builtin(vm)
+
+fn baml.spawn.TaskGroup.name = builtin(vm)
+
+fn baml.spawn.CancelToken.new = builtin(vm)
+
+fn baml.spawn.TaskGroup.new = builtin(vm)
+
+fn baml.spawn.options = builtin(vm)
+
+fn baml.spawn.TaskGroup.queued_count = builtin(vm)
+
+fn baml.spawn.TaskGroup.set_limit = builtin(vm)
+
+fn baml.spawn.SpawnConfig.to_json(self: baml.spawn.SpawnConfig) -> baml.json.json {
+    // Locals:
+    let _0: baml.json.json // _0 // return
+    let _1: baml.spawn.SpawnConfig // self // param
+    let _2: string
+    let _3: type
+
+    bb0: {
+        _3 = load_type(baml.spawn.SpawnConfig);
         _2 = call const fn baml.json.to_string<copy _3>(copy _1) -> [bb1];
     }
 
@@ -7185,15 +7199,15 @@ fn baml.spawn.TaskGroup.to_json(self: baml.spawn.TaskGroup) -> baml.json.json {
     }
 }
 
-fn baml.spawn.SpawnConfig.to_json(self: baml.spawn.SpawnConfig) -> baml.json.json {
+fn baml.spawn.TaskGroup.to_json(self: baml.spawn.TaskGroup) -> baml.json.json {
     // Locals:
     let _0: baml.json.json // _0 // return
-    let _1: baml.spawn.SpawnConfig // self // param
+    let _1: baml.spawn.TaskGroup // self // param
     let _2: string
     let _3: type
 
     bb0: {
-        _3 = load_type(baml.spawn.SpawnConfig);
+        _3 = load_type(baml.spawn.TaskGroup);
         _2 = call const fn baml.json.to_string<copy _3>(copy _1) -> [bb1];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -7091,6 +7091,142 @@ fn baml.panics.Unreachable.to_json(self: baml.panics.Unreachable) -> baml.json.j
     }
 }
 
+fn baml.spawn.CancelToken.any = builtin(vm)
+
+fn baml.spawn.CancelToken.cancel = builtin(vm)
+
+fn baml.spawn.SpawnConfig.from_json(j: baml.json.json) -> baml.spawn.SpawnConfig {
+    // Locals:
+    let _0: baml.spawn.SpawnConfig // _0 // return
+    let _1: baml.json.json // j // param
+    let _2: string
+    let _3: type
+
+    bb0: {
+        _2 = call const fn baml.json.stringify(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _3 = load_type(baml.spawn.SpawnConfig);
+        _0 = call const fn baml.json.from_string<copy _3>(copy _2) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.spawn.CancelToken.from_json(j: baml.json.json) -> baml.spawn.CancelToken {
+    // Locals:
+    let _0: baml.spawn.CancelToken // _0 // return
+    let _1: baml.json.json // j // param
+    let _2: string
+    let _3: type
+
+    bb0: {
+        _2 = call const fn baml.json.stringify(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _3 = load_type(baml.spawn.CancelToken);
+        _0 = call const fn baml.json.from_string<copy _3>(copy _2) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.spawn.TaskGroup.from_json(j: baml.json.json) -> baml.spawn.TaskGroup {
+    // Locals:
+    let _0: baml.spawn.TaskGroup // _0 // return
+    let _1: baml.json.json // j // param
+    let _2: string
+    let _3: type
+
+    bb0: {
+        _2 = call const fn baml.json.stringify(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _3 = load_type(baml.spawn.TaskGroup);
+        _0 = call const fn baml.json.from_string<copy _3>(copy _2) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.spawn.CancelToken.is_cancelled = builtin(vm)
+
+fn baml.spawn.CancelToken.new = builtin(vm)
+
+fn baml.spawn.options = builtin(vm)
+
+fn baml.spawn.TaskGroup.to_json(self: baml.spawn.TaskGroup) -> baml.json.json {
+    // Locals:
+    let _0: baml.json.json // _0 // return
+    let _1: baml.spawn.TaskGroup // self // param
+    let _2: string
+    let _3: type
+
+    bb0: {
+        _3 = load_type(baml.spawn.TaskGroup);
+        _2 = call const fn baml.json.to_string<copy _3>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _0 = call const fn baml.json.parse(copy _2) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.spawn.SpawnConfig.to_json(self: baml.spawn.SpawnConfig) -> baml.json.json {
+    // Locals:
+    let _0: baml.json.json // _0 // return
+    let _1: baml.spawn.SpawnConfig // self // param
+    let _2: string
+    let _3: type
+
+    bb0: {
+        _3 = load_type(baml.spawn.SpawnConfig);
+        _2 = call const fn baml.json.to_string<copy _3>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _0 = call const fn baml.json.parse(copy _2) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.spawn.CancelToken.to_json(self: baml.spawn.CancelToken) -> baml.json.json {
+    // Locals:
+    let _0: baml.json.json // _0 // return
+    let _1: baml.spawn.CancelToken // self // param
+    let _2: string
+    let _3: type
+
+    bb0: {
+        _3 = load_type(baml.spawn.CancelToken);
+        _2 = call const fn baml.json.to_string<copy _3>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _0 = call const fn baml.json.parse(copy _2) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
 fn baml.stream.StreamFinished.from_json(j: baml.json.json) -> baml.stream.StreamFinished {
     // Locals:
     let _0: baml.stream.StreamFinished // _0 // return

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -1489,6 +1489,44 @@ class baml.panics.SdkPanic$stream {
 }
 type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.IndexOutOfBounds$stream | baml.panics.MapKeyNotFound$stream | baml.panics.StackOverflow$stream | baml.panics.AssertionFailed$stream | baml.panics.Unreachable$stream | baml.panics.Cancelled$stream | baml.panics.UserPanic$stream | baml.panics.Exit$stream | baml.panics.AllocFailure$stream | baml.panics.HostUnavailable$stream | baml.panics.NegativeBitShift$stream | baml.panics.SdkPanic$stream
 
+--- <builtin>/baml/ns_spawn/spawn.baml ---
+class baml.spawn.SpawnConfig {
+  _handle: $rust_type
+}
+function baml.spawn.SpawnConfig.to_json(self: baml.spawn.SpawnConfig) -> baml.json.json throws baml.json.JsonSerializationError | baml.json.JsonParseError {
+  baml.json.parse(baml.json.to_string<SpawnConfig>(self)) : baml.json.json
+}
+function baml.spawn.SpawnConfig.from_json(j: baml.json.json) -> baml.spawn.SpawnConfig throws baml.json.JsonParseError | baml.json.JsonDecodeError {
+  baml.json.from_string<T>(baml.json.stringify(j)) : baml.spawn.SpawnConfig
+}
+class baml.spawn.TaskGroup {
+  _handle: $rust_type
+}
+function baml.spawn.TaskGroup.to_json(self: baml.spawn.TaskGroup) -> baml.json.json throws baml.json.JsonSerializationError | baml.json.JsonParseError {
+  baml.json.parse(baml.json.to_string<TaskGroup>(self)) : baml.json.json
+}
+function baml.spawn.TaskGroup.from_json(j: baml.json.json) -> baml.spawn.TaskGroup throws baml.json.JsonParseError | baml.json.JsonDecodeError {
+  baml.json.from_string<T>(baml.json.stringify(j)) : baml.spawn.TaskGroup
+}
+class baml.spawn.CancelToken {
+  _handle: $rust_type
+}
+function baml.spawn.CancelToken.to_json(self: baml.spawn.CancelToken) -> baml.json.json throws baml.json.JsonSerializationError | baml.json.JsonParseError {
+  baml.json.parse(baml.json.to_string<CancelToken>(self)) : baml.json.json
+}
+function baml.spawn.CancelToken.from_json(j: baml.json.json) -> baml.spawn.CancelToken throws baml.json.JsonParseError | baml.json.JsonDecodeError {
+  baml.json.from_string<T>(baml.json.stringify(j)) : baml.spawn.CancelToken
+}
+class baml.spawn.SpawnConfig$stream {
+  _handle: $rust_type
+}
+class baml.spawn.TaskGroup$stream {
+  _handle: $rust_type
+}
+class baml.spawn.CancelToken$stream {
+  _handle: $rust_type
+}
+
 --- <builtin>/baml/ns_stream/stream.baml ---
 class baml.stream.StreamFinished {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -4533,6 +4533,75 @@ function baml.panics.UserPanic.to_json(self: null) -> baml.json.json {
     return
 }
 
+function baml.spawn.CancelToken.any(tokens: baml.spawn.CancelToken[]) -> baml.spawn.CancelToken {
+}
+
+function baml.spawn.CancelToken.cancel(self: null) -> int {
+}
+
+function baml.spawn.CancelToken.from_json(j: baml.json.json) -> baml.spawn.CancelToken {
+    load_var j
+    call baml.json.stringify
+    store_var _2
+    load_type baml.spawn.CancelToken
+    load_var _2
+    call baml.json.from_string
+    return
+}
+
+function baml.spawn.CancelToken.is_cancelled(self: null) -> bool {
+}
+
+function baml.spawn.CancelToken.new() -> baml.spawn.CancelToken {
+}
+
+function baml.spawn.CancelToken.to_json(self: null) -> baml.json.json {
+    load_type baml.spawn.CancelToken
+    load_var self
+    call baml.json.to_string
+    call baml.json.parse
+    return
+}
+
+function baml.spawn.SpawnConfig.from_json(j: baml.json.json) -> baml.spawn.SpawnConfig {
+    load_var j
+    call baml.json.stringify
+    store_var _2
+    load_type baml.spawn.SpawnConfig
+    load_var _2
+    call baml.json.from_string
+    return
+}
+
+function baml.spawn.SpawnConfig.to_json(self: null) -> baml.json.json {
+    load_type baml.spawn.SpawnConfig
+    load_var self
+    call baml.json.to_string
+    call baml.json.parse
+    return
+}
+
+function baml.spawn.TaskGroup.from_json(j: baml.json.json) -> baml.spawn.TaskGroup {
+    load_var j
+    call baml.json.stringify
+    store_var _2
+    load_type baml.spawn.TaskGroup
+    load_var _2
+    call baml.json.from_string
+    return
+}
+
+function baml.spawn.TaskGroup.to_json(self: null) -> baml.json.json {
+    load_type baml.spawn.TaskGroup
+    load_var self
+    call baml.json.to_string
+    call baml.json.parse
+    return
+}
+
+function baml.spawn.options(group: baml.spawn.TaskGroup?, cancel: baml.spawn.CancelToken?) -> baml.spawn.SpawnConfig {
+}
+
 function baml.stream.StreamFinished.from_json(j: baml.json.json) -> baml.stream.StreamFinished {
     alloc_instance baml.stream.StreamFinished
     return

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -4581,6 +4581,12 @@ function baml.spawn.SpawnConfig.to_json(self: null) -> baml.json.json {
     return
 }
 
+function baml.spawn.TaskGroup.active_count(self: null) -> int {
+}
+
+function baml.spawn.TaskGroup.cancel(self: null, pending: bool?, active: bool?) -> int {
+}
+
 function baml.spawn.TaskGroup.from_json(j: baml.json.json) -> baml.spawn.TaskGroup {
     load_var j
     call baml.json.stringify
@@ -4589,6 +4595,21 @@ function baml.spawn.TaskGroup.from_json(j: baml.json.json) -> baml.spawn.TaskGro
     load_var _2
     call baml.json.from_string
     return
+}
+
+function baml.spawn.TaskGroup.limit(self: null) -> int {
+}
+
+function baml.spawn.TaskGroup.name(self: null) -> string? {
+}
+
+function baml.spawn.TaskGroup.new(limit: int, name: string?) -> baml.spawn.TaskGroup {
+}
+
+function baml.spawn.TaskGroup.queued_count(self: null) -> int {
+}
+
+function baml.spawn.TaskGroup.set_limit(self: null, limit: int) -> void {
 }
 
 function baml.spawn.TaskGroup.to_json(self: null) -> baml.json.json {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -4599,7 +4599,7 @@ function baml.spawn.TaskGroup.to_json(self: null) -> baml.json.json {
     return
 }
 
-function baml.spawn.options(group: baml.spawn.TaskGroup?, cancel: baml.spawn.CancelToken?) -> baml.spawn.SpawnConfig {
+function baml.spawn.options(group: baml.spawn.TaskGroup?, cancel: baml.spawn.CancelToken?, detach: bool?) -> baml.spawn.SpawnConfig {
 }
 
 function baml.stream.StreamFinished.from_json(j: baml.json.json) -> baml.stream.StreamFinished {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__03_hir.snap
@@ -2,6 +2,6 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("simple test", () -> void { { let x = 1 Add 2 } assert.equal(x, 3) }, null); registry.register_test("with not_null", () -> void { { let result = "hello" } assert.not_null(result) }, null) } null
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -32,7 +32,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>() -> null {
+fn .<lambda($init_test_36, 0)>() -> null {
     // Locals:
     let _0: null // _0 // return
 
@@ -46,7 +46,7 @@ fn .<lambda($init_test_35, 0)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda($init_test_35, 1)>() -> null {
+fn .<lambda($init_test_36, 1)>() -> null {
     // Locals:
     let _0: null // _0 // return
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("simple test", () -> void { ... }, null) : void
       () -> void { ... } : () -> void throws unknown
@@ -19,7 +19,7 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__06_codegen.snap
@@ -9,16 +9,16 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "simple test"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "with not_null"
-    make_closure .<lambda($init_test_35, 1)>, 0
+    make_closure .<lambda($init_test_36, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__03_hir.snap
@@ -2,6 +2,6 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test_set("concat names", (testset: testing.TestCollector) -> void { { testset.register_test("prefix_" Add "suffix", () -> { {  } null }, null); testset.register_test_set("nested_" Add "group", (testset: testing.TestCollector) -> { { testset.register_test("inner", () -> { {  } null }, null) } null }, null) } null }, null) } null
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -25,7 +25,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
+fn .<lambda($init_test_36, 0)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -55,7 +55,7 @@ fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda(<lambda($init_test_35, 0)>, 1)>() -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 1)>() -> null {
     // Locals:
     let _0: null // _0 // return
 
@@ -70,7 +70,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 1)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda(<lambda($init_test_35, 0)>, 2)>(testset: testing.TestCollector) -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 2)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -93,7 +93,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 2)>(testset: testing.TestCollector) -> n
 }
 
 // lambda[0]
-fn .<lambda(<lambda(<lambda($init_test_35, 0)>, 2)>, 3)>() -> null {
+fn .<lambda(<lambda(<lambda($init_test_36, 0)>, 2)>, 3)>() -> null {
     // Locals:
     let _0: null // _0 // return
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test_set("concat names", (testset: testing.TestCollector) -> void { ... }, null) : void
       (testset: testing.TestCollector) -> void { ... } : (testset: testing.TestCollector) -> void throws unknown
@@ -14,11 +14,11 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__06_codegen.snap
@@ -9,10 +9,10 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "concat names"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test_set
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__03_hir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("throwing body bec...", () -> void { {  } risky() }, null) } null
 }
 function user.risky() -> void  [expr] {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -25,7 +25,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>() -> null {
+fn .<lambda($init_test_36, 0)>() -> null {
     // Locals:
     let _0: null // _0 // return
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__04_tir.snap
@@ -7,7 +7,7 @@ function user.risky() -> void throws string {
     throw "boom" : "boom"
   }
 }
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("throwing body bec...", () -> void { ... }, null) : void
       () -> void { ... } : () -> void throws unknown
@@ -17,5 +17,5 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__06_codegen.snap
@@ -9,10 +9,10 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "throwing body becomes failure"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__03_hir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("new style", () -> void { { let result = "hello" } assert.not_null(result) }, null) } null
 }
 function user.Greet(name: string) -> string  [expr] {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -25,7 +25,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>() -> null {
+fn .<lambda($init_test_36, 0)>() -> null {
     // Locals:
     let _0: null // _0 // return
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__04_tir.snap
@@ -7,7 +7,7 @@ function user.Greet(name: string) -> string throws never {
     "Hello, {name}!" : "Hello, {name}!"
   }
 }
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("new style", () -> void { ... }, null) : void
       () -> void { ... } : () -> void throws unknown
@@ -18,5 +18,5 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__06_codegen.snap
@@ -9,10 +9,10 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "new style"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__03_hir.snap
@@ -2,6 +2,6 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("raw string name", () -> void { {  } assert.is_true(true) }, null); registry.register_test("has \"quotes\" inside", () -> void { {  } assert.is_true(true) }, null); registry.register_test_set("raw testset name", (testset: testing.TestCollector) -> void { { testset.register_test("nested raw name", () -> { {  } assert.is_true(true) }, null) } null }, null) } null
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -39,7 +39,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>() -> null {
+fn .<lambda($init_test_36, 0)>() -> null {
     // Locals:
     let _0: null // _0 // return
 
@@ -53,7 +53,7 @@ fn .<lambda($init_test_35, 0)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda($init_test_35, 1)>() -> null {
+fn .<lambda($init_test_36, 1)>() -> null {
     // Locals:
     let _0: null // _0 // return
 
@@ -67,7 +67,7 @@ fn .<lambda($init_test_35, 1)>() -> null {
 }
 
 // lambda[2]
-fn .<lambda($init_test_35, 2)>(testset: testing.TestCollector) -> null {
+fn .<lambda($init_test_36, 2)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -90,7 +90,7 @@ fn .<lambda($init_test_35, 2)>(testset: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda(<lambda($init_test_35, 2)>, 3)>() -> null {
+fn .<lambda(<lambda($init_test_36, 2)>, 3)>() -> null {
     // Locals:
     let _0: null // _0 // return
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("raw string name", () -> void { ... }, null) : void
       () -> void { ... } : () -> void throws unknown
@@ -23,11 +23,11 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__06_codegen.snap
@@ -9,22 +9,22 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "raw string name"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "has \"quotes\" inside"
-    make_closure .<lambda($init_test_35, 1)>, 0
+    make_closure .<lambda($init_test_36, 1)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "raw testset name"
-    make_closure .<lambda($init_test_35, 2)>, 0
+    make_closure .<lambda($init_test_36, 2)>, 0
     load_const null
     call testing.TestCollector.register_test_set
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__03_hir.snap
@@ -8,7 +8,7 @@ class user.Foo {
 class user.HasWith {
   with: int
 }
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("with as field", () -> void { { let h = user.HasWith { with: 1 } } assert.equal(h.with, 1) }, null) } null
 }
 function user.from_json(j: baml.json.json) -> user.Foo  [expr] {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -25,7 +25,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>() -> null {
+fn .<lambda($init_test_36, 0)>() -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: HasWith // h

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__04_tir.snap
@@ -31,7 +31,7 @@ function user.HasWith.to_json(self: user.HasWith) -> baml.json.json throws baml.
 function user.HasWith.from_json(j: baml.json.json) -> user.HasWith throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   HasWith { with: baml.json.from_json<int>(baml.json.field(j, "with")) } : user.HasWith
 }
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("with as field", () -> void { ... }, null) : void
       () -> void { ... } : () -> void throws unknown
@@ -42,7 +42,7 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
 class user.Foo$stream {
   x: null | int

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__06_codegen.snap
@@ -9,10 +9,10 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "with as field"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__03_hir.snap
@@ -2,6 +2,6 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test_set("basic group", (testset: testing.TestCollector) -> void { { testset.register_test("first", () -> { {  } assert.is_true(true) }, null); testset.register_test("second", () -> { {  } assert.is_true(true) }, null) } null }, null) } null
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -25,7 +25,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
+fn .<lambda($init_test_36, 0)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -55,7 +55,7 @@ fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda(<lambda($init_test_35, 0)>, 1)>() -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 1)>() -> null {
     // Locals:
     let _0: null // _0 // return
 
@@ -69,7 +69,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 1)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda(<lambda($init_test_35, 0)>, 2)>() -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 2)>() -> null {
     // Locals:
     let _0: null // _0 // return
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test_set("basic group", (testset: testing.TestCollector) -> void { ... }, null) : void
       (testset: testing.TestCollector) -> void { ... } : (testset: testing.TestCollector) -> void throws unknown
@@ -14,9 +14,9 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__06_codegen.snap
@@ -9,10 +9,10 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "basic group"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test_set
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__03_hir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test_set("dynamic tests", (testset: testing.TestCollector) -> void { { let cases = ["hello", "world", "foo"]; for case in cases { testset.register_test("check case", () -> { {  } assert.not_null(case) }, null) } } null }, null); registry.register_test_set("conditional tests", (testset: testing.TestCollector) -> void { { { let run_slow = false; testset.register_test("always runs", () -> { {  } assert.is_true(true) }, null) } if (run_slow) { testset.register_test("only when slow", () -> { {  } assert.is_true(true) }, null) } } null }, null) } null
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -32,7 +32,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
+fn .<lambda($init_test_36, 0)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -83,7 +83,7 @@ fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda(<lambda($init_test_35, 0)>, 1)>() -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 1)>() -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: string
@@ -99,7 +99,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 1)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda($init_test_35, 2)>(testset: testing.TestCollector) -> null {
+fn .<lambda($init_test_36, 2)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -137,7 +137,7 @@ fn .<lambda($init_test_35, 2)>(testset: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda(<lambda($init_test_35, 2)>, 3)>() -> null {
+fn .<lambda(<lambda($init_test_36, 2)>, 3)>() -> null {
     // Locals:
     let _0: null // _0 // return
 
@@ -151,7 +151,7 @@ fn .<lambda(<lambda($init_test_35, 2)>, 3)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda(<lambda($init_test_35, 2)>, 4)>() -> null {
+fn .<lambda(<lambda($init_test_36, 2)>, 4)>() -> null {
     // Locals:
     let _0: null // _0 // return
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test_set("dynamic tests", (testset: testing.TestCollector) -> void { ... }, null) : void
       (testset: testing.TestCollector) -> void { ... } : (testset: testing.TestCollector) -> void throws unknown
@@ -30,13 +30,13 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__06_codegen.snap
@@ -9,16 +9,16 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "dynamic tests"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test_set
     pop 1
     load_var registry
     load_const "conditional tests"
-    make_closure .<lambda($init_test_35, 2)>, 0
+    make_closure .<lambda($init_test_36, 2)>, 0
     load_const null
     call testing.TestCollector.register_test_set
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__03_hir.snap
@@ -2,6 +2,6 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test_set("all evals", (testset: testing.TestCollector) -> void { { testset.register_test_set("normal cases", (testset: testing.TestCollector) -> { { testset.register_test("case one", () -> { {  } assert.is_true(true) }, null) } null }, null); testset.register_test_set("hard cases", (testset: testing.TestCollector) -> { { testset.register_test("case two", () -> { {  } assert.is_true(true) }, null) } null }, null) } null }, null) } null
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -25,7 +25,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
+fn .<lambda($init_test_36, 0)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -55,7 +55,7 @@ fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda(<lambda($init_test_35, 0)>, 1)>(testset: testing.TestCollector) -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 1)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -78,7 +78,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 1)>(testset: testing.TestCollector) -> n
 }
 
 // lambda[0]
-fn .<lambda(<lambda(<lambda($init_test_35, 0)>, 1)>, 2)>() -> null {
+fn .<lambda(<lambda(<lambda($init_test_36, 0)>, 1)>, 2)>() -> null {
     // Locals:
     let _0: null // _0 // return
 
@@ -92,7 +92,7 @@ fn .<lambda(<lambda(<lambda($init_test_35, 0)>, 1)>, 2)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda(<lambda($init_test_35, 0)>, 3)>(testset: testing.TestCollector) -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 3)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -115,7 +115,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 3)>(testset: testing.TestCollector) -> n
 }
 
 // lambda[0]
-fn .<lambda(<lambda(<lambda($init_test_35, 0)>, 3)>, 4)>() -> null {
+fn .<lambda(<lambda(<lambda($init_test_36, 0)>, 3)>, 4)>() -> null {
     // Locals:
     let _0: null // _0 // return
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test_set("all evals", (testset: testing.TestCollector) -> void { ... }, null) : void
       (testset: testing.TestCollector) -> void { ... } : (testset: testing.TestCollector) -> void throws unknown
@@ -14,13 +14,13 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__06_codegen.snap
@@ -9,10 +9,10 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "all evals"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test_set
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__03_hir.snap
@@ -7,7 +7,7 @@ class user.Sentiment {
   confidence: float
   reasoning: string
 }
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test_set("test", (testset: testing.TestCollector) -> void { { let topics = ["happy", "sad"]; for sentiments in topics { testset.register_test_set(sentiments, (testset: testing.TestCollector) -> { { let req = baml.http.fetch("http://localhost:..." Add sentiments); let data = req.text(); let tests = GenerateTests$parse(data); for ex in tests { testset.register_test(ex, () -> { { let result = ClassifySentiment("hi"); assert.equal(result.feeling, "positive") } }, null) } } null }, null) }; testset.register_test_set("vibes", (testset: testing.TestCollector) -> { { let topics = ["happy", "sad"]; for sentiments in topics { testset.register_test_set(sentiments, (testset: testing.TestCollector) -> { { let tests = GenerateTests(5, sentiments); for ex in tests { testset.register_test(ex, () -> { { let result = ClassifySentiment("hi"); assert.equal(result.feeling, "positive") } }, null) } } null }, null) } } null }, null) } null }, null) } null
 }
 function user.ClassifySentiment(text: string) -> user.Sentiment  [llm] {

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -25,7 +25,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
+fn .<lambda($init_test_36, 0)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -85,7 +85,7 @@ fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda(<lambda($init_test_35, 0)>, 1)>(testset: testing.TestCollector) -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 1)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -157,7 +157,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 1)>(testset: testing.TestCollector) -> n
 }
 
 // lambda[0]
-fn .<lambda(<lambda(<lambda($init_test_35, 0)>, 1)>, 2)>() -> null {
+fn .<lambda(<lambda(<lambda($init_test_36, 0)>, 1)>, 2)>() -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: Sentiment // result
@@ -184,7 +184,7 @@ fn .<lambda(<lambda(<lambda($init_test_35, 0)>, 1)>, 2)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda(<lambda($init_test_35, 0)>, 3)>(testset: testing.TestCollector) -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 3)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -237,7 +237,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 3)>(testset: testing.TestCollector) -> n
 }
 
 // lambda[0]
-fn .<lambda(<lambda(<lambda($init_test_35, 0)>, 3)>, 4)>(testset: testing.TestCollector) -> null {
+fn .<lambda(<lambda(<lambda($init_test_36, 0)>, 3)>, 4)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -295,7 +295,7 @@ fn .<lambda(<lambda(<lambda($init_test_35, 0)>, 3)>, 4)>(testset: testing.TestCo
 }
 
 // lambda[0]
-fn .<lambda(<lambda(<lambda(<lambda($init_test_35, 0)>, 3)>, 4)>, 5)>() -> null {
+fn .<lambda(<lambda(<lambda(<lambda($init_test_36, 0)>, 3)>, 4)>, 5)>() -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: Sentiment // result

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_tir.snap
@@ -75,7 +75,7 @@ function user.ClassifySentiment2$build_request_stream(text: string) -> baml.http
 function user.ClassifySentiment2$parse(json: string) -> string throws never {
   baml.llm.parse<TFinal>("ClassifySentiment2", json) : string
 }
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test_set("test", (testset: testing.TestCollector) -> void { ... }, null) : void
       (testset: testing.TestCollector) -> void { ... } : (testset: testing.TestCollector) -> void throws unknown
@@ -91,17 +91,17 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
 class user.Sentiment$stream {
   feeling: null | string

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
@@ -16,10 +16,10 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "test"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test_set
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__03_hir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test_set("with shared setup", (testset: testing.TestCollector) -> void { { let base_url = "https://api.examp..."; let timeout = 5000; testset.register_test("uses setup vars", () -> { { assert.not_null(base_url) } assert.equal(timeout, 5000) }, null); testset.register_test("also uses setup", () -> { {  } assert.contains(base_url, "example") }, null) } null }, null) } null
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__04_5_mir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.$init_test_35(registry: testing.TestCollector) -> null {
+fn user.$init_test_36(registry: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // registry // param
@@ -25,7 +25,7 @@ fn user.$init_test_35(registry: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
+fn .<lambda($init_test_36, 0)>(testset: testing.TestCollector) -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: testing.TestCollector // testset // param
@@ -59,7 +59,7 @@ fn .<lambda($init_test_35, 0)>(testset: testing.TestCollector) -> null {
 }
 
 // lambda[0]
-fn .<lambda(<lambda($init_test_35, 0)>, 1)>() -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 1)>() -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: null
@@ -82,7 +82,7 @@ fn .<lambda(<lambda($init_test_35, 0)>, 1)>() -> null {
 }
 
 // lambda[1]
-fn .<lambda(<lambda($init_test_35, 0)>, 2)>() -> null {
+fn .<lambda(<lambda($init_test_36, 0)>, 2)>() -> null {
     // Locals:
     let _0: null // _0 // return
     let _1: string

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test_set("with shared setup", (testset: testing.TestCollector) -> void { ... }, null) : void
       (testset: testing.TestCollector) -> void { ... } : (testset: testing.TestCollector) -> void throws unknown
@@ -16,9 +16,9 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
     null : null
   }
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__06_codegen.snap
@@ -9,10 +9,10 @@ function $init_test(registry: unknown) -> null {
     return
 }
 
-function user.$init_test_35(registry: testing.TestCollector) -> null {
+function user.$init_test_36(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "with shared setup"
-    make_closure .<lambda($init_test_35, 0)>, 0
+    make_closure .<lambda($init_test_36, 0)>, 0
     load_const null
     call testing.TestCollector.register_test_set
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__03_hir.snap
@@ -2,6 +2,6 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("a" Add 1, () -> void { {  } null }, null); registry.register_test(42, () -> void { {  } null }, null); registry.register_test_set("int_name", (testset: testing.TestCollector) -> void { { for i in [1, 2, 3] { testset.register_test(5 Add i, () -> { {  } null }, null) } } null }, null) } null
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("a" + 1, () -> void { ... }, null) : void
       () -> void { ... } : () -> void throws unknown
@@ -28,12 +28,12 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
   !! 106..108: type mismatch: expected string, got 42
   !! 0..0: type mismatch: expected string, got int
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
   !! 181..186: type mismatch: expected string, got int
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_with_runner/baml_tests__diagnostic_errors__test_expr_with_runner__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_with_runner/baml_tests__diagnostic_errors__test_expr_with_runner__03_hir.snap
@@ -2,6 +2,6 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("with quorum", () -> void { { let result = "hello" } assert.not_null(result) }, testing.Quorum(5, 3)) } null
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_with_runner/baml_tests__diagnostic_errors__test_expr_with_runner__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_with_runner/baml_tests__diagnostic_errors__test_expr_with_runner__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("with quorum", () -> void { ... }, testing.Quorum(5, 3)) : void
       () -> void { ... } : () -> void throws unknown
@@ -14,5 +14,5 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
   }
   !! 23..38: unresolved name: Quorum
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_wrong_runner/baml_tests__diagnostic_errors__test_expr_wrong_runner__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_wrong_runner/baml_tests__diagnostic_errors__test_expr_wrong_runner__03_hir.snap
@@ -2,6 +2,6 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("wrong runner type", () -> void { {  } assert.is_true(true) }, 42); registry.register_test("string as runner", () -> void { {  } assert.is_true(true) }, "not a runner"); registry.register_test_set("wrong testset runner", (testset: testing.TestCollector) -> void { { testset.register_test("inner", () -> { {  } assert.is_true(true) }, null) } null }, 42) } null
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_wrong_runner/baml_tests__diagnostic_errors__test_expr_wrong_runner__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_wrong_runner/baml_tests__diagnostic_errors__test_expr_wrong_runner__04_tir.snap
@@ -2,7 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("wrong runner type", () -> void { ... }, 42) : void
       () -> void { ... } : () -> void throws unknown
@@ -26,11 +26,11 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
   !! 237..251: type mismatch: expected testing.TestRunner?, got "not a runner"
   !! 316..318: type mismatch: expected testing.TestSetRunner?, got 42
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_with_runner_ambiguity/baml_tests__diagnostic_errors__test_with_runner_ambiguity__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_with_runner_ambiguity/baml_tests__diagnostic_errors__test_with_runner_ambiguity__03_hir.snap
@@ -5,7 +5,7 @@ source: crates/baml_tests/src/generated_tests.rs
 class user.MyRunner {
   threshold: float
 }
-function user.$init_test_35(registry: testing.TestCollector) -> ?  [expr] {
+function user.$init_test_36(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test("simple runner", () -> void { {  } assert.is_true(true) }, my_runner); registry.register_test("call runner", () -> void { {  } assert.is_true(true) }, testing.Quorum(5, 3)); registry.register_test("constructor runner", () -> void { {  } assert.is_true(true) }, user.MyRunner { threshold: 0.5 }) } null
 }
 function user.from_json(j: baml.json.json) -> user.MyRunner  [expr] {

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_with_runner_ambiguity/baml_tests__diagnostic_errors__test_with_runner_ambiguity__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_with_runner_ambiguity/baml_tests__diagnostic_errors__test_with_runner_ambiguity__04_tir.snap
@@ -11,7 +11,7 @@ function user.MyRunner.to_json(self: user.MyRunner) -> baml.json.json throws bam
 function user.MyRunner.from_json(j: baml.json.json) -> user.MyRunner throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   MyRunner { threshold: baml.json.from_json<float>(baml.json.field(j, "threshold")) } : user.MyRunner
 }
-function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
+function user.$init_test_36(registry: testing.TestCollector) -> ? throws never {
   { : null
     registry.register_test("simple runner", () -> void { ... }, my_runner) : void
       () -> void { ... } : () -> void throws unknown
@@ -33,11 +33,11 @@ function user.$init_test_35(registry: testing.TestCollector) -> ? throws never {
   !! 384..393: unresolved name: my_runner
   !! 512..527: unresolved name: Quorum
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
-lambda user.$init_test_35 {
+lambda user.$init_test_36 {
 }
 class user.MyRunner$stream {
   threshold: null | float

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -148,7 +148,7 @@ namespace baml.panics:
 namespace baml.spawn:
   class CancelToken { methods: [new, any, cancel, is_cancelled, to_json, from_json] }
   class SpawnConfig { methods: [to_json, from_json] }
-  class TaskGroup { methods: [to_json, from_json] }
+  class TaskGroup { methods: [new, cancel, set_limit, limit, name, active_count, queued_count, to_json, from_json] }
   function options
 namespace baml.stream:
   class StreamFinished { methods: [to_json, from_json] }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -145,6 +145,11 @@ namespace baml.panics:
   class StackOverflow { methods: [to_json, from_json] }
   class Unreachable { methods: [to_json, from_json] }
   class UserPanic { methods: [to_json, from_json] }
+namespace baml.spawn:
+  class CancelToken { methods: [new, any, cancel, is_cancelled, to_json, from_json] }
+  class SpawnConfig { methods: [to_json, from_json] }
+  class TaskGroup { methods: [to_json, from_json] }
+  function options
 namespace baml.stream:
   class StreamFinished { methods: [to_json, from_json] }
   class StreamNoYield { methods: [to_json, from_json] }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -566,7 +566,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 
   176   49   load_var 12            (sub)
         50   load_var 2             (name)
-        51   call 481 ntypeargs=0   (testing.TestRegistry.expand_set)
+        51   call 492 ntypeargs=0   (testing.TestRegistry.expand_set)
         52   jump +41               (to 93)
 
   156   53   load_var 3             (_3)
@@ -619,7 +619,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         90   pop 1                  
 
   169   91   load_var 1             (self)
-        92   call 476 ntypeargs=0   (testing.TestRegistry.serialize)
+        92   call 487 ntypeargs=0   (testing.TestRegistry.serialize)
         93   return                 
 }
 
@@ -720,7 +720,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
 
   147   49   load_var 9             (sub)
         50   load_var 2             (name)
-        51   call 480 ntypeargs=0   (testing.TestRegistry.run_test)
+        51   call 491 ntypeargs=0   (testing.TestRegistry.run_test)
         52   jump +20               (to 72)
 
   136   53   load_var 3             (_3)
@@ -744,7 +744,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         68   load_field 1           (body)
         69   load_var 5             (t)
         70   load_field 2           (runner)
-        71   call 487 ntypeargs=0   (testing.run_test)
+        71   call 498 ntypeargs=0   (testing.run_test)
         72   return                 
 }
 
@@ -815,7 +815,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         54   store_var 10           (_25)
 
   122   55   load_var 9             (sub)
-        56   call 476 ntypeargs=0   (testing.TestRegistry.serialize)
+        56   call 487 ntypeargs=0   (testing.TestRegistry.serialize)
         57   store_var 11           (_26)
 
   120   58   load_var 2             (items)
@@ -854,7 +854,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
 function testing.TestRegistry.to_json(self: null) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 488 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 499 ntypeargs=0   (testing.TestCollector.to_json)
        3    load_var 1             (self)
        4    load_field 1           (expansions)
        5    call 19 ntypeargs=0    (baml.Map.to_json)
@@ -1009,7 +1009,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 969 1     
+        4    make_closure 986 1     
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -566,7 +566,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 
   176   49   load_var 12            (sub)
         50   load_var 2             (name)
-        51   call 492 ntypeargs=0   (testing.TestRegistry.expand_set)
+        51   call 499 ntypeargs=0   (testing.TestRegistry.expand_set)
         52   jump +41               (to 93)
 
   156   53   load_var 3             (_3)
@@ -619,7 +619,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         90   pop 1                  
 
   169   91   load_var 1             (self)
-        92   call 487 ntypeargs=0   (testing.TestRegistry.serialize)
+        92   call 494 ntypeargs=0   (testing.TestRegistry.serialize)
         93   return                 
 }
 
@@ -720,7 +720,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
 
   147   49   load_var 9             (sub)
         50   load_var 2             (name)
-        51   call 491 ntypeargs=0   (testing.TestRegistry.run_test)
+        51   call 498 ntypeargs=0   (testing.TestRegistry.run_test)
         52   jump +20               (to 72)
 
   136   53   load_var 3             (_3)
@@ -744,7 +744,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         68   load_field 1           (body)
         69   load_var 5             (t)
         70   load_field 2           (runner)
-        71   call 498 ntypeargs=0   (testing.run_test)
+        71   call 505 ntypeargs=0   (testing.run_test)
         72   return                 
 }
 
@@ -815,7 +815,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         54   store_var 10           (_25)
 
   122   55   load_var 9             (sub)
-        56   call 487 ntypeargs=0   (testing.TestRegistry.serialize)
+        56   call 494 ntypeargs=0   (testing.TestRegistry.serialize)
         57   store_var 11           (_26)
 
   120   58   load_var 2             (items)
@@ -854,7 +854,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
 function testing.TestRegistry.to_json(self: null) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 499 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 506 ntypeargs=0   (testing.TestCollector.to_json)
        3    load_var 1             (self)
        4    load_field 1           (expansions)
        5    call 19 ntypeargs=0    (baml.Map.to_json)
@@ -1009,7 +1009,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 986 1     
+        4    make_closure 993 1     
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -592,7 +592,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 
   176   49   load_var 13            (sub)
         50   load_var 2             (name)
-        51   call 481 ntypeargs=0   (testing.TestRegistry.expand_set)
+        51   call 492 ntypeargs=0   (testing.TestRegistry.expand_set)
         52   jump +43               (to 95)
 
   156   53   load_var 3             (_3)
@@ -647,7 +647,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         92   pop 1                  
 
   169   93   load_var 1             (self)
-        94   call 476 ntypeargs=0   (testing.TestRegistry.serialize)
+        94   call 487 ntypeargs=0   (testing.TestRegistry.serialize)
         95   return                 
 }
 
@@ -752,7 +752,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
 
   147   49   load_var 9             (sub)
         50   load_var 2             (name)
-        51   call 480 ntypeargs=0   (testing.TestRegistry.run_test)
+        51   call 491 ntypeargs=0   (testing.TestRegistry.run_test)
         52   jump +20               (to 72)
 
   136   53   load_var 3             (_3)
@@ -776,7 +776,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         68   load_field 1           (body)
         69   load_var 5             (t)
         70   load_field 2           (runner)
-        71   call 487 ntypeargs=0   (testing.run_test)
+        71   call 498 ntypeargs=0   (testing.run_test)
         72   return                 
 }
 
@@ -849,7 +849,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         56   store_var 12           (_25)
 
   122   57   load_var 11            (sub)
-        58   call 476 ntypeargs=0   (testing.TestRegistry.serialize)
+        58   call 487 ntypeargs=0   (testing.TestRegistry.serialize)
         59   store_var 13           (_26)
 
   120   60   load_var 3             (items)
@@ -891,7 +891,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
 function testing.TestRegistry.to_json(self: null) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 488 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 499 ntypeargs=0   (testing.TestCollector.to_json)
        3    load_var 1             (self)
        4    load_field 1           (expansions)
        5    call 19 ntypeargs=0    (baml.Map.to_json)
@@ -1058,7 +1058,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 969 1     
+        4    make_closure 986 1     
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -592,7 +592,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
 
   176   49   load_var 13            (sub)
         50   load_var 2             (name)
-        51   call 492 ntypeargs=0   (testing.TestRegistry.expand_set)
+        51   call 499 ntypeargs=0   (testing.TestRegistry.expand_set)
         52   jump +43               (to 95)
 
   156   53   load_var 3             (_3)
@@ -647,7 +647,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         92   pop 1                  
 
   169   93   load_var 1             (self)
-        94   call 487 ntypeargs=0   (testing.TestRegistry.serialize)
+        94   call 494 ntypeargs=0   (testing.TestRegistry.serialize)
         95   return                 
 }
 
@@ -752,7 +752,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
 
   147   49   load_var 9             (sub)
         50   load_var 2             (name)
-        51   call 491 ntypeargs=0   (testing.TestRegistry.run_test)
+        51   call 498 ntypeargs=0   (testing.TestRegistry.run_test)
         52   jump +20               (to 72)
 
   136   53   load_var 3             (_3)
@@ -776,7 +776,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         68   load_field 1           (body)
         69   load_var 5             (t)
         70   load_field 2           (runner)
-        71   call 498 ntypeargs=0   (testing.run_test)
+        71   call 505 ntypeargs=0   (testing.run_test)
         72   return                 
 }
 
@@ -849,7 +849,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         56   store_var 12           (_25)
 
   122   57   load_var 11            (sub)
-        58   call 487 ntypeargs=0   (testing.TestRegistry.serialize)
+        58   call 494 ntypeargs=0   (testing.TestRegistry.serialize)
         59   store_var 13           (_26)
 
   120   60   load_var 3             (items)
@@ -891,7 +891,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
 function testing.TestRegistry.to_json(self: null) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 499 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 506 ntypeargs=0   (testing.TestCollector.to_json)
        3    load_var 1             (self)
        4    load_field 1           (expansions)
        5    call 19 ntypeargs=0    (baml.Map.to_json)
@@ -1058,7 +1058,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 986 1     
+        4    make_closure 993 1     
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)

--- a/baml_language/crates/baml_tests/tests/spawn_parallel.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_parallel.rs
@@ -19,9 +19,7 @@ async fn spawn_three_sleeps_runs_in_parallel() {
     let program = compile_source_with_opt(
         r#"
         function nap() -> int {
-            baml.sys.sleep(200) catch (e) {
-                let e => 0
-            };
+            baml.sys.sleep(200);
             1
         }
         function main() -> int {
@@ -33,10 +31,13 @@ async fn spawn_three_sleeps_runs_in_parallel() {
         "#,
         OptLevel::One,
     );
+    // Use the *native* sys-ops so `baml.sys.sleep` actually sleeps — the
+    // default `sys_ops` impl returns `Unsupported`, which would make the
+    // "sleeps" no-ops and the test a false positive.
     let engine = Arc::new(
         BexEngine::new(
             program,
-            Arc::new(sys_ops::SysOps::native()),
+            Arc::new(sys_native::SysOps::native()),
             None,
             Vec::new(),
         )

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -91,8 +91,8 @@ pub use bex_heap::GcStats;
 pub use bex_heap::{ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapPermit};
 use bex_vm::{BexVm, SpanNotification, VmExecState};
 use bex_vm_types::{
-    FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SharedGlobals, SysOp, Value,
-    VmGlobals, types::SpawnConfigData,
+    FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SharedGlobals, SysOp,
+    TaskGroupInner, Value, VmGlobals, types::SpawnConfigData,
 };
 pub use conversion::test_arg_to_external;
 // Re-export CancellationToken for callers.
@@ -1964,6 +1964,7 @@ impl BexEngine {
         name: Option<String>,
         user_cancel: Option<CancellationToken>,
         detach: bool,
+        group: Option<Arc<TaskGroupInner>>,
         call_id: CallId,
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<HeapPtr, EngineError>> + Send + 'static>,
@@ -1976,6 +1977,7 @@ impl BexEngine {
             name,
             user_cancel,
             detach,
+            group,
             call_id,
         ))
     }
@@ -1990,6 +1992,7 @@ impl BexEngine {
         name: Option<String>,
         user_cancel: Option<CancellationToken>,
         detach: bool,
+        group: Option<Arc<TaskGroupInner>>,
         call_id: CallId,
     ) -> Result<HeapPtr, EngineError> {
         // Each spawned thread gets a child cancel token so parent → child
@@ -2024,6 +2027,13 @@ impl BexEngine {
             #[cfg(target_arch = "wasm32")]
             wasm_bindgen_futures::spawn_local(watcher);
         }
+
+        // BEP-034 rate limiting: register with the TaskGroup *synchronously*,
+        // here (before the body task is polled), so a `group.cancel()` /
+        // `active_count()` issued right after `spawn` already observes this
+        // member. The returned ticket is `acquire`d (parked on) inside the body
+        // task, so a queued task does not hold the heap permit while waiting.
+        let group_ticket = group.map(|group| group.register(child_cancel.clone()));
 
         // Build the child VM up-front (synchronously) so the await on the
         // permit only holds Send values across yield points.
@@ -2067,6 +2077,31 @@ impl BexEngine {
             attr: baml_type::TyAttr::default(),
         };
         let task = async move {
+            // BEP-034 rate limiting: if this spawn joined a `TaskGroup`, park
+            // here — WITHOUT the heap permit, so a queued task doesn't block GC
+            // — until a slot frees. A task cancelled while queued (group/user/
+            // parent) settles its future `Cancelled` and never runs its body.
+            // The permit is held for the body's lifetime and releases the slot
+            // (waking the next FIFO waiter) on drop.
+            let _group_permit = match group_ticket {
+                Some(ticket) => match ticket.acquire().await {
+                    Some(permit) => Some(permit),
+                    None => {
+                        let mut permit = inactive.acquire().await;
+                        if let Err(err) =
+                            engine.settle_child_cancelled(&mut permit, future_id).await
+                        {
+                            tracing::error!(
+                                ?err,
+                                ?future_id,
+                                "failed to settle queued-then-cancelled spawn"
+                            );
+                        }
+                        return;
+                    }
+                },
+                None => None,
+            };
             let permit = inactive.acquire().await;
             let mut local_span_state: Option<SpanState> = None;
             match engine
@@ -2563,15 +2598,17 @@ impl BexEngine {
                             _ => None,
                         });
                     // BEP-034 spawn options: read the `SpawnConfig` (cancel
-                    // token + detach flag) from a `with baml.spawn.options(...)`
-                    // clause. `cancel` links into the child's effective token;
-                    // `detach` decouples it from the parent and routes its
-                    // unhandled errors to the root task instead of this spawner.
+                    // token, detach flag, task group) from a
+                    // `with baml.spawn.options(...)` clause. `cancel` links into
+                    // the child's effective token; `detach` decouples it from
+                    // the parent and routes its unhandled errors to the root
+                    // task instead of this spawner; `group` rate-limits it.
                     let config = config_ptr
                         .and_then(Self::read_spawn_config)
                         .unwrap_or_default();
                     let detach = config.detach;
                     let user_cancel = config.cancel;
+                    let group = config.group;
                     let parent_errors_arc = if detach {
                         thread.vm_thread_root_errors_arc()
                     } else {
@@ -2587,6 +2624,7 @@ impl BexEngine {
                             spawn_name,
                             user_cancel,
                             detach,
+                            group,
                             call_id,
                         )
                         .await?;

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -92,7 +92,7 @@ pub use bex_heap::{ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapP
 use bex_vm::{BexVm, SpanNotification, VmExecState};
 use bex_vm_types::{
     FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SharedGlobals, SysOp, Value,
-    VmGlobals,
+    VmGlobals, types::SpawnConfigData,
 };
 pub use conversion::test_arg_to_external;
 // Re-export CancellationToken for callers.
@@ -1920,6 +1920,25 @@ impl BexEngine {
         }
     }
 
+    /// Read the user `CancelToken` out of a `baml.spawn.SpawnConfig` instance
+    /// (BEP-034 spawn options). `config` points at the `SpawnConfig` heap
+    /// instance produced by `baml.spawn.options(...)`; its field 0 (`_handle`)
+    /// is an `Object::RustData(Arc<SpawnConfigData>)`. Returns the configured
+    /// cancel token, or `None` when there was no `cancel = ...` argument.
+    ///
+    /// Safe to deref the pointers because the caller holds the active heap
+    /// permit and `config` is rooted by the `UnscheduledFuture` being handled.
+    fn read_spawn_config_cancel(config: HeapPtr) -> Option<CancellationToken> {
+        let Object::Instance(instance) = (unsafe { config.get() }) else {
+            return None;
+        };
+        let handle_ptr = instance.load_field(0).as_object_ptr()?;
+        match unsafe { handle_ptr.get() } {
+            Object::RustData(data) => data.downcast_ref::<SpawnConfigData>()?.cancel.clone(),
+            _ => None,
+        }
+    }
+
     /// Spawn a fresh `BexThread` that runs the body packaged in `closure`
     /// and settles a newly-allocated future when the body terminates.
     ///
@@ -1940,6 +1959,7 @@ impl BexEngine {
         parent_pending_errors: Arc<ChildErrorQueue>,
         closure: HeapPtr,
         name: Option<String>,
+        user_cancel: Option<CancellationToken>,
         call_id: CallId,
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<HeapPtr, EngineError>> + Send + 'static>,
@@ -1949,6 +1969,7 @@ impl BexEngine {
             parent_pending_errors,
             closure,
             name,
+            user_cancel,
             call_id,
         ))
     }
@@ -1959,12 +1980,33 @@ impl BexEngine {
         parent_pending_errors: Arc<ChildErrorQueue>,
         closure: HeapPtr,
         name: Option<String>,
+        user_cancel: Option<CancellationToken>,
         call_id: CallId,
     ) -> Result<HeapPtr, EngineError> {
         // Each spawned thread gets a child cancel token so parent → child
         // cascade falls out of the token tree without bespoke tracking.
         let child_cancel = parent_cancel.child_token();
         drop(parent_cancel);
+
+        // BEP-034 spawn options: link a user-provided `CancelToken`
+        // (`with baml.spawn.options(cancel = ...)`) into this spawn's effective
+        // token. Firing the user token cancels the child; the watcher
+        // self-terminates when `child_cancel` fires (body done / cancelled
+        // / parent cascade) so it never outlives the spawn.
+        if let Some(user) = user_cancel {
+            let linked = child_cancel.clone();
+            let watcher = async move {
+                tokio::select! {
+                    biased;
+                    () = user.cancelled() => linked.cancel(),
+                    () = linked.cancelled() => {}
+                }
+            };
+            #[cfg(not(target_arch = "wasm32"))]
+            tokio::spawn(watcher);
+            #[cfg(target_arch = "wasm32")]
+            wasm_bindgen_futures::spawn_local(watcher);
+        }
 
         // Build the child VM up-front (synchronously) so the await on the
         // permit only holds Send values across yield points.
@@ -2483,18 +2525,22 @@ impl BexEngine {
                     // child also inherits a clone of our pending-child-
                     // errors queue so it can push back to us if it
                     // terminates fire-and-forget with a throw.
-                    let (closure, name_ptr) = {
+                    let (closure, name_ptr, config_ptr) = {
                         let unscheduled = thread
                             .vm
                             .unscheduled_future(unscheduled)
                             .map_err(EngineError::VmInternalError)?;
-                        (unscheduled.closure, unscheduled.name)
+                        (unscheduled.closure, unscheduled.name, unscheduled.config)
                     };
                     let spawn_name: Option<String> =
                         name_ptr.and_then(|ptr| match unsafe { ptr.get() } {
                             Object::String(s) => Some(s.clone()),
                             _ => None,
                         });
+                    // BEP-034 spawn options: if a `with baml.spawn.options(...)`
+                    // clause supplied a `cancel` token, read it out of the
+                    // `SpawnConfig` and link it into the child's effective token.
+                    let user_cancel = config_ptr.and_then(Self::read_spawn_config_cancel);
                     let parent_errors_arc = thread.vm_thread_pending_errors_arc();
                     let future_ptr = Arc::clone(self)
                         .spawn_thread(
@@ -2502,6 +2548,7 @@ impl BexEngine {
                             parent_errors_arc,
                             closure,
                             spawn_name,
+                            user_cancel,
                             call_id,
                         )
                         .await?;

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -1920,21 +1920,22 @@ impl BexEngine {
         }
     }
 
-    /// Read the user `CancelToken` out of a `baml.spawn.SpawnConfig` instance
-    /// (BEP-034 spawn options). `config` points at the `SpawnConfig` heap
-    /// instance produced by `baml.spawn.options(...)`; its field 0 (`_handle`)
-    /// is an `Object::RustData(Arc<SpawnConfigData>)`. Returns the configured
-    /// cancel token, or `None` when there was no `cancel = ...` argument.
+    /// Read the `SpawnConfigData` (cancel token + detach flag) out of a
+    /// `baml.spawn.SpawnConfig` instance (BEP-034 spawn options). `config`
+    /// points at the `SpawnConfig` heap instance produced by
+    /// `baml.spawn.options(...)`; its field 0 (`_handle`) is an
+    /// `Object::RustData(Arc<SpawnConfigData>)`. Returns `None` when the value
+    /// is not a well-formed `SpawnConfig` (caller defaults it).
     ///
     /// Safe to deref the pointers because the caller holds the active heap
     /// permit and `config` is rooted by the `UnscheduledFuture` being handled.
-    fn read_spawn_config_cancel(config: HeapPtr) -> Option<CancellationToken> {
+    fn read_spawn_config(config: HeapPtr) -> Option<SpawnConfigData> {
         let Object::Instance(instance) = (unsafe { config.get() }) else {
             return None;
         };
         let handle_ptr = instance.load_field(0).as_object_ptr()?;
         match unsafe { handle_ptr.get() } {
-            Object::RustData(data) => data.downcast_ref::<SpawnConfigData>()?.cancel.clone(),
+            Object::RustData(data) => data.downcast_ref::<SpawnConfigData>().cloned(),
             _ => None,
         }
     }
@@ -1953,13 +1954,16 @@ impl BexEngine {
     ///
     /// Returns the heap pointer to the allocated future so the spawning
     /// thread can push it onto its stack as the result of `spawn { ... }`.
+    #[allow(clippy::too_many_arguments)]
     fn spawn_thread(
         self: Arc<Self>,
         parent_cancel: CancellationToken,
         parent_pending_errors: Arc<ChildErrorQueue>,
+        root_pending_errors: Arc<ChildErrorQueue>,
         closure: HeapPtr,
         name: Option<String>,
         user_cancel: Option<CancellationToken>,
+        detach: bool,
         call_id: CallId,
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<HeapPtr, EngineError>> + Send + 'static>,
@@ -1967,25 +1971,38 @@ impl BexEngine {
         Box::pin(self.spawn_thread_inner(
             parent_cancel,
             parent_pending_errors,
+            root_pending_errors,
             closure,
             name,
             user_cancel,
+            detach,
             call_id,
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn spawn_thread_inner(
         self: Arc<Self>,
         parent_cancel: CancellationToken,
         parent_pending_errors: Arc<ChildErrorQueue>,
+        root_pending_errors: Arc<ChildErrorQueue>,
         closure: HeapPtr,
         name: Option<String>,
         user_cancel: Option<CancellationToken>,
+        detach: bool,
         call_id: CallId,
     ) -> Result<HeapPtr, EngineError> {
         // Each spawned thread gets a child cancel token so parent → child
-        // cascade falls out of the token tree without bespoke tracking.
-        let child_cancel = parent_cancel.child_token();
+        // cascade falls out of the token tree without bespoke tracking. A
+        // `detach = true` spawn instead gets a fresh, independent token so the
+        // parent's cancellation (and unhandled-throw cascade) does NOT reach
+        // it — it behaves like a top-level task. This must happen before the
+        // user-token watcher links in, so the watcher targets the right token.
+        let child_cancel = if detach {
+            CancellationToken::new()
+        } else {
+            parent_cancel.child_token()
+        };
         drop(parent_cancel);
 
         // BEP-034 spawn options: link a user-provided `CancelToken`
@@ -2031,7 +2048,13 @@ impl BexEngine {
         // outer-scope `.await`.
         let (future_ptr, future_id, inactive) = self
             .clone()
-            .spawn_thread_setup(child_vm, child_cancel.clone(), name, parent_pending_errors)
+            .spawn_thread_setup(
+                child_vm,
+                child_cancel.clone(),
+                name,
+                parent_pending_errors,
+                root_pending_errors,
+            )
             .await?;
 
         // Phase B note: v1 spans for spawned bodies are deferred. We pass
@@ -2122,6 +2145,7 @@ impl BexEngine {
         child_cancel: CancellationToken,
         name: Option<String>,
         parent_pending_errors: Arc<ChildErrorQueue>,
+        root_pending_errors: Arc<ChildErrorQueue>,
     ) -> Result<(HeapPtr, FutureId, InactiveHeapPermit<BexThread>), EngineError> {
         // One-shot `()` permit for the brief future-allocation window. It
         // is dropped before we create the long-lived `BexThread` permit
@@ -2140,6 +2164,7 @@ impl BexEngine {
             name,
             future_id,
             parent_pending_errors,
+            root_pending_errors,
         );
         let inactive = self.heap_permit_manager.new_permit(child_thread).await;
 
@@ -2537,18 +2562,31 @@ impl BexEngine {
                             Object::String(s) => Some(s.clone()),
                             _ => None,
                         });
-                    // BEP-034 spawn options: if a `with baml.spawn.options(...)`
-                    // clause supplied a `cancel` token, read it out of the
-                    // `SpawnConfig` and link it into the child's effective token.
-                    let user_cancel = config_ptr.and_then(Self::read_spawn_config_cancel);
-                    let parent_errors_arc = thread.vm_thread_pending_errors_arc();
+                    // BEP-034 spawn options: read the `SpawnConfig` (cancel
+                    // token + detach flag) from a `with baml.spawn.options(...)`
+                    // clause. `cancel` links into the child's effective token;
+                    // `detach` decouples it from the parent and routes its
+                    // unhandled errors to the root task instead of this spawner.
+                    let config = config_ptr
+                        .and_then(Self::read_spawn_config)
+                        .unwrap_or_default();
+                    let detach = config.detach;
+                    let user_cancel = config.cancel;
+                    let parent_errors_arc = if detach {
+                        thread.vm_thread_root_errors_arc()
+                    } else {
+                        thread.vm_thread_pending_errors_arc()
+                    };
+                    let root_errors_arc = thread.vm_thread_root_errors_arc();
                     let future_ptr = Arc::clone(self)
                         .spawn_thread(
                             cancel.clone(),
                             parent_errors_arc,
+                            root_errors_arc,
                             closure,
                             spawn_name,
                             user_cancel,
+                            detach,
                             call_id,
                         )
                         .await?;

--- a/baml_language/crates/bex_engine/src/thread.rs
+++ b/baml_language/crates/bex_engine/src/thread.rs
@@ -123,32 +123,47 @@ pub struct BexThread {
     /// Clone of the parent's `pending_child_errors`, or `None` for the
     /// root thread. When this thread terminates with an unhandled throw,
     /// the engine pushes our settled future ptr here so the parent
-    /// observes the error at its next await.
+    /// observes the error at its next await. For a `detach = true` spawn the
+    /// engine sets this to the *root* thread's queue instead of the spawner's.
     pub parent_pending_errors: Option<Arc<ChildErrorQueue>>,
+    /// The root call's `pending_child_errors` queue, propagated unchanged down
+    /// the whole spawn tree (for the root thread this is its own queue). A
+    /// `detach = true` spawn routes its unhandled errors here so they surface
+    /// at the root's next await rather than the spawner's (BEP-034 decision
+    /// #11 / fire-and-forget). Logged-and-dropped if the root already returned.
+    pub root_pending_errors: Arc<ChildErrorQueue>,
 }
 
 impl BexThread {
-    /// Build a root thread — no parent, no future to settle.
+    /// Build a root thread — no parent, no future to settle. The root's own
+    /// `pending_child_errors` queue is also its `root_pending_errors`, so
+    /// detached descendants route their errors back here.
     pub fn new_root(vm: BexVm, cancel: CancellationToken) -> Self {
+        let pending = ChildErrorQueue::new();
         Self {
             vm,
             name: None,
             cancel,
             settles_future: None,
-            pending_child_errors: ChildErrorQueue::new(),
+            pending_child_errors: Arc::clone(&pending),
             parent_pending_errors: None,
+            root_pending_errors: pending,
         }
     }
 
     /// Build a child thread that will settle `future_id` when its body
-    /// terminates. `parent_pending_errors` is a clone of the spawning
-    /// thread's `pending_child_errors` queue Arc.
+    /// terminates. `parent_pending_errors` is the queue this child pushes an
+    /// unhandled error onto (the spawner's queue normally, or the root's for a
+    /// detached spawn). `root_pending_errors` is the root call's queue,
+    /// propagated unchanged so this child's own detached descendants can find
+    /// the root.
     pub fn new_child(
         vm: BexVm,
         cancel: CancellationToken,
         name: Option<String>,
         settles_future: FutureId,
         parent_pending_errors: Arc<ChildErrorQueue>,
+        root_pending_errors: Arc<ChildErrorQueue>,
     ) -> Self {
         Self {
             vm,
@@ -157,6 +172,7 @@ impl BexThread {
             settles_future: Some(settles_future),
             pending_child_errors: ChildErrorQueue::new(),
             parent_pending_errors: Some(parent_pending_errors),
+            root_pending_errors,
         }
     }
 
@@ -206,6 +222,14 @@ impl BexThread {
     /// freshly spawned children as their `parent_pending_errors`.
     pub fn vm_thread_pending_errors_arc(&self) -> Arc<ChildErrorQueue> {
         Arc::clone(&self.pending_child_errors)
+    }
+
+    /// Clone of the root call's `pending_child_errors` Arc, propagated down
+    /// the spawn tree. Used as a detached child's `parent_pending_errors`
+    /// (so its errors surface at the root) and passed unchanged to every
+    /// spawned child as their `root_pending_errors`.
+    pub fn vm_thread_root_errors_arc(&self) -> Arc<ChildErrorQueue> {
+        Arc::clone(&self.root_pending_errors)
     }
 }
 

--- a/baml_language/crates/bex_engine/tests/cancellation.rs
+++ b/baml_language/crates/bex_engine/tests/cancellation.rs
@@ -832,3 +832,88 @@ async fn spawn_with_options_cancel_token_any_composes() {
         start.elapsed()
     );
 }
+
+// ============================================================================
+// BEP-034 spawn options — `detach = true`
+// ============================================================================
+
+/// `detach = true` does not perturb normal completion.
+#[tokio::test]
+async fn spawn_with_options_detach_completes_normally() {
+    let source = r#"
+        function main() -> int {
+            let f = spawn with baml.spawn.options(detach = true) { 42 };
+            await f
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("call should succeed");
+
+    assert_eq!(result, BexExternalValue::Int(42));
+}
+
+/// A `detach = true` spawn still honors an explicit `cancel` token: detach only
+/// drops the *parent* token from the effective token, so a user token linked
+/// via `options(cancel = ...)` still cancels it.
+#[tokio::test]
+async fn spawn_with_options_detach_still_honors_cancel_token() {
+    let source = r#"
+        function main() -> int {
+            let tok = baml.spawn.CancelToken.new();
+            let f = spawn with baml.spawn.options(cancel = tok, detach = true) {
+                baml.sys.sleep(10000);
+                42
+            };
+            let _ = tok.cancel();
+            (await f) catch (e) { baml.panics.Cancelled => 0 }
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let start = std::time::Instant::now();
+    let result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("call should succeed (Cancelled caught)");
+
+    assert_eq!(result, BexExternalValue::Int(0));
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "detached cancel-token took too long: {:?}",
+        start.elapsed()
+    );
+}

--- a/baml_language/crates/bex_engine/tests/cancellation.rs
+++ b/baml_language/crates/bex_engine/tests/cancellation.rs
@@ -917,3 +917,25 @@ async fn spawn_with_options_detach_still_honors_cancel_token() {
         start.elapsed()
     );
 }
+
+/// `spawn ... with` accepts only a `baml.spawn.options(...)` config: any other
+/// expression is a compile error (BEP-034 spawn options, v1). `compile_for_engine`
+/// panics on diagnostics, so a rejected program unwinds here.
+#[test]
+fn spawn_with_non_options_is_rejected() {
+    let bad = r#"
+        function helper() -> int { 1 }
+        function main() -> int {
+            let f = spawn with helper() { 1 };
+            await f
+        }
+    "#;
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {})); // suppress the diagnostic backtrace
+    let compiled = std::panic::catch_unwind(|| compile_for_engine(bad));
+    std::panic::set_hook(prev);
+    assert!(
+        compiled.is_err(),
+        "`spawn with helper()` should fail to compile (with accepts only baml.spawn.options(...))"
+    );
+}

--- a/baml_language/crates/bex_engine/tests/cancellation.rs
+++ b/baml_language/crates/bex_engine/tests/cancellation.rs
@@ -656,3 +656,179 @@ async fn cancelled_panic_shape_equivalence() {
         assert_eq!(s_val, v_val, "field {s_key} differs");
     }
 }
+
+// ============================================================================
+// BEP-034 spawn options — `spawn with baml.spawn.options(cancel = tok)`
+// ============================================================================
+
+/// Firing a BAML-surface `CancelToken` passed via
+/// `baml.spawn.options(cancel = ...)` cancels the spawned child; awaiting it
+/// re-throws `Cancelled`, and it returns well before the 10s sleep would.
+#[tokio::test]
+async fn spawn_with_options_cancel_token_propagates() {
+    let source = r#"
+        function main() -> int {
+            let tok = baml.spawn.CancelToken.new();
+            let f = spawn with baml.spawn.options(cancel = tok) {
+                baml.sys.sleep(10000);
+                42
+            };
+            let _ = tok.cancel();
+            await f
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let start = std::time::Instant::now();
+    let result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await;
+
+    assert_cancelled(&result);
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "cancel via options(cancel=) took too long: {:?}",
+        start.elapsed()
+    );
+}
+
+/// `Cancelled` delivered to a token-cancelled spawn is catchable at the
+/// awaiter — the `catch` arm runs and produces the fallback value.
+#[tokio::test]
+async fn spawn_with_options_cancel_token_is_catchable() {
+    let source = r#"
+        function main() -> int {
+            let tok = baml.spawn.CancelToken.new();
+            let f = spawn with baml.spawn.options(cancel = tok) {
+                baml.sys.sleep(10000);
+                42
+            };
+            let _ = tok.cancel();
+            (await f) catch (e) { baml.panics.Cancelled => 0 }
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("call should succeed (Cancelled caught)");
+
+    assert_eq!(result, BexExternalValue::Int(0));
+}
+
+/// A spawn configured with `options(cancel = tok)` whose token is never fired
+/// completes normally — the option must not perturb the happy path.
+#[tokio::test]
+async fn spawn_with_options_uncancelled_completes_normally() {
+    let source = r#"
+        function main() -> int {
+            let tok = baml.spawn.CancelToken.new();
+            let f = spawn with baml.spawn.options(cancel = tok) { 42 };
+            await f
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("call should succeed");
+
+    assert_eq!(result, BexExternalValue::Int(42));
+}
+
+/// `CancelToken.any([a, b])` composes inputs: firing one input cancels a spawn
+/// configured with the composite token. The awaiter catches `Cancelled` and
+/// returns the fallback; if composition were broken the 10s sleep would run to
+/// completion and yield 42 instead.
+#[tokio::test]
+async fn spawn_with_options_cancel_token_any_composes() {
+    let source = r#"
+        function main() -> int {
+            let a = baml.spawn.CancelToken.new();
+            let b = baml.spawn.CancelToken.new();
+            let combined = baml.spawn.CancelToken.any([a, b]);
+            let f = spawn with baml.spawn.options(cancel = combined) {
+                baml.sys.sleep(10000);
+                42
+            };
+            let _ = a.cancel();
+            (await f) catch (e) { baml.panics.Cancelled => 0 }
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            std::sync::Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+
+    let start = std::time::Instant::now();
+    let result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("call should succeed (Cancelled caught)");
+
+    assert_eq!(result, BexExternalValue::Int(0));
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "any-composed cancel took too long: {:?}",
+        start.elapsed()
+    );
+}

--- a/baml_language/crates/bex_engine/tests/task_group.rs
+++ b/baml_language/crates/bex_engine/tests/task_group.rs
@@ -1,0 +1,255 @@
+//! BEP-034 `TaskGroup` rate limiting: `spawn ... with baml.spawn.options(group = g)`.
+//!
+//! A `TaskGroup` caps how many spawns referencing it run concurrently; excess
+//! spawns queue FIFO and start as earlier ones settle.
+//!
+//! These tests are deterministic: a `TaskGroup` member is registered
+//! *synchronously* at `spawn` time, so `active_count`/`queued_count` observed
+//! right after spawning are exact (no reliance on scheduler timing or on
+//! spawned bodies actually running in parallel).
+
+mod common;
+
+use std::sync::Arc;
+
+use bex_engine::{BexEngine, BexExternalValue, EngineError, FunctionCallContextBuilder};
+use common::compile_for_engine;
+use sys_native::SysOpsExt;
+
+/// Compile `source` and run its `main()` to completion.
+async fn run_main(source: &str) -> Result<BexExternalValue, EngineError> {
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("Failed to create engine"),
+    );
+    engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+}
+
+/// The cap is enforced at admission: spawning four members into a `limit = 2`
+/// group leaves exactly two active and two queued. Registration is synchronous
+/// at `spawn`, so the counts are exact at this point (the bodies — long sleeps —
+/// have not been polled yet). `g.cancel()` then tears the sleeps down.
+#[tokio::test]
+async fn task_group_caps_active_and_queues_rest() {
+    let source = r#"
+        function block() -> int {
+            baml.sys.sleep(5000);
+            1
+        }
+        function main() -> int {
+            let g = baml.spawn.TaskGroup.new(2);
+            let a = spawn with baml.spawn.options(group = g) { block() };
+            let b = spawn with baml.spawn.options(group = g) { block() };
+            let c = spawn with baml.spawn.options(group = g) { block() };
+            let d = spawn with baml.spawn.options(group = g) { block() };
+            let snapshot = g.active_count() * 100 + g.queued_count();
+            let _ = g.cancel();
+            snapshot
+        }
+    "#;
+
+    // 2 active * 100 + 2 queued = 202.
+    let result = run_main(source).await.expect("call should succeed");
+    assert_eq!(result, BexExternalValue::Int(202));
+}
+
+/// More spawns than the limit all complete — the queued ones start as slots
+/// free, and the caller gets every result.
+#[tokio::test]
+async fn task_group_queues_excess_and_all_complete() {
+    let source = r#"
+        function main() -> int {
+            let g = baml.spawn.TaskGroup.new(2);
+            let a = spawn with baml.spawn.options(group = g) { 1 };
+            let b = spawn with baml.spawn.options(group = g) { 1 };
+            let c = spawn with baml.spawn.options(group = g) { 1 };
+            let d = spawn with baml.spawn.options(group = g) { 1 };
+            let e = spawn with baml.spawn.options(group = g) { 1 };
+            (await a) + (await b) + (await c) + (await d) + (await e)
+        }
+    "#;
+
+    let result = run_main(source).await.expect("call should succeed");
+    assert_eq!(result, BexExternalValue::Int(5));
+}
+
+/// `group.cancel()` fires its members' tokens — a long-running member is
+/// cancelled and `await` re-throws `Cancelled` (caught here).
+#[tokio::test]
+async fn task_group_cancel_cancels_members() {
+    let source = r#"
+        function main() -> int {
+            let g = baml.spawn.TaskGroup.new(5);
+            let f = spawn with baml.spawn.options(group = g) {
+                baml.sys.sleep(10000);
+                42
+            };
+            let _ = g.cancel();
+            (await f) catch (e) { baml.panics.Cancelled => 0 }
+        }
+    "#;
+
+    let start = std::time::Instant::now();
+    let result = run_main(source).await.expect("call should succeed");
+    assert_eq!(result, BexExternalValue::Int(0));
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "group.cancel() should be prompt: {:?}",
+        start.elapsed()
+    );
+}
+
+/// `group.cancel(active = false)` cancels only queued members; the running ones
+/// keep their slots. With `limit = 1`, one member is active and one is queued —
+/// cancelling pending-only leaves the active member to finish.
+#[tokio::test]
+async fn task_group_cancel_pending_only() {
+    let source = r#"
+        function main() -> int {
+            let g = baml.spawn.TaskGroup.new(1);
+            let active = spawn with baml.spawn.options(group = g) { 7 };
+            let queued = spawn with baml.spawn.options(group = g) {
+                baml.sys.sleep(10000);
+                1
+            };
+            let signalled = g.cancel(active = false);
+            // Only the queued member is signalled (active stays).
+            let active_result = await active;
+            let queued_result = (await queued) catch (e) { baml.panics.Cancelled => 0 };
+            signalled * 100 + active_result * 10 + queued_result
+        }
+    "#;
+
+    // 1 signalled (the queued one) * 100 + active 7 * 10 + queued cancelled 0 = 170.
+    let result = run_main(source).await.expect("call should succeed");
+    assert_eq!(result, BexExternalValue::Int(170));
+}
+
+/// `limit()` / `set_limit()` round-trip.
+#[tokio::test]
+async fn task_group_set_limit_updates_limit() {
+    let source = r#"
+        function main() -> int {
+            let g = baml.spawn.TaskGroup.new(3);
+            let before = g.limit();
+            g.set_limit(7);
+            before + g.limit()
+        }
+    "#;
+
+    let result = run_main(source).await.expect("call should succeed");
+    assert_eq!(result, BexExternalValue::Int(10));
+}
+
+/// Spawns run concurrently for real IO: three 200ms sleeps with `limit = 3`
+/// complete in ~200ms wall-clock, not ~600ms. Compilation/bootstrap is done
+/// *before* the timer so the threshold only measures execution.
+#[tokio::test]
+async fn task_group_limit_three_runs_concurrently() {
+    let source = r#"
+        function work() -> int {
+            baml.sys.sleep(200);
+            1
+        }
+        function main() -> int {
+            let g = baml.spawn.TaskGroup.new(3);
+            let a = spawn with baml.spawn.options(group = g) { work() };
+            let b = spawn with baml.spawn.options(group = g) { work() };
+            let c = spawn with baml.spawn.options(group = g) { work() };
+            (await a) + (await b) + (await c)
+        }
+    "#;
+
+    // Compile + bootstrap OUTSIDE the timing budget (MIR construction can take
+    // hundreds of ms on a cold build); the threshold only has to absorb
+    // scheduler jitter on top of one 200ms sleep.
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("engine"),
+    );
+
+    let start = std::time::Instant::now();
+    let result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("call should succeed");
+    let elapsed = start.elapsed();
+
+    assert_eq!(result, BexExternalValue::Int(3));
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "limit=3 should run the three sleeps concurrently (~200ms); got {elapsed:?}"
+    );
+}
+
+/// `limit = 1` serializes the same three sleeps: execution is ~600ms, not
+/// ~200ms — the cap actually gates concurrency (contrast with the test above).
+#[tokio::test]
+async fn task_group_limit_one_serializes() {
+    let source = r#"
+        function work() -> int {
+            baml.sys.sleep(200);
+            1
+        }
+        function main() -> int {
+            let g = baml.spawn.TaskGroup.new(1);
+            let a = spawn with baml.spawn.options(group = g) { work() };
+            let b = spawn with baml.spawn.options(group = g) { work() };
+            let c = spawn with baml.spawn.options(group = g) { work() };
+            (await a) + (await b) + (await c)
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(
+            snapshot,
+            Arc::new(sys_native::SysOps::native()),
+            None,
+            Vec::new(),
+        )
+        .expect("engine"),
+    );
+
+    let start = std::time::Instant::now();
+    let result = engine
+        .call_function(
+            "main",
+            vec![],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .expect("call should succeed");
+    let elapsed = start.elapsed();
+
+    assert_eq!(result, BexExternalValue::Int(3));
+    assert!(
+        elapsed >= std::time::Duration::from_millis(450),
+        "limit=1 should serialize the three sleeps (~600ms); got {elapsed:?}"
+    );
+}

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -385,6 +385,9 @@ impl BexHeap {
                 if let Some(name_ptr) = future.name {
                     worklist.push(name_ptr);
                 }
+                if let Some(config_ptr) = future.config {
+                    worklist.push(config_ptr);
+                }
                 worklist.push(future.closure);
             }
             // Primitives have no references
@@ -522,6 +525,11 @@ impl BexHeap {
                     && let Some(&new_ptr) = forwarding.get(name_ptr)
                 {
                     *name_ptr = new_ptr;
+                }
+                if let Some(config_ptr) = &mut future.config
+                    && let Some(&new_ptr) = forwarding.get(config_ptr)
+                {
+                    *config_ptr = new_ptr;
                 }
                 if let Some(&new_ptr) = forwarding.get(&future.closure) {
                     future.closure = new_ptr;
@@ -783,6 +791,11 @@ impl BexHeap {
                     && self.generation_of(name_ptr).is_young()
                 {
                     worklist.push(name_ptr);
+                }
+                if let Some(config_ptr) = future.config
+                    && self.generation_of(config_ptr).is_young()
+                {
+                    worklist.push(config_ptr);
                 }
                 if self.generation_of(future.closure).is_young() {
                     worklist.push(future.closure);
@@ -1891,6 +1904,7 @@ mod tests {
         let future_ptr = tlab.alloc(Object::UnscheduledFuture(UnscheduledFuture {
             closure,
             name: Some(name),
+            config: None,
         }));
 
         let roots = vec![future_ptr];
@@ -2407,6 +2421,7 @@ mod tests {
         let future_container = tlab.alloc(Object::UnscheduledFuture(UnscheduledFuture {
             closure: leaf_for_future,
             name: None,
+            config: None,
         }));
 
         // --- Container: Object::Instance ---

--- a/baml_language/crates/bex_vm/Cargo.toml
+++ b/baml_language/crates/bex_vm/Cargo.toml
@@ -32,7 +32,17 @@ log = { workspace = true }
 num-bigint = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = [ "macros" ] }
+tokio-util = { workspace = true }
 web-time = { workspace = true }
+
+# Native-only: tokio runtime so CancelToken.any can `tokio::spawn` its watcher.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = [ "rt", "macros" ] }
+
+# WASM-only: wasm-bindgen-futures for spawning the watcher.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = { workspace = true }
 
 [build-dependencies]
 baml_builtins2_codegen = { workspace = true }

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -28,6 +28,7 @@ mod math;
 mod media;
 mod primitives;
 mod root;
+mod spawn;
 mod stack_trace;
 mod string;
 mod sys;
@@ -116,7 +117,11 @@ pub trait Continuation: Send {
     clippy::used_underscore_binding,
     clippy::elidable_lifetime_names,
     clippy::needless_lifetimes,
-    clippy::redundant_closure_call
+    clippy::redundant_closure_call,
+    // Static builtin constructors (e.g. `baml.spawn.CancelToken.new`) are
+    // generated as trait methods returning `Value` (the heap instance), not
+    // `Self` — that is the codegen contract, not a smell.
+    clippy::new_ret_no_self
 )]
 mod generated {
     use super::*;

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -254,7 +254,9 @@ fn deep_equals_recursive(
                 }
 
                 (Object::UnscheduledFuture(a_fut), Object::UnscheduledFuture(b_fut)) => {
-                    a_fut.closure == b_fut.closure && a_fut.name == b_fut.name
+                    a_fut.closure == b_fut.closure
+                        && a_fut.name == b_fut.name
+                        && a_fut.config == b_fut.config
                 }
 
                 _ => false,

--- a/baml_language/crates/bex_vm/src/package_baml/spawn.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/spawn.rs
@@ -1,0 +1,101 @@
+//! Native implementations for `namespace baml.spawn` (BEP-034 spawn options):
+//! the `CancelToken` class and the `options(...)` factory.
+//!
+//! `CancelToken` is an opaque class whose `_handle` field holds an
+//! `Object::RustData(Arc<tokio_util::sync::CancellationToken>)`. `SpawnConfig`
+//! is likewise opaque, holding an `Arc<SpawnConfigData>`. Both are built with
+//! the standard `resolve_class` + `alloc_rust_data` + `alloc_instance` pattern
+//! and read back via `as_instance` + `load_field(0)` + `as_rust_data`.
+
+use std::sync::Arc;
+
+use bex_vm_types::types::{CancellationToken, SpawnConfigData, Value};
+
+use super::{BamlClassSpawnCancelToken, BamlNamespaceSpawn, PackageBamlImpl};
+use crate::BexVm;
+
+/// Read the runtime `CancellationToken` out of a `baml.spawn.CancelToken`
+/// receiver. Field 0 (`_handle`) is the `Object::RustData` wrapping the token.
+/// Returns `None` if the value is not a well-formed `CancelToken` instance
+/// (including the `OmittedArg` sentinel for an omitted optional argument).
+fn as_cancellation_token(vm: &BexVm, value: Value) -> Option<CancellationToken> {
+    let instance = vm.as_instance(&value).ok()?;
+    let handle = instance.load_field(0);
+    vm.as_rust_data::<CancellationToken>(&handle).ok().cloned()
+}
+
+/// Allocate a fresh `baml.spawn.CancelToken` instance wrapping `token`.
+fn alloc_cancel_token(vm: &mut BexVm, token: CancellationToken) -> Value {
+    let class = vm.resolve_class("baml.spawn.CancelToken");
+    let handle = vm.alloc_rust_data(Arc::new(token));
+    vm.alloc_instance(class, vec![handle])
+}
+
+impl BamlClassSpawnCancelToken for PackageBamlImpl {
+    // The generated trait fixes the return type as `Value` (the heap
+    // `CancelToken` instance), so it cannot return `Self`.
+    #[allow(clippy::new_ret_no_self)]
+    fn new(vm: &mut BexVm) -> Value {
+        alloc_cancel_token(vm, CancellationToken::new())
+    }
+
+    fn any(vm: &mut BexVm, tokens: &[Value]) -> Value {
+        // A fresh composite token that fires when any input fires. One watcher
+        // task per input links `input.cancelled() -> composite.cancel()`; each
+        // watcher self-terminates when the composite is cancelled (directly or
+        // by a sibling), so they never outlive the composite. Cancelling the
+        // composite does not propagate back to the inputs (one-directional).
+        let composite = CancellationToken::new();
+        for &token in tokens {
+            let Some(input) = as_cancellation_token(vm, token) else {
+                continue;
+            };
+            let out = composite.clone();
+            let watcher = async move {
+                tokio::select! {
+                    biased;
+                    () = input.cancelled() => out.cancel(),
+                    () = out.cancelled() => {}
+                }
+            };
+            #[cfg(not(target_arch = "wasm32"))]
+            tokio::spawn(watcher);
+            #[cfg(target_arch = "wasm32")]
+            wasm_bindgen_futures::spawn_local(watcher);
+        }
+        alloc_cancel_token(vm, composite)
+    }
+
+    fn cancel(vm: &BexVm, canceltoken: &Value) -> i64 {
+        // Returns 1 if this call performed the Pending -> Cancelled transition,
+        // 0 if the token was already cancelled. `CancellationToken::cancel`
+        // returns (), so we snapshot `is_cancelled` first (a benign TOCTOU
+        // under concurrent cancels — the count is best-effort).
+        match as_cancellation_token(vm, *canceltoken) {
+            Some(token) => {
+                let was_cancelled = token.is_cancelled();
+                token.cancel();
+                i64::from(!was_cancelled)
+            }
+            None => 0,
+        }
+    }
+
+    fn is_cancelled(vm: &BexVm, canceltoken: &Value) -> bool {
+        as_cancellation_token(vm, *canceltoken).is_some_and(|t| t.is_cancelled())
+    }
+}
+
+impl BamlNamespaceSpawn for PackageBamlImpl {
+    fn options(vm: &mut BexVm, _group: Option<&Value>, cancel: Option<&Value>) -> Value {
+        // PR1: only `cancel` is honored at runtime; `group` is accepted for
+        // forward compatibility and wired in a follow-up. An omitted optional
+        // argument arrives as the `OmittedArg` sentinel, which is neither null
+        // nor a `CancelToken` instance, so `as_cancellation_token` resolves it
+        // to `None` — exactly the "no cancel token" case.
+        let cancel = cancel.and_then(|value| as_cancellation_token(vm, *value));
+        let class = vm.resolve_class("baml.spawn.SpawnConfig");
+        let handle = vm.alloc_rust_data(Arc::new(SpawnConfigData { cancel }));
+        vm.alloc_instance(class, vec![handle])
+    }
+}

--- a/baml_language/crates/bex_vm/src/package_baml/spawn.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/spawn.rs
@@ -87,15 +87,18 @@ impl BamlClassSpawnCancelToken for PackageBamlImpl {
 }
 
 impl BamlNamespaceSpawn for PackageBamlImpl {
-    fn options(vm: &mut BexVm, _group: Option<&Value>, cancel: Option<&Value>) -> Value {
-        // PR1: only `cancel` is honored at runtime; `group` is accepted for
-        // forward compatibility and wired in a follow-up. An omitted optional
-        // argument arrives as the `OmittedArg` sentinel, which is neither null
-        // nor a `CancelToken` instance, so `as_cancellation_token` resolves it
-        // to `None` — exactly the "no cancel token" case.
+    fn options(
+        vm: &mut BexVm,
+        _group: Option<&Value>,
+        cancel: Option<&Value>,
+        detach: Option<bool>,
+    ) -> Value {
+        // `group` is accepted for forward compatibility and wired in a
+        // follow-up. Omitted optional arguments arrive as `None` here.
         let cancel = cancel.and_then(|value| as_cancellation_token(vm, *value));
+        let detach = detach.unwrap_or(false);
         let class = vm.resolve_class("baml.spawn.SpawnConfig");
-        let handle = vm.alloc_rust_data(Arc::new(SpawnConfigData { cancel }));
+        let handle = vm.alloc_rust_data(Arc::new(SpawnConfigData { cancel, detach }));
         vm.alloc_instance(class, vec![handle])
     }
 }

--- a/baml_language/crates/bex_vm/src/package_baml/spawn.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/spawn.rs
@@ -1,17 +1,24 @@
 //! Native implementations for `namespace baml.spawn` (BEP-034 spawn options):
-//! the `CancelToken` class and the `options(...)` factory.
+//! the `CancelToken` and `TaskGroup` classes and the `options(...)` factory.
 //!
-//! `CancelToken` is an opaque class whose `_handle` field holds an
-//! `Object::RustData(Arc<tokio_util::sync::CancellationToken>)`. `SpawnConfig`
-//! is likewise opaque, holding an `Arc<SpawnConfigData>`. Both are built with
-//! the standard `resolve_class` + `alloc_rust_data` + `alloc_instance` pattern
-//! and read back via `as_instance` + `load_field(0)` + `as_rust_data`.
+//! These are opaque classes whose `_handle` field holds an
+//! `Object::RustData(Arc<…>)`: a `CancellationToken` for `CancelToken`, an
+//! `Arc<TaskGroupInner>` for `TaskGroup`, and a `SpawnConfigData` for
+//! `SpawnConfig`. They are built with the standard `resolve_class` +
+//! `alloc_rust_data` + `alloc_instance` pattern and read back via `as_instance`
+//! + `load_field(0)` + `as_rust_data`.
+#![allow(unsafe_code)]
 
 use std::sync::Arc;
 
-use bex_vm_types::types::{CancellationToken, SpawnConfigData, Value};
+use bex_vm_types::{
+    TaskGroupInner,
+    types::{CancellationToken, Object, SpawnConfigData, Value},
+};
 
-use super::{BamlClassSpawnCancelToken, BamlNamespaceSpawn, PackageBamlImpl};
+use super::{
+    BamlClassSpawnCancelToken, BamlClassSpawnTaskGroup, BamlNamespaceSpawn, PackageBamlImpl,
+};
 use crate::BexVm;
 
 /// Read the runtime `CancellationToken` out of a `baml.spawn.CancelToken`
@@ -29,6 +36,41 @@ fn alloc_cancel_token(vm: &mut BexVm, token: CancellationToken) -> Value {
     let class = vm.resolve_class("baml.spawn.CancelToken");
     let handle = vm.alloc_rust_data(Arc::new(token));
     vm.alloc_instance(class, vec![handle])
+}
+
+/// Borrow the `TaskGroupInner` behind a `baml.spawn.TaskGroup` receiver, for
+/// the read/mutate instance methods (which only need `&TaskGroupInner` —
+/// mutation goes through its internal `Mutex`).
+fn as_task_group(vm: &BexVm, value: Value) -> Option<&TaskGroupInner> {
+    let handle = vm.as_instance(&value).ok()?.load_field(0);
+    vm.as_rust_data::<TaskGroupInner>(&handle).ok()
+}
+
+/// Clone the `Arc<TaskGroupInner>` behind a `baml.spawn.TaskGroup` value, so it
+/// can be shared into a `SpawnConfig` (and onward to the engine's admission).
+fn as_task_group_arc(vm: &BexVm, value: Value) -> Option<Arc<TaskGroupInner>> {
+    let handle = vm.as_instance(&value).ok()?.load_field(0);
+    let ptr = handle.as_object_ptr()?;
+    // SAFETY: native functions run inline on the VM thread with the heap
+    // permit held, so the pointed-to object is not concurrently moved by GC.
+    match unsafe { ptr.get() } {
+        Object::RustData(data) => data.clone().downcast::<TaskGroupInner>().ok(),
+        _ => None,
+    }
+}
+
+/// Allocate a fresh `baml.spawn.TaskGroup` instance wrapping `inner`.
+fn alloc_task_group(vm: &mut BexVm, inner: Arc<TaskGroupInner>) -> Value {
+    let class = vm.resolve_class("baml.spawn.TaskGroup");
+    let handle = vm.alloc_rust_data(inner);
+    vm.alloc_instance(class, vec![handle])
+}
+
+/// Convert a `usize` count/limit to `i64`, saturating at `i64::MAX`. Group
+/// counts and limits are always small in practice; this just makes the cast
+/// explicitly lossless-or-saturating for clippy.
+fn clamp_to_i64(value: usize) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
 }
 
 impl BamlClassSpawnCancelToken for PackageBamlImpl {
@@ -86,19 +128,67 @@ impl BamlClassSpawnCancelToken for PackageBamlImpl {
     }
 }
 
+impl BamlClassSpawnTaskGroup for PackageBamlImpl {
+    // Static constructor: returns the heap `TaskGroup` instance, not `Self`.
+    #[allow(clippy::new_ret_no_self)]
+    fn new(vm: &mut BexVm, limit: i64, name: Option<&str>) -> Value {
+        // A negative limit is clamped to 0 (a paused group) rather than
+        // throwing — the generated `new` returns `Value`, not a fallible type.
+        let limit = usize::try_from(limit).unwrap_or(0);
+        let inner = TaskGroupInner::new(limit, name.map(str::to_owned));
+        alloc_task_group(vm, inner)
+    }
+
+    fn cancel(vm: &BexVm, taskgroup: &Value, pending: Option<bool>, active: Option<bool>) -> i64 {
+        // Both default to `true` (cancel everything) when omitted.
+        match as_task_group(vm, *taskgroup) {
+            Some(group) => {
+                clamp_to_i64(group.cancel(pending.unwrap_or(true), active.unwrap_or(true)))
+            }
+            None => 0,
+        }
+    }
+
+    fn set_limit(vm: &BexVm, taskgroup: &Value, limit: i64) {
+        if let Some(group) = as_task_group(vm, *taskgroup) {
+            group.set_limit(usize::try_from(limit).unwrap_or(0));
+        }
+    }
+
+    fn limit(vm: &BexVm, taskgroup: &Value) -> i64 {
+        as_task_group(vm, *taskgroup).map_or(0, |g| clamp_to_i64(g.limit()))
+    }
+
+    fn name(vm: &BexVm, taskgroup: &Value) -> Option<String> {
+        as_task_group(vm, *taskgroup).and_then(|g| g.name().map(str::to_owned))
+    }
+
+    fn active_count(vm: &BexVm, taskgroup: &Value) -> i64 {
+        as_task_group(vm, *taskgroup).map_or(0, |g| clamp_to_i64(g.active_count()))
+    }
+
+    fn queued_count(vm: &BexVm, taskgroup: &Value) -> i64 {
+        as_task_group(vm, *taskgroup).map_or(0, |g| clamp_to_i64(g.queued_count()))
+    }
+}
+
 impl BamlNamespaceSpawn for PackageBamlImpl {
     fn options(
         vm: &mut BexVm,
-        _group: Option<&Value>,
+        group: Option<&Value>,
         cancel: Option<&Value>,
         detach: Option<bool>,
     ) -> Value {
-        // `group` is accepted for forward compatibility and wired in a
-        // follow-up. Omitted optional arguments arrive as `None` here.
+        // Omitted optional arguments arrive as `None` here.
         let cancel = cancel.and_then(|value| as_cancellation_token(vm, *value));
+        let group = group.and_then(|value| as_task_group_arc(vm, *value));
         let detach = detach.unwrap_or(false);
         let class = vm.resolve_class("baml.spawn.SpawnConfig");
-        let handle = vm.alloc_rust_data(Arc::new(SpawnConfigData { cancel, detach }));
+        let handle = vm.alloc_rust_data(Arc::new(SpawnConfigData {
+            cancel,
+            detach,
+            group,
+        }));
         vm.alloc_instance(class, vec![handle])
     }
 }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -3911,6 +3911,11 @@ impl BexVm {
 
                 // ── Spawn (BEP-034) ────────────────────────────────────────────
                 OpCode::Spawn => {
+                    // Stack layout (pushed by emit in this order): closure, name,
+                    // config. So pop in reverse: config (top), name, closure.
+                    // `config` is the optional `baml.spawn.SpawnConfig` from a
+                    // `with baml.spawn.options(...)` clause, or null.
+                    let config_value = self.stack.ensure_pop();
                     let name_value = self.stack.ensure_pop();
                     let closure_value = self.stack.ensure_pop();
                     let closure_ptr =
@@ -3926,9 +3931,21 @@ impl BexVm {
                         }
                         .into());
                     };
+                    let config_ptr = if config_value.is_null() {
+                        None
+                    } else if let Some(ptr) = config_value.as_object_ptr() {
+                        Some(ptr)
+                    } else {
+                        return Err(VmInternalError::TypeError {
+                            expected: Type::Object(ObjectType::Instance),
+                            got: self.type_of(&config_value),
+                        }
+                        .into());
+                    };
                     let pending_future = bex_vm_types::types::UnscheduledFuture {
                         closure: closure_ptr,
                         name: name_ptr,
+                        config: config_ptr,
                     };
                     let object_index = self.tlab.alloc(Object::UnscheduledFuture(pending_future));
                     return Ok(Some(VmExecState::Spawn(object_index)));

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -15,6 +15,7 @@ pub mod heap_ptr;
 pub mod indexable;
 pub mod lazy_biased_mutex;
 mod roots;
+pub mod task_group;
 pub mod types;
 
 pub use bytecode::{
@@ -26,6 +27,7 @@ pub use indexable::{
     GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, SharedGlobals, StackIndex, VmGlobals,
 };
 pub use roots::{PermitProof, RootHaver, WriteBarrier};
+pub use task_group::{TaskGroupInner, TaskGroupPermit, TaskGroupTicket};
 pub use types::{
     ArrayContainer, ArrayReadGuard, ArrayWriteGuard, AtomicValueSlot, Class, ClassField,
     ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum, EnumVariant, Function,

--- a/baml_language/crates/bex_vm_types/src/task_group.rs
+++ b/baml_language/crates/bex_vm_types/src/task_group.rs
@@ -1,0 +1,320 @@
+//! BEP-034 `TaskGroup`: value-based rate limiting for spawns.
+//!
+//! A `TaskGroup` caps how many spawns referencing it run concurrently. Excess
+//! spawns queue FIFO and start as earlier ones settle; the `spawn` still
+//! returns a `Future` immediately, so queueing is invisible to the caller.
+//! Two spawns share a limit iff they hold the same `Arc<TaskGroupInner>` (the
+//! Rust handle behind a `baml.spawn.TaskGroup` value) — there is no global
+//! registry.
+//!
+//! Admission is the engine's responsibility: a spawned body task calls
+//! [`TaskGroupInner::acquire`] *before* running its body (and without holding
+//! the heap permit, so a parked task doesn't block GC). The returned
+//! [`TaskGroupPermit`] releases the slot on drop and wakes the next waiter.
+
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+/// Shared admission state behind a `baml.spawn.TaskGroup` value.
+pub struct TaskGroupInner {
+    name: Option<String>,
+    state: Mutex<State>,
+}
+
+impl std::fmt::Debug for TaskGroupInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Don't lock `state` in `Debug` — it may be called from contexts that
+        // already hold the lock, and a deadlock there would be nasty.
+        f.debug_struct("TaskGroupInner")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
+struct State {
+    /// Max concurrently-active members. `0` pauses the group (admits nothing).
+    limit: usize,
+    /// Currently-active (running) members.
+    active: usize,
+    /// FIFO order of parked member ids waiting for a slot.
+    waiters: VecDeque<u64>,
+    /// All current members (queued + active), keyed by a monotonic id.
+    members: BTreeMap<u64, Member>,
+    next_id: u64,
+}
+
+struct Member {
+    /// The member's effective cancel token (fired by `group.cancel(...)`).
+    cancel: CancellationToken,
+    /// `true` once admitted (running), `false` while parked.
+    active: bool,
+    /// Grant channel, present only while parked; the releaser takes it to
+    /// hand the slot to this waiter.
+    grant: Option<oneshot::Sender<()>>,
+}
+
+/// RAII slot held by a running member. Releasing it (on drop) frees the slot
+/// and wakes the next FIFO waiter.
+pub struct TaskGroupPermit {
+    group: Arc<TaskGroupInner>,
+    id: u64,
+}
+
+/// A member registered with a group (synchronously, at spawn time) that has not
+/// yet been admitted. The spawned body task [`acquire`](TaskGroupTicket::acquire)s
+/// it to await a concurrency slot.
+pub struct TaskGroupTicket {
+    group: Arc<TaskGroupInner>,
+    id: u64,
+    /// `None` when admitted at registration; `Some` while parked.
+    rx: Option<oneshot::Receiver<()>>,
+    /// The member's effective token (only consulted on the parked path).
+    cancel: CancellationToken,
+}
+
+impl TaskGroupTicket {
+    /// Await admission. Returns the permit (releasing the slot on drop), or
+    /// `None` if the member was cancelled while parked — the caller then
+    /// settles the future `Cancelled` and never runs the body.
+    pub async fn acquire(self) -> Option<TaskGroupPermit> {
+        let TaskGroupTicket {
+            group,
+            id,
+            rx,
+            cancel,
+        } = self;
+        let Some(rx) = rx else {
+            // Admitted at registration — no parking.
+            return Some(TaskGroupPermit { group, id });
+        };
+        tokio::select! {
+            // Cancel-biased: if the member was cancelled (e.g. `group.cancel()`)
+            // it must NOT run, even if a slot was granted in the same window —
+            // `cancel_parked` returns any granted slot and promotes the next
+            // waiter. Without this bias a cancelled-then-promoted member would
+            // run its body anyway.
+            biased;
+            () = cancel.cancelled() => {
+                group.cancel_parked(id);
+                None
+            }
+            res = rx => match res {
+                // Granted: the releaser already incremented `active`, marked
+                // this member active, and removed it from `waiters`.
+                Ok(()) => Some(TaskGroupPermit { group, id }),
+                // Sender dropped (group torn down) — treat as cancellation.
+                Err(_) => { group.cancel_parked(id); None }
+            },
+        }
+    }
+}
+
+impl TaskGroupInner {
+    /// Create a group with concurrency cap `limit` and an optional debug name.
+    pub fn new(limit: usize, name: Option<String>) -> Arc<Self> {
+        Arc::new(Self {
+            name,
+            state: Mutex::new(State {
+                limit,
+                active: 0,
+                waiters: VecDeque::new(),
+                members: BTreeMap::new(),
+                next_id: 0,
+            }),
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state.lock().expect("TaskGroup state poisoned")
+    }
+
+    /// Optional debug name (no semantic meaning).
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// Current concurrency cap.
+    pub fn limit(&self) -> usize {
+        self.lock().limit
+    }
+
+    /// Instantaneous count of running members.
+    pub fn active_count(&self) -> usize {
+        self.lock().active
+    }
+
+    /// Instantaneous count of parked (queued) members.
+    pub fn queued_count(&self) -> usize {
+        self.lock().waiters.len()
+    }
+
+    /// Change the concurrency cap. Increasing admits parked waiters up to the
+    /// new cap immediately; decreasing never preempts running members (new
+    /// admissions simply wait); `0` pauses the group.
+    pub fn set_limit(&self, limit: usize) {
+        let mut st = self.lock();
+        st.limit = limit;
+        Self::promote(&mut st);
+    }
+
+    /// Fire the cancel tokens of the selected members. `pending` selects parked
+    /// members, `active` selects running ones. Returns the number signalled.
+    /// The group stays usable afterward (new spawns get fresh members). Tokens
+    /// are collected under the lock and fired after releasing it, because
+    /// firing a parked member's token re-enters the group (via `acquire`'s
+    /// cancel path) to unqueue it.
+    pub fn cancel(&self, pending: bool, active: bool) -> usize {
+        let to_fire: Vec<CancellationToken> = {
+            let st = self.lock();
+            st.members
+                .values()
+                .filter(|m| if m.active { active } else { pending })
+                .map(|m| m.cancel.clone())
+                .collect()
+        };
+        let count = to_fire.len();
+        for token in to_fire {
+            token.cancel();
+        }
+        count
+    }
+
+    /// Register a member with the group **synchronously**, at spawn time, so
+    /// that `cancel(...)`, `active_count()`, and `queued_count()` observe it
+    /// immediately — before the spawned body task has been polled. Returns a
+    /// [`TaskGroupTicket`] the body task then `acquire`s (awaits admission on).
+    ///
+    /// `cancel` is the spawn's effective token; `group.cancel(...)` fires it.
+    pub fn register(self: &Arc<Self>, cancel: CancellationToken) -> TaskGroupTicket {
+        let mut st = self.lock();
+        let id = st.next_id;
+        st.next_id += 1;
+        if st.active < st.limit {
+            // A slot is free — admit immediately (no parking needed).
+            st.active += 1;
+            st.members.insert(
+                id,
+                Member {
+                    cancel,
+                    active: true,
+                    grant: None,
+                },
+            );
+            TaskGroupTicket {
+                group: Arc::clone(self),
+                id,
+                rx: None,
+                cancel: CancellationToken::new(), // unused on the granted path
+            }
+        } else {
+            // At capacity — park FIFO until a slot frees.
+            let (tx, rx) = oneshot::channel();
+            st.members.insert(
+                id,
+                Member {
+                    cancel: cancel.clone(),
+                    active: false,
+                    grant: Some(tx),
+                },
+            );
+            st.waiters.push_back(id);
+            TaskGroupTicket {
+                group: Arc::clone(self),
+                id,
+                rx: Some(rx),
+                cancel,
+            }
+        }
+    }
+
+    /// Cancel path for a member that observed cancellation. If it had already
+    /// been granted a slot (a grant raced the cancel), release the slot and
+    /// promote the next waiter; otherwise just unqueue it.
+    fn cancel_parked(&self, id: u64) {
+        let mut st = self.lock();
+        if let Some(member) = st.members.remove(&id) {
+            if member.active {
+                st.active -= 1;
+                Self::promote(&mut st);
+            } else {
+                st.waiters.retain(|w| *w != id);
+            }
+        }
+    }
+
+    /// Wake parked waiters while there is spare capacity. Called under lock.
+    fn promote(st: &mut State) {
+        while st.active < st.limit {
+            let Some(id) = st.waiters.pop_front() else {
+                break;
+            };
+            let grant = match st.members.get_mut(&id) {
+                Some(member) => {
+                    member.active = true;
+                    member.grant.take()
+                }
+                // Member already removed (cancelled); skip it.
+                None => continue,
+            };
+            let Some(tx) = grant else { continue };
+            st.active += 1;
+            if tx.send(()).is_err() {
+                // The waiter dropped its receiver (cancelled) between being
+                // popped and the grant. Undo and try the next waiter.
+                st.active -= 1;
+                st.members.remove(&id);
+                continue;
+            }
+            break;
+        }
+    }
+}
+
+impl Drop for TaskGroupPermit {
+    fn drop(&mut self) {
+        let mut st = self.group.lock();
+        if let Some(member) = st.members.remove(&self.id) {
+            if member.active {
+                st.active -= 1;
+            }
+        }
+        TaskGroupInner::promote(&mut st);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn limit_three_grants_three_immediately() {
+        let g = TaskGroupInner::new(3, None);
+        let t1 = g.register(CancellationToken::new());
+        let t2 = g.register(CancellationToken::new());
+        let t3 = g.register(CancellationToken::new());
+        assert_eq!(g.active_count(), 3, "all three admitted at register");
+        assert_eq!(g.queued_count(), 0);
+        let (p1, p2, p3) = (t1.acquire().await, t2.acquire().await, t3.acquire().await);
+        assert!(p1.is_some() && p2.is_some() && p3.is_some());
+        assert_eq!(g.active_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn limit_one_queues_then_promotes() {
+        let g = TaskGroupInner::new(1, None);
+        let t1 = g.register(CancellationToken::new());
+        let _t2 = g.register(CancellationToken::new());
+        let _t3 = g.register(CancellationToken::new());
+        assert_eq!(g.active_count(), 1);
+        assert_eq!(g.queued_count(), 2);
+        let p1 = t1.acquire().await.expect("first admitted");
+        drop(p1); // releasing promotes the next FIFO waiter
+        assert_eq!(g.active_count(), 1, "next waiter promoted");
+        assert_eq!(g.queued_count(), 1);
+    }
+}

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -2338,6 +2338,21 @@ impl std::fmt::Debug for Future {
     }
 }
 
+/// Runtime payload behind a `baml.spawn.SpawnConfig` instance's `_handle`
+/// (`Object::RustData`). Produced by `baml.spawn.options(...)` and read by the
+/// engine when dispatching a `spawn ... with` clause to derive the spawned
+/// task's effective cancel token. BEP-034 "spawn options".
+///
+/// PR1 carries only the optional cancel token; `group` (rate limiting) and
+/// `detach` are added as those features are wired, so the engine's downcast
+/// target stays stable across PRs.
+#[derive(Debug, Clone, Default)]
+pub struct SpawnConfigData {
+    /// User-provided cancel token from `options(cancel = ...)`, if any. Linked
+    /// into the spawn's effective token by the engine.
+    pub cancel: Option<CancellationToken>,
+}
+
 /// A pending user `spawn { body }` request that the engine still has to
 /// dispatch on a fresh `BexThread`.
 ///
@@ -2354,6 +2369,13 @@ pub struct UnscheduledFuture {
     /// the GC keeps the underlying string alive while the unscheduled
     /// future is on the heap.
     pub name: Option<HeapPtr>,
+    /// Optional `baml.spawn.SpawnConfig` instance from a `spawn ... with
+    /// baml.spawn.options(...)` clause (BEP-034 "spawn options"). Held as a
+    /// `HeapPtr` — like `name` — so the GC keeps the config (and the
+    /// `CancelToken`/`TaskGroup` it references) alive while this slot is on the
+    /// heap. `None` when the spawn had no `with` clause. The engine reads the
+    /// config's `_handle` (`SpawnConfigData`) when dispatching the spawn.
+    pub config: Option<HeapPtr>,
 }
 
 /// A unique identifier for a future.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -2363,6 +2363,10 @@ pub struct SpawnConfigData {
     /// (its effective token is independent of the parent's) and its unhandled
     /// errors route to the root task rather than the spawner.
     pub detach: bool,
+    /// `TaskGroup` from `options(group = ...)`, if any. The engine acquires a
+    /// concurrency slot from it before running the spawned body (BEP-034 rate
+    /// limiting).
+    pub group: Option<std::sync::Arc<crate::task_group::TaskGroupInner>>,
 }
 
 /// A pending user `spawn { body }` request that the engine still has to

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -831,6 +831,14 @@ impl Value {
         self.0 == 0
     }
 
+    /// `true` for the `OmittedArg` sentinel — the value the VM passes for an
+    /// optional argument the caller left out. Native builtins treat an omitted
+    /// optional argument the same as an absent one (`None`).
+    #[inline(always)]
+    pub const fn is_omitted(self) -> bool {
+        self.0 == Self::OMITTED_ARG.0
+    }
+
     #[inline(always)]
     pub const fn is_int(self) -> bool {
         self.0 & 1 != 0
@@ -2351,6 +2359,10 @@ pub struct SpawnConfigData {
     /// User-provided cancel token from `options(cancel = ...)`, if any. Linked
     /// into the spawn's effective token by the engine.
     pub cancel: Option<CancellationToken>,
+    /// `detach = true`: the spawn opts out of the parent→child cancel cascade
+    /// (its effective token is independent of the parent's) and its unhandled
+    /// errors route to the root task rather than the spawner.
+    pub detach: bool,
 }
 
 /// A pending user `spawn { body }` request that the engine still has to

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -638,6 +638,7 @@ fn expr_desc_spans<'db>(
         }
         Expr::Spawn {
             name,
+            with_exprs: _,
             body: spawn_body,
         } => {
             spans.push(DetailSpan::Code("spawn ".into()));


### PR DESCRIPTION
Implements the **spawn-options core** of BEP-034 — the `with` clause on `spawn` and the primitives it configures. Builds on the merged `spawn`/`await`/`Future<T,E>` foundation.

```baml
let tok = baml.spawn.CancelToken.new();
let group = baml.spawn.TaskGroup.new(limit = 5);
let f = spawn "fetch" with baml.spawn.options(group = group, cancel = tok, detach = false) {
    baml.http.fetch(url)
};
await f
```

## What's included (4 commits)

1. **`with baml.spawn.options(cancel = ...)` + `CancelToken`** — the `with` clause end-to-end (parser → AST → TIR → MIR → emit → VM → engine), the `baml.spawn` namespace, and `CancelToken` (`new`/`any`/`cancel`/`is_cancelled`). A user token links into a spawn's effective cancel token via a self-terminating watcher; firing it cancels the child and `await` re-throws `Cancelled` (catchable).
2. **`detach = true` + `OmittedArg` codegen fix** — a detached spawn gets a fresh effective token (parent cascade/throw doesn't reach it) and routes unhandled fire-and-forget errors to the root task. Also fixes the codegen so optional builtin params (incl. primitives like `bool?`) accept an omitted argument (general improvement).
3. **`TaskGroup` rate limiting** — `TaskGroup.new(limit, name?)`, `cancel(pending?, active?)`, `set_limit`, `limit`, `name`, `active_count`, `queued_count`, and `options(group = ...)`. Members register synchronously at spawn (so `cancel()`/counts are exact immediately) and park asynchronously for a slot (FIFO, without holding the heap permit), releasing on settle. Admission is cancel-biased so a `group.cancel()`'d member never runs.
4. **Strict `with` validation + `spawn_parallel` fix** — TIR rejects `with` expressions that aren't a `baml.spawn.options(...)` config (type-based, so `let c = options(...); spawn with c` works too). Also fixes `spawn_parallel.rs`, which was a false-positive (it used `sys_ops`, whose `sleep` is `Unsupported`, so its "parallel sleeps" were no-ops) — it now uses `sys_native` real sleeps and genuinely verifies concurrency.

## Notable decisions / findings

- `baml.spawn` collided with the `spawn` **keyword** → `spawn`/`await` are now accepted as member-path segments after `.` (mirrors the existing `KW_CLIENT` precedent), so `baml.spawn.options(...)` parses exactly as the BEP writes it.
- **Spawns do run concurrently for real IO** — verified with execution-only timing: `limit=3` runs three 200ms sleeps in ~200ms; `limit=1` serializes them (~600ms).
- Static methods (`TaskGroup.new`, `CancelToken.new`/`any`) use the existing non-`self` builtin-fn mechanism (like `int.parse`).

## Testing

17 engine cancellation tests, 7 TaskGroup tests (+2 admission unit tests), `ns_cancel_token`/`ns_task_group` BAML fixtures, `baml_src` (1500+ BAML tests + bytecode/CLI targets), `baml_tests --lib`, plus parser/AST/MIR/emit/codegen suites — all green; clippy clean; snapshots regenerated.

## Deferred (out of this scope)

Combinators (`race`/`any`/`all`/`all_complete`/`all_settled`) + `Future.then()`, the full user-middleware system (`SpawnParams` transformers), `await`-over-unions, shielding, `Duration`/`CancelToken.after`, and `TaskGroup.on_event`.

> Branch is currently a few commits behind `canary`; will rebase before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `spawn ... with baml.spawn.options(...)` syntax to configure spawned tasks
  * Introduced `CancelToken` for canceling spawned operations
  * Introduced `TaskGroup` for rate-limiting concurrent spawns with configurable concurrency caps
  * Added `detach` flag to allow spawned tasks to complete independently without blocking

* **Tests**
  * Added spawn cancellation behavior validation
  * Added task group rate-limiting verification tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->