### PR TITLE
VM cleanup

### DIFF
--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -541,14 +541,18 @@ fn emit_copy_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
     }
 
     // Build the fields vec
-    write!(out, "{inner2}vm.alloc_instance(class_ptr, vec![").unwrap();
+    write!(
+        out,
+        "{inner2}Value::object(vm.alloc_instance(class_ptr, vec!["
+    )
+    .unwrap();
     for (i, field) in def.fields.iter().enumerate() {
         if i > 0 {
             out.push_str(", ");
         }
         write!(out, "f_{}", field.name).unwrap();
     }
-    out.push_str("])\n");
+    out.push_str("]))\n");
     writeln!(out, "{inner}}}").unwrap();
     writeln!(out, "{indent}}}\n").unwrap();
 }
@@ -577,7 +581,7 @@ fn copy_field_type(ty: &BamlType) -> String {
 /// Generate the expression to convert a copy struct field to a Value.
 fn copy_field_to_value(field_name: &str, ty: &BamlType) -> String {
     match ty {
-        BamlType::RustType => format!("vm.alloc_rust_data(self.{field_name})"),
+        BamlType::RustType => format!("Value::object(vm.alloc_rust_data(self.{field_name}))"),
         // `to_value` has no error channel (`fn to_value(self, vm) -> Value`),
         // so an out-of-i63 native i64 reaches this path only when caller-side
         // Rust constructed a struct field that violates the i63 BAML
@@ -598,7 +602,7 @@ fn copy_field_to_value(field_name: &str, ty: &BamlType) -> String {
             "vm.try_alloc_bigint(self.{field_name}).unwrap_or_else(|p| panic!(\
                 \"failed to allocate bigint field `{field_name}`: {{p}}\"))"
         ),
-        BamlType::Float => format!("vm.alloc_float(self.{field_name})"),
+        BamlType::Float => format!("Value::object(vm.alloc_float(self.{field_name}))"),
         BamlType::Bool => format!("Value::bool(self.{field_name})"),
         BamlType::Null => "Value::NULL".to_string(),
         // String, List, Map, Optional, Generic, Named, Media — already a Value
@@ -1629,10 +1633,14 @@ fn emit_result_conversion_ok(out: &mut String, b: &NativeBuiltin, indent: &str) 
     {
         writeln!(
             out,
-            "{indent}let result_values: Vec<Value> = result.into_iter().map(|s| vm.alloc_string(s)).collect();"
+            "{indent}let result_values: Vec<Value> = result.into_iter().map(|s| Value::object(vm.alloc_string(s))).collect();"
         )
         .unwrap();
-        writeln!(out, "{indent}Ok(vm.alloc_array(result_values))").unwrap();
+        writeln!(
+            out,
+            "{indent}Ok(Value::object(vm.alloc_array(result_values)))"
+        )
+        .unwrap();
         return;
     }
     let conversion = result_conversion_expr("result", &b.return_type);
@@ -1675,8 +1683,8 @@ fn return_type_needs_alloc(ty: &BamlType) -> bool {
 /// `#[from]` on `VmRustFnError`.
 fn result_conversion_expr(name: &str, ty: &BamlType) -> String {
     match ty {
-        BamlType::String => format!("vm.alloc_string({name})"),
-        BamlType::Uint8Array => format!("vm.alloc_uint8array({name})"),
+        BamlType::String => format!("Value::object(vm.alloc_string({name}))"),
+        BamlType::Uint8Array => format!("Value::object(vm.alloc_uint8array({name}))"),
         // Surface out-of-i63 native returns as a normal VM error instead
         // of silently truncating via the bare `Value::int` constructor's
         // `debug_assert` (which is a no-op in release).
@@ -1687,11 +1695,11 @@ fn result_conversion_expr(name: &str, ty: &BamlType) -> String {
             }})?"
         ),
         BamlType::Bigint => format!("vm.try_alloc_bigint({name})?"),
-        BamlType::Float => format!("vm.alloc_float({name})"),
+        BamlType::Float => format!("Value::object(vm.alloc_float({name}))"),
         BamlType::Bool => format!("Value::bool({name})"),
         BamlType::Null => "Value::NULL".to_string(),
-        BamlType::List(_) => format!("vm.alloc_array({name})"),
-        BamlType::Map(_, _) => format!("vm.alloc_map({name})"),
+        BamlType::List(_) => format!("Value::object(vm.alloc_array({name}))"),
+        BamlType::Map(_, _) => format!("Value::object(vm.alloc_map({name}))"),
         BamlType::Optional(inner) => {
             let inner_conversion = result_conversion_expr("v", inner);
             format!("match {name} {{ Some(v) => {inner_conversion}, None => Value::NULL }}")

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -1657,11 +1657,11 @@ fn return_type_needs_alloc(ty: &BamlType) -> bool {
         BamlType::String
         | BamlType::Uint8Array
         | BamlType::Bigint
+        | BamlType::Float
         | BamlType::List(_)
         | BamlType::Map(_, _) => true,
         BamlType::Optional(inner) => return_type_needs_alloc(inner),
         BamlType::Int
-        | BamlType::Float
         | BamlType::Bool
         | BamlType::Null
         | BamlType::Generic(_)

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -61,8 +61,7 @@ use crate::EngineError;
 /// `collect_roots` / `forward_roots` on the inner. It is **never activated**
 /// by the manager itself — every method requires a [`PermitProof`] from
 /// the caller's own active permit, witnessing that GC is gated externally.
-/// The wrapping [`tokio::sync::Mutex`] provides the single-writer invariant
-/// that previous releases derived from `SharedHeapPermit`.
+/// The wrapping [`tokio::sync::Mutex`] provides the single-writer invariant.
 pub struct FutureManager {
     permit: Mutex<InactiveHeapPermit<FutureManagerInner>>,
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -85,10 +85,10 @@ use async_trait::async_trait;
 use bex_events::{EventKind, FunctionEnd, FunctionEvent, FunctionStart, SpanContext};
 pub use bex_events::{HostSpanContext, RuntimeEvent, SpanId};
 pub use bex_external_types::{BexExternalValue, Ty, TypeName, UnionMetadata};
-use bex_heap::BexHeap;
 // Re-export GcStats for users of the engine
 pub use bex_heap::GcStats;
 pub use bex_heap::{ActiveHeapPermit, HeapGuard, HeapPermitManager, InactiveHeapPermit};
+use bex_heap::{BexHeap, TlabHolder};
 use bex_vm::{BexVm, SpanNotification, VmExecState};
 use bex_vm_types::{
     FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SharedGlobals, SysOp, Value,
@@ -1392,7 +1392,7 @@ impl BexEngine {
                 let collector_ref = bex_vm_types::CollectorRef(
                     Arc::clone(c) as Arc<dyn std::any::Any + Send + Sync>
                 );
-                thread.vm.alloc_collector(collector_ref)
+                Value::object(thread.vm.alloc_collector(collector_ref))
             })
             .collect();
 

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -1816,8 +1816,8 @@ mod tests {
         let captured = tlab.alloc_string("captured_value".to_string());
         let closure_ptr = tlab.alloc(Object::Closure(Closure {
             function: func_ptr,
-            captures: vec![Value::object(captured), Value::int(7)],
-            captured_type_args: vec![],
+            captures: Box::new([Value::object(captured), Value::int(7)]),
+            captured_type_args: Box::new([]),
         }));
 
         let roots = vec![closure_ptr];
@@ -2394,8 +2394,8 @@ mod tests {
         // --- Container: Object::Closure ---
         let closure_container = tlab.alloc(Object::Closure(Closure {
             function: leaf_func,
-            captures: vec![Value::object(leaf_for_closure_cap), Value::int(7)],
-            captured_type_args: vec![],
+            captures: Box::new([Value::object(leaf_for_closure_cap), Value::int(7)]),
+            captured_type_args: Box::new([]),
         }));
 
         // --- Container: Object::Cell ---

--- a/baml_language/crates/bex_heap/src/heap_guard.rs
+++ b/baml_language/crates/bex_heap/src/heap_guard.rs
@@ -21,7 +21,6 @@ use ::std::{
     collections::HashMap,
     sync::{Arc, Weak},
 };
-use ::tokio::sync::Mutex;
 
 /// The lesser of [`u32::MAX`] and [`tokio::sync::Semaphore::MAX_PERMITS`] (depends on compilation target pointer width).
 const MAX_PERMITS: u32 = {
@@ -39,6 +38,7 @@ const MAX_PERMITS: u32 = {
     }
 };
 
+/// The existence of a value that implements this trait proves that the heap is currently accessible for non-exclusive access (e.g. by a VM executor task).
 pub trait HeapPermit<T: RootHaver> {
     /// Get a reference to the root holder (for example, the active VM)
     ///
@@ -177,81 +177,6 @@ impl<T: RootHaver> InactiveHeapPermit<T> {
         // SAFETY: caller upholds the fn-level contract — the permit is active
         // and `&mut self` proves exclusive access on this thread.
         unsafe { &mut *ptr }
-    }
-}
-
-/// For use when multiple threads need to share a single permit.
-///
-/// Ensures only one thread can use the permit at a time,
-/// and yields to exclusive access whenever the permit is released.
-pub struct SharedHeapPermit<T: RootHaver> {
-    inner: Mutex<InactiveHeapPermit<T>>,
-}
-impl<T: RootHaver> SharedHeapPermit<T> {
-    pub fn new(inner: InactiveHeapPermit<T>) -> Self {
-        Self {
-            inner: Mutex::new(inner),
-        }
-    }
-    pub async fn acquire(&self) -> SharedHeapPermitGuard<'_, T> {
-        let state = self.inner.lock().await;
-        let permit = Arc::clone(&state.active)
-            .acquire_owned()
-            .await
-            .unwrap_or_else(|_| unreachable!("Semaphore should never be closed"));
-        SharedHeapPermitGuard {
-            state,
-            _permit: permit,
-            _marker: PhantomData,
-        }
-    }
-}
-
-pub struct SharedHeapPermitGuard<'a, T: RootHaver> {
-    state: tokio::sync::MutexGuard<'a, InactiveHeapPermit<T>>,
-    _permit: tokio::sync::OwnedSemaphorePermit,
-    /// Ties the auto `Send`/`Sync` of `SharedHeapPermitGuard` to `T`.
-    ///
-    /// Without this marker, every field of this struct is unconditionally
-    /// `Sync` (notably because [`PermitCell<T>`] has a manual unconditional
-    /// `unsafe impl Sync` — which is itself load-bearing, so that
-    /// `Weak<PermitCell<dyn RootHaver>>` can live in the manager's shared
-    /// `Mutex<Vec<…>>`). That would let the compiler auto-derive
-    /// `SharedHeapPermitGuard<T>: Sync` even when `T: !Sync`, and two threads
-    /// sharing `&SharedHeapPermitGuard<T>` could each call [`Self::holder`]
-    /// to observe `&T` at the same time — UB when `T: !Sync`.
-    _marker: PhantomData<T>,
-}
-impl<'a, T: RootHaver> HeapPermit<T> for SharedHeapPermitGuard<'a, T> {
-    fn holder(&self) -> &T {
-        // SAFETY: we have a permit to access the heap so we can access the root holder.
-        unsafe { self.state.holder() }
-    }
-    fn holder_mut(&mut self) -> &mut T {
-        // SAFETY: we have a permit to access the heap so we can access the root holder.
-        unsafe { self.state.holder_mut() }
-    }
-    fn proof(&self) -> PermitProof<'_> {
-        // SAFETY: see `ActiveHeapPermit::proof`.
-        #[allow(
-            unsafe_code,
-            reason = "this is the canonical safe constructor of PermitProof"
-        )]
-        unsafe {
-            PermitProof::new()
-        }
-    }
-}
-impl<'a, T: RootHaver> Deref for SharedHeapPermitGuard<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.holder()
-    }
-}
-impl<'a, T: RootHaver> DerefMut for SharedHeapPermitGuard<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.holder_mut()
     }
 }
 

