### PR TITLE
perf(vm): add ContainerLen opcode for .length() intrinsic

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "log",
  "num-bigint",
  "serde_json",
+ "smallvec",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -201,6 +201,7 @@ serde-wasm-bindgen = "0.6"
 serde_json = { version = "1.0.113", features = [ "arbitrary_precision", "preserve_order" ] }
 serde_yaml = "0.9"
 similar = { version = "2.4.0", features = [ "inline" ] }
+smallvec = { version = "1.15", features = [ "const_generics" ] }
 smol_str = { version = "0.3", features = [ "serde", "borsh" ] }
 strsim = { version = "0.11.1" }
 syn = { version = "2", features = [ "full" ] }

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -2980,18 +2980,9 @@ impl PullSink for StackifyCodegen<'_, '_> {
     }
 
     fn len_of_place(&mut self, place: &Place) -> Result<(), Self::Error> {
-        // MIR `Rvalue::Len` is array length.
-        let global_idx = self
-            .globals
-            .get("baml.Array.length")
-            .copied()
-            .unwrap_or_else(|| panic!("undefined function: baml.Array.length"));
+        // MIR `Rvalue::Len` → dedicated ContainerLen opcode (no function call overhead).
         pull_semantics::walk_place_pull(self, place)?;
-        let inst = self.emit(Instruction::Call {
-            callee: GlobalIndex::from_raw(global_idx),
-            ntypeargs: 0,
-        });
-        self.set_operand(inst, OperandMeta::Callable("baml.Array.length".to_string()));
+        self.emit(Instruction::ContainerLen);
         Ok(())
     }
 

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3737,6 +3737,32 @@ impl LoweringContext<'_> {
             return;
         }
 
