### PR TITLE
chore: use sccache for cargo tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,10 +1,13 @@
-export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-
 # Enable beta playground features in the standalone web app by default.
 export NEXT_PUBLIC_FIDDLE_BETA_DEFAULT=true
 
 # speed up building the Ruby client library, which I think defaults to the release build
 export RB_SYS_CARGO_PROFILE="dev"
+
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
+# we hide subcommands like baml-cli login, baml-cli dump-hir from our users by default
+export BAML_INTERNAL=1
 
 # Use nix if nix-shell is available,
 # Otherwise, use mise and brew.
@@ -13,20 +16,64 @@ if command -v nix-shell >/dev/null 2>&1; then
     export PATH=$(pwd)/tools:$PATH
 else
     PATH_add tools/
-    PATH_add "$(brew --prefix llvm)/bin"
+    if [ "${CI:-}" != "true" ] && command -v brew >/dev/null 2>&1; then
+        PATH_add "$(brew --prefix llvm)/bin"
+    fi
 
     # Use mise for tool versioning, e.g. Ruby
-    eval "$(mise activate bash)" || echo "Please run 'brew install mise'"
-    
-    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+    if [ "${CI:-}" = "true" ]; then
+        :
+    elif command -v mise >/dev/null 2>&1; then
+        eval "$(mise activate bash)"
+    else
+        echo "Please install mise"
+    fi
 fi
 
-# we hide subcommands like baml-cli login, baml-cli dump-hir from our users by default
-export BAML_INTERNAL=1
-
-# Load local, machine-specific direnv settings outside the repo.
+# Load local, machine-specific direnv settings outside the repo. This is where
+# local shells define BAML_SCCACHE_R2_* (CI passes them via the environment).
 if [ -f "$HOME/.envrc.baml" ]; then
     source_env "$HOME/.envrc.baml"
+fi
+
+# sccache configuration.
+# ----------------------
+# .envrc is the single source of truth: every value below is set
+# unconditionally, so a RUSTC_WRAPPER / SCCACHE_* already in the environment
+# cannot override it. The R2 credentials (BAML_SCCACHE_R2_*) are the one input
+# we read from the environment; the RUSTC_WRAPPER maps them to the AWS_* names
+# sccache expects and then execs sccache. On POSIX that wrapper is the
+# tools/baml-sccache script. On Windows it's the native `tools_sccache` crate's
+# binary: a .cmd wrapper would be run through cmd.exe, whose ~8191-char
+# command-line limit some crates exceed (e.g. windows-sys, with its enormous
+# `--check-cfg cfg(feature, values(...))` arg -> "The command line is too
+# long"), whereas cargo launches an .exe via CreateProcess directly (32767-char
+# limit). That binary lives in the build tree, so it's selected further below,
+# once it exists.
+case "$(uname -s 2>/dev/null || true)" in
+    # Selected below (needs repo_root). Until the wrapper binary is built, leave
+    # RUSTC_WRAPPER unset so the bootstrap `cargo build -p tools_sccache` runs
+    # with plain rustc.
+    MINGW*|MSYS*|CYGWIN*|Windows_NT) unset RUSTC_WRAPPER ;;
+    *)                               export RUSTC_WRAPPER=baml-sccache ;;
+esac
+export SCCACHE_IDLE_TIMEOUT=0
+export SCCACHE_ERROR_LOG=/tmp/sccache-baml.log
+
+if [ -n "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" ] && [ -n "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]; then
+    export SCCACHE_BUCKET=baml-build1
+    export SCCACHE_REGION=auto
+    export SCCACHE_ENDPOINT=https://321ca319116f1e5eefa9135d9d019a5a.r2.cloudflarestorage.com
+    # Separate the cache namespaces so CI and local builds don't collide.
+    if [ "${CI:-}" = "true" ]; then
+        export SCCACHE_S3_KEY_PREFIX=baml/ci/
+    else
+        export SCCACHE_S3_KEY_PREFIX=baml/local/
+    fi
+else
+    # No R2 credentials (fork-PR CI, or a local shell without ~/.envrc.baml):
+    # use sccache's host-local disk cache instead of R2.
+    unset SCCACHE_BUCKET SCCACHE_REGION SCCACHE_ENDPOINT SCCACHE_S3_KEY_PREFIX
 fi
 
 repo_root=""
@@ -40,7 +87,24 @@ if [ -z "$repo_root" ] && command -v git >/dev/null 2>&1; then
 fi
 
 if [ -n "$repo_root" ]; then
-    export SCCACHE_SERVER_UDS="${repo_root}/.baml-sccache.sock"
+    case "$(uname -s 2>/dev/null || true)" in
+        MINGW*|MSYS*|CYGWIN*|Windows_NT)
+            # Route rustc through the native sccache wrapper (tools_sccache)
+            # once it's been compiled. Prefer a debug build, fall back to
+            # release. Before either exists, RUSTC_WRAPPER stays unset (see
+            # above) so the first `cargo build -p tools_sccache` can produce it.
+            for _wrapper in \
+                "${repo_root}/baml_language/target/debug/baml-sccache.exe" \
+                "${repo_root}/baml_language/target/release/baml-sccache.exe"; do
+                if [ -x "$_wrapper" ]; then
+                    export RUSTC_WRAPPER="$_wrapper"
+                    break
+                fi
+            done
+            unset _wrapper
+            ;;
+        *) export SCCACHE_SERVER_UDS="${repo_root}/.baml-sccache.sock" ;;
+    esac
     export SCCACHE_BASEDIRS="${repo_root}${SCCACHE_BASEDIRS:+:${SCCACHE_BASEDIRS}}"
 fi
 