--- a/baml_language/crates/bex_heap/src/lib.rs
+++ b/baml_language/crates/bex_heap/src/lib.rs
@@ -76,6 +76,5 @@ pub use heap::{BexHeap, DEFAULT_TLAB_SIZE, Generation, HeapStats};
 pub(crate) use heap_debugger::{HeapDebuggerConfig, HeapDebuggerState};
 pub use heap_guard::{
     ActiveHeapPermit, HeapGuard, HeapPermit, HeapPermitManager, InactiveHeapPermit,
-    SharedHeapPermit, SharedHeapPermitGuard,
 };
 pub use tlab::{Tlab, TlabHolder};

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -159,6 +159,12 @@ impl Tlab {
         unsafe { self.heap.make_heap_ptr(ptr) }
     }
 
+    /// Allocate a float object.
+    #[inline]
+    pub fn alloc_float(&mut self, f: f64) -> HeapPtr {
+        self.alloc(Object::Float(f))
+    }
+
     /// Allocate a string object.
     #[inline]
     pub fn alloc_string(&mut self, s: impl Into<bex_str::BexStr>) -> HeapPtr {
@@ -224,6 +230,12 @@ impl Tlab {
     #[inline]
     pub fn alloc_future(&mut self, future: bex_vm_types::Future) -> HeapPtr {
         self.alloc(Object::Future(future))
+    }
+
+    /// Allocate a bound method on the heap.
+    #[inline]
+    pub fn alloc_bound_method(&mut self, method: bex_vm_types::BoundMethod) -> HeapPtr {
+        self.alloc(Object::BoundMethod(method))
     }
 
     /// Get a new chunk from the heap (cold path).
@@ -306,6 +318,62 @@ impl std::fmt::Debug for Tlab {
 pub trait TlabHolder {
     fn tlab(&self) -> &Tlab;
     fn tlab_mut(&mut self) -> &mut Tlab;
+
+    fn alloc(&mut self, obj: Object) -> HeapPtr {
+        self.tlab_mut().alloc(obj)
+    }
+
+    fn alloc_float(&mut self, f: f64) -> HeapPtr {
+        self.tlab_mut().alloc_float(f)
+    }
+
+    fn alloc_string(&mut self, s: impl Into<bex_str::BexStr>) -> HeapPtr {
+        self.tlab_mut().alloc_string(s)
+    }
+
+    fn alloc_array(&mut self, values: Vec<Value>) -> HeapPtr {
+        self.tlab_mut().alloc_array(values)
+    }
+
+    fn alloc_map(&mut self, values: IndexMap<bex_str::BexStr, Value>) -> HeapPtr {
+        self.tlab_mut().alloc_map(values)
+    }
+
+    fn alloc_instance(&mut self, class: HeapPtr, fields: Vec<Value>) -> HeapPtr {
+        self.tlab_mut().alloc_instance(class, fields)
+    }
+
+    fn alloc_variant(&mut self, enm: HeapPtr, index: usize) -> HeapPtr {
+        self.tlab_mut().alloc_variant(enm, index)
+    }
+
+    fn alloc_uint8array(&mut self, data: Vec<u8>) -> HeapPtr {
+        self.tlab_mut().alloc_uint8array(data)
+    }
+
+    fn alloc_bigint(&mut self, value: num_bigint::BigInt) -> HeapPtr {
+        self.tlab_mut().alloc_bigint(value)
+    }
+
+    fn alloc_rust_data(&mut self, data: Arc<dyn std::any::Any + Send + Sync>) -> HeapPtr {
+        self.tlab_mut().alloc_rust_data(data)
+    }
+
+    fn alloc_collector(&mut self, collector: bex_vm_types::CollectorRef) -> HeapPtr {
+        self.tlab_mut().alloc_collector(collector)
+    }
+
+    fn alloc_type(&mut self, ty: baml_type::Ty) -> HeapPtr {
+        self.tlab_mut().alloc_type(ty)
+    }
+
+    fn alloc_future(&mut self, future: bex_vm_types::Future) -> HeapPtr {
+        self.tlab_mut().alloc_future(future)
+    }
+
+    fn alloc_bound_method(&mut self, method: bex_vm_types::BoundMethod) -> HeapPtr {
+        self.tlab_mut().alloc_bound_method(method)
+    }
 }
 
 #[cfg(test)]

--- a/baml_language/crates/bex_vm/src/package_baml/array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/array.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use bex_heap::TlabHolder;
 use bex_vm_types::{HeapPtr, Object, types::Value};
 
 use super::{BamlClassArray, Continuation, NativeCallResult, PackageBamlImpl, make_to_json_callee};
@@ -144,7 +145,7 @@ impl Continuation for MapContinuation {
         self.results.push(value);
         self.idx += 1;
         if self.idx >= self.array.len() {
-            return NativeCallResult::Done(vm.alloc_array(self.results));
+            return NativeCallResult::Done(Value::object(vm.alloc_array(self.results)));
         }
         let next_arg = self.array[self.idx];
         NativeCallResult::YieldToCall {
@@ -354,7 +355,7 @@ impl Continuation for FlatMapContinuation {
         self.results.extend(inner);
         self.idx += 1;
         if self.idx >= self.array.len() {
-            return NativeCallResult::Done(vm.alloc_array(self.results));
+            return NativeCallResult::Done(Value::object(vm.alloc_array(self.results)));
         }
         let next_arg = self.array[self.idx];
         NativeCallResult::YieldToCall {
@@ -387,7 +388,7 @@ impl Continuation for ToJsonContinuation {
         self.idx += 1;
 
         if self.idx >= self.array.len() {
-            return NativeCallResult::Done(vm.alloc_array(self.results));
+            return NativeCallResult::Done(Value::object(vm.alloc_array(self.results)));
         }
 
         let next_val = self.array[self.idx];
@@ -551,7 +552,7 @@ impl BamlClassArray for PackageBamlImpl {
         };
         let array = array.to_vec();
         if array.is_empty() {
-            return NativeCallResult::Done(vm.alloc_array(vec![]));
+            return NativeCallResult::Done(Value::object(vm.alloc_array(vec![])));
         }
         let first_arg = array[0];
         let capacity = array.len();
@@ -570,7 +571,7 @@ impl BamlClassArray for PackageBamlImpl {
 
     fn to_json(vm: &mut BexVm, array: &[Value]) -> NativeCallResult {
         if array.is_empty() {
-            return NativeCallResult::Done(vm.alloc_array(vec![]));
+            return NativeCallResult::Done(Value::object(vm.alloc_array(vec![])));
         }
 
         let array = array.to_vec();
@@ -787,7 +788,7 @@ impl BamlClassArray for PackageBamlImpl {
         };
         let array = array.to_vec();
         if array.is_empty() {
-            return NativeCallResult::Done(vm.alloc_array(vec![]));
+            return NativeCallResult::Done(Value::object(vm.alloc_array(vec![])));
         }
         let first_arg = array[0];
         NativeCallResult::YieldToCall {

--- a/baml_language/crates/bex_vm/src/package_baml/bigint.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/bigint.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 /// so TIR's constant-folder can refuse to fold bigint expressions that the
 /// VM would refuse to allocate.
 pub(crate) use baml_type::MAX_BIGINT_BITS;
+use bex_heap::TlabHolder;
 use bex_str::BexStr;
 use bex_vm_types::Value;
 use num_bigint::{BigInt, BigUint, Sign};
@@ -19,7 +20,7 @@ impl BamlClassBigint for PackageBamlImpl {
         // JSON has no native arbitrary-precision integer; emit a decimal
         // string so the value round-trips losslessly through any consumer.
         // Matches `value_to_serde` for `Object::Bigint` in `package_baml::json`.
-        vm.alloc_string(bigint.to_string())
+        Value::object(vm.alloc_string(bigint.to_string()))
     }
 
     fn abs(bigint: Arc<BigInt>) -> Arc<BigInt> {

--- a/baml_language/crates/bex_vm/src/package_baml/float.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/float.rs
@@ -1,3 +1,4 @@
+use bex_heap::TlabHolder;
 use bex_vm_types::Value;
 
 use super::{BamlClassFloat, PackageBamlImpl};
@@ -35,7 +36,7 @@ fn float_to_int(value: f64, op: &str) -> Result<i64, VmRustFnError> {
 
 impl BamlClassFloat for PackageBamlImpl {
     fn to_json(vm: &mut BexVm, float: f64) -> Value {
-        vm.alloc_float(float)
+        Value::object(vm.alloc_float(float))
     }
     // ── Predicates ────────────────────────────────────────────────────────────
 

--- a/baml_language/crates/bex_vm/src/package_baml/future.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/future.rs
@@ -13,6 +13,7 @@
 //! thread: the first writer to CAS `state` wins, others observe the new
 //! state and become no-ops.
 
+use bex_heap::TlabHolder;
 use bex_vm_types::types::{FutureRead, Object, Value};
 
 use super::{BamlClassFutureFuture, BamlNamespaceFuture, PackageBamlImpl};
@@ -103,7 +104,7 @@ impl BamlClassFutureFuture for PackageBamlImpl {
             _ => None,
         };
         match idx {
-            Some(i) => vm.alloc_variant(enm_ptr, i),
+            Some(i) => Value::object(vm.alloc_variant(enm_ptr, i)),
             None => Value::NULL,
         }
     }

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -65,6 +65,7 @@ fn class_lookup_key(qtn: &TypeName) -> String {
 }
 use std::collections::HashMap;
 
+use bex_heap::TlabHolder;
 use bex_vm_types::{
     HeapPtr,
     types::{Instance, Object, Value},
@@ -222,8 +223,10 @@ fn throw_json_parse_error(vm: &mut BexVm, message: String) -> Result<Value, VmIn
         .ok_or_else(|| VmInternalError::MissingNativeFunction {
             name: JSON_PARSE_ERROR_FQN.to_string(),
         })?;
-    let message_val = vm.alloc_string(message);
-    Ok(vm.alloc_instance(class_ptr, vec![message_val]))
+    let message_val = Value::object(vm.alloc_string(message));
+    Ok(Value::object(
+        vm.alloc_instance(class_ptr, vec![message_val]),
+    ))
 }
 
 fn throw_json_decode_error(
@@ -238,9 +241,11 @@ fn throw_json_decode_error(
         .ok_or_else(|| VmInternalError::MissingNativeFunction {
             name: JSON_DECODE_ERROR_FQN.to_string(),
         })?;
-    let message_val = vm.alloc_string(message);
-    let path_val = vm.alloc_string(path.to_string());
-    Ok(vm.alloc_instance(class_ptr, vec![message_val, path_val]))
+    let message_val = Value::object(vm.alloc_string(message));
+    let path_val = Value::object(vm.alloc_string(path.to_string()));
+    Ok(Value::object(
+        vm.alloc_instance(class_ptr, vec![message_val, path_val]),
+    ))
 }
 
 fn throw_json_serialization_error(
@@ -256,10 +261,13 @@ fn throw_json_serialization_error(
         .ok_or_else(|| VmInternalError::MissingNativeFunction {
             name: JSON_SERIALIZATION_ERROR_FQN.to_string(),
         })?;
-    let message_val = vm.alloc_string(message);
-    let path_val = vm.alloc_string(path.to_string());
-    let reason_val = vm.alloc_string(reason.to_string());
-    Ok(vm.alloc_instance(class_ptr, vec![message_val, path_val, reason_val]))
+    let message_val = Value::object(vm.alloc_string(message));
+    let path_val = Value::object(vm.alloc_string(path.to_string()));
+    let reason_val = Value::object(vm.alloc_string(reason.to_string()));
+    Ok(Value::object(vm.alloc_instance(
+        class_ptr,
+        vec![message_val, path_val, reason_val],
+    )))
 }
 
 fn raise_decode(vm: &mut BexVm, message: impl Into<String>, path: &str) -> VmRustFnError {
@@ -309,17 +317,17 @@ pub fn serde_to_value(vm: &mut BexVm, v: &serde_json::Value) -> Value {
             {
                 v
             } else if let Some(f) = n.as_f64() {
-                vm.alloc_float(f)
+                Value::object(vm.alloc_float(f))
             } else {
                 // Only reachable with serde_json's `arbitrary_precision`
                 // feature (not enabled here). NaN is a sentinel for "we
                 // were handed a number we can't represent at all"; if you
                 // hit this in practice, refuse arbitrary-precision input
                 // upstream rather than relying on this fallback.
-                vm.alloc_float(f64::NAN)
+                Value::object(vm.alloc_float(f64::NAN))
             }
         }
-        serde_json::Value::String(s) => vm.alloc_string(s.clone()),
+        serde_json::Value::String(s) => Value::object(vm.alloc_string(s.clone())),
         serde_json::Value::Array(arr) => {
             let items: Vec<Value> = arr.iter().map(|elem| serde_to_value(vm, elem)).collect();
             Value::object(vm.tlab.alloc(Object::Array(items.into())))
@@ -773,7 +781,7 @@ fn ty_serde_to_value(
         Ty::Float { .. } => match json {
             serde_json::Value::Number(n) => {
                 if let Some(f) = n.as_f64() {
-                    Ok(vm.alloc_float(f))
+                    Ok(Value::object(vm.alloc_float(f)))
                 } else {
                     Err(raise_decode(vm, "expected number", path))
                 }
@@ -782,7 +790,7 @@ fn ty_serde_to_value(
         },
 
         Ty::String { .. } => match json {
-            serde_json::Value::String(s) => Ok(vm.alloc_string(s.clone())),
+            serde_json::Value::String(s) => Ok(Value::object(vm.alloc_string(s.clone()))),
             _ => Err(raise_decode(vm, "expected string", path)),
         },
 
@@ -876,7 +884,7 @@ fn ty_serde_to_value(
                 Ok(Value::bool(*jb))
             }
             (baml_type::Literal::String(s), serde_json::Value::String(js)) if s == js => {
-                Ok(vm.alloc_string(js.clone()))
+                Ok(Value::object(vm.alloc_string(js.clone())))
             }
             (baml_type::Literal::Int(expected), serde_json::Value::Number(n)) => {
                 if let Some(actual) = n.as_i64() {
@@ -889,7 +897,7 @@ fn ty_serde_to_value(
             (baml_type::Literal::Float(s), serde_json::Value::Number(n)) => {
                 if let (Ok(expected), Some(actual)) = (s.parse::<f64>(), n.as_f64()) {
                     if (expected - actual).abs() < f64::EPSILON {
-                        return Ok(vm.alloc_float(actual));
+                        return Ok(Value::object(vm.alloc_float(actual)));
                     }
                 }
                 Err(raise_decode(vm, "literal float mismatch", path))
@@ -1007,7 +1015,7 @@ fn deserialize_enum_variant(
         }
     };
     match idx {
-        Some(i) => Ok(vm.alloc_variant(enm_ptr, i)),
+        Some(i) => Ok(Value::object(vm.alloc_variant(enm_ptr, i))),
         None => Err(raise_decode(
             vm,
             format!("unknown variant `{variant_name}` for enum `{qtn}`"),
@@ -1086,8 +1094,8 @@ fn deserialize_media(
         .get(&key)
         .copied()
         .ok_or_else(|| raise_decode(vm, format!("media class `{qtn}` not found"), path))?;
-    let data_val = vm.alloc_rust_data(media_arc);
-    Ok(vm.alloc_instance(class_ptr, vec![data_val]))
+    let data_val = Value::object(vm.alloc_rust_data(media_arc));
+    Ok(Value::object(vm.alloc_instance(class_ptr, vec![data_val])))
 }
 
 // ─── from_json dispatcher ────────────────────────────────────────────────────

--- a/baml_language/crates/bex_vm/src/package_baml/map.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/map.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use bex_heap::TlabHolder;
 use bex_vm_types::{BexStr, HeapPtr, types::Value};
 use indexmap::IndexMap;
 
@@ -36,7 +37,7 @@ impl Continuation for MapToJsonContinuation {
 
         if self.idx >= self.entries.len() {
             // All entries have been processed — return the completed map.
-            return NativeCallResult::Done(vm.alloc_map(self.results));
+            return NativeCallResult::Done(Value::object(vm.alloc_map(self.results)));
         }
 
         // Yield to call to_json on the next value.
@@ -102,7 +103,9 @@ impl BamlClassMap for PackageBamlImpl {
     }
 
     fn keys(vm: &mut BexVm, map: &IndexMap<BexStr, Value>) -> Vec<Value> {
-        map.keys().map(|k| vm.alloc_string(k.clone())).collect()
+        map.keys()
+            .map(|k| Value::object(vm.alloc_string(k.clone())))
+            .collect()
     }
 
     fn values(map: &IndexMap<BexStr, Value>) -> Vec<Value> {
@@ -151,7 +154,7 @@ impl BamlClassMap for PackageBamlImpl {
         let entries: Vec<(BexStr, Value)> = map.iter().map(|(k, v)| (k.clone(), *v)).collect();
 
         if entries.is_empty() {
-            return NativeCallResult::Done(vm.alloc_map(IndexMap::new()));
+            return NativeCallResult::Done(Value::object(vm.alloc_map(IndexMap::new())));
         }
 
         let first_val = entries[0].1;

--- a/baml_language/crates/bex_vm/src/package_baml/media.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/media.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use baml_type::MediaKind;
+use bex_heap::TlabHolder;
 use bex_vm_types::types::{Object, Value};
 use indexmap::IndexMap;
 
@@ -76,25 +77,25 @@ fn media_value_to_json(
     };
 
     let mime_val = match media.mime_type() {
-        Some(m) => vm.alloc_string(m),
+        Some(m) => Value::object(vm.alloc_string(m)),
         None => Value::NULL,
     };
 
     let mut map: IndexMap<bex_vm_types::BexStr, _> = IndexMap::new();
     map.insert(
         bex_vm_types::BexStr::from("kind"),
-        vm.alloc_string(kind_str.to_string()),
+        Value::object(vm.alloc_string(kind_str.to_string())),
     );
     map.insert(
         bex_vm_types::BexStr::from("source"),
-        vm.alloc_string(source_str.to_string()),
+        Value::object(vm.alloc_string(source_str.to_string())),
     );
     map.insert(
         bex_vm_types::BexStr::from("value"),
-        vm.alloc_string(value_str),
+        Value::object(vm.alloc_string(value_str)),
     );
     map.insert(bex_vm_types::BexStr::from("mime"), mime_val);
-    vm.alloc_map(map)
+    Value::object(vm.alloc_map(map))
 }
 
 // All media accessors and constructors live on `baml_builtins2::MediaValue`

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -38,6 +38,7 @@ mod unstable;
 
 use std::collections::HashMap;
 
+use bex_heap::TlabHolder;
 use bex_vm_types::{
     ArrayReadGuard, HeapPtr, MapReadGuard,
     types::{Instance, Object, Type, Value},
@@ -188,11 +189,10 @@ pub(super) fn make_to_json_callee(vm: &mut BexVm, v: Value) -> Result<HeapPtr, V
     })?;
 
     // Allocate a BoundMethod with the value as receiver.
-    let bound = vm.alloc_bound_method(fn_ptr, v);
-    let Some(bound_ptr) = bound.as_object_ptr() else {
-        unreachable!("alloc_bound_method always returns Value::Object");
-    };
-    Ok(bound_ptr)
+    Ok(vm.alloc_bound_method(bex_vm_types::BoundMethod {
+        function: fn_ptr,
+        receiver: v,
+    }))
 }
 
 // =============================================================================

--- a/baml_language/crates/bex_vm/src/package_baml/string.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/string.rs
@@ -1,3 +1,4 @@
+use bex_heap::TlabHolder;
 use bex_str::BexStr;
 use bex_vm_types::types::Value;
 
@@ -12,7 +13,7 @@ impl BamlClassString for PackageBamlImpl {
         // `string` is already a valid `json` arm — BAML's `json` type alias
         // includes `string` as one of its union members.  Wrap the BexStr
         // back into a heap-allocated `Value::object(Object::String(...))`.
-        vm.alloc_string(string.clone())
+        Value::object(vm.alloc_string(string.clone()))
     }
 
     #[allow(clippy::cast_possible_wrap)]

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1586,24 +1586,6 @@ impl BexVm {
         }
     }
 
-    /// Allocates an array on the heap and returns it to the caller.
-    pub fn alloc_array(&mut self, values: Vec<Value>) -> Value {
-        Value::object(self.tlab.alloc(Object::Array(values.into())))
-    }
-
-    pub fn alloc_map(&mut self, values: IndexMap<bex_vm_types::BexStr, Value>) -> Value {
-        Value::object(self.tlab.alloc(Object::Map(values.into())))
-    }
-
-    pub fn alloc_string(&mut self, s: impl Into<bex_vm_types::BexStr>) -> Value {
-        Value::object(self.tlab.alloc(Object::String(s.into())))
-    }
-
-    /// Allocate a heap-boxed float and return it as a `Value`.
-    pub fn alloc_float(&mut self, f: f64) -> Value {
-        Value::object(self.tlab.alloc(Object::Float(f)))
-    }
-
     /// Allocate a bigint on the heap. Takes an `Arc<BigInt>` to allow sharing.
     ///
     /// Refuses values exceeding `MAX_BIGINT_BITS` so a single arithmetic op
@@ -1929,29 +1911,6 @@ impl BexVm {
         Ok(Value::object(self.tlab.alloc(Object::Bigint(arc))))
     }
 
-    pub fn alloc_uint8array(&mut self, data: Vec<u8>) -> Value {
-        Value::object(self.tlab.alloc_uint8array(data))
-    }
-
-    /// TODO: Seems to low level for an embedder, provide an API that takes
-    /// class name and mapping of field name => value instead.
-    pub fn alloc_instance(&mut self, class: HeapPtr, fields: Vec<Value>) -> Value {
-        Value::object(
-            self.tlab
-                .alloc(Object::Instance(Instance::new(class, vec![], fields))),
-        )
-    }
-
-    // TODO: Same problem as above. Ideally takes (&str, &str) instead.
-    pub fn alloc_variant(&mut self, enm: HeapPtr, index: usize) -> Value {
-        Value::object(self.tlab.alloc(Object::Variant(Variant { enm, index })))
-    }
-
-    /// Allocate a collector object on the heap.
-    pub fn alloc_collector(&mut self, collector: bex_vm_types::CollectorRef) -> Value {
-        Value::object(self.tlab.alloc_collector(collector))
-    }
-
     /// Get collector ref from a Value.
     pub fn as_collector(
         &self,
@@ -1966,13 +1925,6 @@ impl BexVm {
                 got: ObjectType::of(obj).into(),
             }),
         }
-    }
-
-    /// Allocate opaque Rust data on the heap, returning a `Value::object(HeapPtr)`.
-    ///
-    /// Used by generated `copy::` structs for `$rust_type` fields.
-    pub fn alloc_rust_data(&mut self, data: Arc<dyn std::any::Any + Send + Sync>) -> Value {
-        Value::object(self.tlab.alloc_rust_data(data))
     }
 
     /// Downcast a `Value` carrying a heap pointer to `Object::RustData` to `&T`.
@@ -2052,23 +2004,6 @@ impl BexVm {
             }
         }
         None
-    }
-
-    /// Allocate a `BoundMethod` on the heap, binding `function` (a `HeapPtr`
-    /// pointing to an `Object::Function`) to `receiver`.
-    ///
-    /// When the bound method is called via `YieldToCall`, the VM automatically
-    /// inserts `receiver` as the first argument (`self`).
-    pub fn alloc_bound_method(&mut self, function: HeapPtr, receiver: Value) -> Value {
-        Value::object(
-            self.tlab
-                .alloc(Object::BoundMethod(BoundMethod { function, receiver })),
-        )
-    }
-
-    /// Allocate a type descriptor object on the heap.
-    pub fn alloc_type(&mut self, ty: baml_type::Ty) -> Value {
-        Value::object(self.tlab.alloc_type(ty))
     }
 
     /// Stops the execution of the current bytecode in favor of the given
@@ -2220,43 +2155,54 @@ impl BexVm {
         let (class, fields) = match error {
             VmBamlError::InvalidArgument { message } => (
                 ErrorClass::InvalidArgument,
-                vec![self.alloc_string(message)],
+                vec![Value::object(self.alloc_string(message))],
             ),
-            VmBamlError::ParseError { message } => {
-                (ErrorClass::ParseError, vec![self.alloc_string(message)])
-            }
-            VmBamlError::Io { message } => (ErrorClass::Io, vec![self.alloc_string(message)]),
+            VmBamlError::ParseError { message } => (
+                ErrorClass::ParseError,
+                vec![Value::object(self.alloc_string(message))],
+            ),
+            VmBamlError::Io { message } => (
+                ErrorClass::Io,
+                vec![Value::object(self.alloc_string(message))],
+            ),
             VmBamlError::Timeout {
                 message,
                 duration_ms,
             } => (
                 ErrorClass::Timeout,
                 vec![
-                    self.alloc_string(message),
+                    Value::object(self.alloc_string(message)),
                     duration_ms.map_or(Value::NULL, Value::int),
                 ],
             ),
-            VmBamlError::Unsupported { message } => {
-                (ErrorClass::Unsupported, vec![self.alloc_string(message)])
-            }
-            VmBamlError::AccessError { message } => {
-                (ErrorClass::AccessError, vec![self.alloc_string(message)])
-            }
-            VmBamlError::RenderPrompt { message } => {
-                (ErrorClass::RenderPrompt, vec![self.alloc_string(message)])
-            }
-            VmBamlError::NotImplemented { message } => {
-                (ErrorClass::NotImplemented, vec![self.alloc_string(message)])
-            }
-            VmBamlError::LlmClient { message } => {
-                (ErrorClass::LlmClient, vec![self.alloc_string(message)])
-            }
-            VmBamlError::DevOther { message } => {
-                (ErrorClass::DevOther, vec![self.alloc_string(message)])
-            }
-            VmBamlError::HostPanic { message } => {
-                (ErrorClass::HostPanic, vec![self.alloc_string(message)])
-            }
+            VmBamlError::Unsupported { message } => (
+                ErrorClass::Unsupported,
+                vec![Value::object(self.alloc_string(message))],
+            ),
+            VmBamlError::AccessError { message } => (
+                ErrorClass::AccessError,
+                vec![Value::object(self.alloc_string(message))],
+            ),
+            VmBamlError::RenderPrompt { message } => (
+                ErrorClass::RenderPrompt,
+                vec![Value::object(self.alloc_string(message))],
+            ),
+            VmBamlError::NotImplemented { message } => (
+                ErrorClass::NotImplemented,
+                vec![Value::object(self.alloc_string(message))],
+            ),
+            VmBamlError::LlmClient { message } => (
+                ErrorClass::LlmClient,
+                vec![Value::object(self.alloc_string(message))],
+            ),
+            VmBamlError::DevOther { message } => (
+                ErrorClass::DevOther,
+                vec![Value::object(self.alloc_string(message))],
+            ),
+            VmBamlError::HostPanic { message } => (
+                ErrorClass::HostPanic,
+                vec![Value::object(self.alloc_string(message))],
+            ),
         };
         self.alloc_error_value(class, fields)
     }
@@ -2279,10 +2225,10 @@ impl BexVm {
         let frames: Vec<Value> = trace
             .iter()
             .map(|loc| {
-                let file = self.alloc_string(loc.file_path.clone());
+                let file = Value::object(self.alloc_string(loc.file_path.clone()));
                 #[allow(clippy::cast_possible_wrap)]
                 let line = Value::int(loc.error_line as i64);
-                let function_name = self.alloc_string(loc.function_name.clone());
+                let function_name = Value::object(self.alloc_string(loc.function_name.clone()));
                 self.alloc_error_value(ErrorClass::StackFrame, vec![file, line, function_name])
             })
             .collect();
@@ -2317,41 +2263,41 @@ impl BexVm {
                 )
             }
             VmPanic::MapKeyNotFound => {
-                let key = self.alloc_string("(unknown)".to_string());
+                let key = Value::object(self.alloc_string("(unknown)".to_string()));
                 (PanicClass::MapKeyNotFound, vec![key])
             }
             VmPanic::StackOverflow => {
-                let msg = self.alloc_string("stack overflow".to_string());
+                let msg = Value::object(self.alloc_string("stack overflow".to_string()));
                 (PanicClass::StackOverflow, vec![msg])
             }
             VmPanic::AssertionFailed => {
-                let msg = self.alloc_string("assertion failed".to_string());
+                let msg = Value::object(self.alloc_string("assertion failed".to_string()));
                 (PanicClass::AssertionFailed, vec![msg])
             }
             VmPanic::Unreachable => {
-                let msg = self.alloc_string("unreachable code executed".to_string());
+                let msg = Value::object(self.alloc_string("unreachable code executed".to_string()));
                 (PanicClass::Unreachable, vec![msg])
             }
             VmPanic::Cancelled => {
-                let msg = self.alloc_string("operation cancelled".to_string());
+                let msg = Value::object(self.alloc_string("operation cancelled".to_string()));
                 (PanicClass::Cancelled, vec![msg])
             }
             VmPanic::UserPanic { message } => {
-                let msg = self.alloc_string(message);
+                let msg = Value::object(self.alloc_string(message));
                 (PanicClass::UserPanic, vec![msg])
             }
             VmPanic::Exit { code } => (PanicClass::Exit, vec![Value::int(code)]),
             VmPanic::AllocFailure { message } => {
-                let msg = self.alloc_string(message);
+                let msg = Value::object(self.alloc_string(message));
                 (PanicClass::AllocFailure, vec![msg])
             }
             VmPanic::HostUnavailable { resource, message } => {
-                let resource = self.alloc_string(resource);
-                let message = self.alloc_string(message);
+                let resource = Value::object(self.alloc_string(resource));
+                let message = Value::object(self.alloc_string(message));
                 (PanicClass::HostUnavailable, vec![resource, message])
             }
             VmPanic::NegativeBitShift { message } => {
-                let msg = self.alloc_string(message);
+                let msg = Value::object(self.alloc_string(message));
                 (PanicClass::NegativeBitShift, vec![msg])
             }
         };
@@ -3502,12 +3448,12 @@ impl BexVm {
                     let left_v = if left.is_object() {
                         left
                     } else {
-                        self.alloc_float(l)
+                        Value::object(self.alloc_float(l))
                     };
                     let right_v = if right.is_object() {
                         right
                     } else {
-                        self.alloc_float(r)
+                        Value::object(self.alloc_float(r))
                     };
                     return Err(VmError::Thrown(self.panic_to_exception_value(
                         VmPanic::DivisionByZero {
@@ -3530,12 +3476,12 @@ impl BexVm {
                     .into());
                 }
             };
-            self.alloc_float(f)
+            Value::object(self.alloc_float(f))
         } else if left.is_object() && right.is_object() && op == BinOp::Add {
             let ls = self.as_string(&left)?;
             let rs = self.as_string(&right)?;
             let result = bex_str::BexStr::concat(ls.clone(), rs.clone());
-            self.alloc_string(result)
+            Value::object(self.alloc_string(result))
         } else {
             return Err(VmInternalError::CannotApplyBinOp {
                 left: self.type_of(&left),
@@ -4925,7 +4871,7 @@ impl BexVm {
                         }
                     };
 
-                    let value = self.alloc_type(ty);
+                    let value = Value::object(self.alloc_type(ty));
                     self.stack.push(value);
                 }
 
@@ -5428,7 +5374,7 @@ impl BexVm {
                     let Some(l) = value_as_float(self.stack.ensure_pop()) else {
                         std::hint::unreachable_unchecked()
                     };
-                    let v = self.alloc_float(l + r);
+                    let v = Value::object(self.alloc_float(l + r));
                     self.stack.push(v);
                 }
                 OpCode::SubFloat => {
@@ -5438,7 +5384,7 @@ impl BexVm {
                     let Some(l) = value_as_float(self.stack.ensure_pop()) else {
                         std::hint::unreachable_unchecked()
                     };
-                    let v = self.alloc_float(l - r);
+                    let v = Value::object(self.alloc_float(l - r));
                     self.stack.push(v);
                 }
                 OpCode::MulFloat => {
@@ -5448,7 +5394,7 @@ impl BexVm {
                     let Some(l) = value_as_float(self.stack.ensure_pop()) else {
                         std::hint::unreachable_unchecked()
                     };
-                    let v = self.alloc_float(l * r);
+                    let v = Value::object(self.alloc_float(l * r));
                     self.stack.push(v);
                 }
                 OpCode::DivFloat => {
@@ -5471,7 +5417,7 @@ impl BexVm {
                             },
                         )));
                     }
-                    let v = self.alloc_float(l / r);
+                    let v = Value::object(self.alloc_float(l / r));
                     self.stack.push(v);
                 }
 
@@ -5612,7 +5558,7 @@ impl BexVm {
                     if let Some(n) = val.as_int() {
                         self.stack.push(Value::int(-n));
                     } else if let Some(n) = value_as_float(val) {
-                        let v = self.alloc_float(-n);
+                        let v = Value::object(self.alloc_float(-n));
                         self.stack.push(v);
                     } else if let Some(ptr) = val.as_object_ptr() {
                         // Bigint negation. Compute the negated value into an

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1396,7 +1396,7 @@ impl BexVm {
         // implementation with the spawn path.
         let type_args = match self.get_object(function) {
             Object::Function(_) => vec![],
-            Object::Closure(closure) => closure.captured_type_args.clone(),
+            Object::Closure(closure) => closure.captured_type_args.to_vec(),
             other => panic!("expect function or closure as entry point, got {other:?}"),
         };
         self.set_entry_point_with_type_args(function, args, type_args);
@@ -2624,9 +2624,9 @@ impl BexVm {
         // Extract captured_type_args from a Closure callee before we discard
         // the concrete Closure type in favour of the inner Function.
         // These are injected into the new BytecodeFrame after it is created.
-        let closure_type_args: Vec<baml_type::Ty> = match self.get_object(callee_ptr) {
+        let closure_type_args: Box<[baml_type::Ty]> = match self.get_object(callee_ptr) {
             Object::Closure(c) => c.captured_type_args.clone(),
-            _ => vec![],
+            _ => Box::new([]),
         };
 
         // For BoundMethod callees, extract the receiver's class_type_args so
@@ -2634,15 +2634,15 @@ impl BexVm {
         // appended.  This implements the De Bruijn ordering:
         //   frame.type_args = receiver.class_type_args ++ explicit_call_site_args
         // matching enclosing_generic_params() which puts class params first.
-        let bound_method_class_type_args: Vec<baml_type::Ty> = match self.get_object(callee_ptr) {
+        let bound_method_class_type_args: Box<[baml_type::Ty]> = match self.get_object(callee_ptr) {
             Object::BoundMethod(bm) => match bm.receiver.as_object_ptr() {
                 Some(recv_ptr) => match self.get_object(recv_ptr) {
-                    Object::Instance(inst) => inst.class_type_args.clone(),
-                    _ => vec![],
+                    Object::Instance(inst) => inst.class_type_args.clone().into_boxed_slice(),
+                    _ => Box::new([]),
                 },
-                None => vec![],
+                None => Box::new([]),
             },
-            _ => vec![],
+            _ => Box::new([]),
         };
 
         // Resolve the callee: either a plain Function, a Closure, or a BoundMethod wrapping one.
@@ -2838,7 +2838,7 @@ impl BexVm {
                     function: callee_ptr,
                     instruction_ptr: 0,
                     locals_offset,
-                    type_args: initial_type_args,
+                    type_args: initial_type_args.into_vec(),
                     faulting_pc: 0,
                 }));
                 self.allocate_real_locals_for_frame(callee_ptr)?;
@@ -4836,8 +4836,8 @@ impl BexVm {
                     let function_ptr = self.idx_to_ptr(ObjectIndex::from_raw(obj_idx_raw));
                     let closure = Object::Closure(Closure {
                         function: function_ptr,
-                        captures,
-                        captured_type_args,
+                        captures: captures.into_boxed_slice(),
+                        captured_type_args: captured_type_args.into_boxed_slice(),
                     });
                     let ptr = self.tlab.alloc(closure);
                     self.stack.push(Value::object(ptr));

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -4449,7 +4449,6 @@ impl BexVm {
                         );
                         let visible_arity = full_arity.saturating_sub(1);
                         let receiver = bm.receiver;
-                        let fn_ptr = bm.function;
                         let _popped = self.stack.ensure_pop();
                         let args_offset = self
                             .stack
@@ -4458,8 +4457,15 @@ impl BexVm {
                             .ok_or(VmInternalError::NotEnoughItemsOnStack(visible_arity))?;
                         self.stack.insert(args_offset, receiver);
                         let locals_offset = StackIndex::from_raw(args_offset);
+                        // Pass the BoundMethod pointer (not its inner function) so
+                        // `execute_call_from_locals_offset` seeds the receiver's
+                        // `class_type_args` into the new frame — generic instance
+                        // methods invoked through a bound-method value would
+                        // otherwise start with an empty class-type-arg prefix. The
+                        // receiver is already on the stack, and the helper resolves
+                        // the inner function itself without re-inserting it.
                         if let Some(state) = self.execute_call_from_locals_offset(
-                            fn_ptr,
+                            callee_ptr,
                             locals_offset,
                             full_arity,
                             frame_idx,

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -28,12 +28,12 @@ pub use indexable::{
 };
 pub use roots::{PermitProof, RootHaver, WriteBarrier};
 pub use types::{
-    ArrayContainer, ArrayReadGuard, ArrayWriteGuard, AtomicValueSlot, Class, ClassField,
-    ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum, EnumVariant, Function,
-    FunctionKind, FunctionMeta, FunctionOrigin, Future, FutureRead, HostClosure, Instance,
-    LockedContainer, LockedReadGuard, LockedWriteGuard, MapContainer, MapReadGuard, MapWriteGuard,
-    MediaValue, Object, ObjectType, PanicClass, Program, PromptAst, RetryPolicyMeta, SysOp,
-    SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase, Uint8ArrayContainer,
+    ArrayContainer, ArrayReadGuard, ArrayWriteGuard, AtomicValueSlot, BoundMethod, Class,
+    ClassField, ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum, EnumVariant,
+    Function, FunctionKind, FunctionMeta, FunctionOrigin, Future, FutureRead, HostClosure,
+    Instance, LockedContainer, LockedReadGuard, LockedWriteGuard, MapContainer, MapReadGuard,
+    MapWriteGuard, MediaValue, Object, ObjectType, PanicClass, Program, PromptAst, RetryPolicyMeta,
+    SysOp, SysOpErrorCategory, SysOpPanicCategory, TestArgValue, TestCase, Uint8ArrayContainer,
     Uint8ArrayReadGuard, Uint8ArrayWriteGuard, UnscheduledFuture, Value, ValueKind, Variant,
     format_float, sys_op_for_path, type_tags,
 };

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -1665,17 +1665,9 @@ pub enum Object {
     Sentinel(SentinelKind),
 }
 
-// BexStr is larger than String on wasm32 (20 vs 12 bytes) due to u64 fields,
-// so allow 88 bytes on 32-bit targets.
-#[cfg(target_pointer_width = "64")]
 const _: () = assert!(
-    std::mem::size_of::<Object>() <= 80,
-    "Object enum size regression — expected <= 80 bytes (64-bit)"
-);
-#[cfg(target_pointer_width = "32")]
-const _: () = assert!(
-    std::mem::size_of::<Object>() <= 88,
-    "Object enum size regression — expected <= 88 bytes (32-bit)"
+    std::mem::size_of::<Object>() <= 64,
+    "Object enum size regression — expected <= 64 bytes"
 );
 
 // Custom borsh for Object: RustData and Collector contain non-serializable
@@ -1802,7 +1794,7 @@ pub struct Closure {
     /// Pointer to the underlying `Object::Function`.
     pub function: HeapPtr,
     /// Captured cells, one per closed-over variable (each is `Object::Cell`).
-    pub captures: Vec<Value>,
+    pub captures: Box<[Value]>,
     /// Type arguments captured from the enclosing generic context at the time
     /// the closure is created by `MakeClosure`.
     ///
@@ -1811,7 +1803,7 @@ pub struct Closure {
     /// before the cell captures.  These become `frame.type_args` when the
     /// closure is invoked, so that `LoadType(TypeArgRef(N))` inside the
     /// closure body resolves correctly.
-    pub captured_type_args: Vec<baml_type::Ty>,
+    pub captured_type_args: Box<[baml_type::Ty]>,
 }
 
 /// A method bound to a specific receiver instance.


### PR DESCRIPTION
- Limits `Object` enum to 64 bytes by converting some `Vec<_>` into `Box<[_]>`
- Moved `alloc_*` methods from `BexVM` onto the `TlabHolder` trait and made them use the `Tlab`'s version of the methods instead of re-implementing separately
- Deleted the unused `SharedHeapPermit` type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed public types SharedHeapPermit and SharedHeapPermitGuard; Closure struct field types changed (captures and type-args now use boxed slices). Update code that relied on those types.

* **Refactor**
  * Heap/value representation and VM allocation handling unified for more consistent runtime values.
  * Serialization and to-json paths standardized to return consistent runtime value objects.

* **New Features**
  * Added allocation helpers and convenience methods for runtime object creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoundaryML/baml/pull/3613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->