### PR TITLE
Add numeric min and max builtins

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/core.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/core.baml
@@ -9,3 +9,33 @@ function deep_copy<T>(value: T) -> T {
 function deep_equals<T>(a: T, b: T) -> bool {
   $rust_function
 }
+
+/// Returns the larger of two numeric values.
+///
+/// Both arguments must be the same numeric type: either both `int` or both
+/// `float`. The return type is the same as the argument type.
+///
+/// # Examples
+/// ```
+/// baml.max(3, 5)       // 5
+/// baml.max(3.0, 5.0)   // 5.0
+/// ```
+//baml:mut_vm
+function max<T>(a: T, b: T) -> T {
+  $rust_function
+}
+
+/// Returns the smaller of two numeric values.
+///
+/// Both arguments must be the same numeric type: either both `int` or both
+/// `float`. The return type is the same as the argument type.
+///
+/// # Examples
+/// ```
+/// baml.min(3, 5)       // 3
+/// baml.min(3.0, 5.0)   // 3.0
+/// ```
+//baml:mut_vm
+function min<T>(a: T, b: T) -> T {
+  $rust_function
+}

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -40,6 +40,8 @@ fn is_fallible(b: &NativeBuiltin) -> bool {
                 | "baml.media.Video.to_json"
                 | "baml.media.Image.to_json"
                 | "baml.Float.random"
+                | "baml.max"
+                | "baml.min"
                 // `bigint.pow` raises `AllocFailure` (a panic, not in `throws`) when
                 // the estimated result size exceeds `MAX_BIGINT_BITS`.
                 | "baml.Bigint.pow"
@@ -155,7 +157,7 @@ fn build_namespace_tree(builtins: &[NativeBuiltin]) -> NamespaceNode<'_> {
         let rest = b.path.strip_prefix("baml.").unwrap_or(&b.path);
         let segments: Vec<&str> = rest.split('.').collect();
         let baml_method_name = segments.last().unwrap().to_string();
-        let rust_method_name = camel_to_snake(&baml_method_name);
+        let rust_method_name = rust_method_name_for_builtin(&segments, &baml_method_name);
 
         let entry = BuiltinEntry {
             builtin: b,
@@ -186,6 +188,14 @@ fn build_namespace_tree(builtins: &[NativeBuiltin]) -> NamespaceNode<'_> {
     }
 
     root
+}
+
+fn rust_method_name_for_builtin(segments: &[&str], baml_method_name: &str) -> String {
+    if segments.len() == 1 && matches!(baml_method_name, "max" | "min") {
+        format!("baml_{}", camel_to_snake(baml_method_name))
+    } else {
+        camel_to_snake(baml_method_name)
+    }
 }
 
 // ============================================================================
@@ -2013,6 +2023,12 @@ mod tests {
             output.contains("fn deep_equals(vm: &BexVm, a: &Value, b: &Value) -> bool;"),
             "BamlPackageBaml should have deep_equals with &BexVm:\n{output}"
         );
+        assert!(
+            output.contains(
+                "fn baml_max(vm: &mut BexVm, a: &Value, b: &Value) -> Result<Value, VmRustFnError>;"
+            ),
+            "BamlPackageBaml should expose baml.max with a conflict-free Rust method name:\n{output}"
+        );
     }
 
     #[test]