--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -57,3 +57,14 @@ runs:
         # every consumer's cache at once.
         cache_key_prefix: mise-baml1
         install_args: ${{ inputs.install_args }}
+        # Keep mise's shims OFF $PATH. mise-action exports the concrete
+        # installed-tool bin dirs into PATH directly, so the narrow set we
+        # asked for via install_args still resolves. But if the shims dir is
+        # on PATH, the first bare invocation of any shimmed tool (e.g. the
+        # `sccache --version` verify step, or cargo using RUSTC_WRAPPER=sccache)
+        # makes mise materialize the *whole* mise.toml environment, and with
+        # MISE_YES=1 (set by mise-action) it auto-installs every other tool in
+        # the config — cargo:bacon/cross/wasm-pack/..., protoc, pnpm, etc. That
+        # defeats install_args entirely and, on Windows where those cargo:*
+        # tools fall back to failing source compiles, it breaks the job.
+        add_shims_to_path: false

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -1,95 +1,44 @@
-# Cache strategy
-# ==============
+# sccache strategy
+# ================
 #
-# GHA caching has two quirks we have to dance around:
+# This workflow uses sccache for Rust compilation artifacts and
+# Swatinem/rust-cache for Cargo registry/git state — i.e. everything cargo
+# downloads before it compiles: the crates.io index, the `.crate` tarballs, and
+# the git checkouts of our forks (minijinja, aws-sdk-rust, google-cloud-rust).
+# `cache-all-crates: true` keeps all of those (the git forks in particular,
+# which are large and otherwise re-cloned on every runner); `cache-targets:
+# false` leaves the compiled `target/` tree to sccache so the two caches don't
+# compete.
 #
-#   - an per-repo cache limit (ours is set to 30GiB) for *all* PRs, and
-#   - a rule that only the default branch's cache can be shared by
-#     different branches
+# Because `target/` is excluded, rust-cache's payload is small (registry + git,
+# no build output). As on canary, only canary writes the cache
+# (`save-if: ${{ github.ref == 'refs/heads/canary' }}`); PR branches read the
+# shared entry instead of each saving a fresh one, so cache usage doesn't blow
+# out. rust-cache keys are content-addressed on Cargo.lock, so jobs sharing a
+# `shared-key` reuse the same entry.
 #