+        // Check if callee is `.length()` on a container — emit Rvalue::Len instead of Call.
+        if let Operand::Constant(Constant::Function(ref item)) = callee_operand {
+            let name = item.to_string();
+            if name == "baml.Array.length"
+                || name == "baml.Map.length"
+                || name == "baml.string.length"
+                || name == "baml.Uint8Array.length"
+            {
+                if let Some(receiver_operand) = arg_operands.first() {
+                    let place = match receiver_operand {
+                        Operand::Copy(p) | Operand::Move(p) => p.clone(),
+                        Operand::Constant(_) => {
+                            let tmp = self.builder.temp(baml_type::Ty::unknown());
+                            self.builder
+                                .assign(Place::Local(tmp), Rvalue::Use(receiver_operand.clone()));
+                            Place::Local(tmp)
+                        }
+                    };
+                    self.builder.assign(dest, Rvalue::Len(place));
+                    self.builder.goto(target);
+                    self.builder.set_current_block(target);
+                    return;
+                }
+            }
+        }
+
         // Check if callee is a compiler intrinsic (log.*, baml.events.send).
         // Intrinsics are void side effects — emit as a statement, not a call.
         if let Some(op) = self.check_intrinsic(callee) {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/builtins.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/builtins.snap
@@ -54,7 +54,7 @@ function builtins.builtins_bind_method_call() -> int {
     load_const 2
     load_const 3
     alloc_array 3
-    call baml.Array.length
+    container_len
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/byte_strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/byte_strings.snap
@@ -276,6 +276,6 @@ function byte_strings.byte_strings_zeroes_basic() -> uint8array {
 
 function byte_strings.get_len(data: uint8array) -> int {
     load_var data
-    call baml.Uint8Array.length
+    container_len
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
@@ -102,7 +102,7 @@ function for_loops.for_loops_first_even(xs: int[]) -> int {
   L0:
     load_var __for_idx
     load_var xs
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -147,7 +147,7 @@ function for_loops.for_loops_for_with_break(xs: int[]) -> int {
   L0:
     load_var __for_idx
     load_var xs
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L2
     load_var xs
@@ -184,7 +184,7 @@ function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
   L0:
     load_var __for_idx
     load_var xs
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -224,7 +224,7 @@ function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
   L0:
     load_var __for_idx
     load_var grid
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -244,7 +244,7 @@ function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
   L3:
     load_var __for_idx_1
     load_var _8
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L4
     jump L5
@@ -288,7 +288,7 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
   L0:
     load_var __for_idx
     load_var arr_a
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -308,7 +308,7 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
   L3:
     load_var __for_idx_1
     load_var arr_b
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L4
     jump L5
@@ -345,7 +345,7 @@ function for_loops.for_loops_render(xs: string[]) -> string {
   L0:
     load_var __for_idx
     load_var xs
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -394,7 +394,7 @@ function for_loops.for_loops_sum(xs: int[]) -> int {
   L0:
     load_var __for_idx
     load_var xs
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -431,7 +431,7 @@ function for_loops.for_loops_sum_let_var() -> int {
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -468,7 +468,7 @@ function for_loops.for_loops_sum_let_var_no_parens() -> int {
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
@@ -286,7 +286,7 @@ function fs.fs_file_read_bytes_n_fn() -> bool {
     sys_op baml.fs.remove
     pop 1
     load_var data
-    call baml.Uint8Array.length
+    container_len
     load_const 3
     call baml.deep_equals
     return
@@ -476,7 +476,7 @@ function fs.fs_open_and_read_bytes_fn() -> bool {
     sys_op baml.fs.remove
     pop 1
     load_var data
-    call baml.Uint8Array.length
+    container_len
     load_const 16
     call baml.deep_equals
     return
@@ -707,7 +707,7 @@ function fs.fs_read_dir_empty_dir_fn() -> bool {
     pop 1
     load_const "/tmp/baml_fs_read_dir_empty_abc"
     sys_op baml.fs.read_dir
-    call baml.Array.length
+    container_len
     load_const 0
     call baml.deep_equals
     return
@@ -752,7 +752,7 @@ function fs.fs_read_dir_returns_entries_fn() -> bool {
     sys_op baml.fs.remove
     pop 1
     load_var entries
-    call baml.Array.length
+    container_len
     load_const 3
     call baml.deep_equals
     store_var count_ok
@@ -924,7 +924,7 @@ function fs.fs_write_bytes_fn() -> bool {
     jump_if_false L0
     pop 1
     load_var readback
-    call baml.Uint8Array.length
+    container_len
     load_const 11
     call baml.deep_equals
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/glob.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/glob.snap
@@ -455,9 +455,6 @@ function glob.scan_follows_symlinked_directory_checks() -> bool[] {
     sys_op baml.glob.Glob.scan
     store_var result
     load_var result
-    call baml.Array.length
-    store_var _29
-    load_var result
     load_const "link_dir/hidden_via_link.txt"
     call baml.Array.includes
     store_var _30
@@ -471,7 +468,8 @@ function glob.scan_follows_symlinked_directory_checks() -> bool[] {
     load_const null
     sys_op baml.sys.shell
     pop 1
-    load_var _29
+    load_var result
+    container_len
     load_const 1
     cmp_int_op ==
     load_var _30
@@ -513,9 +511,6 @@ function glob.scan_matches_absolute_pattern_checks() -> bool[] {
     sys_op baml.glob.Glob.scan
     store_var result
     load_var result
-    call baml.Array.length
-    store_var _19
-    load_var result
     load_var root
     load_const "/file.txt"
     bin_op +
@@ -527,7 +522,8 @@ function glob.scan_matches_absolute_pattern_checks() -> bool[] {
     load_const null
     sys_op baml.sys.shell
     pop 1
-    load_var _19
+    load_var result
+    container_len
     load_const 1
     cmp_int_op ==
     load_var _20
@@ -653,9 +649,6 @@ function glob.scan_opts_include_dot_absolute_and_dirs_checks() -> bool[] {
     sys_op baml.glob.Glob.scan
     store_var result
     load_var result
-    call baml.Array.length
-    store_var _23
-    load_var result
     load_var root
     load_const "/.hidden.txt"
     bin_op +
@@ -679,7 +672,8 @@ function glob.scan_opts_include_dot_absolute_and_dirs_checks() -> bool[] {
     load_const null
     sys_op baml.sys.shell
     pop 1
-    load_var _23
+    load_var result
+    container_len
     load_const 3
     cmp_int_op ==
     load_var _24

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_alias.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_alias.snap
@@ -72,7 +72,7 @@ function json_alias.json_array_len() -> int {
 
   L1:
     load_var arr
-    call baml.Array.length
+    container_len
 
   L2:
     return
@@ -93,7 +93,7 @@ function json_alias.json_map_has_key() -> bool {
 
   L1:
     load_var m
-    call baml.Map.length
+    container_len
     load_const 1
     cmp_int_op ==
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_parse_stringify.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_parse_stringify.snap
@@ -70,7 +70,7 @@ function json_parse_stringify.parse_array_len() -> int {
 
   L1:
     load_var j
-    call baml.Array.length
+    container_len
 
   L2:
     return
@@ -128,7 +128,7 @@ function json_parse_stringify.parse_then_match_array_len() -> int {
 
   L1:
     load_var j
-    call baml.Array.length
+    container_len
 
   L2:
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_to_from_string.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_to_from_string.snap
@@ -314,7 +314,7 @@ function json_to_from_string.from_string_json_passthrough_object_len() -> int {
 
   L1:
     load_var j
-    call baml.Map.length
+    container_len
 
   L2:
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -223,7 +223,7 @@ function lambdas.lambdas_captures_loop_variable_accumulation() -> int {
   L0:
     load_var __for_idx
     load_var _4
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -492,17 +492,15 @@ function lambdas.lambdas_issue_d_capture_as_call_destination() -> int {
 }
 
 function lambdas.lambdas_issue_e_method_resolution_different_types() -> int {
-    load_const 1
-    load_const 2
-    load_const 3
-    alloc_array 3
-    call baml.Array.length
-    store_var arr_len
     load_const "hello"
     make_closure .<lambda(lambdas_issue_e_method_resolution_different_types, 0)>, 0
     call_indirect
     store_var _6
-    load_var arr_len
+    load_const 1
+    load_const 2
+    load_const 3
+    alloc_array 3
+    container_len
     load_const 10
     mul_int
     load_var _6

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
@@ -259,7 +259,7 @@ function lexical_scoping.for_loop_restores_outer() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -456,7 +456,7 @@ function lexical_scoping.rule2_for_outer_mutation_escapes() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/baml_src/maps.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/maps.snap
@@ -199,7 +199,7 @@ function maps.map_clear_already_empty_main() -> int {
     call baml.Map.clear
     pop 1
     load_var m
-    call baml.Map.length
+    container_len
     return
 }
 
@@ -235,7 +235,7 @@ function maps.map_clear_removes_all_main() -> int {
     call baml.Map.clear
     pop 1
     load_var m
-    call baml.Map.length
+    container_len
     return
 }
 
@@ -362,7 +362,7 @@ function maps.map_delete_shrinks_length_main() -> int {
     call baml.Map.delete
     pop 1
     load_var m
-    call baml.Map.length
+    container_len
     return
 }
 
@@ -410,7 +410,7 @@ function maps.map_get_or_insert_grows_length_main() -> int {
     call baml.Map.get_or_insert
     pop 1
     load_var m
-    call baml.Map.length
+    container_len
     return
 }
 
@@ -498,7 +498,7 @@ function maps.map_len_helper() -> int {
     load_const "hi"
     load_const "it_works"
     alloc_map 2
-    call baml.Map.length
+    container_len
     return
 }
 
@@ -528,7 +528,7 @@ function maps.map_set_grows_length_main() -> int {
     call baml.Map.set
     pop 1
     load_var m
-    call baml.Map.length
+    container_len
     return
 }
 
@@ -550,7 +550,7 @@ function maps.map_set_replace_preserves_length_main() -> int {
     call baml.Map.set
     pop 1
     load_var m
-    call baml.Map.length
+    container_len
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/optional_function_parameters.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/optional_function_parameters.snap
@@ -188,7 +188,7 @@ function optional_function_parameters.push_default(value: int, items: int[]) -> 
     call baml.Array.push
     pop 1
     load_var items
-    call baml.Array.length
+    container_len
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -750,7 +750,7 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
@@ -761,7 +761,7 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L1
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L1
@@ -772,7 +772,7 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L2
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op ==
     pop_jump_if_false L2
@@ -806,7 +806,7 @@ function patterns_new_runtime.from_array_boxes(boxes: patterns_new_runtime.BoxT<
   L0:
     load_var __for_idx
     load_var boxes
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -1058,7 +1058,7 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     is_type patterns_new_runtime.Cell1[]
     pop_jump_if_false L0
     load_var _3
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1074,7 +1074,7 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var _11
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1095,13 +1095,13 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     is_type patterns_new_runtime.Cell1[]
     pop_jump_if_false L1
     load_var _29
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var _29
     load_var _29
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -1114,13 +1114,13 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     is_type int[]
     pop_jump_if_false L1
     load_var _37
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
     load_var _37
     load_var _37
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_array_element
@@ -1137,14 +1137,14 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     load_field .cells
     store_var_load_var _47
     load_var _47
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
     load_field .row
     store_var_load_var _51
     load_var _51
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_array_element
@@ -1178,7 +1178,7 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     is_type int[]
     pop_jump_if_false L0
     load_var _5
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1199,7 +1199,7 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     is_type int[]
     pop_jump_if_false L1
     load_var _20
-    call baml.Array.length
+    container_len
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L1
@@ -1220,13 +1220,13 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     is_type int[]
     pop_jump_if_false L2
     load_var _36
-    call baml.Array.length
+    container_len
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L2
     load_var _36
     load_var _36
-    call baml.Array.length
+    container_len
     load_const 3
     sub_int
     load_array_element
@@ -1239,7 +1239,7 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     is_type int[][]
     pop_jump_if_false L3
     load_var p
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L3
@@ -1250,13 +1250,13 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     is_type int[]
     pop_jump_if_false L3
     load_var _62
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L3
     load_var _62
     load_var _62
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -1274,7 +1274,7 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     load_array_element
     store_var_load_var _72
     load_var _72
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -1285,7 +1285,7 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     load_field .0
     store_var_load_var _48
     load_var _48
-    call baml.Array.length
+    container_len
     load_const 3
     sub_int
     load_array_element
@@ -1319,7 +1319,7 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     is_type patterns_new_runtime.Row1[]
     pop_jump_if_false L0
     load_var _3
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1335,7 +1335,7 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     is_type patterns_new_runtime.Slot1[]
     pop_jump_if_false L0
     load_var _11
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1351,7 +1351,7 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     is_type patterns_new_runtime.Atom1[]
     pop_jump_if_false L0
     load_var _19
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1377,13 +1377,13 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     is_type patterns_new_runtime.Row1[]
     pop_jump_if_false L1
     load_var _44
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var _44
     load_var _44
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -1396,13 +1396,13 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     is_type patterns_new_runtime.Slot1[]
     pop_jump_if_false L1
     load_var _52
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var _52
     load_var _52
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -1415,13 +1415,13 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     is_type patterns_new_runtime.Atom1[]
     pop_jump_if_false L1
     load_var _60
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
     load_var _60
     load_var _60
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_array_element
@@ -1443,21 +1443,21 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     load_field .rows
     store_var_load_var _72
     load_var _72
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
     load_field .slots
     store_var_load_var _76
     load_var _76
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
     load_field .atoms
     store_var_load_var _80
     load_var _80
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_array_element
@@ -1486,7 +1486,7 @@ function patterns_new_runtime.prefix_length(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1672,7 +1672,7 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     is_type bool[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1689,13 +1689,13 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     is_type bool[]
     pop_jump_if_false L1
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -1709,7 +1709,7 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     is_type bool[]
     pop_jump_if_false L2
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L2
@@ -1775,7 +1775,7 @@ function patterns_new_runtime.score_empty_prefix_rest(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
@@ -1802,7 +1802,7 @@ function patterns_new_runtime.score_exact_length_45() -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var _1
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -1818,7 +1818,7 @@ function patterns_new_runtime.score_exact_length_45() -> int {
     is_type int[]
     pop_jump_if_false L1
     load_var _1
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op ==
     pop_jump_if_false L1
@@ -2005,7 +2005,7 @@ function patterns_new_runtime.score_int_string_array(v: int[] | string[]) -> int
     is_type int[]
     pop_jump_if_false L0
     load_var v
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -2038,7 +2038,7 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2061,7 +2061,7 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L1
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2108,7 +2108,7 @@ function patterns_new_runtime.score_opat(input: patterns_new_runtime.OPat_A | pa
     is_type int[]
     pop_jump_if_false L1
     load_var _8
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op ==
     pop_jump_if_false L1
@@ -2143,7 +2143,7 @@ function patterns_new_runtime.score_or_array_refine(v: int[] | string[]) -> int 
     is_type int[]
     pop_jump_if_false L0
     load_var v
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -2159,7 +2159,7 @@ function patterns_new_runtime.score_or_array_refine(v: int[] | string[]) -> int 
     is_type int[]
     pop_jump_if_false L1
     load_var v
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2202,7 +2202,7 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     is_type int[][]
     pop_jump_if_false L0
     load_var rows
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -2213,7 +2213,7 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var _6
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2229,7 +2229,7 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     is_type int[][]
     pop_jump_if_false L1
     load_var rows
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2240,7 +2240,7 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     is_type int[]
     pop_jump_if_false L1
     load_var _22
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2279,7 +2279,7 @@ function patterns_new_runtime.score_or_share(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -2295,7 +2295,7 @@ function patterns_new_runtime.score_or_share(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L1
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2333,13 +2333,13 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     is_type int[][]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_array_element
@@ -2347,7 +2347,7 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     pop_jump_if_false L0
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -2361,14 +2361,14 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
 
   L1:
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_const 100
     mul_int
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_array_element
@@ -2379,7 +2379,7 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     add_int
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -2493,7 +2493,7 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2504,7 +2504,7 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     pop_jump_if_false L0
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_array_element
@@ -2512,7 +2512,7 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     pop_jump_if_false L0
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -2532,7 +2532,7 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     mul_int
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     sub_int
     load_array_element
@@ -2541,7 +2541,7 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     add_int
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -2578,7 +2578,7 @@ function patterns_new_runtime.score_rest_copy(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2595,14 +2595,12 @@ function patterns_new_runtime.score_rest_copy(xs: int[]) -> int {
 
   L1:
     load_var xs
-    call baml.Array.length
-    store_var _14
-    load_var xs
     load_const 0
     load_array_element
     load_const 10
     mul_int
-    load_var _14
+    load_var xs
+    container_len
     load_const 1
     sub_int
     add_int
@@ -2616,7 +2614,7 @@ function patterns_new_runtime.score_strings_len(xs: string[]) -> int {
     is_type string[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2633,7 +2631,7 @@ function patterns_new_runtime.score_strings_len(xs: string[]) -> int {
 
   L1:
     load_var xs
-    call baml.Array.length
+    container_len
 
   L2:
     return
@@ -2644,13 +2642,13 @@ function patterns_new_runtime.score_suffix_rest(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -2664,14 +2662,14 @@ function patterns_new_runtime.score_suffix_rest(xs: int[]) -> int {
 
   L1:
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_const 10
     mul_int
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -2686,7 +2684,7 @@ function patterns_new_runtime.score_team2(teams: patterns_new_runtime.Team2[]) -
     is_type patterns_new_runtime.Team2[]
     pop_jump_if_false L0
     load_var teams
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -2702,7 +2700,7 @@ function patterns_new_runtime.score_team2(teams: patterns_new_runtime.Team2[]) -
     is_type int[]
     pop_jump_if_false L0
     load_var _8
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2718,7 +2716,7 @@ function patterns_new_runtime.score_team2(teams: patterns_new_runtime.Team2[]) -
     is_type patterns_new_runtime.Team2[]
     pop_jump_if_false L1
     load_var teams
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2734,7 +2732,7 @@ function patterns_new_runtime.score_team2(teams: patterns_new_runtime.Team2[]) -
     is_type int[]
     pop_jump_if_false L1
     load_var _27
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2780,7 +2778,7 @@ function patterns_new_runtime.score_team3(team: patterns_new_runtime.Team3) -> i
     is_type int[]
     pop_jump_if_false L0
     load_var _3
-    call baml.Array.length
+    container_len
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
@@ -2810,7 +2808,7 @@ function patterns_new_runtime.score_team4(team: patterns_new_runtime.Team4) -> i
     is_type int[]
     pop_jump_if_false L0
     load_var _3
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2840,7 +2838,7 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2856,7 +2854,7 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
     pop_jump_if_false L0
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -2882,7 +2880,7 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
     add_int
     load_var xs
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -2897,7 +2895,7 @@ function patterns_new_runtime.score_user_score(users: patterns_new_runtime.UserS
     is_type patterns_new_runtime.UserScore[]
     pop_jump_if_false L0
     load_var users
-    call baml.Array.length
+    container_len
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
@@ -2905,15 +2903,13 @@ function patterns_new_runtime.score_user_score(users: patterns_new_runtime.UserS
 
   L0:
     load_var users
-    call baml.Array.length
-    store_var _12
-    load_var users
     load_const 0
     load_array_element
     load_field .score
     load_const 10
     mul_int
-    load_var _12
+    load_var users
+    container_len
     load_const 1
     sub_int
     add_int
@@ -2931,7 +2927,7 @@ function patterns_new_runtime.score_wildcard_second(xs: int[]) -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var xs
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2960,7 +2956,7 @@ function patterns_new_runtime.score_wildcard_user(users: patterns_new_runtime.Us
     is_type patterns_new_runtime.UserScore[]
     pop_jump_if_false L0
     load_var users
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -2995,7 +2991,7 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     is_type int[][]
     pop_jump_if_false L0
     load_var v
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -3006,7 +3002,7 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     is_type int[]
     pop_jump_if_false L0
     load_var _6
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -3027,13 +3023,13 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     is_type int[][]
     pop_jump_if_false L1
     load_var _19
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var _19
     load_var _19
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -3041,7 +3037,7 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     is_type int[]
     pop_jump_if_false L1
     load_var _25
-    call baml.Array.length
+    container_len
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
@@ -3061,7 +3057,7 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     load_field .0
     store_var_load_var _33
     load_var _33
-    call baml.Array.length
+    container_len
     load_const 1
     sub_int
     load_array_element
@@ -3192,7 +3188,7 @@ function patterns_new_runtime.test_for_class_binds_inner_zip() -> int {
   L0:
     load_var __for_idx
     load_var _12
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3244,7 +3240,7 @@ function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
   L0:
     load_var __for_idx
     load_var _12
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3322,7 +3318,7 @@ function patterns_new_runtime.test_for_deep_class_sums() -> int {
   L0:
     load_var __for_idx
     load_var _12
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3368,7 +3364,7 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
   L0:
     load_var __for_idx
     load_var _9
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3382,8 +3378,10 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     load_var __for_idx
     load_array_element
     load_field .scores
-    call baml.Array.length
+    container_len
+    store_var _16
     load_var total
+    load_var _16
     add_int
     store_var total
     load_var __for_idx
@@ -3410,7 +3408,7 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3479,7 +3477,7 @@ function patterns_new_runtime.test_for_let_chain_of_bindings() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3524,7 +3522,7 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3538,11 +3536,8 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     load_var __for_idx
     load_array_element
     store_var_load_var row
-    call baml.Array.length
+    container_len
     store_var _13
-    load_var row
-    call baml.Array.length
-    store_var _18
     load_var total
     load_var _13
     load_const 100
@@ -3553,7 +3548,8 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     load_const 10
     mul_int
     add_int
-    load_var _18
+    load_var row
+    container_len
     add_int
     add_int
     store_var total
@@ -3579,7 +3575,7 @@ function patterns_new_runtime.test_for_let_or_same_binding() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3632,7 +3628,7 @@ function patterns_new_runtime.test_for_let_or_six_bindings() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3732,7 +3728,7 @@ function patterns_new_runtime.test_for_nested_rest_irrefutable() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3776,7 +3772,7 @@ function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
   L0:
     load_var __for_idx
     load_var _6
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3846,7 +3842,7 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
   L0:
     load_var __for_idx
     load_var _6
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -3859,8 +3855,10 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     load_var _6
     load_var __for_idx
     load_array_element
-    call baml.Array.length
+    container_len
+    store_var _12
     load_var total
+    load_var _12
     add_int
     store_var total
     load_var __for_idx
@@ -3887,7 +3885,7 @@ function patterns_new_runtime.test_for_rest_wildcard_irrefutable() -> int {
   L0:
     load_var __for_idx
     load_var _6
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -4068,7 +4066,7 @@ function patterns_new_runtime.test_match_alphabet() -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var _1
-    call baml.Array.length
+    container_len
     load_const 26
     cmp_int_op ==
     pop_jump_if_false L0
@@ -4325,7 +4323,7 @@ function patterns_new_runtime.test_match_array_shadows_outer() -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var _3
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
@@ -4407,7 +4405,7 @@ function patterns_new_runtime.test_match_chain_trailing_binding() -> int {
     is_type int[][]
     pop_jump_if_false L0
     load_var _1
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -4418,7 +4416,7 @@ function patterns_new_runtime.test_match_chain_trailing_binding() -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var _8
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -4548,7 +4546,7 @@ function patterns_new_runtime.test_match_nested_array_projects_inner() -> int {
     is_type int[][]
     pop_jump_if_false L0
     load_var _1
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -4559,7 +4557,7 @@ function patterns_new_runtime.test_match_nested_array_projects_inner() -> int {
     is_type int[]
     pop_jump_if_false L0
     load_var _7
-    call baml.Array.length
+    container_len
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L0
@@ -4674,7 +4672,7 @@ function patterns_new_runtime.test_match_wildcard_chained_array() -> int {
     load_const 5
     load_const 6
     alloc_array 3
-    call baml.Array.length
+    container_len
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
@@ -153,7 +153,7 @@ function typed_inputs.sum(arr: int[]) -> int {
   L0:
     load_var __for_idx
     load_var arr
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
@@ -343,7 +343,7 @@ function watch.watch_break_unwatches_fn() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L3
     load_var _2
@@ -487,7 +487,7 @@ function watch.watch_continue_unwatches_fn() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -639,7 +639,7 @@ function watch.watch_for_throw_fails() -> int {
   L0:
     load_var __for_idx
     load_var _1
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -3187,7 +3187,8 @@ fn baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner_state
 
     bb2: {
         _25 = copy _1.2;
-        _24 = call const fn baml.Array.length(copy _25) -> [bb3];
+        _24 = len(_25);
+        goto -> bb3;
     }
 
     bb3: {
@@ -3199,7 +3200,8 @@ fn baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner_state
         _27 = copy _1.0;
         _28 = copy _1.4;
         _30 = copy _1.2;
-        _29 = call const fn baml.Array.length(copy _30) -> [bb5];
+        _29 = len(_30);
+        goto -> bb5;
     }
 
     bb5: {
@@ -3527,7 +3529,8 @@ fn baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: baml.llm
 
     bb2: {
         _47 = copy _1.2;
-        _46 = call const fn baml.Array.length(copy _47) -> [bb3];
+        _46 = len(_47);
+        goto -> bb3;
     }
 
     bb3: {
@@ -3538,7 +3541,8 @@ fn baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: baml.llm
     bb4: {
         _49 = copy _1.4;
         _51 = copy _1.2;
-        _50 = call const fn baml.Array.length(copy _51) -> [bb5];
+        _50 = len(_51);
+        goto -> bb5;
     }
 
     bb5: {
@@ -3767,7 +3771,8 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
 
     bb2: {
         _35 = copy _1.2;
-        _34 = call const fn baml.Array.length(copy _35) -> [bb3];
+        _34 = len(_35);
+        goto -> bb3;
     }
 
     bb3: {
@@ -3778,7 +3783,8 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
     bb4: {
         _37 = copy _1.4;
         _39 = copy _1.2;
-        _38 = call const fn baml.Array.length(copy _39) -> [bb5];
+        _38 = len(_39);
+        goto -> bb5;
     }
 
     bb5: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -2273,7 +2273,7 @@ function baml.llm.Client.build_attempt_with_state(self: null, planner_state: bam
   L1:
     load_var self
     load_field .sub_clients
-    call baml.Array.length
+    container_len
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L2
@@ -2286,14 +2286,12 @@ function baml.llm.Client.build_attempt_with_state(self: null, planner_state: bam
     load_var self
     load_field .counter
     store_var _28
-    load_var self
-    load_field .sub_clients
-    call baml.Array.length
-    store_var _29
     load_var planner_state
     load_var _27
     load_var _28
-    load_var _29
+    load_var self
+    load_field .sub_clients
+    container_len
     call baml.llm.PlannerState.rr_pick_index
     store_var idx
     load_var self
@@ -2320,7 +2318,7 @@ function baml.llm.Client.build_attempt_with_state(self: null, planner_state: bam
   L5:
     load_var __for_idx
     load_var _9
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L6
     jump L7
@@ -2342,7 +2340,7 @@ function baml.llm.Client.build_attempt_with_state(self: null, planner_state: bam
   L8:
     load_var __for_idx_1
     load_var _15
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L9
     jump L10
@@ -2475,7 +2473,7 @@ function baml.llm.Client.build_plan_with_state(self: null, planner_state: baml.l
   L9:
     load_var __for_idx
     load_var _26
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L10
     jump L11
@@ -2525,17 +2523,13 @@ function baml.llm.Client.execute_once_oneshot(self: null, context: baml.llm.Exec
   L1:
     load_var self
     load_field .sub_clients
-    call baml.Array.length
+    container_len
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L2
     jump L3
 
   L2:
-    load_var self
-    load_field .sub_clients
-    call baml.Array.length
-    pop 1
     load_var self
     copy 0
     load_field .counter
@@ -2562,7 +2556,7 @@ function baml.llm.Client.execute_once_oneshot(self: null, context: baml.llm.Exec
   L5:
     load_var __for_idx
     load_var _35
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L6
     jump L7
@@ -2698,17 +2692,13 @@ function baml.llm.Client.execute_once_stream(self: null, context: baml.llm.Execu
   L1:
     load_var self
     load_field .sub_clients
-    call baml.Array.length
+    container_len
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L2
     jump L3
 
   L2:
-    load_var self
-    load_field .sub_clients
-    call baml.Array.length
-    pop 1
     load_var self
     copy 0
     load_field .counter
@@ -2735,7 +2725,7 @@ function baml.llm.Client.execute_once_stream(self: null, context: baml.llm.Execu
   L5:
     load_var __for_idx
     load_var _22
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L6
     jump L7
@@ -3328,7 +3318,7 @@ function baml.llm.PlannerState.rr_local_offset(self: null, client_name: string) 
   L0:
     load_var __for_idx
     load_var _4
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
@@ -127,7 +127,7 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -233,7 +233,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
   L3:
     load_var __for_idx
     load_var _13
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L4
     jump L8
@@ -348,7 +348,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
   L3:
     load_var __for_idx
     load_var _13
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L4
     jump L8
@@ -487,7 +487,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L7
@@ -503,7 +503,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
   L2:
     load_var __for_idx_1
     load_var _28
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L3
     jump L4
@@ -640,7 +640,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L7
@@ -656,7 +656,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
   L2:
     load_var __for_idx_1
     load_var _13
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L3
     jump L4
@@ -740,7 +740,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L8
@@ -756,7 +756,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
   L2:
     load_var __for_idx_1
     load_var _12
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L3
     jump L4

--- a/baml_language/crates/baml_tests/snapshots/compiles/byte_string_literals/baml_tests__compiles__byte_string_literals__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/byte_string_literals/baml_tests__compiles__byte_string_literals__04_5_mir.snap
@@ -9,7 +9,8 @@ fn user.ByteStringBasic() -> int {
 
     bb0: {
         _1 = b"<5 bytes>";
-        _0 = call const fn baml.Uint8Array.length(copy _1) -> [bb1];
+        _0 = len(_1);
+        goto -> bb1;
     }
 
     bb1: {
@@ -44,7 +45,8 @@ fn user.ByteStringEmpty() -> int {
 
     bb0: {
         _1 = b"<0 bytes>";
-        _0 = call const fn baml.Uint8Array.length(copy _1) -> [bb1];
+        _0 = len(_1);
+        goto -> bb1;
     }
 
     bb1: {
@@ -77,7 +79,8 @@ fn user.ByteStringHexEscapes() -> int {
 
     bb0: {
         _1 = b"<5 bytes>";
-        _0 = call const fn baml.Uint8Array.length(copy _1) -> [bb1];
+        _0 = len(_1);
+        goto -> bb1;
     }
 
     bb1: {
@@ -94,7 +97,8 @@ fn user.ByteStringInCondition() -> int {
 
     bb0: {
         _3 = b"<3 bytes>";
-        _2 = call const fn baml.Uint8Array.length(copy _3) -> [bb1];
+        _2 = len(_3);
+        goto -> bb1;
     }
 
     bb1: {
@@ -171,7 +175,8 @@ fn user.ByteStringPassAndReturn(data: uint8array) -> int {
     let _1: uint8array // data // param
 
     bb0: {
-        _0 = call const fn baml.Uint8Array.length(copy _1) -> [bb1];
+        _0 = len(_1);
+        goto -> bb1;
     }
 
     bb1: {
@@ -186,7 +191,8 @@ fn user.ByteStringStandardEscapes() -> int {
 
     bb0: {
         _1 = b"<6 bytes>";
-        _0 = call const fn baml.Uint8Array.length(copy _1) -> [bb1];
+        _0 = len(_1);
+        goto -> bb1;
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/byte_string_literals/baml_tests__compiles__byte_string_literals__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/byte_string_literals/baml_tests__compiles__byte_string_literals__06_codegen.snap
@@ -4,7 +4,7 @@ source: crates/baml_tests/src/generated_tests.rs
 function user.ByteStringBasic() -> int {
     load_const b"\x68\x65\x6c\x6c\x6f"
     call baml.deep_copy
-    call baml.Uint8Array.length
+    container_len
     return
 }
 
@@ -19,7 +19,7 @@ function user.ByteStringDirectIndexRead() -> int {
 function user.ByteStringEmpty() -> int {
     load_const b""
     call baml.deep_copy
-    call baml.Uint8Array.length
+    container_len
     return
 }
 
@@ -35,14 +35,14 @@ function user.ByteStringEquality() -> bool {
 function user.ByteStringHexEscapes() -> int {
     load_const b"\x48\x65\x6c\x6c\x6f"
     call baml.deep_copy
-    call baml.Uint8Array.length
+    container_len
     return
 }
 
 function user.ByteStringInCondition() -> int {
     load_const b"\x61\x62\x63"
     call baml.deep_copy
-    call baml.Uint8Array.length
+    container_len
     load_const 0
     cmp_int_op >
     pop_jump_if_false L0
@@ -89,13 +89,13 @@ function user.ByteStringMutate() -> int? {
 
 function user.ByteStringPassAndReturn(data: uint8array) -> int {
     load_var data
-    call baml.Uint8Array.length
+    container_len
     return
 }
 
 function user.ByteStringStandardEscapes() -> int {
     load_const b"\x0a\x09\x0d\x00\x5c\x22"
     call baml.deep_copy
-    call baml.Uint8Array.length
+    container_len
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
@@ -18,7 +18,7 @@ function user.sum_array(arr: int[]) -> int {
   L0:
     load_var __for_idx
     load_var arr
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L5
@@ -32,7 +32,7 @@ function user.sum_array(arr: int[]) -> int {
   L2:
     load_var __for_idx_1
     load_var _12
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L3
     jump L4

--- a/baml_language/crates/baml_tests/snapshots/compiles/function_call/baml_tests__compiles__function_call__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/function_call/baml_tests__compiles__function_call__04_5_mir.snap
@@ -11,7 +11,8 @@ fn user.array_length() -> int {
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = copy _1;
-        _0 = call const fn baml.Array.length(copy _2) -> [bb1];
+        _0 = len(_2);
+        goto -> bb1;
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/function_call/baml_tests__compiles__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/function_call/baml_tests__compiles__function_call__06_codegen.snap
@@ -57,7 +57,7 @@ function user.array_length() -> int {
     load_const 2
     load_const 3
     alloc_array 3
-    call baml.Array.length
+    container_len
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
@@ -325,7 +325,7 @@ function user.test_shadowing() -> string {
   L0:
     load_var __for_idx
     load_var _5
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
@@ -60,7 +60,7 @@ function user.for_loop_restores_outer() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
@@ -276,7 +276,7 @@ function user.iterator_style_for_loop() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -379,7 +379,7 @@ function user.nested_for_loop() -> int {
   L0:
     load_var __for_idx
     load_var _2
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -404,7 +404,7 @@ function user.nested_for_loop() -> int {
   L3:
     load_var __for_idx_1
     load_var _8
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L4
     jump L5

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__04_5_mir.snap
@@ -673,7 +673,8 @@ fn user.nested_paren_union_array_one(items: (int | string)[]) -> int {
     let _1: (int | string)[] // items // param
 
     bb0: {
-        _0 = call const fn baml.Array.length(copy _1) -> [bb1];
+        _0 = len(_1);
+        goto -> bb1;
     }
 
     bb1: {
@@ -702,7 +703,8 @@ fn user.nested_paren_union_array_three(v: (int | string)[][]) -> int {
     let _1: (int | string)[][] // v // param
 
     bb0: {
-        _0 = call const fn baml.Array.length(copy _1) -> [bb1];
+        _0 = len(_1);
+        goto -> bb1;
     }
 
     bb1: {
@@ -716,7 +718,8 @@ fn user.nested_paren_union_array_two(items: (int | string)[]) -> int {
     let _1: (int | string)[] // items // param
 
     bb0: {
-        _0 = call const fn baml.Array.length(copy _1) -> [bb1];
+        _0 = len(_1);
+        goto -> bb1;
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
@@ -298,7 +298,7 @@ function user.for_let_ascription(items: int[]) -> int {
   L0:
     load_var __for_idx
     load_var items
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -332,7 +332,7 @@ function user.for_let_fn_narrow(items: ((int) -> int throws never)[]) -> int {
   L0:
     load_var __for_idx
     load_var items
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -366,7 +366,7 @@ function user.for_let_with_narrow(items: int[]) -> int {
   L0:
     load_var __for_idx
     load_var items
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -406,7 +406,7 @@ function user.match_nested_paren_union(v: (int | string)[]) -> int {
 
 function user.nested_paren_union_array_one(items: (int | string)[]) -> int {
     load_var items
-    call baml.Array.length
+    container_len
     return
 }
 
@@ -417,13 +417,13 @@ function user.nested_paren_union_array_optional(v: (int | string)[]?) -> int {
 
 function user.nested_paren_union_array_three(v: (int | string)[][]) -> int {
     load_var v
-    call baml.Array.length
+    container_len
     return
 }
 
 function user.nested_paren_union_array_two(items: (int | string)[]) -> int {
     load_var items
-    call baml.Array.length
+    container_len
     return
 }
 

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -189,7 +189,7 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
        4    store_var 4            (__for_idx)
        5    load_var 4             (__for_idx)
        6    load_var 3             (_3)
-       7    call 21 ntypeargs=0    (baml.Array.length)
+       7    container_len          
        8    cmp_int_op <           
        9    pop_jump_if_false +2   (to 11)
        10   jump +5                (to 15)
@@ -287,7 +287,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
        26   store_var 9             (__for_idx)
        27   load_var 9              (__for_idx)
        28   load_var 8              (_13)
-       29   call 21 ntypeargs=0     (baml.Array.length)
+       29   container_len           
        30   cmp_int_op <            
        31   pop_jump_if_false +2    (to 33)
        32   jump +32                (to 64)
@@ -387,7 +387,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
        26   store_var 9             (__for_idx)
        27   load_var 9              (__for_idx)
        28   load_var 8              (_13)
-       29   call 21 ntypeargs=0     (baml.Array.length)
+       29   container_len           
        30   cmp_int_op <            
        31   pop_jump_if_false +2    (to 33)
        32   jump +32                (to 64)
@@ -515,7 +515,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         5    store_var 4            (__for_idx)
         6    load_var 4             (__for_idx)
         7    load_var 3             (_3)
-        8    call 21 ntypeargs=0    (baml.Array.length)
+        8    container_len          
         9    cmp_int_op <           
         10   pop_jump_if_false +2   (to 12)
         11   jump +42               (to 53)
@@ -529,7 +529,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         17   store_var 10           (__for_idx_1)
         18   load_var 10            (__for_idx_1)
         19   load_var 9             (_28)
-        20   call 21 ntypeargs=0    (baml.Array.length)
+        20   container_len          
         21   cmp_int_op <           
         22   pop_jump_if_false +2   (to 24)
         23   jump +5                (to 28)
@@ -668,7 +668,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         5    store_var 4            (__for_idx)
         6    load_var 4             (__for_idx)
         7    load_var 3             (_3)
-        8    call 21 ntypeargs=0    (baml.Array.length)
+        8    container_len          
         9    cmp_int_op <           
         10   pop_jump_if_false +2   (to 12)
         11   jump +42               (to 53)
@@ -682,7 +682,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         17   store_var 7            (__for_idx_1)
         18   load_var 7             (__for_idx_1)
         19   load_var 6             (_13)
-        20   call 21 ntypeargs=0    (baml.Array.length)
+        20   container_len          
         21   cmp_int_op <           
         22   pop_jump_if_false +2   (to 24)
         23   jump +5                (to 28)
@@ -760,7 +760,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         7    store_var 4            (__for_idx)
         8    load_var 4             (__for_idx)
         9    load_var 3             (_3)
-        10   call 21 ntypeargs=0    (baml.Array.length)
+        10   container_len          
         11   cmp_int_op <           
         12   pop_jump_if_false +2   (to 14)
         13   jump +58               (to 71)
@@ -773,7 +773,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         19   store_var 6            (__for_idx_1)
         20   load_var 6             (__for_idx_1)
         21   load_var 5             (_12)
-        22   call 21 ntypeargs=0    (baml.Array.length)
+        22   container_len          
         23   cmp_int_op <           
         24   pop_jump_if_false +2   (to 26)
         25   jump +3                (to 28)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -201,7 +201,7 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
        4    store_var 5            (__for_idx)
        5    load_var 5             (__for_idx)
        6    load_var 4             (_3)
-       7    call 21 ntypeargs=0    (baml.Array.length)
+       7    container_len          
        8    cmp_int_op <           
        9    pop_jump_if_false +2   (to 11)
        10   jump +5                (to 15)
@@ -305,7 +305,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
        26   store_var 10            (__for_idx)
        27   load_var 10             (__for_idx)
        28   load_var 9              (_13)
-       29   call 21 ntypeargs=0     (baml.Array.length)
+       29   container_len           
        30   cmp_int_op <            
        31   pop_jump_if_false +2    (to 33)
        32   jump +34                (to 66)
@@ -407,7 +407,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
        26   store_var 10            (__for_idx)
        27   load_var 10             (__for_idx)
        28   load_var 9              (_13)
-       29   call 21 ntypeargs=0     (baml.Array.length)
+       29   container_len           
        30   cmp_int_op <            
        31   pop_jump_if_false +2    (to 33)
        32   jump +34                (to 66)
@@ -541,7 +541,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         5    store_var 4            (__for_idx)
         6    load_var 4             (__for_idx)
         7    load_var 3             (_3)
-        8    call 21 ntypeargs=0    (baml.Array.length)
+        8    container_len          
         9    cmp_int_op <           
         10   pop_jump_if_false +2   (to 12)
         11   jump +42               (to 53)
@@ -555,7 +555,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
         17   store_var 11           (__for_idx_1)
         18   load_var 11            (__for_idx_1)
         19   load_var 10            (_28)
-        20   call 21 ntypeargs=0    (baml.Array.length)
+        20   container_len          
         21   cmp_int_op <           
         22   pop_jump_if_false +2   (to 24)
         23   jump +5                (to 28)
@@ -700,7 +700,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         5    store_var 4            (__for_idx)
         6    load_var 4             (__for_idx)
         7    load_var 3             (_3)
-        8    call 21 ntypeargs=0    (baml.Array.length)
+        8    container_len          
         9    cmp_int_op <           
         10   pop_jump_if_false +2   (to 12)
         11   jump +42               (to 53)
@@ -714,7 +714,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
         17   store_var 7            (__for_idx_1)
         18   load_var 7             (__for_idx_1)
         19   load_var 6             (_13)
-        20   call 21 ntypeargs=0    (baml.Array.length)
+        20   container_len          
         21   cmp_int_op <           
         22   pop_jump_if_false +2   (to 24)
         23   jump +5                (to 28)
@@ -792,7 +792,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         7    store_var 5            (__for_idx)
         8    load_var 5             (__for_idx)
         9    load_var 4             (_3)
-        10   call 21 ntypeargs=0    (baml.Array.length)
+        10   container_len          
         11   cmp_int_op <           
         12   pop_jump_if_false +2   (to 14)
         13   jump +60               (to 73)
@@ -805,7 +805,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
         19   store_var 8            (__for_idx_1)
         20   load_var 8             (__for_idx_1)
         21   load_var 7             (_12)
-        22   call 21 ntypeargs=0    (baml.Array.length)
+        22   container_len          
         23   cmp_int_op <           
         24   pop_jump_if_false +2   (to 26)
         25   jump +5                (to 30)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -203,7 +203,7 @@ function testing.TestCollector.find_testset(self: null, name: string) -> testing
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L2
@@ -309,7 +309,7 @@ function testing.TestCollector.register_test(self: null, name: string, body: () 
   L3:
     load_var __for_idx
     load_var _13
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L4
     jump L8
@@ -424,7 +424,7 @@ function testing.TestCollector.register_test_set(self: null, name: string, colle
   L3:
     load_var __for_idx
     load_var _13
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L4
     jump L8
@@ -563,7 +563,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L7
@@ -579,7 +579,7 @@ function testing.TestRegistry.expand_set(self: null, name: string) -> (testing.S
   L2:
     load_var __for_idx_1
     load_var _28
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L3
     jump L4
@@ -716,7 +716,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L7
@@ -732,7 +732,7 @@ function testing.TestRegistry.run_test(self: null, name: string) -> testing.Test
   L2:
     load_var __for_idx_1
     load_var _13
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L3
     jump L4
@@ -816,7 +816,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
   L0:
     load_var __for_idx
     load_var _3
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L1
     jump L8
@@ -832,7 +832,7 @@ function testing.TestRegistry.serialize(self: null) -> (testing.SerializedTest |
   L2:
     load_var __for_idx_1
     load_var _12
-    call baml.Array.length
+    container_len
     cmp_int_op <
     pop_jump_if_false L3
     jump L4

--- a/baml_language/crates/bex_vm/Cargo.toml
+++ b/baml_language/crates/bex_vm/Cargo.toml
@@ -32,6 +32,7 @@ indexmap = { workspace = true }
 log = { workspace = true }
 num-bigint = { workspace = true }
 serde_json = { workspace = true }
+smallvec = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 web-time = { workspace = true }

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -249,6 +249,7 @@ pub(crate) fn display_instruction(
         | Instruction::CaptureRef(_)
         | Instruction::Return
         | Instruction::SendEvent
+        | Instruction::ContainerLen
         | Instruction::Spawn
         | Instruction::LoadType(_) => String::new(),
     };
@@ -427,6 +428,7 @@ fn instruction_style(instruction: &Instruction) -> Style {
         }
         Instruction::StoreDeref(_) | Instruction::StoreCapture(_) => Style::new().green(),
         Instruction::SendEvent => Style::new().green().bright(),
+        Instruction::ContainerLen => Style::new().cyan(),
     }
 }
 
@@ -956,6 +958,7 @@ fn display_instruction_textual(
         Instruction::StoreCapture(idx) => format!("store_capture {idx}"),
         Instruction::CaptureRef(idx) => format!("capture_ref {idx}"),
         Instruction::SendEvent => "send_event".to_string(),
+        Instruction::ContainerLen => "container_len".to_string(),
     }
 }
 
@@ -1225,6 +1228,7 @@ pub fn display_compact_bytecode(
             | OpCode::Unreachable
             | OpCode::MakeCell
             | OpCode::SendEvent
+            | OpCode::ContainerLen
             | OpCode::Spawn
             | OpCode::Add
             | OpCode::Sub

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -16,6 +16,8 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use smallvec::SmallVec;
+
 /// Branch hint: tells the compiler this condition is almost never true.
 /// Used on the cold side of `if unlikely(cond) { ... }` in the dispatch
 /// loop's hot path — measurably faster than letting the compiler guess
@@ -2542,7 +2544,8 @@ impl BexVm {
 
                 // Native functions should manage their own gc roots (or never yield).
                 // They have no data on the stack.
-                let args: Vec<Value> = self.stack.drain(locals_offset..).collect();
+                // SmallVec avoids heap allocation for calls with ≤4 args (the common case).
+                let args: SmallVec<[Value; 4]> = self.stack.drain(locals_offset..).collect();
 
                 // Run Rust native function, converting NativeCallResult → VmError.
                 match func(self, &args) {
@@ -4853,6 +4856,32 @@ impl BexVm {
                 }
 
                 // ── Array / Map element ops ───────────────────────────────────
+                OpCode::ContainerLen => {
+                    let container = self.stack.ensure_pop();
+                    let Some(ptr) = container.as_object_ptr() else {
+                        return Err(VmInternalError::TypeError {
+                            expected: ObjectType::Array.into(),
+                            got: self.type_of(&container),
+                        }
+                        .into());
+                    };
+                    #[allow(clippy::cast_possible_wrap)]
+                    let len = match self.get_object(ptr) {
+                        Object::Array(arr) => arr.len() as i64,
+                        Object::Uint8Array(bytes) => bytes.len() as i64,
+                        Object::Map(map) => map.len() as i64,
+                        Object::String(s) => s.len() as i64,
+                        other => {
+                            return Err(VmInternalError::TypeError {
+                                expected: ObjectType::Array.into(),
+                                got: ObjectType::of(other).into(),
+                            }
+                            .into());
+                        }
+                    };
+                    self.stack.push(Value::int(len));
+                }
+
                 OpCode::LoadArrayElement => {
                     let index_value = self.stack.ensure_pop();
                     let array_value = self.stack.ensure_pop();

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -403,6 +403,12 @@ pub enum Instruction {
     /// the result is the element at that index.
     LoadArrayElement,
 
+    /// Pops a container (Array, `Uint8Array`, Map, or String) from the stack
+    /// and pushes its length as an int.
+    ///
+    /// Format: `CONTAINER_LEN` — stack: [container] → [int]
+    ContainerLen,
+
     /// Loads a value from a map at a given key.
     ///
     /// Format: `LOAD_MAP_ELEMENT` where the stack contains [map, key] and
@@ -756,6 +762,7 @@ pub enum OpCode {
     Unreachable,
     MakeCell,
     SendEvent,
+    ContainerLen,
 
     // ── Expanded arithmetic (no operands, 1 byte) ──────────────
     Add,
@@ -896,6 +903,7 @@ impl OpCode {
             | Self::Unreachable
             | Self::MakeCell
             | Self::SendEvent
+            | Self::ContainerLen
             | Self::Spawn
             | Self::Add
             | Self::Sub
@@ -1027,6 +1035,7 @@ impl TryFrom<u8> for OpCode {
             x if x == Self::Unreachable as u8 => Ok(Self::Unreachable),
             x if x == Self::MakeCell as u8 => Ok(Self::MakeCell),
             x if x == Self::SendEvent as u8 => Ok(Self::SendEvent),
+            x if x == Self::ContainerLen as u8 => Ok(Self::ContainerLen),
             x if x == Self::Add as u8 => Ok(Self::Add),
             x if x == Self::Sub as u8 => Ok(Self::Sub),
             x if x == Self::Mul as u8 => Ok(Self::Mul),
@@ -1148,6 +1157,7 @@ impl std::fmt::Display for OpCode {
             Self::Unreachable => "UNREACHABLE",
             Self::MakeCell => "MAKE_CELL",
             Self::SendEvent => "SEND_EVENT",
+            Self::ContainerLen => "CONTAINER_LEN",
             Self::Add => "ADD",
             Self::Sub => "SUB",
             Self::Mul => "MUL",
@@ -1546,6 +1556,7 @@ impl std::fmt::Display for Instruction {
             Instruction::StoreCapture(idx) => write!(f, "STORE_CAPTURE {idx}"),
             Instruction::CaptureRef(idx) => write!(f, "CAPTURE_REF {idx}"),
             Instruction::SendEvent => f.write_str("SEND_EVENT"),
+            Instruction::ContainerLen => f.write_str("CONTAINER_LEN"),
         }
     }
 }
@@ -1908,6 +1919,7 @@ impl Bytecode {
                 | Instruction::Unreachable
                 | Instruction::MakeCell
                 | Instruction::SendEvent
+                | Instruction::ContainerLen
                 | Instruction::Spawn => {}
 
                 // ── Expanded sub-enum ops: no operands ──────────────
@@ -2200,6 +2212,7 @@ impl Bytecode {
             Instruction::Unreachable => OpCode::Unreachable,
             Instruction::MakeCell => OpCode::MakeCell,
             Instruction::SendEvent => OpCode::SendEvent,
+            Instruction::ContainerLen => OpCode::ContainerLen,
 
             // Expanded sub-enum variants
             Instruction::BinOp(op) => match op {

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -406,7 +406,7 @@ pub enum Instruction {
     /// Pops a container (Array, `Uint8Array`, Map, or String) from the stack
     /// and pushes its length as an int.
     ///
-    /// Format: `CONTAINER_LEN` — stack: [container] → [int]
+    /// Format: `CONTAINER_LEN` — stack: \[container\] → \[int\]
     ContainerLen,
 
     /// Loads a value from a map at a given key.

--- a/baml_language/tools/speedtest/src/speedtest/runner.py
+++ b/baml_language/tools/speedtest/src/speedtest/runner.py
@@ -321,8 +321,7 @@ def cmd_run(args):
     tag = getattr(args, 'tag', None)
     bl_dir = save_baseline(rdir, run_path, data, tag=tag)
 
-    cli_info = data.get("cli") or {}
-    branch = (cli_info.get("git") or {}).get("branch", "unknown")
+    branch = bl_dir.name
 
     print(f"\nResults saved to {branch}/latest", file=sys.stderr)
     if tag:

--- a/baml_language/tools/speedtest/src/speedtest/runner.py
+++ b/baml_language/tools/speedtest/src/speedtest/runner.py
@@ -113,7 +113,7 @@ def _repo_root():
 def cmd_run(args):
     """Execute the 'run' subcommand — the main benchmark loop."""
     repo_root = _repo_root()
-    baml_cli = args.baml or str(repo_root / "target" / "release" / "baml-cli")
+    baml_cli = os.path.abspath(args.baml or str(repo_root / "target" / "release" / "baml-cli"))
 
     # ── Build ────────────────────────────────────────────────────────────
     if args.build:
@@ -313,7 +313,7 @@ def cmd_run(args):
         runners_used.append("bun")
 
     rdir = results_dir(args)
-    data = build_run_data(args, results, runners_used)
+    data = build_run_data(args, results, runners_used, baml_cli=baml_cli)
 
     run_path = save_run(rdir, data, profile_files)
 
@@ -321,8 +321,8 @@ def cmd_run(args):
     tag = getattr(args, 'tag', None)
     bl_dir = save_baseline(rdir, run_path, data, tag=tag)
 
-    cli_info = data.get("cli", {})
-    branch = cli_info.get("git", {}).get("branch", "unknown")
+    cli_info = data.get("cli") or {}
+    branch = (cli_info.get("git") or {}).get("branch", "unknown")
 
     print(f"\nResults saved to {branch}/latest", file=sys.stderr)
     if tag:

--- a/baml_language/tools/speedtest/src/speedtest/storage.py
+++ b/baml_language/tools/speedtest/src/speedtest/storage.py
@@ -82,7 +82,7 @@ def _cli_info(cli_path):
 
 def _branch_slug(cli_info):
     """Get the branch name for baseline storage. Returns 'NO_BRANCH' if not in a repo."""
-    git = cli_info.get("git", {})
+    git = cli_info.get("git") or {}
     if not git or not git.get("in_repo"):
         return "NO_BRANCH"
     branch = git.get("branch", "unknown")
@@ -97,9 +97,9 @@ def generate_run_id():
     return now.strftime("%Y%m%d-%H%M%S") + f"-{commit}"
 
 
-def build_run_data(args, results, runners_used):
+def build_run_data(args, results, runners_used, *, baml_cli=None):
     """Build the complete meta.json — metadata + workload timings."""
-    baml_cli = args.baml or ""
+    baml_cli = baml_cli or args.baml or ""
 
     workloads = []
     for row in results:


### PR DESCRIPTION
## Summary

- Adds a dedicated `ContainerLen` opcode that replaces native function calls to `.length()` on Array, Map, String, and Uint8Array
- The MIR lowering now intercepts these calls and emits `Rvalue::Len` (which already existed in the IR but was never generated), and the bytecode emitter maps it to the new single-byte opcode instead of a `Call` instruction
- Also switches the native function call arg buffer from `Vec<Value>` to `SmallVec<[Value; 4]>`, avoiding heap allocation for native calls with ≤4 args (the common case)
- Fixes a crash in the speedtest tool when `--baml` is not passed (CLI path wasn't resolved to absolute)

### Why this matters

Profiling showed that `.length()` on arrays goes through the full native call path: resolve callable → drain args into heap-allocated Vec → call Rust fn (which just reads `vec.len()`) → free Vec → push result. For bubble sort's inner loop, that's ~25M native function calls for what should be a single field read.

### Speedtest results (`speedtest compare canary vbv_container-len-opcode`)

| Workload | Change |
|----------|--------|
| bubble sort 5k | **-20%** |
| substring slice 100k | **-21%** |
| array build+sum 100k | **-20%** |
| grid alloc 1000x100 | **-20%** |
| string split 100k | **-11%** |
| split short literal 100k | **-10%** |
| contains medium literal 100k | **-10%** |
| trim padded literal 100k | **-10%** |

No regressions on any benchmark.

## Test plan

- [x] `cargo clippy` passes
- [x] `baml-cli run --file bubble_sort.baml main` produces correct output (5001)
- [x] `speedtest run --build` passes all 30 workloads
- [x] `speedtest compare` shows improvements on `.length()`-heavy workloads, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Container/string length is now a dedicated VM operation and the VM avoids heap allocation for common native-call cases, improving runtime efficiency.

* **Debug / Tooling**
  * Disassembly and debug output recognize and display the new length operation.
  * Speedtest runner resolves CLI paths to absolute locations and reports branch from saved baseline for more reliable results.

* **Chores**
  * Added workspace dependency to support the changes; speedtest persistence API now accepts an explicit CLI override.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->