### PR TITLE
fix(ci): point release-cli at reusable workflow

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   build-cli:
-    uses: ./.github/workflows/build-cli-release-reusable.yaml 
+    uses: ./.github/workflows/build-cli-release.reusable.yaml


### PR DESCRIPTION
## Summary
- point `release-cli.yaml` at the existing `build-cli-release.reusable.yaml` workflow
- keep the standalone CLI release trigger aligned with `release.yml`

## Why
The repository contains `.github/workflows/build-cli-release.reusable.yaml`, and `release.yml` already references that dotted filename. The standalone CLI release workflow currently points at `build-cli-release-reusable.yaml`, which does not exist, so a release event cannot start that reusable workflow.

## Validation
- static scan: every local `./.github/workflows/...` `uses:` target in workflow files exists
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->