-# It's therefore important that we keep the `canary` cache populated, and
-# because GHA caches are immutable, the daily `canary-cache-refresh.yml`
-# workflow purges canary's rust-cache entries and then re-invokes this
-# workflow so the savers below repopulate fresh content. (That purge lives
-# in a separate workflow specifically so `actions: write` is never granted
-# on the `workflow_call` path from `ci.yaml`, which would expose it to
-# PR-controlled cargo build code. See the comment in
-# `canary-cache-refresh.yml`.) The low storage limit means we also try to
-# reuse `shared-key`s:
+# mise installs sccache and direnv, then each cargo job loads .envrc via
+# `direnv export gha` so CI uses the exact same sccache config as local shells:
+# .envrc is the single source of truth. The R2 credentials are passed through
+# GitHub Actions secrets using the same BAML_SCCACHE_R2_* names that the
+# RUSTC_WRAPPER maps to AWS_* before exec'ing sccache — the `tools/baml-sccache`
+# script on POSIX, and the native `tools_sccache` crate's binary on Windows
+# (built per-job; see the "Build native sccache wrapper" step).
 #
-# 1. Only canary writes (`save-if: ${{ github.ref == 'refs/heads/canary' }}`).
-#    PR / merge_group / feature-branch runs read from canary's cache
-#    scope but don't save their own — keeps the 30 GiB budget from
-#    fragmenting one entry per ref. `canary-cache-refresh.yml`'s daily
-#    purge + repopulate cycle keeps canary's entries fresh past the 7-day
-#    inactivity TTL during quiet periods.
-#
-# 2. One designated saver per `shared-key`. Every other job that uses
-#    the same key passes `save-if: false` and is read-only. Two jobs
-#    saving under the same key would overwrite each other with
-#    different `target/` snapshots, burning budget without adding
-#    coverage.
-#
-# Saver/reader map
-# ----------------
-#
-# | shared-key      | saver (canary-only)   | readers (`save-if: false`)                      |
-# | --------------- | --------------------- | ----------------------------------------------- |
-# | `linux-cargo`   | `cargo-test-linux`    | `sdk-tests/linux`, `cargo-doc`,                 |
-# |                 |                       | `snapshot-tests`, `ci.yaml::prek`,              |
-# |                 |                       | `ci.yaml::proto-sync`, `size-gate::linux`,      |
-# |                 |                       | `size-gate::report`                             |
-# | `linux-wasm`    | `cargo-test-wasm`     | `size-gate::wasm`, `wasm-pack-tests`,           |
-# |                 |                       | `webview-tests` (browser/unit/typecheck)        |
-# | `linux-msrv`    | `cargo-build-msrv`    | —                                               |
-# | `macos-cargo`   | `cargo-test-macos`    | `sdk-tests/macos`, `size-gate::macos`           |
-# | `windows-cargo` | `cargo-test-windows`  | `sdk-tests/windows`, `size-gate::windows`       |
-# | `linux-arm-bench` | `ci.yaml::benchmarks-build` | — (bench-only; see note)                  |
-#
-# Note: `linux-arm-bench` is bench-specific on purpose — its saver builds only
-# `baml_tests` benches, so it's a thin seed not worth sharing with a general
-# ARM job (which would still rebuild most of the workspace). It is also NOT
-# touched by the daily purge in `canary-cache-refresh.yml` (that purge
-# repopulates via this reusable workflow, which has no ARM job); it
-# self-refreshes whenever `benchmarks-build` runs on canary, and only ages out
-# after the 7-day TTL during fully ARM-idle periods.
-#
-# `cargo-test-linux` is the saver for `linux-cargo` because it builds
-# the broadest target/ tree (`cargo test --no-run --all-features`
-# across the whole workspace) — that's the most useful seed for the
-# subcommand variants the readers run (`cargo doc`, narrower
-# snapshot tests, the sdks/nodejs/bridge_nodejs build, prek's
-# checks). Per-OS cargo-test jobs are the savers on macos/windows
-# for the same reason.
-#
-# Every rust-cache invocation also passes `cache-all-crates: true`
-# and `cache-workspace-crates: true`. By default rust-cache only
-# caches registry-resolved deps and strips workspace-crate artifacts
-# out of `target/` before saving. We override both: `cache-all-crates`
-# pulls in `~/.cargo/git/` (most importantly our aws-sdk-rust fork,
-# which is otherwise re-downloaded on every Windows run), and
-# `cache-workspace-crates` keeps the compiled workspace `target/` so
-# PRs reading from canary's cache restart with the workspace crates
-# already built. Cache size grows accordingly; the daily refresh in
-# `canary-cache-refresh.yml` bounds it.
-#
-# TODO: in our current setup, any PR that touches Cargo.lock — dependency bump,
-# new crate, anything that re-resolves — will therefore be unable to restore
-# from canary's build cache.  Swatinem/rust-cache@v2 hashes Cargo.lock (and
-# Cargo.toml, rust-toolchain.toml) into every cache key, so any such PRs will
-# have a new hash (and the action provides no mechanism to bypass this).
-# rust-cache's `restore-keys` salvage a deps-only partial restore by prefix,
-# but the entire workspace recompiles.
+# Secretless runs (e.g. fork PRs) still install sccache, but .envrc sees no R2
+# credentials and falls back to the runner-local cache.
 name: Cargo Tests (Reusable)
 
 on:
-  workflow_call: {}
+  workflow_call:
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
-# Read-only by design: the daily cache refresh runs in
-# `canary-cache-refresh.yml`, which is the only place `actions: write`
-# is granted. Keeping this workflow read-only means callers (ci.yaml,
-# canary-cache-refresh.yml) never have to grant elevated scope to PR
-# runs that go through the workflow_call path.
+# Read-only by design: these jobs run PR-controlled cargo build/test code, so
+# they should not need elevated repository permissions.
 permissions:
   contents: read
 
@@ -98,12 +47,18 @@ defaults:
     shell: bash
 
 env:
+  # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
+  # .envrc itself so it stays the single source of truth across CI and local.
+  # The R2 credentials .envrc maps to AWS_* for sccache (mapped to AWS_*).
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+
   cargo-test-linux:
     name: "cargo test (linux)"
     runs-on: blacksmith-16vcpu-ubuntu-2404
@@ -113,19 +68,32 @@ jobs:
         with:
           persist-credentials: false
 
-      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - name: "Install sccache and direnv"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv"
+
+      - name: "Verify sccache"
+        run: sccache --version
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-workspace-crates: true
-          # See the cache strategy explanation at the top of this file.
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/canary' }}
           shared-key: "linux-cargo"
+
+      - name: "Load .envrc with direnv"
+        run: |
+          set -euo pipefail
+
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -152,6 +120,22 @@ jobs:
             baml_language/**/*.snap.new
             baml_language/**/target/nextest/
 
+      - name: "Show sccache stats"
+        if: always()
+        run: sccache --show-stats
+
+      - name: "Dump sccache stats (json)"
+        if: always()
+        run: sccache --show-stats --stats-format json > sccache-stats-test-linux.json
+
+      - name: "Upload sccache stats"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-stats-test-linux
+          path: sccache-stats-test-linux.json
+          if-no-files-found: ignore
+
       - name: "Rename cargo timings"
         if: always()
         run: mv target/cargo-timings/cargo-timing.html target/cargo-timings/cargo-timing-test-linux.html
@@ -176,19 +160,32 @@ jobs:
         with:
           persist-credentials: false
 
-      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - name: "Install sccache and direnv"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv"
+
+      - name: "Verify sccache"
+        run: sccache --version
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-workspace-crates: true
-          # See the cache strategy explanation at the top of this file.
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/canary' }}
           shared-key: "macos-cargo"
