### PR TITLE
test(floats): cover float == / != equality semantics

### DIFF
--- a/baml_language/crates/baml_tests/baml_src/ns_floats/floats.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_floats/floats.baml
@@ -764,3 +764,232 @@ function float_random_distinct_values() -> bool {
 test "float_random_distinct_values" {
     assert.is_true(float_random_distinct_values())
 }
+
+// ─── Equality (== / !=) ───────────────────────────────────────────────────────
+//
+// Float `==`/`!=` follow JS/TS (IEEE 754) semantics: NaN != NaN, NaN == NaN is
+// false, +0.0 == -0.0, +inf == +inf, +inf != -inf. int/float mix is allowed
+// (int widened to f64); float-vs-bigint is the one rejected pairing (compile
+// error E0004 — bigint past 2^53 can't round-trip f64).
+//
+// Two distinct code paths are exercised: the compiler constant-folds `==` on two
+// float literals (try_fold_binary), while a non-literal operand forces the VM
+// float-compare opcode. Cases below cover both so a divergence would be caught.
+
+// Constant-folded path (both operands literals — folded by the compiler)
+
+test "float_eq_float_eq_int_literal_fold" {
+    assert.is_true(3.0 == 3)
+}
+
+test "float_eq_float_neq_int_distinct_fold" {
+    assert.is_true(2.5 != 2)
+}
+
+test "float_eq_fold_ordinary_equal" {
+    assert.is_true(1.5 == 1.5)
+}
+
+test "float_eq_fold_ordinary_unequal_false" {
+    assert.is_true((1.5 == 2.5) == false)
+}
+
+test "float_eq_int_eq_float_literal_fold" {
+    assert.is_true(2 == 2.0)
+}
+
+test "float_eq_large_integer_valued_fold" {
+    assert.is_true(1000000.0 == 1000000)
+}
+
+test "float_eq_neg_zero_lit_equals_neg_zero_lit_fold" {
+    assert.is_true(-0.0 == -0.0)
+}
+
+test "float_eq_positive_zero_equals_negative_zero_fold" {
+    assert.is_true(0.0 == -0.0)
+}
+
+// Folded or runtime depending on operand shape
+
+test "float_eq_null_eq_float_symmetric_false" {
+    assert.is_true((null == 2.0) == false)
+}
+
+test "float_eq_two_pow_53_exact" {
+    assert.is_true(9007199254740992.0 == 9007199254740992)
+}
+
+// Runtime VM path (≥1 non-literal operand forces the float-eq opcode)
+
+test "float_eq_classic_imprecision_sum" {
+    assert.is_true(0.1 + 0.2 != 0.3)
+}
+
+test "float_eq_div_third_eq_shortest" {
+    assert.is_true(1.0 / 3.0 == 0.3333333333333333)
+}
+
+test "float_eq_div_third_ne_truncated" {
+    assert.is_true(1.0 / 3.0 != 0.333)
+}
+
+test "float_eq_float_eq_null_is_false" {
+    assert.is_true((float.parse("1.5") == null) == false)
+}
+
+test "float_eq_float_neq_null_is_true" {
+    assert.is_true(float.parse("1.5") != null)
+}
+
+test "float_eq_half_underflow_to_zero" {
+    assert.is_true((float.parse("5e-324") / 2.0) == 0.0)
+}
+
+test "float_eq_inf_minus_inf_is_nan_ne_self" {
+    assert.is_true((float.inf() - float.inf()) != (float.inf() - float.inf()))
+}
+
+test "float_eq_inf_plus_one_equals_inf" {
+    assert.is_true(float.inf() == (float.inf() + 1.0))
+}
+
+test "float_eq_large_magnitude_precision_loss" {
+    assert.is_true(float.parse("1e16") + 1.0 == float.parse("1e16"))
+}
+
+test "float_eq_max_finite_ne_inf" {
+    assert.is_true(float.parse("1.7976931348623157e308") != float.inf())
+}
+
+test "float_eq_mul_imprecision_eq_rounded" {
+    assert.is_true(0.1 * 3.0 == 0.30000000000000004)
+}
+
+test "float_eq_mul_imprecision_ne_point3" {
+    assert.is_true(0.1 * 3.0 != 0.3)
+}
+
+test "float_eq_nan_arith_propagates_ne_self" {
+    assert.is_true((float.nan() + 1.0) != (float.nan() + 1.0))
+}
+
+test "float_eq_nan_const_not_equal_number" {
+    assert.is_true((float.nan() == 1.5) == false)
+}
+
+test "float_eq_nan_eq_null_is_false" {
+    assert.is_true((float.nan() == null) == false)
+}
+
+test "float_eq_nan_ne_number_is_true" {
+    assert.is_true(float.nan() != 0.0)
+}
+
+test "float_eq_nan_ne_self_is_true" {
+    assert.is_true(float.parse("nan") != float.parse("nan"))
+}
+
+test "float_eq_nan_not_equal_infinity" {
+    assert.is_true((float.nan() == float.inf()) == false)
+}
+
+test "float_eq_nan_not_equal_to_self" {
+    assert.is_true((float.parse("nan") == float.parse("nan")) == false)
+}
+
+test "float_eq_neg_inf_equals_neg_inf" {
+    assert.is_true(-float.inf() == -float.inf())
+}
+
+test "float_eq_neg_zero_from_division" {
+    assert.is_true((-1.0 / float.inf()) == 0.0)
+}
+
+test "float_eq_neg_zero_ne_pos_zero_runtime_false" {
+    assert.is_true((float.parse("-0.0") != 0.0) == false)
+}
+
+test "float_eq_overflow_to_inf" {
+    assert.is_true(float.parse("1.0e308") * 10.0 == float.inf())
+}
+
+test "float_eq_parse_inf_equals_inf_const" {
+    assert.is_true(float.parse("inf") == float.inf())
+}
+
+test "float_eq_parse_inf_ne_neg_inf" {
+    assert.is_true(float.parse("inf") != float.parse("-inf"))
+}
+
+test "float_eq_parse_neg_inf_equals_neg_inf_const" {
+    assert.is_true(float.parse("-inf") == -float.inf())
+}
+
+test "float_eq_parse_roundtrip" {
+    assert.is_true(float.parse("1.5") == 1.5)
+}
+
+test "float_eq_parse_roundtrip_imprecise_all_runtime" {
+    assert.is_true(float.parse("0.1") + float.parse("0.2") != float.parse("0.3"))
+}
+
+test "float_eq_pi_eq_pi" {
+    assert.is_true(float.pi() == float.pi())
+}
+
+test "float_eq_pi_ne_truncated" {
+    assert.is_true(float.pi() != 3.14)
+}
+
+test "float_eq_pos_inf_equals_pos_inf" {
+    assert.is_true(float.inf() == float.inf())
+}
+
+test "float_eq_pos_inf_ne_neg_inf" {
+    assert.is_true(float.inf() != -float.inf())
+}
+
+test "float_eq_runtime_float_eq_int" {
+    assert.is_true(float.parse("2") == 2)
+}
+
+test "float_eq_runtime_float_neq_int_distinct" {
+    assert.is_true(float.parse("2.5") != 2)
+}
+
+test "float_eq_runtime_int_eq_float" {
+    assert.is_true(5 == float.parse("5.0"))
+}
+
+test "float_eq_runtime_int_neq_float_distinct" {
+    assert.is_true(3 != float.parse("3.5"))
+}
+
+test "float_eq_runtime_ordinary_unequal_false" {
+    assert.is_true((float.parse("1.5") == 2.5) == false)
+}
+
+test "float_eq_runtime_signed_zero" {
+    assert.is_true(float.parse("-0.0") == 0.0)
+}
+
+test "float_eq_self_equal_nonliteral" {
+    assert.is_true(float.parse("0.1") == float.parse("0.1"))
+}
+
+test "float_eq_sqrt_irrational_ne_two" {
+    assert.is_true((2.0).sqrt() * (2.0).sqrt() != 2.0)
+}
+
+test "float_eq_sqrt_irrational_property" {
+    assert.is_true(((2.0).sqrt() * (2.0).sqrt()) == 2.0000000000000004)
+}
+
+test "float_eq_subnormal_nonzero" {
+    assert.is_true(float.parse("5e-324") != 0.0)
+}
+
+test "float_eq_sum_equals_exact_rounded" {
+    assert.is_true(0.1 + 0.2 == 0.30000000000000004)
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/floats.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/floats.snap
@@ -854,6 +854,324 @@ function floats.$init_test_ns_floats_floats(registry: testing.TestCollector) -> 
     load_const null
     call testing.TestCollector.register_test
     pop 1
+    load_var registry
+    load_const "float_eq_float_eq_int_literal_fold"
+    make_closure .<lambda($init_test_ns_floats_floats, 142)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_float_neq_int_distinct_fold"
+    make_closure .<lambda($init_test_ns_floats_floats, 143)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_fold_ordinary_equal"
+    make_closure .<lambda($init_test_ns_floats_floats, 144)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_fold_ordinary_unequal_false"
+    make_closure .<lambda($init_test_ns_floats_floats, 145)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_int_eq_float_literal_fold"
+    make_closure .<lambda($init_test_ns_floats_floats, 146)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_large_integer_valued_fold"
+    make_closure .<lambda($init_test_ns_floats_floats, 147)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_neg_zero_lit_equals_neg_zero_lit_fold"
+    make_closure .<lambda($init_test_ns_floats_floats, 148)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_positive_zero_equals_negative_zero_fold"
+    make_closure .<lambda($init_test_ns_floats_floats, 149)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_null_eq_float_symmetric_false"
+    make_closure .<lambda($init_test_ns_floats_floats, 150)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_two_pow_53_exact"
+    make_closure .<lambda($init_test_ns_floats_floats, 151)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_classic_imprecision_sum"
+    make_closure .<lambda($init_test_ns_floats_floats, 152)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_div_third_eq_shortest"
+    make_closure .<lambda($init_test_ns_floats_floats, 153)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_div_third_ne_truncated"
+    make_closure .<lambda($init_test_ns_floats_floats, 154)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_float_eq_null_is_false"
+    make_closure .<lambda($init_test_ns_floats_floats, 155)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_float_neq_null_is_true"
+    make_closure .<lambda($init_test_ns_floats_floats, 156)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_half_underflow_to_zero"
+    make_closure .<lambda($init_test_ns_floats_floats, 157)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_inf_minus_inf_is_nan_ne_self"
+    make_closure .<lambda($init_test_ns_floats_floats, 158)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_inf_plus_one_equals_inf"
+    make_closure .<lambda($init_test_ns_floats_floats, 159)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_large_magnitude_precision_loss"
+    make_closure .<lambda($init_test_ns_floats_floats, 160)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_max_finite_ne_inf"
+    make_closure .<lambda($init_test_ns_floats_floats, 161)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_mul_imprecision_eq_rounded"
+    make_closure .<lambda($init_test_ns_floats_floats, 162)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_mul_imprecision_ne_point3"
+    make_closure .<lambda($init_test_ns_floats_floats, 163)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_nan_arith_propagates_ne_self"
+    make_closure .<lambda($init_test_ns_floats_floats, 164)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_nan_const_not_equal_number"
+    make_closure .<lambda($init_test_ns_floats_floats, 165)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_nan_eq_null_is_false"
+    make_closure .<lambda($init_test_ns_floats_floats, 166)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_nan_ne_number_is_true"
+    make_closure .<lambda($init_test_ns_floats_floats, 167)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_nan_ne_self_is_true"
+    make_closure .<lambda($init_test_ns_floats_floats, 168)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_nan_not_equal_infinity"
+    make_closure .<lambda($init_test_ns_floats_floats, 169)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_nan_not_equal_to_self"
+    make_closure .<lambda($init_test_ns_floats_floats, 170)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_neg_inf_equals_neg_inf"
+    make_closure .<lambda($init_test_ns_floats_floats, 171)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_neg_zero_from_division"
+    make_closure .<lambda($init_test_ns_floats_floats, 172)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_neg_zero_ne_pos_zero_runtime_false"
+    make_closure .<lambda($init_test_ns_floats_floats, 173)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_overflow_to_inf"
+    make_closure .<lambda($init_test_ns_floats_floats, 174)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_parse_inf_equals_inf_const"
+    make_closure .<lambda($init_test_ns_floats_floats, 175)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_parse_inf_ne_neg_inf"
+    make_closure .<lambda($init_test_ns_floats_floats, 176)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_parse_neg_inf_equals_neg_inf_const"
+    make_closure .<lambda($init_test_ns_floats_floats, 177)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_parse_roundtrip"
+    make_closure .<lambda($init_test_ns_floats_floats, 178)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_parse_roundtrip_imprecise_all_runtime"
+    make_closure .<lambda($init_test_ns_floats_floats, 179)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_pi_eq_pi"
+    make_closure .<lambda($init_test_ns_floats_floats, 180)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_pi_ne_truncated"
+    make_closure .<lambda($init_test_ns_floats_floats, 181)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_pos_inf_equals_pos_inf"
+    make_closure .<lambda($init_test_ns_floats_floats, 182)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_pos_inf_ne_neg_inf"
+    make_closure .<lambda($init_test_ns_floats_floats, 183)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_runtime_float_eq_int"
+    make_closure .<lambda($init_test_ns_floats_floats, 184)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_runtime_float_neq_int_distinct"
+    make_closure .<lambda($init_test_ns_floats_floats, 185)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_runtime_int_eq_float"
+    make_closure .<lambda($init_test_ns_floats_floats, 186)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_runtime_int_neq_float_distinct"
+    make_closure .<lambda($init_test_ns_floats_floats, 187)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_runtime_ordinary_unequal_false"
+    make_closure .<lambda($init_test_ns_floats_floats, 188)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_runtime_signed_zero"
+    make_closure .<lambda($init_test_ns_floats_floats, 189)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_self_equal_nonliteral"
+    make_closure .<lambda($init_test_ns_floats_floats, 190)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_sqrt_irrational_ne_two"
+    make_closure .<lambda($init_test_ns_floats_floats, 191)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_sqrt_irrational_property"
+    make_closure .<lambda($init_test_ns_floats_floats, 192)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_subnormal_nonzero"
+    make_closure .<lambda($init_test_ns_floats_floats, 193)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_sum_equals_exact_rounded"
+    make_closure .<lambda($init_test_ns_floats_floats, 194)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
     load_const null
     return
 }


### PR DESCRIPTION
## What

Adds **53 in-BAML test blocks** to `ns_floats/floats.baml` covering the `==` / `!=` operators on floats. Regenerates the `floats` bytecode snapshot.

## Why

Float equality **already works** end-to-end:
- **Type-checker** (`infer_binary_op`): permissive — any two operands → `bool`; `int == float` widens int to f64.
- **Constant folder** (`try_fold_binary`): literal `float == float` is folded at compile time — a *separate* path from runtime.
- **VM** (`exec_cmpop` + dedicated `CmpFloatEq` opcode): IEEE 754 semantics.

…but there was **no test coverage**: `floats.baml` deliberately used epsilon checks and `operators.baml` only tested `int == int`. This locks in the behavior.

## Coverage

Cases are grouped by code path (compile-fold vs runtime, forced via `float.parse(...)`/calls) so a divergence between the folder and the VM would be caught. They follow JS/TS (IEEE 754) conventions:

- **NaN**: `NaN != NaN` true, `NaN == NaN` false, NaN vs number/inf/null, NaN propagation through arithmetic
- **Infinity**: `+inf == +inf`, `+inf != -inf`, overflow → inf, max-finite ≠ inf, `inf - inf` → NaN
- **Signed zero**: `0.0 == -0.0`, `-1.0/inf` → `-0.0`
- **int/float mixing**: `2 == 2.0`, `3.0 == 3` (both paths)
- **Precision**: `0.1 + 0.2 != 0.3`, `== 0.30000000000000004`, `1.0/3.0`, sqrt identities, subnormals (`5e-324`), large-magnitude loss
- **null**: `float == null` → false (allowed, not an error)

The one rejected pairing — `float == bigint` (compile error E0004, bigint past 2⁵³ can't round-trip f64) — is unchanged and not expressible as a passing test.

## Testing

```
cargo run -p baml_cli -- test --from crates/baml_tests/baml_src -i "::float_eq_*"
# 53 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for float comparison operations, covering IEEE-754 semantics and edge cases: NaN behavior and self-inequality, positive/negative infinity handling, signed-zero behavior, overflow-to-infinity conversions, precision and rounding imprecision scenarios, and parsing-based test cases including scientific notation edge ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->