@@ -2039,7 +2055,7 @@ mod tests {
             let rest = b.path.strip_prefix("baml.").unwrap_or(&b.path);
             let segments: Vec<&str> = rest.split('.').collect();
             let baml_name = segments.last().unwrap();
-            let name = camel_to_snake(baml_name);
+            let name = rust_method_name_for_builtin(&segments, baml_name);
             let has_mut_receiver = b
                 .receiver
                 .as_ref()

--- a/baml_language/crates/baml_builtins2_codegen/src/extract.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/extract.rs
@@ -958,6 +958,15 @@ mod tests {
             .expect("missing deep_equals");
         assert_eq!(deep_equals.vm_usage, VmUsage::Ref);
 
+        let baml_max = vm_builtins
+            .iter()
+            .find(|b| b.path == "baml.max")
+            .expect("missing max");
+        assert!(baml_max.receiver.is_none());
+        assert_eq!(baml_max.params.len(), 2);
+        assert_eq!(baml_max.generics, vec!["T"]);
+        assert_eq!(baml_max.vm_usage, VmUsage::MutRef);
+
         assert_eq!(array_length.vm_usage, VmUsage::None);
         assert_eq!(array_push.vm_usage, VmUsage::None);
         assert_eq!(math_trunc.vm_usage, VmUsage::None);

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2417,6 +2417,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         self.record_function_coercion_if_needed(*arg, &arg_ty, &expected_arg_ty);
                     }
                 }
+                self.validate_numeric_min_max_call(expr_id, body, &param_arg_pairs);
 
                 let substituted_ret = crate::generics::substitute_ty(ret, &bindings);
                 let mut erase_diags = Vec::new();
@@ -2603,6 +2604,90 @@ impl<'db> TypeInferenceBuilder<'db> {
                 expr_id,
                 Vec::new(),
             );
