### PR TITLE
fix(beps): generate API tokens with crypto randomness

### DIFF
--- a/typescript/apps/beps/convex/users.ts
+++ b/typescript/apps/beps/convex/users.ts
@@ -304,13 +304,32 @@ export const linkSlackUserId = internalMutation({
 // API TOKEN MANAGEMENT
 // ─────────────────────────────────────────────────────────────────────────────
 
+const API_TOKEN_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const API_TOKEN_PREFIX = "bep_";
+const API_TOKEN_RANDOM_LENGTH = 32;
+const API_TOKEN_MAX_BYTE =
+  Math.floor(256 / API_TOKEN_ALPHABET.length) * API_TOKEN_ALPHABET.length;
+
 function generateApiToken(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  const prefix = "bep_";
-  let token = prefix;
-  for (let i = 0; i < 32; i++) {
-    token += chars.charAt(Math.floor(Math.random() * chars.length));
+  const randomBytes = new Uint8Array(API_TOKEN_RANDOM_LENGTH);
+  let token = API_TOKEN_PREFIX;
+
+  while (token.length < API_TOKEN_PREFIX.length + API_TOKEN_RANDOM_LENGTH) {
+    crypto.getRandomValues(randomBytes);
+
+    for (const byte of randomBytes) {
+      if (byte >= API_TOKEN_MAX_BYTE) {
+        continue;
+      }
+
+      token += API_TOKEN_ALPHABET[byte % API_TOKEN_ALPHABET.length];
+      if (token.length === API_TOKEN_PREFIX.length + API_TOKEN_RANDOM_LENGTH) {
+        break;
+      }
+    }
   }
+
   return token;
 }
 


### PR DESCRIPTION
## Summary
- Replace BEP API token generation based on `Math.random()` with `crypto.getRandomValues()`.
- Keep the existing `bep_` prefix and 32-character alphanumeric token format.
- Use rejection sampling so random bytes map evenly to the token alphabet.

## Testing
- `git diff --check`
- `node` smoke test for token format/uniqueness using the same generator logic
- `pnpm -C typescript/apps/beps exec tsc --noEmit --project convex/tsconfig.json` *(blocked locally: dependencies are not installed in this worktree, so Convex/Node modules cannot be resolved)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API token generation has been upgraded with enhanced randomization and improved entropy handling mechanisms. The update reduces selection bias, strengthens overall token security, and ensures more unique and reliable tokens for API authentication and secure communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->