+
+      - name: "Load .envrc with direnv"
+        run: |
+          set -euo pipefail
+
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -205,6 +202,22 @@ jobs:
       - name: "Run tests"
         run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/)'
         working-directory: baml_language
+
+      - name: "Show sccache stats"
+        if: always()
+        run: sccache --show-stats
+
+      - name: "Dump sccache stats (json)"
+        if: always()
+        run: sccache --show-stats --stats-format json > sccache-stats-test-macos.json
+
+      - name: "Upload sccache stats"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-stats-test-macos
+          path: sccache-stats-test-macos.json
+          if-no-files-found: ignore
 
       - name: "Rename cargo timings"
         if: always()
@@ -232,19 +245,47 @@ jobs:
         with:
           persist-credentials: false
 
-      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - name: "Install sccache and direnv"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv"
+
+      - name: "Verify sccache"
+        run: sccache --version
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-workspace-crates: true
-          # See the cache strategy explanation at the top of this file.
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/canary' }}
           shared-key: "windows-cargo"
+
+      - name: "Load .envrc with direnv"
+        run: |
+          set -euo pipefail
+
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
+
+      - name: "Build native sccache wrapper"
+        run: |
+          set -euo pipefail
+          # The native RUSTC_WRAPPER (tools_sccache crate) maps the R2 creds and
+          # execs sccache; cargo launches it via CreateProcess (32767-char
+          # limit), avoiding cmd.exe's ~8191-char limit that windows-sys' huge
+          # `--check-cfg cfg(feature, values(...))` line blows past. The binary
+          # lives in the build tree, so build it first — .envrc leaves
+          # RUSTC_WRAPPER unset until it exists, so this bootstrap compiles with
+          # plain rustc — then point RUSTC_WRAPPER at it for the cargo steps
+          # below.
+          cargo build -p tools_sccache
+          echo "RUSTC_WRAPPER=$(pwd -W)/target/debug/baml-sccache.exe" >> "$GITHUB_ENV"
+        working-directory: baml_language
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -261,6 +302,22 @@ jobs:
       - name: "Run tests"
         run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/)'
         working-directory: baml_language
+
+      - name: "Show sccache stats"
+        if: always()
+        run: sccache --show-stats
+
+      - name: "Dump sccache stats (json)"
+        if: always()
+        run: sccache --show-stats --stats-format json > sccache-stats-test-windows.json
+
+      - name: "Upload sccache stats"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-stats-test-windows
+          path: sccache-stats-test-windows.json
+          if-no-files-found: ignore
 
       - name: "Rename cargo timings"
         if: always()
@@ -307,32 +364,47 @@ jobs:
         with:
           persist-credentials: false
 
-      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - name: "Install sccache, direnv, python, and uv"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv python uv"
+
+      - name: "Verify sccache"
+        run: sccache --version
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-workspace-crates: true
-          # See the cache strategy explanation at the top of this file.
+          cache-targets: false
           save-if: false
           shared-key: ${{ matrix.rust-cache-key }}