+        }
+    }
+
+    fn validate_numeric_min_max_call(
+        &mut self,
+        expr_id: ExprId,
+        body: &ExprBody,
+        param_arg_pairs: &[(&FunctionParamTy, ExprId)],
+    ) {
+        let callee = match &body.exprs[expr_id] {
+            Expr::Call { callee, .. } | Expr::OptionalCall { callee, .. } => *callee,
+            _ => return,
+        };
+        let Some(function) = self.call_target_name(callee, body) else {
+            return;
+        };
+        if !matches!(function.as_str(), "baml.max" | "baml.min") || param_arg_pairs.len() != 2 {
+            return;
+        }
+
+        let left = self
+            .expressions
+            .get(&param_arg_pairs[0].1)
+            .cloned()
+            .unwrap_or(Ty::Unknown {
+                attr: TyAttr::default(),
+            });
+        let right = self
+            .expressions
+            .get(&param_arg_pairs[1].1)
+            .cloned()
+            .unwrap_or(Ty::Unknown {
+                attr: TyAttr::default(),
+            });
+
+        if matches!(
+            (&left, &right),
+            (Ty::Unknown { .. } | Ty::Error { .. }, _) | (_, Ty::Unknown { .. } | Ty::Error { .. })
+        ) {
+            return;
+        }
+
+        let left_kind = self.numeric_min_max_kind(&left);
+        let right_kind = self.numeric_min_max_kind(&right);
+        if left_kind.is_some() && left_kind == right_kind {
+            return;
+        }
+
+        self.context.report_simple(
+            TirTypeError::NumericMinMaxTypeMismatch {
+                function,
+                left,
+                right,
+            },
+            expr_id,
+        );
+    }
+
+    fn numeric_min_max_kind(&self, ty: &Ty) -> Option<PrimitiveType> {
+        let expanded = self.expand_alias_chains(ty.clone());
+        Self::numeric_min_max_kind_expanded(&expanded)
+    }
+
+    fn numeric_min_max_kind_expanded(ty: &Ty) -> Option<PrimitiveType> {
+        match ty {
+            Ty::Primitive(kind @ (PrimitiveType::Int | PrimitiveType::Float), _) => {
+                Some(kind.clone())
+            }
+            Ty::Literal(lit, _, _) => match PrimitiveType::from_literal(lit) {
+                kind @ (PrimitiveType::Int | PrimitiveType::Float) => Some(kind),
+                _ => None,
+            },
+            Ty::Union(members, _) => {
+                let mut kind = None;
+                for member in members {
+                    let member_kind = Self::numeric_min_max_kind_expanded(member)?;
+                    if kind.as_ref().is_some_and(|kind| kind != &member_kind) {
+                        return None;
+                    }
+                    kind = Some(member_kind);
+                }
+                kind
+            }
+            _ => None,
         }
     }
 

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -33,6 +33,8 @@ use crate::{
 pub enum TirTypeError {
     /// Type mismatch: expected vs actual.
     TypeMismatch { expected: Ty, got: Ty },
+    /// `baml.min`/`baml.max` are same-type numeric builtins.
+    NumericMinMaxTypeMismatch { function: Name, left: Ty, right: Ty },
     /// Member not found on a known type.
     ///
     /// Reported when the base type IS resolved (known class/enum) but the
@@ -233,6 +235,16 @@ impl fmt::Display for TirTypeError {
                     humanize_ty(got)
                 )
             }
+            TirTypeError::NumericMinMaxTypeMismatch {
+                function,
+                left,
+                right,
+            } => write!(
+                f,
+                "`{function}` expects both arguments to be the same numeric type (`int` or `float`), got {} and {}",
+                humanize_ty(left),
+                humanize_ty(right)
+            ),
             TirTypeError::UnresolvedMember { base_type, member } => {
                 write!(
                     f,

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -867,7 +867,9 @@ fn tir_type_error_to_diagnostic_id(
 ) -> DiagnosticId {
     use baml_compiler2_tir::infer_context::TirTypeError;
     match error {
-        TirTypeError::TypeMismatch { .. } => DiagnosticId::TypeMismatch,
+        TirTypeError::TypeMismatch { .. } | TirTypeError::NumericMinMaxTypeMismatch { .. } => {
+            DiagnosticId::TypeMismatch
+        }
         TirTypeError::UnresolvedMember { .. } => DiagnosticId::NoSuchField,
         TirTypeError::UnresolvedName { .. } => DiagnosticId::UnknownVariable,
         TirTypeError::DeadCode { .. } => DiagnosticId::TypeMismatch,

--- a/baml_language/crates/baml_tests/tests/numeric_min_max.rs
+++ b/baml_language/crates/baml_tests/tests/numeric_min_max.rs
@@ -1,0 +1,80 @@
+//! Tests for root numeric min/max builtins.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+#[tokio::test]
+async fn baml_max_int() {
+    let output = baml_test!(
+        r#"
+            function main() -> int {
+                baml.max(-7, 3)
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Int(3)));
+}
+
+#[tokio::test]
+async fn baml_min_int() {
+    let output = baml_test!(
+        r#"
+            function main() -> int {
+                baml.min(-7, 3)
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Int(-7)));
+}
+
+#[tokio::test]
+async fn baml_max_float() {
+    let output = baml_test!(
+        r#"
+            function main() -> float {
+                baml.max(-7.5, 3.25)
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Float(3.25)));
+}
+
+#[tokio::test]
+async fn baml_min_float() {
+    let output = baml_test!(
+        r#"
+            function main() -> float {
+                baml.min(-7.5, 3.25)
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Float(-7.5)));
+}
+
+#[tokio::test]
+#[should_panic(expected = "expects both arguments to be the same numeric type")]
+async fn baml_min_rejects_mixed_numeric_types() {
+    let _output = baml_test!(
+        r#"
+            function main() -> float {
+                baml.min(1, 2.0)
+            }
+        "#
+    );
+}
+
+#[tokio::test]
+#[should_panic(expected = "expects both arguments to be the same numeric type")]
+async fn baml_max_rejects_strings() {
+    let _output = baml_test!(
+        r#"
+            function main() -> string {
+                baml.max("a", "b")
+            }
+        "#
+    );
+}

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -10,7 +10,7 @@
 //! - `math` — `BamlNamespaceMath` (trunc)
 //! - `media` — `BamlClassMedia{Pdf,Audio,Video,Image}` + `BamlNamespaceMedia`
 //! - `unstable` — `BamlNamespaceUnstable` (string)
-//! - `root` — `BamlPackageBaml` (`deep_copy`, `deep_equals`)
+//! - `root` — `BamlPackageBaml` (`deep_copy`, `deep_equals`, `min`, `max`)
 //!
 //! # Adding a new builtin
 //!

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -7,7 +7,10 @@ use bex_vm_types::{
 use indexmap::IndexMap;
 
 use super::{BamlPackageBaml, PackageBamlImpl};
-use crate::BexVm;
+use crate::{
+    BexVm,
+    errors::{VmBamlError, VmRustFnError},
+};
 
 impl BamlPackageBaml for PackageBamlImpl {
     fn deep_copy(vm: &mut BexVm, value: &Value) -> Value {
@@ -18,6 +21,56 @@ impl BamlPackageBaml for PackageBamlImpl {
     fn deep_equals(vm: &BexVm, a: &Value, b: &Value) -> bool {
         let mut visited = HashMap::new();
         deep_equals_recursive(vm, *a, *b, &mut visited)
+    }
+
+    fn baml_max(vm: &mut BexVm, a: &Value, b: &Value) -> Result<Value, VmRustFnError> {
+        numeric_min_max(vm, *a, *b, NumericMinMax::Max)
+    }
+
+    fn baml_min(vm: &mut BexVm, a: &Value, b: &Value) -> Result<Value, VmRustFnError> {
+        numeric_min_max(vm, *a, *b, NumericMinMax::Min)
+    }
+}
+
+enum NumericMinMax {
+    Min,
+    Max,
+}
+
+fn numeric_min_max(
+    vm: &mut BexVm,
+    a: Value,
+    b: Value,
+    op: NumericMinMax,
+) -> Result<Value, VmRustFnError> {
+    if let (Some(a_int), Some(b_int)) = (a.as_int(), b.as_int()) {
+        let result = match op {
+            NumericMinMax::Min => a_int.min(b_int),
+            NumericMinMax::Max => a_int.max(b_int),
+        };
+        return Ok(Value::int(result));
+    }
+
+    if let (Some(a_float), Some(b_float)) = (value_as_float(vm, a), value_as_float(vm, b)) {
+        let result = match op {
+            NumericMinMax::Min => a_float.min(b_float),
+            NumericMinMax::Max => a_float.max(b_float),
+        };
+        return Ok(vm.alloc_float(result));
+    }
+
+    Err(VmBamlError::InvalidArgument {
+        message: "baml.max/min require both arguments to be int or both arguments to be float"
+            .to_string(),
+    }
+    .into())
+}
+
+fn value_as_float(vm: &BexVm, value: Value) -> Option<f64> {
+    let ptr = value.as_object_ptr()?;
+    match vm.get_object(ptr) {
+        Object::Float(float) => Some(*float),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

- Add root `baml.max` and `baml.min` builtins for same-type numeric values (`int`/`float`).
- Add TIR validation so both arguments must resolve to the same numeric type.
- Implement VM native handling and codegen extraction/generation coverage.
- Add focused runtime/type-check tests for int, float, mixed numeric, and non-numeric calls.

## Testing
Please describe how you tested these changes

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in linux cloud workspace

Commands run:
- `cargo test -p baml_builtins2_codegen`
- `cargo test -p baml_tests --test numeric_min_max`
- `cargo test --lib` (reached unrelated environment linker failures: missing Node N-API symbols in `bridge_nodejs` and missing `libpython3.12` for `bridge_python`)
- `cargo test -p baml_compiler2_tir --lib`
- `cargo test -p bex_vm --lib`
- `cargo test -p baml_lsp2_actions --lib`

## Screenshots
If applicable, add screenshots to help explain your changes

N/A

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The stdlib currently cannot represent true overloaded function definitions with the same bytecode name, so these are exposed as generic same-type numeric builtins with compiler-side validation to provide the intended int/float overload behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4ea2710-70a8-4ae6-a843-0e24a58b76b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4ea2710-70a8-4ae6-a843-0e24a58b76b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

