### PR TITLE
fix(playground): enable retry for root testsets

### DIFF
--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -317,6 +317,7 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
               onRunTest={onRunTest}
               testRunResults={testRunResults}
               failedExpands={failedExpands}
+              onRetryExpand={onRetryExpand}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

- Pass the existing `onRetryExpand` callback into root-level `TestTreeNode` items.
- This makes top-level lazy testsets show a working retry action after expansion fails, matching nested testsets.

## Why

`TestTreeNode` already supports rendering and invoking a retry button when `failedExpands` contains the testset name, and nested testsets receive `onRetryExpand`. The root `treeItems.map` omitted that prop, so a failed top-level testset could show failure state without the retry callback wired.

## Checks

- `git diff --check`
- `npm --prefix typescript2/pkg-playground run typecheck` attempted, but this clean worktree has no `node_modules`, so it fails before this change on missing dependencies such as `react`, `lucide-react`, and `@b/pkg-proto`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retry functionality for failed test expansions. Users can now successfully retry failed lazy testset expansions through the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->