+
+      - name: "Load .envrc with direnv"
+        run: |
+          set -euo pipefail
+
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
+
+      # Windows-only: swap the .cmd RUSTC_WRAPPER for the native tools_sccache
+      # .exe. See the matching step in `cargo-test-windows` for why.
+      - name: "Build native sccache wrapper"
+        if: matrix.os-label == 'windows'
+        run: |
+          set -euo pipefail
+          cargo build -p tools_sccache
+          echo "RUSTC_WRAPPER=$(pwd -W)/target/debug/baml-sccache.exe" >> "$GITHUB_ENV"
+        working-directory: baml_language
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-
-      # sdk_test_* crates shell out to `uv sync` against the generated
-      # Python project under target/uv-cache. python + uv are the only
-      # mise tools the matrix needs.
-      - name: "Install mise"
-        uses: ./.github/actions/setup-mise
-        with:
-          install_args: "python uv"
 
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
@@ -350,6 +422,22 @@ jobs:
           path: |
             baml_language/sdk_tests/crates/*/generated/
             baml_language/target/nextest/
+          if-no-files-found: ignore
+
+      - name: "Show sccache stats"
+        if: always()
+        run: sccache --show-stats
+
+      - name: "Dump sccache stats (json)"
+        if: always()
+        run: sccache --show-stats --stats-format json > sccache-stats-sdk-tests-${{ matrix.os-label }}.json
+
+      - name: "Upload sccache stats"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-stats-sdk-tests-${{ matrix.os-label }}
+          path: sccache-stats-sdk-tests-${{ matrix.os-label }}.json
           if-no-files-found: ignore
 
       - name: "Rename cargo timings"
@@ -373,21 +461,34 @@ jobs:
         with:
           persist-credentials: false
 
-      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: |
           rustup show
           rustup target add wasm32-unknown-unknown
         working-directory: baml_language
 
+      - name: "Install sccache and direnv"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv"
+
+      - name: "Verify sccache"
+        run: sccache --version
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-workspace-crates: true
-          # See the cache strategy explanation at the top of this file.
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/canary' }}
           shared-key: "linux-wasm"
+
+      - name: "Load .envrc with direnv"
+        run: |
+          set -euo pipefail
+
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
 
       - name: "Build for WASM"
         run: |
@@ -398,6 +499,22 @@ jobs:
       - name: "List WASM artifacts"
         run: ls -lh target/wasm32-unknown-unknown/release/*.wasm || true
         working-directory: baml_language
+
+      - name: "Show sccache stats"
+        if: always()
+        run: sccache --show-stats
+
+      - name: "Dump sccache stats (json)"
+        if: always()
+        run: sccache --show-stats --stats-format json > sccache-stats-test-wasm.json
+
+      - name: "Upload sccache stats"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-stats-test-wasm
+          path: sccache-stats-test-wasm.json
+          if-no-files-found: ignore
 
       - name: "Rename cargo timings"
         if: always()
@@ -432,7 +549,6 @@ jobs:
           file: "baml_language/Cargo.toml"
           field: "workspace.package.rust-version"
 
-      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain (MSRV)"
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
@@ -441,20 +557,50 @@ jobs:
           rustup default "${MSRV}"
         working-directory: baml_language
 
+      - name: "Install sccache and direnv"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv"
+
+      - name: "Verify sccache"
+        run: sccache --version
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-workspace-crates: true
-          # See the cache strategy explanation at the top of this file.
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/canary' }}
           shared-key: "linux-msrv"
+
+      - name: "Load .envrc with direnv"
+        run: |
+          set -euo pipefail
+
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
 
       - name: "Build with MSRV"
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
         run: cargo "+${MSRV}" test --no-run --all-features --timings
         working-directory: baml_language
+
+      - name: "Show sccache stats"
+        if: always()
+        run: sccache --show-stats
+
+      - name: "Dump sccache stats (json)"
+        if: always()
+        run: sccache --show-stats --stats-format json > sccache-stats-msrv.json
+
+      - name: "Upload sccache stats"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-stats-msrv
+          path: sccache-stats-msrv.json
+          if-no-files-found: ignore
 
       - name: "Rename cargo timings"
         if: always()
@@ -481,20 +627,50 @@ jobs:
         run: rustup show
         working-directory: baml_language
 
+      - name: "Install sccache and direnv"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv"
+
+      - name: "Verify sccache"
+        run: sccache --version
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-workspace-crates: true
-          # See the cache strategy explanation at the top of this file.
+          cache-targets: false
           save-if: false
           shared-key: "linux-cargo"
+
+      - name: "Load .envrc with direnv"
+        run: |
+          set -euo pipefail
+
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
 
       - name: "Generate documentation"
         run: cargo doc --all --no-deps --timings
         working-directory: baml_language
         env:
           RUSTDOCFLAGS: "-D warnings"
+
+      - name: "Show sccache stats"
+        if: always()
+        run: sccache --show-stats
+
+      - name: "Dump sccache stats (json)"
+        if: always()
+        run: sccache --show-stats --stats-format json > sccache-stats-doc.json
+
+      - name: "Upload sccache stats"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-stats-doc
+          path: sccache-stats-doc.json
+          if-no-files-found: ignore
 
       - name: "Rename cargo timings"
         if: always()
@@ -517,32 +693,37 @@ jobs:
         with:
           persist-credentials: false
 
-      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - name: "Install sccache, direnv, python, and uv"
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv python uv"
+
+      - name: "Verify sccache"
+        run: sccache --version
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-workspace-crates: true
-          # See the cache strategy explanation at the top of this file.
+          cache-targets: false
           save-if: false
           shared-key: "linux-cargo"
+
+      - name: "Load .envrc with direnv"
+        run: |
+          set -euo pipefail
+
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
 
       - name: "Install cargo insta and nextest"
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-insta,cargo-nextest
-
-      # rig test scripts shell out to `uv run` (and bring their own
-      # Python via uv), so the only mise tools snapshot-tests needs are
-      # python + uv.
-      - name: "Install mise"
-        uses: ./.github/actions/setup-mise
-        with:
-          install_args: "python uv"
 
       - name: "Build tests with --timings"
         run: cargo test --no-run -p baml_tests -p baml_cli -p baml_lsp2_actions --all-features --timings
@@ -573,6 +754,22 @@ jobs:
             baml_language/**/*.snap
             baml_language/**/*.snap.new
 
