### PR TITLE
feat(python): make natives/sysops callable

### DIFF
--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -1257,10 +1257,7 @@ impl BexEngine {
         }
 
         let (function_index, kind) = self.lookup_function(function_name)?;
-        if matches!(
-            kind,
-            bex_vm_types::FunctionKind::SysOp(_) | bex_vm_types::FunctionKind::NativeUnresolved
-        ) {
+        if matches!(kind, bex_vm_types::FunctionKind::NativeUnresolved) {
             return Err(EngineError::NotInvokableAsEntry {
                 name: function_name.to_string(),
                 kind: format!("{kind:?}"),

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -1257,11 +1257,10 @@ impl BexEngine {
         }
 
         let (function_index, kind) = self.lookup_function(function_name)?;
-        // Only bytecode functions can be invoked as engine entry points.
-        // Sysops + `$rust_function` natives reach their handlers through
-        // an enclosing bytecode frame's `Call` / `YieldToCall` — there's
-        // no frame for them to return into at the top level.
-        if !matches!(kind, bex_vm_types::FunctionKind::Bytecode) {
+        if matches!(
+            kind,
+            bex_vm_types::FunctionKind::SysOp(_) | bex_vm_types::FunctionKind::NativeUnresolved
+        ) {
             return Err(EngineError::NotInvokableAsEntry {
                 name: function_name.to_string(),
                 kind: format!("{kind:?}"),

--- a/baml_language/crates/bex_engine/tests/function_resolution.rs
+++ b/baml_language/crates/bex_engine/tests/function_resolution.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use baml_project::testing::compile_multi_file;
 use bex_engine::{BexEngine, CallId, EngineError, FunctionCallContextBuilder};
+use bex_heap::BexExternalValue;
 use sys_native::SysOpsExt;
 
 fn engine(files: &[(&str, &str)]) -> Arc<BexEngine> {
@@ -118,23 +119,20 @@ fn find_user_function_does_not_expose_stdlib() {
     assert_eq!(main_info.qualified_name, "user.main");
 }
 
-/// `BexEngine::call_function*` requires a [`FunctionKind::Bytecode`]
-/// callee — `$rust_function` natives, sysops, and unresolved natives
-/// have no enclosing bytecode frame to `YieldToCall` back into, so
-/// dispatch can't honor a yield. Without the gate, a future host
-/// calling e.g. `baml.json.to_string<T>` directly would crash deep in
-/// the VM with a misleading internal error. Catching it at the engine
-/// boundary surfaces a clean, documented `NotInvokableAsEntry`.
+/// `BexEngine::call_function*` rejects sysops as entry points. Native
+/// `$rust_function` entries are wrapped by the VM in a synthetic bytecode
+/// caller, but sysops still need to be reached from an existing bytecode
+/// frame that can resume after the engine executes the operation.
 #[tokio::test]
-async fn call_function_rejects_non_bytecode_entry() {
+async fn call_function_rejects_sysop_entry() {
     let eng = engine(&[("main.baml", "function main() -> int { 1 }")]);
 
-    // `baml.json.to_string` is a `$rust_function` native (see
-    // baml_builtins2/baml_std/baml/ns_json/json.baml). Invoking it as
-    // an entry must be rejected up-front.
+    // `baml.fs.exists` is a `$rust_io_function` sysop (see
+    // baml_builtins2/baml_std/baml/ns_fs/fs.baml). Invoking it as an
+    // entry must be rejected up-front.
     let result = eng
         .call_function(
-            "baml.json.to_string",
+            "baml.fs.exists",
             vec![],
             FunctionCallContextBuilder::new(CallId::next()).build(),
             true,
@@ -143,14 +141,12 @@ async fn call_function_rejects_non_bytecode_entry() {
 
     match result {
         Err(EngineError::NotInvokableAsEntry { name, .. }) => {
-            assert_eq!(name, "baml.json.to_string");
+            assert_eq!(name, "baml.fs.exists");
         }
         other => panic!("expected NotInvokableAsEntry, got {other:?}"),
     }
 
-    // Sanity: bytecode entries (including LLM-typed bytecode, which is
-    // `FunctionKind::Bytecode + FunctionMeta::Llm`) still work — this
-    // gate only blocks `Native`/`SysOp`/`NativeUnresolved`.
+    // Sanity: bytecode entries still work.
     let ok = eng
         .call_function(
             "user.main",
@@ -160,4 +156,26 @@ async fn call_function_rejects_non_bytecode_entry() {
         )
         .await;
     assert!(ok.is_ok(), "bytecode entry must still resolve: {ok:?}");
+}
+
+/// `baml.math.trunc(value: float) -> int` is a `$rust_function` →
+/// `FunctionKind::Native`. Calling it as an entry point should truncate
+/// toward zero and return `3`, not reject with `NotInvokableAsEntry`.
+#[tokio::test]
+async fn native_trunc_callable_as_entry_point() {
+    let eng = engine(&[("main.baml", "function main() -> int { 1 }")]);
+
+    let result = eng
+        .call_function(
+            "baml.math.trunc",
+            vec![BexExternalValue::Float(3.7)],
+            FunctionCallContextBuilder::new(CallId::next()).build(),
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(BexExternalValue::Int(n)) => assert_eq!(n, 3, "trunc(3.7) should be 3"),
+        other => panic!("expected Ok(Int(3)) from baml.math.trunc as entry, got {other:?}"),
+    }
 }

--- a/baml_language/crates/bex_engine/tests/function_resolution.rs
+++ b/baml_language/crates/bex_engine/tests/function_resolution.rs
@@ -119,31 +119,25 @@ fn find_user_function_does_not_expose_stdlib() {
     assert_eq!(main_info.qualified_name, "user.main");
 }
 
-/// `BexEngine::call_function*` rejects sysops as entry points. Native
-/// `$rust_function` entries are wrapped by the VM in a synthetic bytecode
-/// caller, but sysops still need to be reached from an existing bytecode
-/// frame that can resume after the engine executes the operation.
+/// `baml.fs.exists(path: string) -> bool` is a `$rust_io_function` →
+/// `FunctionKind::SysOp`. Calling it as an entry point should yield to the
+/// engine, resume the synthesized entry frame, and return the sysop result.
 #[tokio::test]
-async fn call_function_rejects_sysop_entry() {
+async fn sysop_fs_exists_callable_as_entry_point() {
     let eng = engine(&[("main.baml", "function main() -> int { 1 }")]);
 
-    // `baml.fs.exists` is a `$rust_io_function` sysop (see
-    // baml_builtins2/baml_std/baml/ns_fs/fs.baml). Invoking it as an
-    // entry must be rejected up-front.
     let result = eng
         .call_function(
             "baml.fs.exists",
-            vec![],
+            vec![BexExternalValue::String(".".into())],
             FunctionCallContextBuilder::new(CallId::next()).build(),
             true,
         )
         .await;
 
     match result {
-        Err(EngineError::NotInvokableAsEntry { name, .. }) => {
-            assert_eq!(name, "baml.fs.exists");
-        }
-        other => panic!("expected NotInvokableAsEntry, got {other:?}"),
+        Ok(BexExternalValue::Bool(exists)) => assert!(exists, "'.' should exist"),
+        other => panic!("expected Ok(Bool(true)) from baml.fs.exists as entry, got {other:?}"),
     }
 
     // Sanity: bytecode entries still work.
@@ -177,5 +171,28 @@ async fn native_trunc_callable_as_entry_point() {
     match result {
         Ok(BexExternalValue::Int(n)) => assert_eq!(n, 3, "trunc(3.7) should be 3"),
         other => panic!("expected Ok(Int(3)) from baml.math.trunc as entry, got {other:?}"),
+    }
+}
+
+/// Generic `$rust_function` entries must still expose host-provided type args
+/// to the native through `current_call_type_args()`.
+#[tokio::test]
+async fn generic_native_json_to_string_callable_as_entry_point() {
+    let eng = engine(&[("main.baml", "function main() -> int { 1 }")]);
+
+    let result = eng
+        .call_function(
+            "baml.json.to_string",
+            vec![BexExternalValue::Int(7)],
+            FunctionCallContextBuilder::new(CallId::next())
+                .with_type_args(vec![baml_type::Ty::int()])
+                .build(),
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(BexExternalValue::String(s)) => assert_eq!(s.as_str(), "7"),
+        other => panic!("expected Ok(String(\"7\")) from baml.json.to_string<int>, got {other:?}"),
     }
 }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -67,11 +67,12 @@ use ::core::any::TypeId;
 use ::core::sync::atomic::AtomicBool;
 use bex_heap::{BexHeap, Tlab};
 use bex_vm_types::{
-    BinOp, CmpOp, FunctionKind, FutureRead, HeapPtr, Object, ObjectIndex, ObjectPool, ObjectType,
-    PanicClass, PermitProof, StackIndex, UnaryOp, Value, Variant, VmGlobals,
-    bytecode::{self, BlockNotification},
+    BinOp, CmpOp, FunctionKind, FutureRead, GlobalIndex, HeapPtr, Object, ObjectIndex, ObjectPool,
+    ObjectType, PanicClass, PermitProof, StackIndex, UnaryOp, Value, Variant, VmGlobals,
+    bytecode::{self, BlockNotification, Instruction},
     types::{
-        BoundMethod, Closure, ConstValue, Function, FunctionType, Instance, Type, UnscheduledFuture,
+        BoundMethod, Closure, ConstValue, Function, FunctionOrigin, FunctionType, Instance, Type,
+        UnscheduledFuture,
     },
 };
 use indexmap::IndexMap;
@@ -1275,16 +1276,10 @@ impl BexVm {
     /// `type_args` slot. Use when the host invokes a generic function
     /// (e.g. a user function with `<T>`) and needs to thread `T` through.
     ///
-    /// Entry points must be [`bex_vm_types::FunctionKind::Bytecode`] —
-    /// either a bare `Object::Function` or an `Object::Closure` wrapping
-    /// one (BEP-034 spawn). The engine boundary
-    /// (`bex_engine::BexEngine::call_function_bound_args` — backticks
-    /// rather than an intra-doc link because `bex_vm` doesn't depend on
-    /// `bex_engine`; the relationship goes the other way) rejects
-    /// `SysOp` / `Native` / `NativeUnresolved` callees with
-    /// `EngineError::NotInvokableAsEntry` before reaching this method,
-    /// because there's no enclosing bytecode frame for a native to
-    /// `YieldToCall` back into at the top level.
+    /// Bytecode entry points are pushed directly. Native entry points are
+    /// wrapped in a synthetic bytecode caller that executes
+    /// `CALL <native>; RETURN`, giving the normal call path a real caller
+    /// frame for synchronous results and `YieldToCall` continuations.
     pub fn set_entry_point_with_type_args(
         &mut self,
         function: HeapPtr,
@@ -1299,33 +1294,121 @@ impl BexVm {
             "expect function or closure as entry point, got {:?}",
             self.get_object(function)
         );
-        debug_assert!(
-            match self.get_object(function) {
-                Object::Function(f) => matches!(f.kind, bex_vm_types::FunctionKind::Bytecode),
-                Object::Closure(_) => true,
-                _ => false,
-            },
-            "entry points must be Function::Bytecode or Closure; engine \
-             boundary should have rejected this — see \
-             EngineError::NotInvokableAsEntry"
-        );
 
-        self.pending_call_type_args.clone_from(&type_args);
+        let callable_kind = match self.get_object(function) {
+            Object::Function(f) => f.kind,
+            Object::Closure(closure) => {
+                let func_obj = unsafe { closure.function.get() };
+                match func_obj {
+                    Object::Function(f) => f.kind,
+                    other => panic!("expect closure function, got {other:?}"),
+                }
+            }
+            other => panic!("expect function or closure as entry point, got {other:?}"),
+        };
 
+        match callable_kind {
+            FunctionKind::Bytecode => {
+                self.pending_call_type_args.clone_from(&type_args);
+                self.stack.extend(args.iter().copied());
+                self.frames.push(Frame::Bytecode(BytecodeFrame {
+                    function,
+                    instruction_ptr: 0,
+                    locals_offset: StackIndex::from_raw(0),
+                    type_args,
+                    faulting_pc: 0,
+                }));
+
+                // Entry functions need the same frame-local pre-allocation as normal
+                // bytecode calls now that INIT_LOCALS is gone from bytecode.
+                self.allocate_real_locals_for_frame(function)
+                    .expect("entry point must be a valid function frame");
+            }
+            FunctionKind::Native(_) => {
+                self.push_native_entry_frame(function, args, type_args);
+            }
+            FunctionKind::SysOp(_) | FunctionKind::NativeUnresolved => {
+                panic!("entry point kind is not directly invokable: {callable_kind:?}");
+            }
+        }
+    }
+
+    fn global_index_for_function_ptr(&self, function: HeapPtr) -> Option<GlobalIndex> {
+        self.globals
+            .as_slice(self.proof())
+            .iter()
+            .position(|value| value.as_object_ptr() == Some(function))
+            .map(GlobalIndex::from_raw)
+    }
+
+    fn push_native_entry_frame(
+        &mut self,
+        function: HeapPtr,
+        args: &[Value],
+        type_args: Vec<baml_type::Ty>,
+    ) {
+        let callee_global = self
+            .global_index_for_function_ptr(function)
+            .expect("native entry point must be present in globals");
+        let ntypeargs = u16::try_from(type_args.len()).expect("native entry type args fit in u16");
+
+        let (callee_name, return_type, throws_type) = match self.get_object(function) {
+            Object::Function(f) => (f.name.clone(), f.return_type.clone(), f.throws_type.clone()),
+            other => panic!("expect native function as entry point, got {other:?}"),
+        };
+
+        self.pending_call_type_args.clear();
+        for ty in type_args {
+            let ty_ptr = self.tlab.alloc(Object::Type(Box::new(ty)));
+            self.stack.push(Value::object(ty_ptr));
+        }
         self.stack.extend(args.iter().copied());
 
+        let mut bytecode = bytecode::Bytecode {
+            instructions: vec![
+                Instruction::Call {
+                    callee: callee_global,
+                    ntypeargs,
+                },
+                Instruction::Return,
+            ],
+            ..bytecode::Bytecode::default()
+        };
+        bytecode.compact = Some(bytecode.lower_to_compact());
+
+        let entry_function = Function {
+            name: format!("$entry::{callee_name}"),
+            source_file: String::new(),
+            arity: 0,
+            real_local_count: 0,
+            bytecode,
+            kind: FunctionKind::Bytecode,
+            local_names: Vec::new(),
+            debug_locals: Vec::new(),
+            span: baml_type::Span::fake(),
+            block_notifications: Vec::new(),
+            viz_nodes: Vec::new(),
+            return_type,
+            stream_return_type: baml_type::Ty::Null {
+                attr: baml_type::TyAttr::default(),
+            },
+            param_names: Vec::new(),
+            param_types: Vec::new(),
+            param_has_default: Vec::new(),
+            throws_type,
+            origin: FunctionOrigin::Internal,
+            body_meta: None,
+            trace: false,
+        };
+        let entry_ptr = self.tlab.alloc(Object::Function(Box::new(entry_function)));
+
         self.frames.push(Frame::Bytecode(BytecodeFrame {
-            function,
+            function: entry_ptr,
             instruction_ptr: 0,
             locals_offset: StackIndex::from_raw(0),
-            type_args,
+            type_args: Vec::new(),
             faulting_pc: 0,
         }));
-
-        // Entry functions need the same frame-local pre-allocation as normal
-        // bytecode calls now that INIT_LOCALS is gone from bytecode.
-        self.allocate_real_locals_for_frame(function)
-            .expect("entry point must be a valid function frame");
     }
 
     /// Restores the VM state and prepares it for the next execution.

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -164,16 +164,18 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use baml_type::{Name, Ty, TyAttr, TyTemplate, TypeName};
-    use bex_heap::{BexHeap, Tlab};
+    use bex_heap::{BexHeap, CollectionLevel, Tlab};
     use bex_vm_types::{
-        EarlyYieldCheck, GlobalPool, Object, ObjectIndex, Value, ValueKind, VmGlobals,
-        bytecode::{FieldCopy, FieldCopySet},
-        types::{Class, ClassField, Instance, type_tags},
+        EarlyYieldCheck, FunctionKind, GlobalPool, HeapPtr, Object, ObjectIndex, RootHaver, Value,
+        ValueKind, VmGlobals,
+        bytecode::{Bytecode, FieldCopy, FieldCopySet},
+        types::{Class, ClassField, Function, FunctionOrigin, Instance, type_tags},
     };
 
-    use super::{BexVm, VmExecState, WatchNotification, value_type_tag};
+    use super::{BexVm, Frame, VmExecState, WatchNotification, value_type_tag};
     use crate::{
         indexable::EvalStack,
+        package_baml::{NativeCallResult, NativeFunction},
         watch::{NodeId, RootState, Watch, WatchFilter},
     };
 
@@ -238,6 +240,52 @@ mod tests {
             argv: Arc::from([]),
             pending_call_type_args: Vec::new(),
         }
+    }
+
+    fn native_done(_vm: &mut BexVm, _args: &[Value]) -> NativeCallResult {
+        NativeCallResult::Done(Value::int(42))
+    }
+
+    fn native_function_object() -> Object {
+        let native: NativeFunction = native_done;
+        Object::Function(Box::new(Function {
+            name: "test_native".to_string(),
+            source_file: String::new(),
+            arity: 0,
+            real_local_count: 0,
+            bytecode: Bytecode::default(),
+            kind: FunctionKind::Native(native as *const ()),
+            local_names: Vec::new(),
+            debug_locals: Vec::new(),
+            span: baml_type::Span::fake(),
+            block_notifications: Vec::new(),
+            viz_nodes: Vec::new(),
+            return_type: int_ty(),
+            stream_return_type: Ty::Null {
+                attr: TyAttr::default(),
+            },
+            param_names: Vec::new(),
+            param_types: Vec::new(),
+            param_has_default: Vec::new(),
+            throws_type: None,
+            origin: FunctionOrigin::Internal,
+            body_meta: None,
+            trace: false,
+        }))
+    }
+
+    fn vm_with_native_entry() -> (BexVm, HeapPtr) {
+        let mut vm = test_vm(vec![native_function_object()]);
+        let native_ptr = vm.idx_to_ptr(ObjectIndex::from_raw(0));
+        vm.globals = VmGlobals::Owned(GlobalPool::from_vec(vec![Value::object(native_ptr)]));
+        (vm, native_ptr)
+    }
+
+    fn trampoline_ptr(vm: &BexVm) -> HeapPtr {
+        let Some(Frame::Bytecode(frame)) = vm.frames.last() else {
+            panic!("expected trampoline bytecode frame");
+        };
+        frame.function
     }
 
     #[test]
@@ -305,6 +353,86 @@ mod tests {
         assert_eq!(
             dest.field_values().collect::<Vec<_>>(),
             vec![Value::int(10), Value::int(2)]
+        );
+    }
+
+    #[test]
+    fn trampoline_function_survives_gc_while_frame_is_active() {
+        let (mut vm, native_ptr) = vm_with_native_entry();
+
+        vm.set_entry_point(native_ptr, &[]);
+        let trampoline = trampoline_ptr(&vm);
+
+        let mut roots = Vec::new();
+        vm.collect_roots(&mut roots);
+        assert!(
+            roots.contains(&trampoline),
+            "active trampoline frame must root its synthetic function"
+        );
+
+        let (stats, _remapped_roots, forwarding) = unsafe {
+            vm.heap
+                .collect_garbage_generational(&roots, CollectionLevel::Major)
+        };
+
+        assert_eq!(stats.live_count, 1);
+        assert!(
+            forwarding.contains_key(&trampoline),
+            "active trampoline function must be forwarded by GC"
+        );
+
+        vm.forward_roots(&forwarding);
+
+        let moved_trampoline = trampoline_ptr(&vm);
+        assert!(
+            matches!(vm.get_object(moved_trampoline), Object::Function(f) if f.name == "$entry::test_native"),
+            "frame should point at the moved trampoline function after forwarding"
+        );
+
+        let result = vm.exec().expect("native trampoline should execute");
+        assert!(
+            matches!(result, VmExecState::Complete(value) if value == Value::int(42)),
+            "native trampoline should return the native result"
+        );
+    }
+
+    #[test]
+    fn trampoline_function_is_collected_after_return() {
+        let (mut vm, native_ptr) = vm_with_native_entry();
+
+        vm.set_entry_point(native_ptr, &[]);
+        let trampoline = trampoline_ptr(&vm);
+
+        let result = vm.exec().expect("native trampoline should execute");
+        assert!(
+            matches!(result, VmExecState::Complete(value) if value == Value::int(42)),
+            "native trampoline should return the native result"
+        );
+        assert!(
+            vm.frames.is_empty(),
+            "trampoline frame should be popped after return"
+        );
+
+        let mut roots = Vec::new();
+        vm.collect_roots(&mut roots);
+        assert!(
+            !roots.contains(&trampoline),
+            "returned trampoline function must not remain rooted"
+        );
+
+        let (stats, _remapped_roots, forwarding) = unsafe {
+            vm.heap
+                .collect_garbage_generational(&roots, CollectionLevel::Major)
+        };
+
+        assert_eq!(stats.live_count, 0);
+        assert!(
+            stats.collected_count >= 1,
+            "GC should collect the unrooted trampoline function"
+        );
+        assert!(
+            !forwarding.contains_key(&trampoline),
+            "unrooted trampoline function must not be forwarded after return"
         );
     }
 }
@@ -1276,10 +1404,10 @@ impl BexVm {
     /// `type_args` slot. Use when the host invokes a generic function
     /// (e.g. a user function with `<T>`) and needs to thread `T` through.
     ///
-    /// Bytecode entry points are pushed directly. Native entry points are
-    /// wrapped in a synthetic bytecode caller that executes
-    /// `CALL <native>; RETURN`, giving the normal call path a real caller
-    /// frame for synchronous results and `YieldToCall` continuations.
+    /// Bytecode entry points are pushed directly. Native and sysop entries are
+    /// wrapped in a synthetic bytecode caller that executes either
+    /// `CALL <native>; RETURN` or `SYS_OP <sysop>; RETURN`, giving the normal VM
+    /// machinery a bytecode frame to resume into.
     pub fn set_entry_point_with_type_args(
         &mut self,
         function: HeapPtr,
@@ -1301,10 +1429,10 @@ impl BexVm {
                 let func_obj = unsafe { closure.function.get() };
                 match func_obj {
                     Object::Function(f) => f.kind,
-                    other => panic!("expect closure function, got {other:?}"),
+                    other => unreachable!("expect closure function, got {other:?}"),
                 }
             }
-            other => panic!("expect function or closure as entry point, got {other:?}"),
+            other => unreachable!("expect function or closure as entry point, got {other:?}"),
         };
 
         match callable_kind {
@@ -1324,11 +1452,11 @@ impl BexVm {
                 self.allocate_real_locals_for_frame(function)
                     .expect("entry point must be a valid function frame");
             }
-            FunctionKind::Native(_) => {
-                self.push_native_entry_frame(function, args, type_args);
+            FunctionKind::Native(_) | FunctionKind::SysOp(_) => {
+                self.push_trampoline_frame(function, args, type_args, callable_kind);
             }
-            FunctionKind::SysOp(_) | FunctionKind::NativeUnresolved => {
-                panic!("entry point kind is not directly invokable: {callable_kind:?}");
+            FunctionKind::NativeUnresolved => {
+                unreachable!("entry point kind is not directly invokable: {callable_kind:?}");
             }
         }
     }
@@ -1341,37 +1469,55 @@ impl BexVm {
             .map(GlobalIndex::from_raw)
     }
 
-    fn push_native_entry_frame(
+    fn push_trampoline_frame(
         &mut self,
         function: HeapPtr,
         args: &[Value],
         type_args: Vec<baml_type::Ty>,
+        callable_kind: FunctionKind,
     ) {
         let callee_global = self
             .global_index_for_function_ptr(function)
-            .expect("native entry point must be present in globals");
-        let ntypeargs = u16::try_from(type_args.len()).expect("native entry type args fit in u16");
+            .expect("entry point must be present in globals");
+        let ntypeargs = u16::try_from(type_args.len()).expect("entry type args fit in u16");
 
         let (callee_name, return_type, throws_type) = match self.get_object(function) {
             Object::Function(f) => (f.name.clone(), f.return_type.clone(), f.throws_type.clone()),
-            other => panic!("expect native function as entry point, got {other:?}"),
+            other => unreachable!("expect function as entry point, got {other:?}"),
         };
 
         self.pending_call_type_args.clear();
-        for ty in type_args {
-            let ty_ptr = self.tlab.alloc(Object::Type(Box::new(ty)));
-            self.stack.push(Value::object(ty_ptr));
+        match callable_kind {
+            FunctionKind::Native(_) => {
+                for ty in type_args {
+                    let ty_ptr = self.tlab.alloc(Object::Type(Box::new(ty)));
+                    self.stack.push(Value::object(ty_ptr));
+                }
+                self.stack.extend(args.iter().copied());
+            }
+            FunctionKind::SysOp(_) => {
+                self.stack.extend(args.iter().copied());
+            }
+            FunctionKind::Bytecode | FunctionKind::NativeUnresolved => {
+                unreachable!("trampoline frame requires Native or SysOp")
+            }
         }
-        self.stack.extend(args.iter().copied());
 
-        let mut bytecode = bytecode::Bytecode {
-            instructions: vec![
+        let instructions = match callable_kind {
+            FunctionKind::Native(_) => vec![
                 Instruction::Call {
                     callee: callee_global,
                     ntypeargs,
                 },
                 Instruction::Return,
             ],
+            FunctionKind::SysOp(_) => vec![Instruction::SysOp(callee_global), Instruction::Return],
+            FunctionKind::Bytecode | FunctionKind::NativeUnresolved => {
+                unreachable!("trampoline frame requires Native or SysOp")
+            }
+        };
+        let mut bytecode = bytecode::Bytecode {
+            instructions,
             ..bytecode::Bytecode::default()
         };
         bytecode.compact = Some(bytecode.lower_to_compact());

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_errors.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_errors.py
@@ -121,7 +121,16 @@ def test_str_is_non_empty():
 # ---------------------------------------------------------------------------
 
 # `File "<src>", line N, in <fn>` — the wire trace-line shape.
-_TRACE_LINE = r'File "(?P<file>[^"]+)", line (?P<line>\d+), in (?P<func>[^"]+)'
+_TRACE_LINE = r'File "(?P<file>[^"]*)", line (?P<line>\d+), in (?P<func>[^"]+)'
+
+
+def _python_traceback_line(line: str) -> str:
+    """Python tracebacks are 1-indexed, even for synthetic builtin frames."""
+    m = re.fullmatch(_TRACE_LINE, line)
+    if m is None:
+        return line
+    lineno = max(int(m["line"]), 1)
+    return f'File "{m["file"]}", line {lineno}, in {m["func"]}'
 
 
 def test_baml_error_carries_baml_trace():
@@ -152,9 +161,12 @@ def test_baml_trace_spliced_into_python_traceback():
     else:
         pytest.fail("ParseJson did not raise BamlError")
 
-    # Every wire trace line must appear verbatim in the rendered traceback...
+    # Every wire trace line must appear in the rendered traceback. Builtin
+    # frames may carry line 0 on the wire, but Python traceback objects render
+    # locations as 1-indexed lines.
     for line in wire_trace:
-        assert line in rendered, f"{line!r} not spliced into:\n{rendered}"
+        expected = _python_traceback_line(line)
+        assert expected in rendered, f"{expected!r} not spliced into:\n{rendered}"
     # ...and the splice must name the throwing BAML function + its source.
     assert re.search(
         r'File "[^"]*types\.baml", line \d+, in user\.throws_test\.ParseJson',

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_host_callables.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_host_callables.py
@@ -184,6 +184,15 @@ def test_call_repeatedly_with_zero_n_returns_empty_list():
     assert invocations == []
 
 
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "A host-callable error can still surface as an unhandled throw "
+        "rather than a VM-side catchable throw on the current sys-op "
+        "single-yield path. Making that path consistently catchable is "
+        "outside the scope of this PR."
+    ),
+)
 def test_call_with_throwing_catches_host_callable_error():
     """A host exception should surface as a catchable
     `baml.errors.HostCallable` throw; BAML's `catch (e)` should match.

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_host_callables.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_host_callables.py
@@ -184,25 +184,9 @@ def test_call_repeatedly_with_zero_n_returns_empty_list():
     assert invocations == []
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "A host-callable error currently surfaces as an unhandled throw "
-        "rather than a VM-side catchable throw: on the current sys-op "
-        "single-yield path the engine returns the throw without re-entering "
-        "the VM, so the in-VM exception table is bypassed. In-BAML "
-        "`try/catch` over a host call therefore cannot run, even though "
-        "`throws root.errors.HostCallable` type-checks and the handler "
-        "compiles. It will become catchable once sys-op call sites are "
-        "awaited explicitly: the await becomes the catch point and the "
-        "error rides the catchable path."
-    ),
-)
 def test_call_with_throwing_catches_host_callable_error():
     """A host exception should surface as a catchable
     `baml.errors.HostCallable` throw; BAML's `catch (e)` should match.
-    Currently fails because the sys-op path emits an unhandled throw
-    directly to the engine, not a VM-side throw walk.
     """
 
     def cb(_x: int) -> str:

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_stdlib_entrypoints.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_stdlib_entrypoints.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from baml_sdk.baml.fs import exists
+from baml_sdk.baml.math import trunc
+
+
+# `baml.math.trunc(value: float) -> int` is a `$rust_function` →
+# `FunctionKind::Native`. Calling it as an entry point should truncate toward
+# zero and return `3`, not reject with `NotInvokableAsEntry`.
+def test_native_trunc_callable_as_entry_point():
+    assert trunc(3.7) == 3
+
+
+# `baml.fs.exists(path: string) -> bool` is a `$rust_io_function` →
+# `FunctionKind::SysOp`. Calling it as an entry point should run the
+# filesystem sysop and return a bool. `.` exists in the generated fixture
+# directory on the test host.
+def test_sysop_fs_exists_callable_as_entry_point():
+    assert exists(".") is True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native and sysop (stdlib) functions can be invoked as direct entry points, including calls with type parameters.

* **Bug Fixes**
  * Improved BAML traceback normalization in Python error reports.
  * Host-thrown errors from callables are now correctly caught and reported in the Python SDK (test no longer xfail).

* **Tests**
  * Added/updated tests validating entry-point callability, function-resolution behavior, and GC/lifecycle of transient entry trampolines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->