### PR TITLE
Compiler speedups

### DIFF
--- a/baml_language/crates/baml_compiler2_hir/src/file_package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/file_package.rs
@@ -7,7 +7,7 @@
 use baml_base::{Name, SourceFile};
 
 /// Package/namespace info for a file.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, salsa::Update)]
 pub struct PackageInfo {
     /// Package name: "user", "baml", or "env".
     pub package: Name,
@@ -31,6 +31,13 @@ fn extract_ns_name(component: &str) -> Option<Name> {
 }
 
 /// Determine which package a file belongs to based on its path.
+///
+/// Salsa-tracked (keyed on `file`) so the path parsing — `to_string_lossy`,
+/// `strip_prefix`, component iteration, and the `Vec<Name>` allocation — runs
+/// once per file instead of on every call. This is called from ~100 sites
+/// across every compiler phase (often in per-class/per-function loops), so
+/// memoizing it removes a pervasive, repeated path-parsing cost.
+#[salsa::tracked]
 pub fn file_package(db: &dyn crate::Db, file: SourceFile) -> PackageInfo {
     let path = file.path(db);
     let path_str = path.to_string_lossy();

--- a/baml_language/crates/baml_tests/Cargo.toml
+++ b/baml_language/crates/baml_tests/Cargo.toml
@@ -57,6 +57,10 @@ tokio = { workspace = true, features = [ "rt-multi-thread", "macros", "net" ] }
 wiremock = { workspace = true }
 
 [[bench]]
+name = "compiler_benchmark"
+harness = false
+
+[[bench]]
 name = "runtime_benchmark"
 harness = false
 

--- a/baml_language/crates/baml_tests/benches/compiler_benchmark.rs
+++ b/baml_language/crates/baml_tests/benches/compiler_benchmark.rs
@@ -1,0 +1,115 @@
+//! BAML Compiler Benchmarks
+//!
+//! Run with: cargo bench --bench compiler_benchmark
+//!
+//! These complement the VM execution benchmarks in runtime_benchmark.rs.
+//! Compiler benchmarks measure the cost of turning BAML source into a bytecode
+//! `Program` (parse → HIR → TIR → MIR → emit); the runtime benchmarks measure
+//! how fast that bytecode then executes.
+//!
+//! Two reference workloads are provided:
+//!   * `compile_empty_project` — an empty project (a single file with nothing
+//!     but a comment). With no user code to lower, the wall-clock here is the
+//!     compiler's *constant overhead* (loading builtin stubs, Salsa setup,
+//!     empty-program emit), so it acts as a fixed-cost baseline.
+//!   * `compile_baml_tests_project` — the whole `baml_src/` test project (dozens
+//!     of files exercising every language feature). This is the realistic
+//!     multi-file compilation workload.
+
+use std::path::{Path, PathBuf};
+
+use baml_compiler2_emit::{CompileOptions, generate_project_bytecode};
+use baml_project::ProjectDatabase;
+use baml_workspace::discover_baml_files;
+use divan::{Bencher, black_box};
+
+fn main() {
+    if cfg!(debug_assertions) {
+        eprintln!("Skipping compiler_benchmark in debug/test profile.");
+        return;
+    }
+    divan::main();
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// A project loaded from disk as `(canonical_path, contents)` pairs.
+///
+/// Reading the source files off disk is done once, up front, so it never
+/// pollutes the measured region — each benchmark sample only pays for building
+/// a fresh `ProjectDatabase` and compiling it.
+type ProjectSources = Vec<(PathBuf, String)>;
+
+/// Read every `.baml` file under `root` into memory.
+fn read_project(root: &Path) -> ProjectSources {
+    discover_baml_files(root)
+        .into_iter()
+        .map(|path| {
+            let content = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+            (path, content)
+        })
+        .collect()
+}
+
+/// Build a fresh [`ProjectDatabase`] rooted at `root` and populated with
+/// `sources`. Mirrors how the CLI loads a project (`set_project_root` first,
+/// then add each discovered file) so the compiler sees the same project shape.
+fn build_db(root: &Path, sources: &ProjectSources) -> ProjectDatabase {
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(root);
+    for (path, content) in sources {
+        db.add_or_update_file(path, content);
+    }
+    db
+}
+
+/// Compile a populated database to bytecode, measuring only the compile step.
+fn compile(db: &ProjectDatabase) {
+    let program = generate_project_bytecode(
+        db,
+        &CompileOptions {
+            emit_test_cases: true,
+        },
+    )
+    .expect("benchmark compilation failed");
+    black_box(program);
+}
+
+/// Benchmark compiling the project rooted at `root`: read sources once, then
+/// per sample build a fresh (uncached) database and compile it. A fresh
+/// database is required because Salsa would otherwise memoize the first
+/// compile and every later sample would measure a cache hit.
+fn bench_compile_project(bencher: Bencher, root: &Path) {
+    let sources = read_project(root);
+    bencher
+        .with_inputs(|| build_db(root, &sources))
+        .bench_values(|db| compile(&db));
+}
+
+// ============================================================================
+// Benchmarks
+// ============================================================================
+
+/// Constant-overhead baseline: an empty project (the `__baml_std__` fixture,
+/// whose only file is a comment). With no user code to compile, the measured
+/// time is the compiler's fixed cost (builtin stubs, Salsa setup, empty emit).
+#[divan::bench]
+fn compile_empty_project(bencher: Bencher) {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("projects/compiles/__baml_std__");
+    bench_compile_project(bencher, &root);
+}
+
+/// Realistic multi-file workload: the full `baml_src/` test project.
+///
+/// A single compile of this project takes seconds, so the sample count is
+/// capped at a handful (one compile per sample) to keep the overall benchmark
+/// runtime reasonable — the per-sample cost is large enough that even a few
+/// samples give a stable median.
+#[divan::bench(sample_count = 5, sample_size = 1)]
+fn compile_baml_tests_project(bencher: Bencher) {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("baml_src");
+    bench_compile_project(bencher, &root);
+}

--- a/baml_language/crates/baml_tests/build.rs
+++ b/baml_language/crates/baml_tests/build.rs
@@ -1,4 +1,4 @@
-//! Build script that generates tests from projects/ directory and benchmarks from benches/.
+//! Build script that generates tests from the projects/ directory.
 //! Each folder becomes a test module with comprehensive compiler phase tests.
 
 use std::{

--- a/baml_language/scripts/bench-compare
+++ b/baml_language/scripts/bench-compare
@@ -33,6 +33,8 @@ usage() {
     echo "  $0 compare <base.json> <new.json>  Compare two results"
     echo "  $0 flamegraph [workload.baml]    Record samply flame graph"
     echo "  $0 divan                         Run divan wall-clock benchmarks"
+    echo "  $0 compiler                      Run divan compiler (parse/compile) benchmarks"
+    echo "  $0 flamegraph-compiler [filter]  Record samply flame graph of a compile benchmark"
     exit 1
 }
 
@@ -231,6 +233,48 @@ cmd_divan() {
     cargo bench --bench runtime_benchmark -- vm_ "$@"
 }
 
+# ---- compiler: wall-clock compile-time benchmarks ----
+cmd_compiler() {
+    cargo bench --bench compiler_benchmark -- "$@"
+}
+
+# ---- compiler flamegraph: samply record of a compile benchmark ----
+# Profiles the compiler_benchmark divan binary so the flame graph shows where
+# the compiler spends its time (parse → HIR → TIR → MIR → emit). Defaults to the
+# full-project workload, which runs long enough to gather dense samples; pass a
+# divan filter (e.g. compile_empty_project) to profile a different benchmark.
+cmd_flamegraph_compiler() {
+    local filter="${1:-compile_baml_tests_project}"
+
+    echo "==> Building compiler_benchmark (profiling profile)..."
+    cargo build --bench compiler_benchmark --profile profiling -p baml_tests 2>&1 | tail -3
+
+    # Find the binary (executable Mach-O in deps/, not .o/.d/.rmeta files)
+    local bin
+    bin=$(find target/profiling/deps -name "compiler_benchmark-*" -type f \
+        ! -name "*.o" ! -name "*.d" ! -name "*.rmeta" ! -name "*.rlib" \
+        -perm +111 2>/dev/null \
+        | sort -t- -k2 | tail -1)
+
+    if [[ -z "$bin" ]]; then
+        echo "ERROR: could not find compiler_benchmark binary in target/profiling/deps/"
+        exit 1
+    fi
+
+    local commit
+    commit=$(git rev-parse --short HEAD)
+    local output="/tmp/bex-compiler-flamegraph-${commit}.json"
+
+    echo "==> Binary: $bin"
+    echo "==> Recording with samply (filter: $filter)..."
+    samply record --save-only --rate 10000 -o "$output" \
+        "$bin" "$filter"
+
+    echo ""
+    echo "==> Profile saved to $output"
+    echo "    View with: samply load $output"
+}
+
 # ---- dispatch ----
 case "${1:-}" in
     run)        shift; cmd_run "$@" ;;
@@ -238,5 +282,7 @@ case "${1:-}" in
     compare)    shift; cmd_compare "$@" ;;
     flamegraph) shift; cmd_flamegraph "$@" ;;
     divan)      shift; cmd_divan "$@" ;;
+    compiler)   shift; cmd_compiler "$@" ;;
+    flamegraph-compiler) shift; cmd_flamegraph_compiler "$@" ;;
     *)          usage ;;
 esac


### PR DESCRIPTION
Adds salsa caching to three functions, resulting in a ~60% speedup on the `baml_tests/baml_cli` compilation time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compiler benchmarking suite to measure BAML compilation performance.
  * Added flamegraph profiling tool for analyzing compiler performance bottlenecks.

* **Chores**
  * Optimized internal compilation caching for improved performance.
  * Updated build documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->