### PR TITLE
fix: report line-local columns for VM events

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -1050,11 +1050,18 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         self.bytecode.instructions.len()
     }
 
-    /// Convert a byte offset to a 1-indexed line number.
-    fn offset_to_line(&self, offset: u32) -> usize {
+    /// Convert a byte offset to a 1-indexed line number and 0-indexed column.
+    fn offset_to_line_column(&self, offset: u32) -> (usize, u32) {
         match self.line_starts.binary_search(&offset) {
-            Ok(idx) => idx + 1,
-            Err(idx) => idx,
+            Ok(idx) => (idx + 1, 0),
+            Err(idx) => {
+                if idx == 0 {
+                    (0, offset)
+                } else {
+                    let line_start = self.line_starts[idx - 1];
+                    (idx, offset.saturating_sub(line_start))
+                }
+            }
         }
     }
 
@@ -1076,26 +1083,26 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
     /// lines. Non-sequence expression entries fall back to end-line attribution
     /// when a span crosses lines, which avoids collapsing multiline operand
     /// spans to the previous line.
-    fn span_to_line(&self, span: Span, sequence_point: bool) -> usize {
+    fn span_to_line_column(&self, span: Span, sequence_point: bool) -> (usize, u32) {
         let start: u32 = span.range.start().into();
         let start = self.normalize_span_start_offset(start);
-        let start_line = self.offset_to_line(start);
+        let (start_line, start_column) = self.offset_to_line_column(start);
 
         if sequence_point {
-            return start_line;
+            return (start_line, start_column);
         }
 
         let start_u32: u32 = span.range.start().into();
         let end_u32: u32 = span.range.end().into();
         if end_u32 > start_u32 {
             let end_minus_one = end_u32 - 1;
-            let end_line = self.offset_to_line(end_minus_one);
+            let (end_line, end_column) = self.offset_to_line_column(end_minus_one);
             if end_line > start_line && end_line - start_line <= 1 {
-                return end_line;
+                return (end_line, end_column);
             }
         }
 
-        start_line
+        (start_line, start_column)
     }
 
     /// Set the current debug span used for subsequent emitted instructions.
@@ -1117,7 +1124,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         };
 
         if must_emit {
-            let line = self.span_to_line(span, self.pending_sequence_point);
+            let (line, column) = self.span_to_line_column(span, self.pending_sequence_point);
             let discriminator = if self.pending_sequence_point {
                 let counter = self.next_line_discriminator.entry(line).or_insert(0);
                 let out = *counter;
@@ -1130,6 +1137,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 pc,
                 span,
                 line,
+                column,
                 sequence_point: self.pending_sequence_point,
                 discriminator,
             });

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -5645,7 +5645,7 @@ impl BexVm {
                                 (
                                     entry.span.file_id.as_u32(),
                                     u32::try_from(entry.line).unwrap_or(u32::MAX),
-                                    entry.span.range.start().into(),
+                                    entry.column,
                                     u32::from(entry.span.range.start()),
                                     u32::from(entry.span.range.end()),
                                 )

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -1616,6 +1616,8 @@ pub struct LineTableEntry {
     pub span: Span,
     /// 1-indexed source line for quick stack traces/disassembly.
     pub line: usize,
+    /// 0-indexed source column paired with `line`.
+    pub column: u32,
     /// True when this entry is a debugger sequence point.
     pub sequence_point: bool,
     /// Distinguishes multiple stops on the same line.
@@ -2119,6 +2121,7 @@ impl Bytecode {
                 pc: index_to_offset[entry.pc],
                 span: entry.span,
                 line: entry.line,
+                column: entry.column,
                 sequence_point: entry.sequence_point,
                 discriminator: entry.discriminator,
             })
@@ -2526,6 +2529,7 @@ mod compact_tests {
                     pc: 0,
                     span: Span::default(),
                     line: 1,
+                    column: 0,
                     sequence_point: true,
                     discriminator: 0,
                 },
@@ -2533,6 +2537,7 @@ mod compact_tests {
                     pc: 1,
                     span: Span::default(),
                     line: 2,
+                    column: 4,
                     sequence_point: true,
                     discriminator: 0,
                 },
@@ -2543,7 +2548,9 @@ mod compact_tests {
         };
         let compact = bc.lower_to_compact();
         assert_eq!(compact.line_table[0].pc, 0); // instruction 0 → byte 0
+        assert_eq!(compact.line_table[0].column, 0);
         assert_eq!(compact.line_table[1].pc, 2); // instruction 1 → byte 2 (after 2-byte LoadIntSmall)
+        assert_eq!(compact.line_table[1].column, 4);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- track the 0-indexed source column alongside each bytecode line-table entry
- preserve that column when lowering bytecode to compact form
- use the recorded line-local column for `SendEvent` source locations while keeping start/end offsets unchanged

## Tests

- `rustfmt --edition 2024 baml_language/crates/baml_compiler2_emit/src/emit.rs baml_language/crates/bex_vm/src/vm.rs baml_language/crates/bex_vm_types/src/bytecode.rs`
- `git diff --check`
- Not run: `cargo test -p bex_vm_types line_table_translated --manifest-path baml_language/Cargo.toml` cannot link in this local macOS environment because `xcrun` fails to load the installed CommandLineTools `libxcrun.dylib` as arm64/arm64e while compiling build scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced source location tracking to include precise column offsets alongside line numbers in debug information, enabling more accurate error reporting and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->