### PR TITLE
fix(promptfiddle): compare log decorations by byte length

### DIFF
--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -68,6 +68,7 @@ declare const self: DedicatedWorkerGlobalScope;
 // ---------------------------------------------------------------------------
 
 let disposed = false;
+const textEncoder = new TextEncoder();
 
 function dispose(): void {
   if (disposed) return;
@@ -452,7 +453,10 @@ function onPlaygroundNotification(notification: PlaygroundNotification): void {
           // Heuristic: only show decoration if the formatted output is longer than the source span.
           // This filters out constant literals (where output ≈ source) and shows expanded variables.
           const sourceSpanLength = source.endOffset - source.startOffset;
-          const isLikelyVariable = message.length > sourceSpanLength + 5;
+          // Rust source spans are byte offsets, so compare the UTF-8 byte length
+          // instead of JavaScript UTF-16 code units.
+          const messageByteLen = textEncoder.encode(message).length;
+          const isLikelyVariable = messageByteLen > sourceSpanLength + 5;
 
           if (isLikelyVariable) {
             const existing = decorationsByLine.get(line);


### PR DESCRIPTION
## Summary
- Match the WASM playground log-decoration heuristic to the WebSocket path by comparing UTF-8 byte length.
- Rust source spans are byte offsets, so this avoids hiding inline log decorations for non-ASCII values.

## Testing
- `git diff --check`
- targeted static check that the worker no longer compares `message.length > sourceSpanLength`
- `node` smoke test showing a non-ASCII value (`你好世界`) is detected by UTF-8 byte length where UTF-16 code-unit length failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of inline log display in the editor by fixing byte-length calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->