+      - name: "Show sccache stats"
+        if: always()
+        run: sccache --show-stats
+
+      - name: "Dump sccache stats (json)"
+        if: always()
+        run: sccache --show-stats --stats-format json > sccache-stats-snapshot.json
+
+      - name: "Upload sccache stats"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-stats-snapshot
+          path: sccache-stats-snapshot.json
+          if-no-files-found: ignore
+
       - name: "Rename cargo timings"
         if: always()
         run: mv target/cargo-timings/cargo-timing.html target/cargo-timings/cargo-timing-snapshot.html
@@ -588,7 +785,6 @@ jobs:
   cargo-timings:
     name: "cargo timings (merged)"
     runs-on: ubuntu-latest
-    if: always()
     needs:
       - cargo-test-linux
       - cargo-test-macos
@@ -604,4 +800,23 @@ jobs:
         with:
           name: cargo-timings
           pattern: cargo-timings-*
+          delete-merged: true
+  sccache-stats:
+    name: "sccache stats (merged)"
+    runs-on: ubuntu-latest
+    needs:
+      - cargo-test-linux
+      - cargo-test-macos
+      - cargo-test-windows
+      - sdk-tests
+      - cargo-test-wasm
+      - cargo-build-msrv
+      - cargo-doc
+      - snapshot-tests
+    steps:
+      - name: "Merge sccache stats artifacts"
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: sccache-stats
+          pattern: sccache-stats-*
           delete-merged: true

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -8209,6 +8209,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "tools_sccache"
+version = "0.1.0"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -17,6 +17,9 @@ members = [
   # The failures surface via `cargo test`'s
   # `build_diagnostics::no_build_failures` test.
   "sdk_tests/crates/nodejs_typescript",
+  # Native RUSTC_WRAPPER shim (see tools_sccache/src/main.rs); the Windows
+  # counterpart to the tools/baml-sccache POSIX script, built explicitly in CI.
+  "tools_sccache",
 ]
 exclude = [
   # Generated Python rig-test outputs do not contain Cargo manifests, but the

--- a/baml_language/tools_sccache/Cargo.toml
+++ b/baml_language/tools_sccache/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tools_sccache"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+# This is a CI/build helper, not part of the shipped product. It shells out to
+# spawn a child process, which has no meaning on wasm32-unknown-unknown, so keep
+# it out of the WASM build's package selection (see cargo-tests.reusable.yaml).
+[package.metadata.ci]
+wasm_support = false
+
+# Build the binary under the recognizable `baml-sccache` name, matching the
+# shell wrappers in tools/.
+[[bin]]
+name = "baml-sccache"
+path = "src/main.rs"

--- a/baml_language/tools_sccache/src/main.rs
+++ b/baml_language/tools_sccache/src/main.rs
@@ -1,0 +1,43 @@
+//! Native `RUSTC_WRAPPER` shim — the compiled counterpart to the
+//! `tools/baml-sccache` shell script, used on Windows.
+//!
+//! cargo invokes `RUSTC_WRAPPER` once per crate, passing the full rustc command
+//! line through to it. A Windows `.cmd`/`.bat` wrapper is run through
+//! `cmd.exe`, whose ~8191-character command-line limit some crates exceed —
+//! e.g. `windows-sys`, with its enormous `--check-cfg cfg(feature,
+//! values(...))` argument — producing "The command line is too long". A real
+//! `.exe` is launched by cargo via `CreateProcess` directly (32767-character
+//! limit), so routing rustc through this binary avoids the cmd.exe hop and its
+//! tighter limit entirely.
+//!
+//! Its only job, like the shell script, is to map the `BAML_SCCACHE_R2_*`
+//! credentials to the `AWS_*` names sccache reads, then hand off to sccache
+//! with the same arguments.
+
+use std::process::{Command, exit};
+
+fn main() {
+    // sccache reads the R2 credentials under the AWS_* names. We run before any
+    // threads are spawned, so the set_var calls are sound.
+    for (from, to) in [
+        ("BAML_SCCACHE_R2_ACCESS_KEY_ID", "AWS_ACCESS_KEY_ID"),
+        ("BAML_SCCACHE_R2_SECRET_ACCESS_KEY", "AWS_SECRET_ACCESS_KEY"),
+    ] {
+        if let Some(value) = std::env::var_os(from) {
+            // SAFETY: single-threaded at this point; no concurrent env access.
+            unsafe { std::env::set_var(to, value) };
+        }
+    }
+
+    // argv[1..] is `<path-to-rustc> <args...>`; forward it verbatim to sccache.
+    // Use *_os to preserve non-UTF-8 paths/arguments.
+    let args = std::env::args_os().skip(1);
+
+    match Command::new("sccache").args(args).status() {
+        Ok(status) => exit(status.code().unwrap_or(1)),
+        Err(err) => {
+            eprintln!("baml-sccache: failed to spawn sccache: {err}");
+            exit(127);
+        }
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,8 @@ node = "22"         # For pnpm
 java = "temurin-23"
 
 uv = "0.11.3"
+direnv = "2.37.1"
+sccache = "0.10.0"
 
 # Rust tools
 "cargo:bacon" = "latest"


### PR DESCRIPTION
Use sccache (R2-backed) for Rust **compilation** artifacts in the cargo CI jobs, configured entirely from `.envrc` so CI matches local shells.

- `tools_sccache` crate / `tools/baml-sccache` wrapper: a `RUSTC_WRAPPER` that maps `BAML_SCCACHE_R2_*` → `AWS_*` and execs sccache (native crate on Windows, shell script on POSIX).
- mise installs sccache + direnv; each cargo job loads `.envrc` via `direnv export gha` (the single source of truth for the sccache/R2 config).
- **Swatinem/rust-cache still caches the cargo registry/git download state**, with `cache-targets: false` so sccache owns `target/` and the two caches don't compete. Fork PRs without R2 secrets fall back to the runner-local cache.

Follow-up #3624 replaces Swatinem for the download caches with a granular, Cargo.lock-driven R2 action (`cache-cargo-home`); this PR is the sccache base it stacks on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
