### PR TITLE
Add e2e tests for CLI exit codes on compilation errors

### DIFF
--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -207,7 +207,7 @@ fn test_compilation_error_returns_nonzero_exit_code() {
     );
 }
 
-/// `baml test` with no tests should return exit code 5 (NoTestsRun), not 0.
+/// `baml test` with no tests should return exit code 5 (`NoTestsRun`), not 0.
 #[test]
 fn test_no_tests_returns_specific_exit_code() {
     let built = common::ensure_built();

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -1,0 +1,232 @@
+// End-to-end tests for CLI exit codes on compilation errors.
+//
+// These tests verify that `baml-cli` commands return non-zero exit codes
+// when compilation errors occur. This is critical for CI/CD pipelines and
+// scripting use cases where the exit code is used to determine success or
+// failure.
+
+mod common;
+
+use std::{
+    path::Path,
+    process::{Command, Output},
+};
+
+use common::BuiltPaths;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Run a baml-cli command and return the output (stdout, stderr, exit code).
+fn run_baml_cli(built: &BuiltPaths, dir: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(&built.baml_cli);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.current_dir(dir);
+    cmd.output().expect("spawn baml-cli")
+}
+
+/// Create a minimal project structure with the given source code.
+fn create_project(dir: &Path, source: &str) {
+    std::fs::write(
+        dir.join("baml.toml"),
+        "[package]\nname = \"test-project\"\n",
+    )
+    .unwrap();
+    let src = dir.join("baml_src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("main.baml"), source).unwrap();
+}
+
+/// Create a project with a generator block for testing the generate command.
+fn create_project_with_generator(dir: &Path, source: &str) {
+    let generator_block = r#"
+generator py {
+    output_type "python/pydantic"
+    output_dir ".."
+    naming_convention "preserve-case"
+}
+"#;
+    let full_source = format!("{source}\n{generator_block}");
+    create_project(dir, &full_source);
+}
+
+// ============================================================================
+// Tests for `baml generate` exit codes
+// ============================================================================
+
+/// Compilation errors must result in a non-zero exit code for `baml generate`.
+/// This is critical for CI/CD pipelines that use exit codes to gate deployments.
+#[test]
+fn generate_compilation_error_returns_nonzero_exit_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Create a project with an unresolved type error
+    create_project_with_generator(
+        tmp.path(),
+        "function test_func() -> UndefinedType {\n  \"never called\"\n}\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for compilation error, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // Verify the exit code is specifically 4 (ExitCode::Other)
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "Expected exit code 4 for compilation error, got: {:?}",
+        output.status.code(),
+    );
+
+    // Verify the error message mentions the unresolved type
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("UndefinedType") || stderr.contains("unresolved"),
+        "Expected error message to mention the unresolved type, got: {stderr}",
+    );
+}
+
+/// Multiple compilation errors should still result in a non-zero exit code.
+#[test]
+fn generate_multiple_compilation_errors_returns_nonzero_exit_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Create a project with multiple errors
+    create_project_with_generator(
+        tmp.path(),
+        r#"
+function bad_func1() -> UnknownType1 {
+  "never"
+}
+function bad_func2() -> UnknownType2 {
+  "called"
+}
+"#,
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for multiple compilation errors",
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "Expected exit code 4 for compilation errors",
+    );
+}
+
+/// A valid project should return exit code 0 from `baml generate`.
+#[test]
+fn generate_valid_project_returns_zero_exit_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Create a valid project
+    create_project_with_generator(
+        tmp.path(),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for valid project, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+// ============================================================================
+// Tests for `baml run` exit codes
+// ============================================================================
+
+/// Compilation errors must result in a non-zero exit code for `baml run --list`.
+#[test]
+fn run_list_compilation_error_returns_nonzero_exit_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        "function broken() -> MissingType {\n  \"never\"\n}\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["run", "--list", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for compilation error in `baml run --list`",
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "Expected exit code 4 for compilation error",
+    );
+}
+
+// ============================================================================
+// Tests for `baml test` exit codes
+// ============================================================================
+
+/// Compilation errors must result in a non-zero exit code for `baml test`.
+#[test]
+fn test_compilation_error_returns_nonzero_exit_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        "function broken() -> MissingType {\n  \"never\"\n}\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["test", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for compilation error in `baml test`",
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "Expected exit code 4 for compilation error",
+    );
+}
+
+/// `baml test` with no tests should return exit code 5 (NoTestsRun), not 0.
+#[test]
+fn test_no_tests_returns_specific_exit_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Valid project with no tests
+    create_project(
+        tmp.path(),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["test", "--from", "."]);
+
+    // NoTestsRun maps to exit code 5
+    assert_eq!(
+        output.status.code(),
+        Some(5),
+        "Expected exit code 5 for no tests found, got: {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
- [x] This PR adds tests to verify the CLI exit code behavior reported in the issue

## Changes
This PR adds end-to-end tests that verify `baml-cli` commands return non-zero exit codes when compilation errors occur.

**Investigation findings:**
- Verified that the current CLI implementation **correctly returns non-zero exit codes** (exit code 4) for compilation errors
- The `generate`, `run`, and `test` commands all properly return exit code 4 (ExitCode::Other) when compilation errors are detected
- Exit code 5 is returned when no tests are found

**New tests added:**
- `generate_compilation_error_returns_nonzero_exit_code` - Verifies generate command returns exit code 4 for unresolved type errors
- `generate_multiple_compilation_errors_returns_nonzero_exit_code` - Verifies multiple errors still result in exit code 4
- `generate_valid_project_returns_zero_exit_code` - Verifies successful generation returns exit code 0
- `run_list_compilation_error_returns_nonzero_exit_code` - Verifies run --list returns exit code 4 for compilation errors
- `test_compilation_error_returns_nonzero_exit_code` - Verifies test command returns exit code 4 for compilation errors
- `test_no_tests_returns_specific_exit_code` - Verifies test command returns exit code 5 when no tests are found

## Testing
- [x] Unit tests added/updated
- [x] All 6 new tests pass
- [x] All 158 existing baml_cli lib tests pass
- [x] Manual testing performed (verified exit codes via shell)

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
The CLI exit codes are correctly implemented. These tests serve as regression tests to ensure the behavior remains correct in future changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1780078649003669?thread_ts=1780078649.003669&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-86baf61f-a1d3-5b5a-96f5-e50d652dbd63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86baf61f-a1d3-5b5a-96f5-e50d652dbd63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite for exit code behavior, verifying correct handling during compilation failures and when no tests are found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->