### PR TITLE
Fix 17 interface-union bugs (F1–F17)

### DIFF
--- a/baml_language/.gitignore
+++ b/baml_language/.gitignore
@@ -14,3 +14,6 @@ rpi/
 
 # insta pending snapshot scratch files (resolved by `cargo insta review`)
 *.pending-snap
+
+# Local scratch projects / fuzz repros (not part of the build)
+workflow_scratch_files/

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3918,10 +3918,10 @@ impl<'db> LoweringContext<'db> {
             // Receiver prefix may be a union containing an interface member
             // (`(Dog | Named).name`): dispatch the field read on the runtime
             // class across all members' implementors.
-            if let Some(Tir2Ty::Union(members, _)) = self
+            if let Some(members) = self
                 .path_segment_types
                 .get(&(self.current_metadata_scope, expr_id, seg_idx - 1))
-                .cloned()
+                .and_then(Self::tir_union_members)
                 && self.lower_union_iface_field_access(base_local, &members, seg, &target_place)
             {
                 if is_last {
@@ -4689,10 +4689,10 @@ impl LoweringContext<'_> {
                 // union of concrete classes (a local or field chain bound to a
                 // `match`/`if` whose arms are different classes). Same receiver
                 // type slot, same field-chain lowering.
-                else if let Some(Tir2Ty::Union(members, _)) = self
+                else if let Some(members) = self
                     .path_segment_types
                     .get(&(self.current_metadata_scope, callee, prefix_idx))
-                    .cloned()
+                    .and_then(Self::tir_union_members)
                 {
                     let receiver_segments = &segments[..segments.len() - 1];
                     let recv_local = self.lower_path_receiver_to_local(
@@ -6069,11 +6069,7 @@ impl<'db> LoweringContext<'db> {
                 || self
                     .expr_types
                     .get(&self.expr_metadata_key(base))
-                    .cloned()
-                    .and_then(|t| match t {
-                        Tir2Ty::Union(members, _) => Some(members),
-                        _ => None,
-                    })
+                    .and_then(Self::tir_union_members)
                     .is_some_and(|members| {
                         self.lower_union_iface_field_access(base_local, &members, field, &dest)
                     });
@@ -6416,8 +6412,10 @@ impl<'db> LoweringContext<'db> {
         args: &[AstExprId],
         dest: &Place,
     ) -> bool {
-        let Some(Tir2Ty::Union(members, _)) =
-            self.expr_types.get(&self.expr_metadata_key(base)).cloned()
+        let Some(members) = self
+            .expr_types
+            .get(&self.expr_metadata_key(base))
+            .and_then(Self::tir_union_members)
         else {
             return false;
         };
@@ -6443,8 +6441,10 @@ impl<'db> LoweringContext<'db> {
         args: &[AstExprId],
         dest: &Place,
     ) -> bool {
-        let Some(Tir2Ty::Union(members, _)) =
-            self.expr_types.get(&self.expr_metadata_key(base)).cloned()
+        let Some(members) = self
+            .expr_types
+            .get(&self.expr_metadata_key(base))
+            .and_then(Self::tir_union_members)
         else {
             return false;
         };
@@ -9436,6 +9436,18 @@ impl LoweringContext<'_> {
     ) {
         let mut visited = HashSet::new();
         self.emit_is_tir_type_branch_inner(scrutinee, ty, success, failure, &mut visited);
+    }
+
+    /// The members of a union receiver, transparently unwrapping `Optional`
+    /// layers — `(Dog | Named)?` after a null check still dispatches the
+    /// field/method on the underlying union. Returns `None` when `ty` isn't a
+    /// (optionally-wrapped) union.
+    fn tir_union_members(ty: &Tir2Ty) -> Option<Vec<Tir2Ty>> {
+        match ty {
+            Tir2Ty::Union(members, _) => Some(members.clone()),
+            Tir2Ty::Optional(inner, _) => Self::tir_union_members(inner),
+            _ => None,
+        }
     }
 
     /// Whether `ty` is (or contains, inside a union/optional) a *generic*

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -6466,25 +6466,21 @@ impl<'db> LoweringContext<'db> {
         members: &[Tir2Ty],
         method: &Name,
     ) -> Option<Vec<InterfaceMethodCandidate>> {
-        // Pure class unions are handled by `try_lower_union_dispatch`; only step
-        // in when an interface member is present.
-        if !members.iter().any(|m| matches!(m, Tir2Ty::Interface(..))) {
-            return None;
-        }
+        // This runs only after `emit_union_class_dispatch` (the direct-method
+        // class-union path) has declined, so it also covers a *pure class* union
+        // whose members satisfy `method` through an inherited interface default
+        // (`class Dog { implements Greeter {} }`), not just unions that name an
+        // interface member directly.
         let mut candidates: Vec<InterfaceMethodCandidate> = Vec::new();
         for member in members {
             match member {
                 Tir2Ty::Class(qtn, _, _) => {
                     let class_tn = qtn_to_type_name(qtn);
-                    let item_ref = self.class_method_item_ref_by_name(&class_tn, method)?;
-                    candidates.push(InterfaceMethodCandidate {
-                        guard: InterfaceDispatchGuard::Type(Ty::Class(
-                            class_tn,
-                            Vec::new(),
-                            TyAttr::default(),
-                        )),
-                        item_ref,
-                    });
+                    let member_candidates = self.class_member_method_candidates(&class_tn, method);
+                    if member_candidates.is_empty() {
+                        return None;
+                    }
+                    candidates.extend(member_candidates);
                 }
                 Tir2Ty::Interface(..) => {
                     let (iface_tn, iface_type_args) =
@@ -6500,6 +6496,79 @@ impl<'db> LoweringContext<'db> {
             }
         }
         Some(candidates)
+    }
+
+    /// Dispatch candidates for calling `method` on a concrete-class union member.
+    /// A direct own/override method dispatches on the class tag; otherwise the
+    /// method may be supplied by an interface the class implements — an inherited
+    /// `implements I {}` default, a field-link, or an out-of-body
+    /// `implements I for C` — so fall back to the same implementor resolution
+    /// used for interface arms. Without this, a `Dog | Cat` union whose members
+    /// satisfy a method only through an inherited default resolved to nothing and
+    /// the call dispatched as a map read (VM `expected map, got instance`).
+    fn class_member_method_candidates(
+        &self,
+        class_tn: &TypeName,
+        method: &Name,
+    ) -> Vec<InterfaceMethodCandidate> {
+        if let Some(item_ref) = self.class_method_item_ref_by_name(class_tn, method) {
+            return vec![InterfaceMethodCandidate {
+                guard: InterfaceDispatchGuard::Type(Ty::Class(
+                    class_tn.clone(),
+                    Vec::new(),
+                    TyAttr::default(),
+                )),
+                item_ref,
+            }];
+        }
+        let Some(class_loc) = self.resolve_class_loc_by_type_name(class_tn) else {
+            return Vec::new();
+        };
+        let class_tree = file_item_tree(self.db, class_loc.file(self.db));
+        let class_data = &class_tree[class_loc.id(self.db)];
+        let mut out = Vec::new();
+        for impl_block in &class_data.implements {
+            if let Some((iface_tn, iface_args)) =
+                self.resolve_implements_target_view(&impl_block.target, class_loc)
+            {
+                out.extend(self.resolve_implementor_method_candidates(
+                    class_tn,
+                    &iface_tn,
+                    &iface_args,
+                    method,
+                ));
+            }
+        }
+        out
+    }
+
+    /// Field-read candidates for a concrete-class union member whose `field` is
+    /// supplied by an interface view (`implements Named { name as full }`) rather
+    /// than a class-owned slot. Mirrors [`class_member_method_candidates`].
+    fn class_member_field_candidates(
+        &self,
+        class_tn: &TypeName,
+        field: &Name,
+    ) -> Vec<InterfaceFieldCandidate> {
+        let Some(class_loc) = self.resolve_class_loc_by_type_name(class_tn) else {
+            return Vec::new();
+        };
+        let class_tree = file_item_tree(self.db, class_loc.file(self.db));
+        let class_data = &class_tree[class_loc.id(self.db)];
+        let mut out = Vec::new();
+        for impl_block in &class_data.implements {
+            if let Some((iface_tn, iface_args)) =
+                self.resolve_implements_target_view(&impl_block.target, class_loc)
+            {
+                out.extend(self.resolve_implementor_interface_field_candidates(
+                    class_tn,
+                    &iface_tn,
+                    &iface_args,
+                    field,
+                ));
+            }
+        }
+        out
     }
 
     /// Emit a class-tag dispatch switch for a method call whose receiver
@@ -6746,27 +6815,37 @@ impl<'db> LoweringContext<'db> {
         field: &Name,
         dest: &Place,
     ) -> bool {
-        if !members.iter().any(|m| matches!(m, Tir2Ty::Interface(..))) {
-            return false;
-        }
+        // Runs only after `lower_union_class_field_access` declines, so it also
+        // covers a pure class union whose `field` is supplied by an interface
+        // view rather than a class-owned slot.
         let mut resolved: Vec<InterfaceFieldCandidate> = Vec::new();
         for member in members {
             match member {
                 Tir2Ty::Class(qtn, _, _) => {
                     let class_tn = qtn_to_type_name(qtn);
-                    let Some(field_idx) = self
+                    if let Some(field_idx) = self
                         .class_fields
                         .get(&class_tn)
                         .and_then(|fields| fields.get(field.as_str()))
                         .copied()
-                    else {
-                        return false;
-                    };
-                    resolved.push(InterfaceFieldCandidate {
-                        impl_tn: class_tn,
-                        guard: InterfaceClassGuard::Any,
-                        field_idx,
-                    });
+                    {
+                        resolved.push(InterfaceFieldCandidate {
+                            impl_tn: class_tn,
+                            guard: InterfaceClassGuard::Any,
+                            field_idx,
+                        });
+                    } else {
+                        // The field may be supplied by an interface view
+                        // (`implements Named { name as full }`) rather than a
+                        // class-owned slot. Resolve it through the class's
+                        // implemented interfaces, mirroring the method path.
+                        let member_candidates =
+                            self.class_member_field_candidates(&class_tn, field);
+                        if member_candidates.is_empty() {
+                            return false;
+                        }
+                        resolved.extend(member_candidates);
+                    }
                 }
                 Tir2Ty::Interface(..) => {
                     let Some((iface_tn, iface_type_args)) =
@@ -7648,9 +7727,13 @@ impl<'db> LoweringContext<'db> {
                         ) else {
                             continue;
                         };
-                        if !out.iter().any(|(tn, _)| tn == impl_tn) {
-                            out.push((impl_tn.clone(), guard));
-                        }
+                        // Push every matching guard — a generic class can satisfy
+                        // the requested instantiation through more than one
+                        // type-arg projection (`Pair<L, R>` implementing
+                        // `Slot<L>` and `Slot<R>`), and dropping all but the first
+                        // would make some runtime values fail the `is` test.
+                        // Redundant identical branches are harmless (both succeed).
+                        out.push((impl_tn.clone(), guard));
                     }
                 }
             }
@@ -10522,15 +10605,17 @@ impl LoweringContext<'_> {
         if self.pattern_contains_structural(pat_id) {
             return None;
         }
-        // A generic-interface pattern (`Slot<int>`) cannot be discriminated by a
+        // A generic-interface pattern (`Slot<int>`, or one nested in a union /
+        // optional like `Slot<int> | Slot<string>`) cannot be discriminated by a
         // flat type-tag switch: every instantiation shares the bare interface's
-        // implementor tags, so two arms (`Slot<int>` / `Slot<string>`) would
-        // collide and the first would wrongly capture both. Disqualify the
-        // switch so the match-chain runtime test — which filters implementors by
-        // the specific instantiation — is used instead.
-        if let Some(Tir2Ty::Interface(_, type_args, _)) =
-            self.pat_types.get(&self.pat_metadata_key(pat_id))
-            && !type_args.is_empty()
+        // implementor tags, so arms would collide and the first would wrongly
+        // capture all of them. Disqualify the switch (recursively) so the
+        // match-chain runtime test — which filters implementors by the specific
+        // instantiation — is used instead.
+        if self
+            .pat_types
+            .get(&self.pat_metadata_key(pat_id))
+            .is_some_and(Self::tir_ty_needs_generic_interface_test)
         {
             return None;
         }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3876,6 +3876,22 @@ impl<'db> LoweringContext<'db> {
                 current_ty = target_ty;
                 continue;
             }
+            // Receiver prefix may be a union containing an interface member
+            // (`(Dog | Named).name`): dispatch the field read on the runtime
+            // class across all members' implementors.
+            if let Some(Tir2Ty::Union(members, _)) = self
+                .path_segment_types
+                .get(&(self.current_metadata_scope, expr_id, seg_idx - 1))
+                .cloned()
+                && self.lower_union_iface_field_access(base_local, &members, seg, &target_place)
+            {
+                if is_last {
+                    return;
+                }
+                current_place = target_place;
+                current_ty = target_ty;
+                continue;
+            }
 
             // Dynamic map key fallback
             let key_local = self.builder.temp(Ty::String {
@@ -4498,6 +4514,12 @@ impl LoweringContext<'_> {
             if self.try_lower_union_dispatch(expr_id, base_id, &member_name, args, &dest) {
                 return;
             }
+            // Receiver may be a union containing an interface member
+            // (e.g. `Animal | Vehicle`), where every member declares the
+            // method — dispatch on the runtime class across all implementors.
+            if self.try_lower_union_iface_dispatch(expr_id, base_id, &member_name, args, &dest) {
+                return;
+            }
         }
         // BEP-044: `default.<method>(...)` inside an `implements I { ... }`
         // block emits a static call to `I`'s default function, with the
@@ -4648,6 +4670,16 @@ impl LoweringContext<'_> {
                         args,
                         &dest,
                     ) {
+                        return;
+                    }
+                    // Union containing an interface member: dispatch on the
+                    // runtime class across all implementors.
+                    if let Some(candidates) =
+                        self.union_iface_method_candidates(&members, &method_name)
+                        && self.emit_method_candidate_switch(
+                            recv_local, &candidates, expr_id, args, &dest,
+                        )
+                    {
                         return;
                     }
                 }
@@ -5991,7 +6023,18 @@ impl<'db> LoweringContext<'db> {
                     unwrapped_ty,
                     field,
                     &dest,
-                );
+                )
+                || self
+                    .expr_types
+                    .get(&self.expr_metadata_key(base))
+                    .cloned()
+                    .and_then(|t| match t {
+                        Tir2Ty::Union(members, _) => Some(members),
+                        _ => None,
+                    })
+                    .is_some_and(|members| {
+                        self.lower_union_iface_field_access(base_local, &members, field, &dest)
+                    });
             if handled_union_field {
                 return;
             }
@@ -6343,6 +6386,80 @@ impl<'db> LoweringContext<'db> {
         self.emit_union_class_dispatch(recv_local, &members, method, expr_id, args, dest)
     }
 
+    /// A method call whose receiver is a union that contains at least one
+    /// *interface* member (e.g. `Animal | Vehicle`, where every member declares
+    /// `method`). BEP-044: a method present on every union member dispatches on
+    /// the runtime class. Expand each interface member to its implementor
+    /// candidates (and each class member to itself) and emit one class-tag
+    /// switch. Falls through (returns false) if any member contributes no
+    /// candidate, so the caller can report the real error.
+    fn try_lower_union_iface_dispatch(
+        &mut self,
+        expr_id: AstExprId,
+        base: AstExprId,
+        method: &Name,
+        args: &[AstExprId],
+        dest: &Place,
+    ) -> bool {
+        let Some(Tir2Ty::Union(members, _)) =
+            self.expr_types.get(&self.expr_metadata_key(base)).cloned()
+        else {
+            return false;
+        };
+        let Some(candidates) = self.union_iface_method_candidates(&members, method) else {
+            return false;
+        };
+        let receiver_op = self.lower_to_operand(base);
+        let receiver_ty = self.expr_ty(base);
+        let recv_local = self.operand_to_local(receiver_op, receiver_ty);
+        self.emit_method_candidate_switch(recv_local, &candidates, expr_id, args, dest)
+    }
+
+    /// Build the runtime-class dispatch candidates for calling `method` on a
+    /// union receiver that contains at least one interface member. Returns
+    /// `None` (caller falls through) for a pure class union (handled elsewhere)
+    /// or when any member contributes no candidate.
+    fn union_iface_method_candidates(
+        &self,
+        members: &[Tir2Ty],
+        method: &Name,
+    ) -> Option<Vec<InterfaceMethodCandidate>> {
+        // Pure class unions are handled by `try_lower_union_dispatch`; only step
+        // in when an interface member is present.
+        if !members.iter().any(|m| matches!(m, Tir2Ty::Interface(..))) {
+            return None;
+        }
+        let mut candidates: Vec<InterfaceMethodCandidate> = Vec::new();
+        for member in members {
+            match member {
+                Tir2Ty::Class(qtn, _, _) => {
+                    let class_tn = qtn_to_type_name(qtn);
+                    let item_ref = self.class_method_item_ref_by_name(&class_tn, method)?;
+                    candidates.push(InterfaceMethodCandidate {
+                        guard: InterfaceDispatchGuard::Type(Ty::Class(
+                            class_tn,
+                            Vec::new(),
+                            TyAttr::default(),
+                        )),
+                        item_ref,
+                    });
+                }
+                Tir2Ty::Interface(..) => {
+                    let (iface_tn, iface_type_args) =
+                        self.interface_dispatch_target_for_tir_ty(member)?;
+                    let member_candidates =
+                        self.interface_method_candidates_for(&iface_tn, &iface_type_args, method);
+                    if member_candidates.is_empty() {
+                        return None;
+                    }
+                    candidates.extend(member_candidates);
+                }
+                _ => return None,
+            }
+        }
+        Some(candidates)
+    }
+
     /// Emit a class-tag dispatch switch for a method call whose receiver
     /// (`recv_local`) has the union type `members`. Returns false (lowering
     /// nothing) unless every member is a class declaring `method`.
@@ -6417,6 +6534,24 @@ impl<'db> LoweringContext<'db> {
             method,
             args,
         } = call;
+        let resolved = self.interface_method_candidates_for(iface_tn, iface_type_args, method);
+        if resolved.is_empty() {
+            return false;
+        }
+        self.emit_method_candidate_switch(recv_local, &resolved, expr_id, args, dest)
+    }
+
+    /// Resolve every concrete-class dispatch candidate for calling `method`
+    /// through interface `iface_tn` (with `iface_type_args`): each in-body
+    /// implementor's method (or the interface default it inherits) plus every
+    /// out-of-body / primitive type implementor. Shared by the single-interface
+    /// receiver path and the union-receiver path.
+    fn interface_method_candidates_for(
+        &self,
+        iface_tn: &TypeName,
+        iface_type_args: &[Tir2Ty],
+        method: &Name,
+    ) -> Vec<InterfaceMethodCandidate> {
         let class_impls = self
             .interface_implementors
             .get(iface_tn)
@@ -6427,13 +6562,9 @@ impl<'db> LoweringContext<'db> {
             .get(iface_tn)
             .cloned()
             .unwrap_or_default();
-        if class_impls.is_empty() && type_impls.is_empty() {
-            return false;
-        }
         // Resolve the call target for every implementor. If the implementor
         // doesn't directly declare the method, fall back to the interface
-        // whose default it inherits. Skip dispatch entirely if no
-        // implementor resolves.
+        // whose default it inherits.
         let mut resolved: Vec<InterfaceMethodCandidate> = class_impls
             .iter()
             .flat_map(|impl_tn| {
@@ -6462,6 +6593,20 @@ impl<'db> LoweringContext<'db> {
                 item_ref,
             });
         }
+        resolved
+    }
+
+    /// Emit a runtime class-tag switch that calls the matching
+    /// `InterfaceMethodCandidate` for `recv_local`. Returns false (emitting
+    /// nothing) when there are no candidates.
+    fn emit_method_candidate_switch(
+        &mut self,
+        recv_local: Local,
+        resolved: &[InterfaceMethodCandidate],
+        expr_id: AstExprId,
+        args: &[AstExprId],
+        dest: &Place,
+    ) -> bool {
         if resolved.is_empty() {
             return false;
         }
@@ -6543,6 +6688,84 @@ impl<'db> LoweringContext<'db> {
                 )
             })
             .collect();
+        self.emit_interface_field_candidate_switch(recv_local, &resolved, dest)
+    }
+
+    /// A field read whose receiver is a union with at least one interface member
+    /// (e.g. `(Dog | Named).name`). Each member contributes the concrete classes
+    /// it can be at runtime — a class member is itself; an interface member is
+    /// every implementor (reading the linked field view) — and we dispatch on
+    /// the runtime class. Returns false (caller falls through) if any member
+    /// contributes no candidate.
+    fn lower_union_iface_field_access(
+        &mut self,
+        recv_local: Local,
+        members: &[Tir2Ty],
+        field: &Name,
+        dest: &Place,
+    ) -> bool {
+        if !members.iter().any(|m| matches!(m, Tir2Ty::Interface(..))) {
+            return false;
+        }
+        let mut resolved: Vec<InterfaceFieldCandidate> = Vec::new();
+        for member in members {
+            match member {
+                Tir2Ty::Class(qtn, _, _) => {
+                    let class_tn = qtn_to_type_name(qtn);
+                    let Some(field_idx) = self
+                        .class_fields
+                        .get(&class_tn)
+                        .and_then(|fields| fields.get(field.as_str()))
+                        .copied()
+                    else {
+                        return false;
+                    };
+                    resolved.push(InterfaceFieldCandidate {
+                        impl_tn: class_tn,
+                        guard: InterfaceClassGuard::Any,
+                        field_idx,
+                    });
+                }
+                Tir2Ty::Interface(..) => {
+                    let Some((iface_tn, iface_type_args)) =
+                        self.interface_dispatch_target_for_tir_ty(member)
+                    else {
+                        return false;
+                    };
+                    let Some(impls) = self.interface_implementors.get(&iface_tn).cloned() else {
+                        return false;
+                    };
+                    let member_candidates: Vec<InterfaceFieldCandidate> = impls
+                        .iter()
+                        .flat_map(|impl_tn| {
+                            self.resolve_implementor_interface_field_candidates(
+                                impl_tn,
+                                &iface_tn,
+                                &iface_type_args,
+                                field,
+                            )
+                        })
+                        .collect();
+                    if member_candidates.is_empty() {
+                        return false;
+                    }
+                    resolved.extend(member_candidates);
+                }
+                _ => return false,
+            }
+        }
+        self.emit_interface_field_candidate_switch(recv_local, &resolved, dest)
+    }
+
+    /// Emit a runtime class-tag switch that reads `field` from `recv_local`
+    /// using whichever `InterfaceFieldCandidate` matches. Returns false
+    /// (emitting nothing) when there are no candidates.
+    fn emit_interface_field_candidate_switch(
+        &mut self,
+        recv_local: Local,
+        resolved: &[InterfaceFieldCandidate],
+        dest: &Place,
+    ) -> bool {
         if resolved.is_empty() {
             return false;
         }
@@ -7331,6 +7554,66 @@ impl<'db> LoweringContext<'db> {
             .into_iter()
             .find(|(tn, _)| self.interface_declares_method(tn, method))
             .map(|(tn, _)| tn)
+    }
+
+    /// Class-tag dispatch guards for every implementor that satisfies the
+    /// *specific instantiation* `iface_tn<iface_type_args>`. Implementors of a
+    /// different instantiation (e.g. `StrSlot: Slot<string>` when the request is
+    /// `Slot<int>`) are excluded, because `interface_class_guard_for_args`
+    /// returns `None` for a non-matching argument list. Used by the runtime
+    /// `is`-type test so a generic-interface pattern respects its type argument.
+    fn interface_implementor_class_guards(
+        &self,
+        iface_tn: &TypeName,
+        iface_type_args: &[Tir2Ty],
+    ) -> Vec<(TypeName, InterfaceClassGuard)> {
+        let Some(impls) = self.interface_implementors.get(iface_tn).cloned() else {
+            return Vec::new();
+        };
+        let Some(requested_views) =
+            self.interface_closure_type_name_views(iface_tn, iface_type_args)
+        else {
+            return Vec::new();
+        };
+        let mut out: Vec<(TypeName, InterfaceClassGuard)> = Vec::new();
+        for impl_tn in &impls {
+            let Some(class_loc) = self.resolve_class_loc_by_type_name(impl_tn) else {
+                continue;
+            };
+            let item_tree = file_item_tree(self.db, class_loc.file(self.db));
+            let class_data = &item_tree[class_loc.id(self.db)];
+            for impl_block in &class_data.implements {
+                let Some((target_tn, target_args)) =
+                    self.resolve_implements_target_view(&impl_block.target, class_loc)
+                else {
+                    continue;
+                };
+                let Some(target_views) =
+                    self.interface_closure_type_name_views(&target_tn, &target_args)
+                else {
+                    continue;
+                };
+                for (target_view_tn, target_view_args) in target_views {
+                    for (requested_tn, requested_args) in &requested_views {
+                        if target_view_tn != *requested_tn {
+                            continue;
+                        }
+                        let Some(guard) = interface_class_guard_for_args(
+                            &target_view_args,
+                            requested_args,
+                            &class_data.generic_params,
+                            &self.resolved_aliases.aliases,
+                        ) else {
+                            continue;
+                        };
+                        if !out.iter().any(|(tn, _)| tn == impl_tn) {
+                            out.push((impl_tn.clone(), guard));
+                        }
+                    }
+                }
+            }
+        }
+        out
     }
 
     fn resolve_implementor_interface_field_candidates(
@@ -9030,6 +9313,21 @@ impl LoweringContext<'_> {
         self.emit_is_tir_type_branch_inner(scrutinee, ty, success, failure, &mut visited);
     }
 
+    /// Whether `ty` is (or contains, inside a union/optional) a *generic*
+    /// interface instantiation, whose runtime test must respect its type
+    /// argument. Used to opt only these patterns into the TIR-typed test path,
+    /// leaving non-interface patterns on the unchanged erased fast path.
+    fn tir_ty_needs_generic_interface_test(ty: &Tir2Ty) -> bool {
+        match ty {
+            Tir2Ty::Interface(_, args, _) => !args.is_empty(),
+            Tir2Ty::Union(members, _) => members
+                .iter()
+                .any(Self::tir_ty_needs_generic_interface_test),
+            Tir2Ty::Optional(inner, _) => Self::tir_ty_needs_generic_interface_test(inner),
+            _ => false,
+        }
+    }
+
     fn emit_is_tir_type_branch_inner(
         &mut self,
         scrutinee: Local,
@@ -9131,6 +9429,32 @@ impl LoweringContext<'_> {
                 }
 
                 visited.remove(&key);
+            }
+            // A generic-interface pattern (`Slot<int>`) must respect its type
+            // argument: test only the implementors of *that* instantiation, not
+            // every implementor of the bare interface. Without this, a
+            // `StrSlot` (only `Slot<string>`) wrongly matches a `Slot<int>` arm
+            // and feeds a string into integer code (`tagged_int_add` panic).
+            Tir2Ty::Interface(iface_qtn, type_args, _) if !type_args.is_empty() => {
+                let iface_tn = qtn_to_type_name(iface_qtn);
+                let guards = self.interface_implementor_class_guards(&iface_tn, type_args);
+                if guards.is_empty() {
+                    self.builder.goto(failure);
+                    return;
+                }
+                let mut next_check = self.builder.current_block();
+                for (idx, (impl_tn, guard)) in guards.iter().enumerate() {
+                    let bb_next = if idx + 1 == guards.len() {
+                        failure
+                    } else {
+                        self.builder.create_block()
+                    };
+                    self.builder.set_current_block(next_check);
+                    self.emit_interface_class_guard_branch(
+                        scrutinee, impl_tn, guard, success, bb_next,
+                    );
+                    next_check = bb_next;
+                }
             }
             // Singleton-valued types pin a specific runtime value, so emit
             // equality checks rather than type-tag tests. `is_type` on a
@@ -9640,12 +9964,23 @@ impl LoweringContext<'_> {
                         .branch(Operand::Copy(Place::Local(test_local)), success, failure);
                 }
                 _ => {
-                    let annotation_ty = self
-                        .pat_types
-                        .get(&self.pat_metadata_key(pat_id))
-                        .map(|tir_ty| convert_tir2_ty(tir_ty, &self.resolved_aliases))
-                        .unwrap_or_else(|| self.resolve_type_annotation(ty_expr));
-                    self.emit_is_type_branch(scrutinee, annotation_ty, success, failure);
+                    // A generic-interface pattern (`Slot<int>`) needs the
+                    // TIR-typed test, which preserves the type argument and
+                    // tests only the implementors of *that* instantiation —
+                    // otherwise the erased path matches every implementor and a
+                    // `Slot<string>` value falls into a `Slot<int>` arm. Other
+                    // patterns keep the erased fast path (unchanged codegen).
+                    let tir_ty = self.pat_types.get(&self.pat_metadata_key(pat_id)).cloned();
+                    if let Some(tir_ty) = &tir_ty
+                        && Self::tir_ty_needs_generic_interface_test(tir_ty)
+                    {
+                        self.emit_is_tir_type_branch(scrutinee, tir_ty, success, failure);
+                    } else {
+                        let annotation_ty = tir_ty
+                            .map(|t| convert_tir2_ty(&t, &self.resolved_aliases))
+                            .unwrap_or_else(|| self.resolve_type_annotation(ty_expr));
+                        self.emit_is_type_branch(scrutinee, annotation_ty, success, failure);
+                    }
                 }
             },
             AstPattern::Or(sub_pats) => {
@@ -10143,6 +10478,18 @@ impl LoweringContext<'_> {
     fn classify_pattern_type_tag(&self, pat_id: AstPatId) -> Option<Vec<i64>> {
         let pat = &self.body.patterns[pat_id];
         if self.pattern_contains_structural(pat_id) {
+            return None;
+        }
+        // A generic-interface pattern (`Slot<int>`) cannot be discriminated by a
+        // flat type-tag switch: every instantiation shares the bare interface's
+        // implementor tags, so two arms (`Slot<int>` / `Slot<string>`) would
+        // collide and the first would wrongly capture both. Disqualify the
+        // switch so the match-chain runtime test — which filters implementors by
+        // the specific instantiation — is used instead.
+        if let Some(Tir2Ty::Interface(_, type_args, _)) =
+            self.pat_types.get(&self.pat_metadata_key(pat_id))
+            && !type_args.is_empty()
+        {
             return None;
         }
         // Bind/Array patterns may carry a `:T` type ascription; resolve

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2743,14 +2743,23 @@ impl<'db> TypeInferenceBuilder<'db> {
                     });
                 }
 
-                // If any arm is Unknown/Error, a member's resolution already
-                // reported the real error (e.g. an ambiguous interface method →
-                // E0121), so don't also emit a misleading
-                // `unknown | unknown is not a function`.
-                if expanded
+                // When *every* non-function arm is already in recovery
+                // (Unknown/Error), a member's resolution already reported the
+                // real error (e.g. an ambiguous interface method → E0121), so
+                // don't also emit a misleading `unknown | unknown is not a
+                // function`. But if a concrete non-function arm remains (e.g.
+                // `int | unknown`), that arm is genuinely not callable and must
+                // still be diagnosed.
+                let has_recovery_arm = expanded
                     .iter()
-                    .any(|a| matches!(a, Ty::Unknown { .. } | Ty::Error { .. }))
-                {
+                    .any(|a| matches!(a, Ty::Unknown { .. } | Ty::Error { .. }));
+                let has_concrete_non_function_arm = expanded.iter().any(|a| {
+                    !matches!(
+                        a,
+                        Ty::Function { .. } | Ty::Unknown { .. } | Ty::Error { .. }
+                    )
+                });
+                if has_recovery_arm && !has_concrete_non_function_arm {
                     self.infer_args_for_recovery(args, body);
                     return CheckedCallInner {
                         result: Ty::Unknown {

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -8048,7 +8048,16 @@ impl<'db> TypeInferenceBuilder<'db> {
             // The union-callee fold requires every arm to share a shape and
             // skips `self` for method calls, so re-attach a `self` param here
             // to match the class arms (`(self: Animal) -> R`, not `() -> R`).
-            return ty.map(|t| Self::prepend_self_param_if_method(t, self_ty.clone(), bound));
+            // Only for actual methods — a function-typed interface *field* must
+            // keep its declared signature rather than gain a phantom `self`.
+            let is_method = self.interface_closure_declares_method(&iface_name, member);
+            return ty.map(|t| {
+                if is_method {
+                    Self::prepend_self_param_if_method(t, self_ty.clone(), bound)
+                } else {
+                    t
+                }
+            });
         }
         // Class / primitive member: the read-only probe handles its own fields
         // and methods.

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -7676,6 +7676,25 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // If ALL members have the field, return Union(resolved_types).
                 // If any member is missing the field, report per-member errors.
                 let members = members.clone();
+                // A shared implementor of two of the union's interfaces makes an
+                // unqualified method call ambiguous (E0121) — reject it instead
+                // of silently picking the first interface's default.
+                if let Some((class_name, sources)) =
+                    self.union_interface_method_ambiguity(&members, member)
+                {
+                    self.context.report_at_member(
+                        TirTypeError::AmbiguousInterfaceMethod {
+                            class_name,
+                            method_name: member.clone(),
+                            sources,
+                        },
+                        at,
+                        Vec::new(),
+                    );
+                    return Ty::Unknown {
+                        attr: TyAttr::default(),
+                    };
+                }
                 let mut resolved: Vec<(Ty, Option<Ty>)> = Vec::with_capacity(members.len());
                 for m in &members {
                     let r = self.resolve_union_member_ty(m, member, at, bound);
@@ -7999,6 +8018,26 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // Use report_at_segment for missing members so the span points at the
                 // segment token, not the full path.
                 let members = members.clone();
+                // A shared implementor of two of the union's interfaces makes an
+                // unqualified method call ambiguous (E0121) — reject it instead
+                // of silently picking the first interface's default.
+                if let Some((class_name, sources)) =
+                    self.union_interface_method_ambiguity(&members, member)
+                {
+                    self.context.report_at_segment(
+                        TirTypeError::AmbiguousInterfaceMethod {
+                            class_name,
+                            method_name: member.clone(),
+                            sources,
+                        },
+                        path_id,
+                        seg_idx,
+                        Vec::new(),
+                    );
+                    return Ty::Unknown {
+                        attr: TyAttr::default(),
+                    };
+                }
                 let mut resolved: Vec<(Ty, Option<Ty>)> = Vec::with_capacity(members.len());
                 for m in &members {
                     let r = self.resolve_union_member_ty(m, member, path_id, bound);
@@ -8040,6 +8079,65 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.resolve_member(base_ty, member, path_id, bound)
             }
         }
+    }
+
+    /// Conservative ambiguity check for accessing `member` (a method) on a union
+    /// whose members include interfaces. If some class implements two or more of
+    /// the union's interfaces and `member` is declared by ≥2 of them, then a
+    /// value of the union could be that class — for which a direct
+    /// `value.member()` is rejected as ambiguous (E0121). The static union type
+    /// admits such a class, so the call is genuinely ambiguous; report it rather
+    /// than silently dispatching to the first interface's default.
+    ///
+    /// Returns `(class_name, formatted_sources)` for the E0121 diagnostic, or
+    /// `None` when no shared implementor makes the call ambiguous.
+    fn union_interface_method_ambiguity(
+        &self,
+        members: &[Ty],
+        member: &Name,
+    ) -> Option<(Name, Vec<String>)> {
+        let iface_qtns: FxHashSet<crate::ty::QualifiedTypeName> = members
+            .iter()
+            .filter_map(|m| match m {
+                Ty::Interface(qtn, _, _) => Some(qtn.clone()),
+                _ => None,
+            })
+            .collect();
+        // A single interface can't have a cross-member shared-implementor clash.
+        if iface_qtns.len() < 2 {
+            return None;
+        }
+        let db = self.context.db();
+        let registry = crate::interfaces::package_implements_registry(db, self.package_id);
+        let mut seen: FxHashSet<crate::ty::QualifiedTypeName> = FxHashSet::default();
+        for rule in &registry.interface_impl_rules {
+            let Ty::Interface(rule_iface, _, _) = &rule.interface_ty else {
+                continue;
+            };
+            if !iface_qtns.contains(rule_iface) {
+                continue;
+            }
+            let Ty::Class(class_qtn, _, _) = &rule.for_ty_pattern else {
+                continue;
+            };
+            if !seen.insert(class_qtn.clone()) {
+                continue;
+            }
+            // Which of THIS union's interfaces declare `member` on the class.
+            let sources: Vec<(crate::ty::QualifiedTypeName, Vec<Ty>)> = self
+                .implemented_interface_method_sources(class_qtn, &[], member)
+                .into_iter()
+                .filter(|(_, qtn, _)| iface_qtns.contains(qtn))
+                .map(|(_, qtn, args)| (qtn, args))
+                .collect();
+            if sources.len() >= 2 {
+                return Some((
+                    class_qtn.name().clone(),
+                    self.format_interface_method_sources(sources.into_iter()),
+                ));
+            }
+        }
+        None
     }
 
     /// Resolve `member` on one constituent `m` of a union receiver.

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -3193,13 +3193,13 @@ impl<'db> TypeInferenceBuilder<'db> {
             // than emitting a generic `type mismatch`. (Interface→sibling
             // projections keep the type-mismatch form, which names both
             // interfaces.)
-            if let (Ty::Interface(iface_qtn, _, _), false) =
+            if let (Ty::Interface(_, _, _), false) =
                 (&target_ty, matches!(base_ty, Ty::Interface(..)))
             {
                 self.context.report_simple(
                     TirTypeError::TypeDoesNotImplementInterface {
                         value_type: base_ty,
-                        interface_name: iface_qtn.name().clone(),
+                        interface: target_ty.clone(),
                     },
                     expr_id,
                 );
@@ -7456,6 +7456,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             | Ty::Literal(baml_base::Literal::String(_), _, _) => {
                 // Bridge: string / string-literal → String class
                 self.resolve_builtin_member(&["String"], &[], member, at)
+                    .or_else(|| {
+                        self.try_registry_member(base_ty, Name::new("string"), member, at, bound)
+                    })
                     .unwrap_or_else(|| {
                         self.context.report_at_member_simple(
                             TirTypeError::UnresolvedMember {
@@ -7490,6 +7493,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             Ty::Primitive(PrimitiveType::Bigint, _)
             | Ty::Literal(baml_base::Literal::Bigint(_), _, _) => self
                 .resolve_builtin_member(&["Bigint"], &[], member, at)
+                .or_else(|| {
+                    self.try_registry_member(base_ty, Name::new("bigint"), member, at, bound)
+                })
                 .unwrap_or_else(|| {
                     self.context.report_at_member_simple(
                         TirTypeError::UnresolvedMember {
@@ -7506,6 +7512,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             Ty::Primitive(PrimitiveType::Float, _)
             | Ty::Literal(baml_base::Literal::Float(_), _, _) => self
                 .resolve_builtin_member(&["Float"], &[], member, at)
+                .or_else(|| {
+                    self.try_registry_member(base_ty, Name::new("float"), member, at, bound)
+                })
                 .unwrap_or_else(|| {
                     self.context.report_at_member_simple(
                         TirTypeError::UnresolvedMember {
@@ -7522,6 +7531,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             Ty::Primitive(PrimitiveType::Bool, _)
             | Ty::Literal(baml_base::Literal::Bool(_), _, _) => self
                 .resolve_builtin_member(&["Bool"], &[], member, at)
+                .or_else(|| self.try_registry_member(base_ty, Name::new("bool"), member, at, bound))
                 .unwrap_or_else(|| {
                     self.context.report_at_member_simple(
                         TirTypeError::UnresolvedMember {
@@ -7537,6 +7547,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             // null / Null companion class
             Ty::Primitive(PrimitiveType::Null, _) => self
                 .resolve_builtin_member(&["Null"], &[], member, at)
+                .or_else(|| self.try_registry_member(base_ty, Name::new("null"), member, at, bound))
                 .unwrap_or_else(|| {
                     self.context.report_at_member_simple(
                         TirTypeError::UnresolvedMember {
@@ -7640,10 +7651,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // If ALL members have the field, return Union(resolved_types).
                 // If any member is missing the field, report per-member errors.
                 let members = members.clone();
-                let resolved: Vec<(Ty, Option<Ty>)> = members
-                    .iter()
-                    .map(|m| (m.clone(), self.try_resolve_member_on_ty(m, member)))
-                    .collect();
+                let mut resolved: Vec<(Ty, Option<Ty>)> = Vec::with_capacity(members.len());
+                for m in &members {
+                    let r = self.resolve_union_member_ty(m, member, at, bound);
+                    resolved.push((m.clone(), r));
+                }
 
                 if resolved.iter().all(|(_, r)| r.is_some()) {
                     // All members have the field — return union of resolved types
@@ -7962,10 +7974,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // Use report_at_segment for missing members so the span points at the
                 // segment token, not the full path.
                 let members = members.clone();
-                let resolved: Vec<(Ty, Option<Ty>)> = members
-                    .iter()
-                    .map(|m| (m.clone(), self.try_resolve_member_on_ty(m, member)))
-                    .collect();
+                let mut resolved: Vec<(Ty, Option<Ty>)> = Vec::with_capacity(members.len());
+                for m in &members {
+                    let r = self.resolve_union_member_ty(m, member, path_id, bound);
+                    resolved.push((m.clone(), r));
+                }
 
                 if resolved.iter().all(|(_, r)| r.is_some()) {
                     let field_tys: Vec<Ty> =
@@ -8001,6 +8014,154 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // to resolve_member which handles them with proper error reporting.
                 self.resolve_member(base_ty, member, path_id, bound)
             }
+        }
+    }
+
+    /// Resolve `member` on one constituent `m` of a union receiver.
+    ///
+    /// Interface members can't be resolved by the read-only
+    /// [`try_resolve_member_on_ty`](Self::try_resolve_member_on_ty) probe — it
+    /// returns the `Ty::Unknown` sentinel, which makes a method present on
+    /// every member collapse into a non-callable `unknown | unknown` union
+    /// (BEP-044 union dispatch, formerly E0006). Resolve interface members
+    /// through the full interface machinery instead, but suppress the
+    /// diagnostics and the single-interface `MemberResolution` it records: a
+    /// union method/field access dispatches on the runtime class (see MIR
+    /// `try_lower_union_iface_dispatch` / `try_lower_interface_field_access`),
+    /// not a stored per-member resolution.
+    fn resolve_union_member_ty(
+        &mut self,
+        m: &Ty,
+        member: &Name,
+        at: ExprId,
+        bound: bool,
+    ) -> Option<Ty> {
+        if let Ty::Interface(iface_name, type_args, _) = m {
+            let iface_name = iface_name.clone();
+            let type_args = type_args.clone();
+            let self_ty = Ty::Interface(iface_name.clone(), type_args.clone(), TyAttr::default());
+            let ty = self.resolve_member_suppressing_side_effects(at, |this| {
+                this.resolve_interface_member(&iface_name, &type_args, member, at, bound)
+            });
+            // A bound interface *method* comes back self-stripped, but class
+            // method members of the same union keep `self` (the unbound form).
+            // The union-callee fold requires every arm to share a shape and
+            // skips `self` for method calls, so re-attach a `self` param here
+            // to match the class arms (`(self: Animal) -> R`, not `() -> R`).
+            return ty.map(|t| Self::prepend_self_param_if_method(t, self_ty.clone(), bound));
+        }
+        // Class / primitive member: the read-only probe handles its own fields
+        // and methods.
+        if let Some(ty) = self.try_resolve_member_on_ty(m, member) {
+            return Some(ty);
+        }
+        // A class member whose `member` is contributed by two or more interface
+        // field views (`implements Named { name as full }` +
+        // `implements Labeled { name as handle }`) is genuinely ambiguous — the
+        // same E0131 the single-class receiver path emits, with the `.as<I>`
+        // projection hint. Surface it directly (not suppressed) and treat the
+        // member as resolved so the union doesn't also blame it with a misleading
+        // "no member" (E0007).
+        if let Ty::Class(class_name, _, _) = m {
+            let field_sources = self.class_interface_field_sources(class_name, member);
+            if field_sources.len() > 1 {
+                let related = self
+                    .package_items
+                    .lookup_type(class_name.namespace(), class_name.name())
+                    .map(|def| {
+                        vec![RelatedNote::new(
+                            RelatedLocation::Item(def),
+                            "class defined here",
+                        )]
+                    })
+                    .unwrap_or_default();
+                self.context.report_at_member(
+                    TirTypeError::AmbiguousInterfaceField {
+                        class_name: class_name.name().clone(),
+                        field_name: member.clone(),
+                        sources: field_sources,
+                    },
+                    at,
+                    related,
+                );
+                return Some(Ty::Unknown {
+                    attr: TyAttr::default(),
+                });
+            }
+        }
+        // Out-of-body / blanket `implements I for T` rules aren't in the type's
+        // in-body members, so a union member backed only by such a rule (e.g.
+        // `int` in `int | Dog` with `implements Debuggable for int`) is missed
+        // above. Consult the registry — suppressing diagnostics + the recorded
+        // resolution — so the member resolves (and a genuinely-lacking member
+        // like `Dog` is the only one blamed).
+        let receiver_name = match m {
+            Ty::Class(qtn, _, _) => qtn.name().clone(),
+            _ => Name::new("value"),
+        };
+        let member_ty = m.clone();
+        let self_ty = m.clone();
+        let ty = self.resolve_member_suppressing_side_effects(at, |this| {
+            this.try_registry_member(&member_ty, receiver_name.clone(), member, at, bound)
+        });
+        ty.map(|t| Self::prepend_self_param_if_method(t, self_ty.clone(), bound))
+    }
+
+    /// Run `f` (a member-resolution probe that may report diagnostics and record
+    /// a single `MemberResolution` at `at`) and roll back both side effects.
+    /// Used by union-member resolution, where the real diagnostics/dispatch are
+    /// decided across all members (and at the MIR layer), not per-member.
+    fn resolve_member_suppressing_side_effects(
+        &mut self,
+        at: ExprId,
+        f: impl FnOnce(&mut Self) -> Option<Ty>,
+    ) -> Option<Ty> {
+        let diag_snapshot = self.context.diagnostic_count();
+        let saved_resolution = self.resolutions.remove(&at);
+        let saved_generics = self.interface_method_generic_params.remove(&at);
+        let ty = f(self);
+        self.context.truncate_diagnostics(diag_snapshot);
+        self.resolutions.remove(&at);
+        self.interface_method_generic_params.remove(&at);
+        if let Some(r) = saved_resolution {
+            self.resolutions.insert(at, r);
+        }
+        if let Some(g) = saved_generics {
+            self.interface_method_generic_params.insert(at, g);
+        }
+        ty
+    }
+
+    /// Re-attach a `self` parameter (typed `self_ty`) to a self-stripped bound
+    /// method type, so it shares the self-included shape of class method members
+    /// in a union callee. No-op for non-function types or unbound calls.
+    fn prepend_self_param_if_method(ty: Ty, self_ty: Ty, bound: bool) -> Ty {
+        match ty {
+            Ty::Function {
+                generic_params,
+                generic_param_bounds,
+                params,
+                ret,
+                throws,
+                attr,
+            } if bound => {
+                let mut with_self = Vec::with_capacity(params.len() + 1);
+                with_self.push(FunctionParamTy {
+                    name: Some(Name::new("self")),
+                    ty: self_ty,
+                    mode: FunctionParamMode::Required,
+                });
+                with_self.extend(params);
+                Ty::Function {
+                    generic_params,
+                    generic_param_bounds,
+                    params: with_self,
+                    ret,
+                    throws,
+                    attr,
+                }
+            }
+            other => other,
         }
     }
 
@@ -10735,6 +10896,16 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// `implements I` block never satisfies `I`, even if it has matching
     /// fields and methods.
     fn is_subtype(&self, sub: &Ty, sup: &Ty) -> bool {
+        // Reflexivity: a type variable is a subtype of *itself*, regardless of
+        // any bound. Checked before bound-substitution below — otherwise a
+        // bounded `T extends Animal` would rewrite `sub` to `Animal` and then
+        // reject `T <: T` (the self-contradictory "expected T, got T"), which
+        // breaks `fn id<T extends Animal>(a: T) -> T { return a }`.
+        if let (Ty::TypeVar(a, _), Ty::TypeVar(b, _)) = (sub, sup)
+            && a == b
+        {
+            return true;
+        }
         if let Ty::TypeVar(name, _) = sub
             && let Some(bound) = self.generic_param_bounds.get(name)
         {
@@ -11148,6 +11319,31 @@ impl<'db> TypeInferenceBuilder<'db> {
     ///
     /// String concatenation is only valid for `Add`; other arithmetic ops on
     /// strings are invalid and return `Unknown` (triggering an error upstream).
+    /// Whether `ty` is a non-object primitive — `int`/`float`/`bigint`/`bool`/
+    /// `null` (and their literals). These are tagged values with no heap object,
+    /// so the VM cannot string-concatenate them (`exec_binop` only concatenates
+    /// two objects). String-typed and `uint8array`/media values ARE objects.
+    fn is_non_object_primitive(ty: &Ty) -> bool {
+        matches!(
+            ty,
+            Ty::Primitive(
+                PrimitiveType::Int
+                    | PrimitiveType::Float
+                    | PrimitiveType::Bigint
+                    | PrimitiveType::Bool
+                    | PrimitiveType::Null,
+                _,
+            ) | Ty::Literal(
+                baml_base::Literal::Int(_)
+                    | baml_base::Literal::Float(_)
+                    | baml_base::Literal::Bigint(_)
+                    | baml_base::Literal::Bool(_),
+                _,
+                _,
+            )
+        )
+    }
+
     fn infer_arithmetic(op: baml_compiler2_ast::BinaryOp, lhs: &Ty, rhs: &Ty) -> Ty {
         fn promote(a: PrimitiveType, b: &PrimitiveType) -> Option<PrimitiveType> {
             if a == *b {
@@ -11210,8 +11406,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Ty::Primitive(PrimitiveType::Int, TyAttr::default())
             }
             (Some(PrimitiveType::String), _) | (_, Some(PrimitiveType::String)) => {
-                // String concatenation only for Add
-                if matches!(op, baml_compiler2_ast::BinaryOp::Add) {
+                // String concatenation, Add only. The VM concatenates any two
+                // *objects* via `as_string` (string, uint8array, …), but a
+                // non-object primitive (int/float/bigint/bool/null) has no object
+                // representation and aborts at runtime. So `string + int` must be
+                // a type error here rather than inferring `string` and crashing
+                // the VM (F4), while `string + uint8array` stays valid.
+                if matches!(op, baml_compiler2_ast::BinaryOp::Add)
+                    && !Self::is_non_object_primitive(lhs)
+                    && !Self::is_non_object_primitive(rhs)
+                {
                     Ty::Primitive(PrimitiveType::String, TyAttr::default())
                 } else {
                     Ty::Unknown {
@@ -12259,12 +12463,46 @@ impl TypeInferenceBuilder<'_> {
             && !crate::generics::contains_typevar(&scrut_for_check)
             && !self.is_subtype(&pat_natural, &scrut_for_check)
             && !self.is_subtype(&scrut_for_check, &pat_natural)
+            && !self.pattern_overlaps_scrut_member(&pat_natural, &scrut_for_check)
         {
             let err = TirTypeError::TypeMismatch {
                 expected: scrut_ty.clone(),
                 got: pat_natural,
             };
             self.report_at_pat_or_expr(err, pat_id, at_expr);
+        }
+    }
+
+    /// A match arm is valid if its pattern overlaps *any* member of a
+    /// union/optional scrutinee — the arm matches that member's values even
+    /// when other members don't (`null`, or an unrelated class). Without this,
+    /// `let a: Animal => …` over `(Dog | Cat)?` is wrongly rejected because the
+    /// whole `Dog | Cat | null` isn't a subtype of `Animal` (the `null` arm) and
+    /// `Animal` isn't a subtype of the union either.
+    fn pattern_overlaps_scrut_member(&self, pat: &Ty, scrut: &Ty) -> bool {
+        let members = self.flatten_union_optional_members(scrut);
+        // Only a genuine union/optional contributes >1 member; a scalar scrut
+        // yields itself and was already covered by the two `is_subtype` checks.
+        members.len() > 1
+            && members
+                .iter()
+                .any(|m| self.is_subtype(pat, m) || self.is_subtype(m, pat))
+    }
+
+    /// Flatten a (possibly nested) union/optional type into its leaf members,
+    /// with `null` materialized for each `Optional` layer.
+    fn flatten_union_optional_members(&self, ty: &Ty) -> Vec<Ty> {
+        match self.expand_alias_chains(ty.clone()) {
+            Ty::Union(members, _) => members
+                .iter()
+                .flat_map(|m| self.flatten_union_optional_members(m))
+                .collect(),
+            Ty::Optional(inner, _) => {
+                let mut out = self.flatten_union_optional_members(&inner);
+                out.push(Ty::Primitive(PrimitiveType::Null, TyAttr::default()));
+                out
+            }
+            other => vec![other],
         }
     }
 
@@ -13099,10 +13337,11 @@ impl TypeInferenceBuilder<'_> {
         match &w.ctor {
             Ctor::Class(qtn, _) => {
                 let names = self.class_field_names_ordered(qtn);
+                let qtn_str = qtn.render_user_facing();
                 if w.fields.is_empty() {
-                    return format!("{qtn} {{}}");
+                    return format!("{qtn_str} {{}}");
                 }
-                let mut out = format!("{qtn} {{ ");
+                let mut out = format!("{qtn_str} {{ ");
                 for (i, fld) in w.fields.iter().enumerate() {
                     if i > 0 {
                         out.push_str(", ");

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -8113,7 +8113,21 @@ impl<'db> TypeInferenceBuilder<'db> {
         let ty = self.resolve_member_suppressing_side_effects(at, |this| {
             this.try_registry_member(&member_ty, receiver_name.clone(), member, at, bound)
         });
-        ty.map(|t| Self::prepend_self_param_if_method(t, self_ty.clone(), bound))
+        // Only re-attach `self` for methods (mirrors the interface branch). The
+        // registry resolves `member` as a method exactly when some out-of-body
+        // interface declares it as one; a function-typed interface *field*
+        // satisfied out-of-body must keep its declared signature rather than
+        // gain a phantom `self`.
+        let is_method = !self
+            .registry_interface_method_sources(&member_ty, member)
+            .is_empty();
+        ty.map(|t| {
+            if is_method {
+                Self::prepend_self_param_if_method(t, self_ty.clone(), bound)
+            } else {
+                t
+            }
+        })
     }
 
     /// Run `f` (a member-resolution probe that may report diagnostics and record

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2743,6 +2743,22 @@ impl<'db> TypeInferenceBuilder<'db> {
                     });
                 }
 
+                // If any arm is Unknown/Error, a member's resolution already
+                // reported the real error (e.g. an ambiguous interface method →
+                // E0121), so don't also emit a misleading
+                // `unknown | unknown is not a function`.
+                if expanded
+                    .iter()
+                    .any(|a| matches!(a, Ty::Unknown { .. } | Ty::Error { .. }))
+                {
+                    self.infer_args_for_recovery(args, body);
+                    return CheckedCallInner {
+                        result: Ty::Unknown {
+                            attr: TyAttr::default(),
+                        },
+                        bindings_from_inference: false,
+                    };
+                }
                 // Not all arms are functions — report not callable.
                 self.context.report_simple(
                     TirTypeError::NotCallable {
@@ -8064,18 +8080,15 @@ impl<'db> TypeInferenceBuilder<'db> {
         if let Some(ty) = self.try_resolve_member_on_ty(m, member) {
             return Some(ty);
         }
-        // A class member whose `member` is contributed by two or more interface
-        // field views (`implements Named { name as full }` +
-        // `implements Labeled { name as handle }`) is genuinely ambiguous — the
-        // same E0131 the single-class receiver path emits, with the `.as<I>`
-        // projection hint. Surface it directly (not suppressed) and treat the
-        // member as resolved so the union doesn't also blame it with a misleading
-        // "no member" (E0007).
-        if let Ty::Class(class_name, _, _) = m {
-            let field_sources = self.class_interface_field_sources(class_name, member);
-            if field_sources.len() > 1 {
-                let related = self
-                    .package_items
+        // A class member contributed by two or more interfaces is genuinely
+        // ambiguous — emit the same E0131 (field) / E0121 (method) the
+        // single-class receiver path emits, with the `.as<I>` projection hint.
+        // Surface it directly (not suppressed) and treat the member as resolved,
+        // so the union doesn't instead collapse to a misleading
+        // `unknown | unknown` (E0006) or blame the member with a false E0007.
+        if let Ty::Class(class_name, type_args, _) = m {
+            let related = || {
+                self.package_items
                     .lookup_type(class_name.namespace(), class_name.name())
                     .map(|def| {
                         vec![RelatedNote::new(
@@ -8083,7 +8096,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                             "class defined here",
                         )]
                     })
-                    .unwrap_or_default();
+                    .unwrap_or_default()
+            };
+            let field_sources = self.class_interface_field_sources(class_name, member);
+            if field_sources.len() > 1 {
                 self.context.report_at_member(
                     TirTypeError::AmbiguousInterfaceField {
                         class_name: class_name.name().clone(),
@@ -8091,7 +8107,26 @@ impl<'db> TypeInferenceBuilder<'db> {
                         sources: field_sources,
                     },
                     at,
-                    related,
+                    related(),
+                );
+                return Some(Ty::Unknown {
+                    attr: TyAttr::default(),
+                });
+            }
+            let method_sources: Vec<String> = self.format_interface_method_sources(
+                self.implemented_interface_method_sources(class_name, type_args, member)
+                    .into_iter()
+                    .map(|(_, qtn, args)| (qtn, args)),
+            );
+            if method_sources.len() >= 2 {
+                self.context.report_at_member(
+                    TirTypeError::AmbiguousInterfaceMethod {
+                        class_name: class_name.name().clone(),
+                        method_name: member.clone(),
+                        sources: method_sources,
+                    },
+                    at,
+                    related(),
                 );
                 return Some(Ty::Unknown {
                     attr: TyAttr::default(),

--- a/baml_language/crates/baml_compiler2_tir/src/exhaustiveness.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/exhaustiveness.rs
@@ -507,6 +507,7 @@ impl fmt::Display for WitnessPat {
             },
             Ctor::Single(ty) => write_single_witness(f, ty),
             Ctor::Class(qtn, _) => {
+                let qtn = qtn.render_user_facing();
                 if self.fields.is_empty() {
                     return write!(f, "{qtn} {{}}");
                 }
@@ -520,6 +521,7 @@ impl fmt::Display for WitnessPat {
                 write!(f, " }}")
             }
             Ctor::Interface(ty) => {
+                let ty = ty.render_user_facing();
                 if self.fields.is_empty() {
                     return write!(f, "{ty} {{}}");
                 }
@@ -593,8 +595,12 @@ fn write_single_witness(f: &mut fmt::Formatter<'_>, ty: &Ty) -> fmt::Result {
 fn write_member_ty_witness(f: &mut fmt::Formatter<'_>, ty: &Ty) -> fmt::Result {
     match ty {
         Ty::Primitive(p, _) => write!(f, "{p}"),
-        Ty::Class(qtn, _, _) | Ty::Enum(qtn, _) => write!(f, "{qtn}"),
-        Ty::EnumVariant(qtn, variant, _) => write!(f, "{qtn}.{variant}"),
+        // Interfaces are open-world, so a union-member witness names the
+        // uncovered interface (`Animal`, `Slot<int>`) rather than collapsing to
+        // a bare `_`. Rendered user-facing (no `user.` package prefix).
+        Ty::Interface(_, _, _) => write!(f, "{}", ty.render_user_facing()),
+        Ty::Class(qtn, _, _) | Ty::Enum(qtn, _) => write!(f, "{}", qtn.render_user_facing()),
+        Ty::EnumVariant(qtn, variant, _) => write!(f, "{}.{variant}", qtn.render_user_facing()),
         Ty::Literal(_, _, _) => write_single_witness(f, ty),
         _ => write!(f, "_"),
     }

--- a/baml_language/crates/baml_compiler2_tir/src/exhaustiveness.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/exhaustiveness.rs
@@ -1932,14 +1932,14 @@ mod tests {
             "all Optional<bool> pairs except false/false should be missing"
         );
         for expected in [
-            "user.OptionalPair { true, true }",
-            "user.OptionalPair { true, false }",
-            "user.OptionalPair { true, null }",
-            "user.OptionalPair { false, true }",
-            "user.OptionalPair { false, null }",
-            "user.OptionalPair { null, true }",
-            "user.OptionalPair { null, false }",
-            "user.OptionalPair { null, null }",
+            "OptionalPair { true, true }",
+            "OptionalPair { true, false }",
+            "OptionalPair { true, null }",
+            "OptionalPair { false, true }",
+            "OptionalPair { false, null }",
+            "OptionalPair { null, true }",
+            "OptionalPair { null, false }",
+            "OptionalPair { null, null }",
         ] {
             assert!(
                 witnesses.iter().any(|w| w == expected),
@@ -1958,10 +1958,7 @@ mod tests {
             2,
             "all pairs with a non-false right side should be missing"
         );
-        for expected in [
-            "user.OptionalPair { _, true }",
-            "user.OptionalPair { _, null }",
-        ] {
+        for expected in ["OptionalPair { _, true }", "OptionalPair { _, null }"] {
             assert!(
                 witnesses.iter().any(|w| w == expected),
                 "expected {expected} in witnesses, got {witnesses:?}"

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -295,7 +295,9 @@ pub enum TirTypeError {
     /// implement interface `I`. A clearer form of the generic type-mismatch.
     TypeDoesNotImplementInterface {
         value_type: Ty,
-        interface_name: Name,
+        /// The full interface type (with any generic args), so the diagnostic
+        /// names `Cargo<int>` rather than the bare `Cargo`.
+        interface: Ty,
     },
     /// BEP-044: a value almost satisfies an interface via a blanket impl, but a
     /// generic bound (`T extends Bound`) is not met. Names the failed bound.
@@ -731,11 +733,12 @@ impl fmt::Display for TirTypeError {
             ),
             TirTypeError::TypeDoesNotImplementInterface {
                 value_type,
-                interface_name,
+                interface,
             } => write!(
                 f,
-                "type `{}` does not implement interface `{interface_name}`",
-                value_type.render_user_facing()
+                "type `{}` does not implement interface `{}`",
+                value_type.render_user_facing(),
+                interface.render_user_facing()
             ),
             TirTypeError::BlanketBoundNotSatisfied { value_type, bound } => write!(
                 f,
@@ -1039,6 +1042,20 @@ impl<'db> InferContext<'db> {
 
     pub fn db(&self) -> &'db dyn crate::Db {
         self.db
+    }
+
+    /// Number of diagnostics recorded so far. Paired with
+    /// [`truncate_diagnostics`](Self::truncate_diagnostics) to run a
+    /// speculative resolution (e.g. probing one member of a union) and roll
+    /// back any diagnostics it emitted.
+    pub fn diagnostic_count(&self) -> usize {
+        self.diagnostics.borrow().diagnostics.len()
+    }
+
+    /// Drop every diagnostic recorded after index `n` (see
+    /// [`diagnostic_count`](Self::diagnostic_count)).
+    pub fn truncate_diagnostics(&self, n: usize) {
+        self.diagnostics.borrow_mut().diagnostics.truncate(n);
     }
 
     pub fn scope(&self) -> ScopeId<'db> {

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/catch/exhaustiveness_checks.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/catch/exhaustiveness_checks.baml
@@ -63,14 +63,14 @@ function NonExhaustiveMatchInsideCatch(x: int, pet: Pet) -> string {
 //     │     
 //     │     Note: Error code: E0063
 // ────╯
-// error: non-exhaustive match on type Pet; missing: user.Dog { type: _ }
+// error: non-exhaustive match on type Pet; missing: Dog { type: _ }
 //     ╭─[ catch_exhaustiveness_checks.baml:27:9 ]
 //     │
 //  27 │ ╭─▶     _ => match (pet) {
 //     ┆ ┆   
 //  29 │ ├─▶     }
 //     │ │           
-//     │ ╰─────────── non-exhaustive match on type Pet; missing: user.Dog { type: _ }
+//     │ ╰─────────── non-exhaustive match on type Pet; missing: Dog { type: _ }
 //     │     
 //     │     Note: Error code: E0062
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/compound_ops.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/compound_ops.baml
@@ -35,6 +35,24 @@ function CompoundAssignments() -> int {
 
 //----
 //- diagnostics
+// error: operator `Add` cannot be applied to `int` and `"five"`
+//     ╭─[ invalid_assignment_compound_ops.baml:15:2 ]
+//     │
+//  15 │     c += "five";
+//     │     ┬  
+//     │     ╰── operator `Add` cannot be applied to `int` and `"five"`
+//     │ 
+//     │ Note: Error code: E0004
+// ────╯
+// error: operator `Add` cannot be applied to `string` and `100`
+//     ╭─[ invalid_assignment_compound_ops.baml:19:2 ]
+//     │
+//  19 │     d += 100;
+//     │     ┬  
+//     │     ╰── operator `Add` cannot be applied to `string` and `100`
+//     │ 
+//     │ Note: Error code: E0004
+// ────╯
 // error: operator `Add` cannot be applied to `int` and `true`
 //     ╭─[ invalid_assignment_compound_ops.baml:23:2 ]
 //     │

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__04_tir.snap
@@ -562,7 +562,7 @@ function user.ExhaustiveDoubleMaybe(dm: user.DoubleMaybe) -> string throws never
       null =>
         "nothing" : "nothing"
   }
-  !! 17329..17448: non-exhaustive match on `DoubleMaybe`; missing: user.Success { data: _ }, user.Failure { reason: _ }
+  !! 17329..17448: non-exhaustive match on `DoubleMaybe`; missing: Success { data: _ }, Failure { reason: _ }
   !! 17372..17379: unreachable arm
   !! 17406..17415: unreachable arm
 }
@@ -574,7 +574,7 @@ function user.NonExhaustiveDoubleMaybeMissingNull(dm: user.DoubleMaybe) -> strin
       f: Failure =>
         f.reason : string
   }
-  !! 17573..17665: non-exhaustive match on `DoubleMaybe`; missing: user.Success { data: _ }, user.Failure { reason: _ }, null, null
+  !! 17573..17665: non-exhaustive match on `DoubleMaybe`; missing: Success { data: _ }, Failure { reason: _ }, null, null
   !! 17616..17623: unreachable arm
   !! 17650..17659: unreachable arm
 }
@@ -584,7 +584,7 @@ function user.NonExhaustiveTypeAliasMissingOne(r: user.Result) -> string throws 
       s: Success =>
         s.data : string
   }
-  !! 18033..18088: non-exhaustive match on `Result`; missing: user.Failure { reason: _ }
+  !! 18033..18088: non-exhaustive match on `Result`; missing: Failure { reason: _ }
 }
 function user.NonExhaustiveFullResultMissingOne(r: user.FullResult) -> string throws never {
   { : string
@@ -594,7 +594,7 @@ function user.NonExhaustiveFullResultMissingOne(r: user.FullResult) -> string th
       f: Failure =>
         f.reason : string
   }
-  !! 18215..18306: non-exhaustive match on `FullResult`; missing: user.Pending { eta: _ }
+  !! 18215..18306: non-exhaustive match on `FullResult`; missing: Pending { eta: _ }
 }
 function user.StringLiteralAfterStringType(s: string) -> string throws never {
   { : "any string" | "unreachable"
@@ -676,7 +676,7 @@ function user.NonExhaustiveClassPlusLiteralMissingClass(x: user.SuccessOr200) ->
       200 =>
         "http ok" : "http ok"
   }
-  !! 20827..20874: non-exhaustive match on `SuccessOr200`; missing: user.Success { data: _ }
+  !! 20827..20874: non-exhaustive match on `SuccessOr200`; missing: Success { data: _ }
 }
 function user.ExhaustiveEnumWithTypedPattern(s: user.Status) -> string throws never {
   { : "any status"
@@ -720,7 +720,7 @@ function user.PartialUnionPatternCoverage(r: user.FullResult) -> string throws n
       x: Success | Failure =>
         "not pending" : "not pending"
   }
-  !! 22561..22633: non-exhaustive match on `FullResult`; missing: user.Pending { eta: _ }
+  !! 22561..22633: non-exhaustive match on `FullResult`; missing: Pending { eta: _ }
 }
 function user.LiteralAfterTypedPattern(x: int) -> string throws never {
   { : "int" | "unreachable"

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__05_diagnostics.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 42814
 ---
 === COMPILER2 DIAGNOSTICS ===
   [type] error: unreachable arm
@@ -250,14 +249,14 @@ assertion_line: 42814
      │     Note: Error code: E0062
 ─────╯
 
-  [type] error: non-exhaustive match on type DoubleMaybe; missing: user.Success { data: _ }, user.Failure { reason: _ }
+  [type] error: non-exhaustive match on type DoubleMaybe; missing: Success { data: _ }, Failure { reason: _ }
      ╭─[ match_exhaustiveness.baml:598:60 ]
      │
  598 │ ╭─▶ function ExhaustiveDoubleMaybe(dm: DoubleMaybe) -> string {
      ┆ ┆   
  603 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type DoubleMaybe; missing: user.Success { data: _ }, user.Failure { reason: _ }
+     │ ╰─────────── non-exhaustive match on type DoubleMaybe; missing: Success { data: _ }, Failure { reason: _ }
      │     
      │     Note: Error code: E0062
 ─────╯
@@ -282,14 +281,14 @@ assertion_line: 42814
      │ Note: Error code: E0063
 ─────╯
 
-  [type] error: non-exhaustive match on type DoubleMaybe; missing: user.Success { data: _ }, user.Failure { reason: _ }, null, null
+  [type] error: non-exhaustive match on type DoubleMaybe; missing: Success { data: _ }, Failure { reason: _ }, null, null
      ╭─[ match_exhaustiveness.baml:607:74 ]
      │
  607 │ ╭─▶ function NonExhaustiveDoubleMaybeMissingNull(dm: DoubleMaybe) -> string {
      ┆ ┆   
  611 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type DoubleMaybe; missing: user.Success { data: _ }, user.Failure { reason: _ }, null, null
+     │ ╰─────────── non-exhaustive match on type DoubleMaybe; missing: Success { data: _ }, Failure { reason: _ }, null, null
      │     
      │     Note: Error code: E0062
 ─────╯
@@ -314,26 +313,26 @@ assertion_line: 42814
      │ Note: Error code: E0063
 ─────╯
 
-  [type] error: non-exhaustive match on type Result; missing: user.Failure { reason: _ }
+  [type] error: non-exhaustive match on type Result; missing: Failure { reason: _ }
      ╭─[ match_exhaustiveness.baml:620:65 ]
      │
  620 │ ╭─▶ function NonExhaustiveTypeAliasMissingOne(r: Result) -> string {
      ┆ ┆   
  623 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type Result; missing: user.Failure { reason: _ }
+     │ ╰─────────── non-exhaustive match on type Result; missing: Failure { reason: _ }
      │     
      │     Note: Error code: E0062
 ─────╯
 
-  [type] error: non-exhaustive match on type FullResult; missing: user.Pending { eta: _ }
+  [type] error: non-exhaustive match on type FullResult; missing: Pending { eta: _ }
      ╭─[ match_exhaustiveness.baml:627:70 ]
      │
  627 │ ╭─▶ function NonExhaustiveFullResultMissingOne(r: FullResult) -> string {
      ┆ ┆   
  631 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type FullResult; missing: user.Pending { eta: _ }
+     │ ╰─────────── non-exhaustive match on type FullResult; missing: Pending { eta: _ }
      │     
      │     Note: Error code: E0062
 ─────╯
@@ -384,14 +383,14 @@ assertion_line: 42814
      │     Note: Error code: E0062
 ─────╯
 
-  [type] error: non-exhaustive match on type SuccessOr200; missing: user.Success { data: _ }
+  [type] error: non-exhaustive match on type SuccessOr200; missing: Success { data: _ }
      ╭─[ match_exhaustiveness.baml:711:80 ]
      │
  711 │ ╭─▶ function NonExhaustiveClassPlusLiteralMissingClass(x: SuccessOr200) -> string {
      ┆ ┆   
  714 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type SuccessOr200; missing: user.Success { data: _ }
+     │ ╰─────────── non-exhaustive match on type SuccessOr200; missing: Success { data: _ }
      │     
      │     Note: Error code: E0062
 ─────╯
@@ -462,14 +461,14 @@ assertion_line: 42814
      │     Note: Error code: E0001
 ─────╯
 
-  [type] error: non-exhaustive match on type FullResult; missing: user.Pending { eta: _ }
+  [type] error: non-exhaustive match on type FullResult; missing: Pending { eta: _ }
      ╭─[ match_exhaustiveness.baml:763:64 ]
      │
  763 │ ╭─▶ function PartialUnionPatternCoverage(r: FullResult) -> string {
      ┆ ┆   
  766 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type FullResult; missing: user.Pending { eta: _ }
+     │ ╰─────────── non-exhaustive match on type FullResult; missing: Pending { eta: _ }
      │     
      │     Note: Error code: E0062
 ─────╯

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_new/baml_tests__diagnostic_errors__patterns_new__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_new/baml_tests__diagnostic_errors__patterns_new__04_tir.snap
@@ -128,7 +128,7 @@ function user.class_destructure_field_union_missing_int(m: user.Mixed) -> int th
       Mixed { value: bool } =>
         2 : 2
   }
-  !! 3872..3966: non-exhaustive match on `Mixed`; missing: user.Mixed { value: int }
+  !! 3872..3966: non-exhaustive match on `Mixed`; missing: Mixed { value: int }
 }
 class user.Pair {
   kind: int | bool
@@ -150,7 +150,7 @@ function user.class_destructure_two_field_union_missing_combination(p: user.Pair
       Pair { kind: bool, payload: int } =>
         3 : 3
   }
-  !! 4338..4504: non-exhaustive match on `Pair`; missing: user.Pair { kind: true, payload: string }, user.Pair { kind: false, payload: string }
+  !! 4338..4504: non-exhaustive match on `Pair`; missing: Pair { kind: true, payload: string }, Pair { kind: false, payload: string }
 }
 enum user.Color3
 function user.enum_with_single_missing_variant(c: user.Color3) -> int throws never {
@@ -199,7 +199,7 @@ function user.class_field_bool_narrowing_missing_true(f: user.Flagged) -> int th
       Flagged { flag: false, note: string } =>
         2 : 2
   }
-  !! 6045..6170: non-exhaustive match on `Flagged`; missing: user.Flagged { flag: true, note: _ }
+  !! 6045..6170: non-exhaustive match on `Flagged`; missing: Flagged { flag: true, note: _ }
 }
 class user.Box2 {
   first: bool
@@ -221,7 +221,7 @@ function user.nested_class_optional_missing_combination(b: user.Box2) -> int thr
       Box2 { first: false, second: null } =>
         3 : 3
   }
-  !! 6509..6679: non-exhaustive match on `Box2`; missing: user.Box2 { first: false, second: [..] }
+  !! 6509..6679: non-exhaustive match on `Box2`; missing: Box2 { first: false, second: [..] }
 }
 function user.int_literal_non_exhaustive(n: int) -> int throws never {
   { : 1
@@ -247,7 +247,7 @@ function user.or_pattern_two_field_non_exhaustive(p: user.IntPair) -> int throws
       IntPair { a: 0 | 1, b: 2 | 3 } =>
         1 : 1
   }
-  !! 7321..7387: non-exhaustive match on `IntPair`; missing: user.IntPair { a: 0, b: _ }, user.IntPair { a: 1, b: _ }, user.IntPair { a: _, b: _ }
+  !! 7321..7387: non-exhaustive match on `IntPair`; missing: IntPair { a: 0, b: _ }, IntPair { a: 1, b: _ }, IntPair { a: _, b: _ }
 }
 function user.or_pattern_optional_int_non_exhaustive(x: int?) -> int throws never {
   { : 0 | 1

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_new/baml_tests__diagnostic_errors__patterns_new__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_new/baml_tests__diagnostic_errors__patterns_new__05_diagnostics.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 46698
 ---
 === COMPILER2 DIAGNOSTICS ===
   [hir] error: Or-pattern alternatives must bind the same names. Inconsistent across branches: x, y
@@ -124,26 +123,26 @@ assertion_line: 46698
      │ Note: Error code: E0063
 ─────╯
 
-  [type] error: non-exhaustive match on type Mixed; missing: user.Mixed { value: int }
+  [type] error: non-exhaustive match on type Mixed; missing: Mixed { value: int }
      ╭─[ patterns_new.baml:121:70 ]
      │
  121 │ ╭─▶ function class_destructure_field_union_missing_int(m: Mixed) -> int {
      ┆ ┆   
  125 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type Mixed; missing: user.Mixed { value: int }
+     │ ╰─────────── non-exhaustive match on type Mixed; missing: Mixed { value: int }
      │     
      │     Note: Error code: E0062
 ─────╯
 
-  [type] error: non-exhaustive match on type Pair; missing: user.Pair { kind: true, payload: string }, user.Pair { kind: false, payload: string }
+  [type] error: non-exhaustive match on type Pair; missing: Pair { kind: true, payload: string }, Pair { kind: false, payload: string }
      ╭─[ patterns_new.baml:136:81 ]
      │
  136 │ ╭─▶ function class_destructure_two_field_union_missing_combination(p: Pair) -> int {
      ┆ ┆   
  141 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type Pair; missing: user.Pair { kind: true, payload: string }, user.Pair { kind: false, payload: string }
+     │ ╰─────────── non-exhaustive match on type Pair; missing: Pair { kind: true, payload: string }, Pair { kind: false, payload: string }
      │     
      │     Note: Error code: E0062
 ─────╯
@@ -184,26 +183,26 @@ assertion_line: 46698
      │     Note: Error code: E0062
 ─────╯
 
-  [type] error: non-exhaustive match on type Flagged; missing: user.Flagged { flag: true, note: _ }
+  [type] error: non-exhaustive match on type Flagged; missing: Flagged { flag: true, note: _ }
      ╭─[ patterns_new.baml:209:70 ]
      │
  209 │ ╭─▶ function class_field_bool_narrowing_missing_true(f: Flagged) -> int {
      ┆ ┆   
  213 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type Flagged; missing: user.Flagged { flag: true, note: _ }
+     │ ╰─────────── non-exhaustive match on type Flagged; missing: Flagged { flag: true, note: _ }
      │     
      │     Note: Error code: E0062
 ─────╯
 
-  [type] error: non-exhaustive match on type Box2; missing: user.Box2 { first: false, second: [..] }
+  [type] error: non-exhaustive match on type Box2; missing: Box2 { first: false, second: [..] }
      ╭─[ patterns_new.baml:224:69 ]
      │
  224 │ ╭─▶ function nested_class_optional_missing_combination(b: Box2) -> int {
      ┆ ┆   
  229 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type Box2; missing: user.Box2 { first: false, second: [..] }
+     │ ╰─────────── non-exhaustive match on type Box2; missing: Box2 { first: false, second: [..] }
      │     
      │     Note: Error code: E0062
 ─────╯
@@ -220,14 +219,14 @@ assertion_line: 46698
      │     Note: Error code: E0062
 ─────╯
 
-  [type] error: non-exhaustive match on type IntPair; missing: user.IntPair { a: 0, b: _ }, user.IntPair { a: 1, b: _ }, user.IntPair { a: _, b: _ }
+  [type] error: non-exhaustive match on type IntPair; missing: IntPair { a: 0, b: _ }, IntPair { a: 1, b: _ }, IntPair { a: _, b: _ }
      ╭─[ patterns_new.baml:250:66 ]
      │
  250 │ ╭─▶ function or_pattern_two_field_non_exhaustive(p: IntPair) -> int {
      ┆ ┆   
  253 │ ├─▶     }
      │ │           
-     │ ╰─────────── non-exhaustive match on type IntPair; missing: user.IntPair { a: 0, b: _ }, user.IntPair { a: 1, b: _ }, user.IntPair { a: _, b: _ }
+     │ ╰─────────── non-exhaustive match on type IntPair; missing: IntPair { a: 0, b: _ }, IntPair { a: 1, b: _ }, IntPair { a: _, b: _ }
      │     
      │     Note: Error code: E0062
 ─────╯

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_type_error/baml_tests__diagnostic_errors__simple_type_error__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_type_error/baml_tests__diagnostic_errors__simple_type_error__04_tir.snap
@@ -3,8 +3,8 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
 function user.Foo() -> int throws never {
-  { : string
-    1 + "foo" : string
+  { : unknown
+    1 + "foo" : unknown
   }
-  !! 26..35: type mismatch: expected int, got string
+  !! 26..35: operator `Add` cannot be applied to `1` and `"foo"`
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_type_error/baml_tests__diagnostic_errors__simple_type_error__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_type_error/baml_tests__diagnostic_errors__simple_type_error__05_diagnostics.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === COMPILER2 DIAGNOSTICS ===
-  [type] error: type mismatch: expected int, got string
+  [type] error: operator `Add` cannot be applied to `1` and `"foo"`
    ╭─[ simple_type_error.baml:2:3 ]
    │
  2 │   1 + "foo"
    │   ────┬────  
-   │       ╰────── type mismatch: expected int, got string
+   │       ╰────── operator `Add` cannot be applied to `1` and `"foo"`
    │ 
-   │ Note: Error code: E0001
+   │ Note: Error code: E0004
 ───╯

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__04_tir.snap
@@ -25,6 +25,7 @@ function user.$init_test_main(registry: testing.TestCollector) -> ? throws never
         }
     null : null
   }
+  !! 80..88: operator `Add` cannot be applied to `"a"` and `1`
   !! 106..108: type mismatch: expected string, got 42
   !! 0..0: type mismatch: expected string, got int
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__05_diagnostics.snap
@@ -12,6 +12,16 @@ source: crates/baml_tests/src/generated_tests.rs
    │ Note: Error code: E0001
 ───╯
 
+  [type] error: operator `Add` cannot be applied to `"a"` and `1`
+   ╭─[ main.baml:3:5 ]
+   │
+ 3 │ test "a" + 1 {
+   │     ────┬───  
+   │         ╰───── operator `Add` cannot be applied to `"a"` and `1`
+   │ 
+   │ Note: Error code: E0004
+───╯
+
   [type] error: type mismatch: expected string, got 42
    ╭─[ main.baml:7:6 ]
    │

--- a/baml_language/crates/baml_tests/tests/interfaces.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces.rs
@@ -9465,6 +9465,92 @@ async fn union_fuzz_class_only_union_method_dispatch() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// PR #3638 review follow-ups: extra union cases surfaced by CodeRabbit/Cursor on
+// the F1–F17 fix branch. Each reproduced a real bug before the follow-up fix.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A class-only union whose members satisfy a method only through an *inherited*
+/// interface default (`class Dog { implements Greeter {} }`) used to type-check
+/// and then crash the VM (`expected map, got instance`) because the union
+/// dispatch resolved only direct class methods. It must dispatch the inherited
+/// default on the runtime class.
+#[tokio::test]
+async fn union_fuzz_pr_class_union_inherited_default_method() {
+    let output = baml_test!(
+        r#"
+        interface Greeter {
+          function greet(self) -> string { return "hello" }
+        }
+        class Dog { implements Greeter {} }
+        class Cat { implements Greeter {} }
+        function describe(x: Dog | Cat) -> string { return x.greet() }
+        function main() -> string { return describe(Dog {}) + "/" + describe(Cat {}) }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("hello/hello".into())
+    );
+}
+
+/// Reflection generic-arg equivalence must treat unions nested inside wrappers
+/// (`Box<(int | string)?>`) order-insensitively too — the `Optional`/`List`/`Map`
+/// layers used to fall back to structural equality and defeat the union-set
+/// comparison, so the reversed `Box<(string | int)?>` answered `false`.
+#[tokio::test]
+async fn union_fuzz_pr_reflection_nested_union_arg_order_insensitive() {
+    let output = baml_test!(
+        r#"
+        interface Box<T> { function get(self) -> T }
+        class UBox {
+          value: int
+          implements Box<(int | string)?> {
+            function get(self) -> (int | string)? { return self.value }
+          }
+        }
+        function main() -> int {
+          let ub = reflect.type_of<UBox>()
+          let fwd = reflect.type_of<Box<(int | string)?>>()
+          let rev = reflect.type_of<Box<(string | int)?>>()
+          let a = 0
+          if ub.implements(fwd) { a = a + 1 }
+          if ub.implements(rev) { a = a + 10 }
+          return a
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(11));
+}
+
+/// A function-typed interface *field* in a union must keep its declared
+/// signature: the union-member resolver used to prepend a phantom `self` to any
+/// function-typed member, turning `(int) -> string` into
+/// `(self: I, int) -> string` and breaking the union callee shape.
+#[tokio::test]
+async fn union_fuzz_pr_function_typed_interface_field_in_union() {
+    let output = baml_test!(
+        r#"
+        interface HasHandler { handler: (int) -> string }
+        class A {
+          handler: (int) -> string
+          label: string
+          implements HasHandler {}
+        }
+        function getHandler(x: HasHandler | A) -> (int) -> string { return x.handler }
+        function main() -> string {
+          let a: HasHandler = A { handler: (n: int) -> string { return "handled" }, label: "a" }
+          let h = getHandler(a)
+          return h(5)
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("handled".into())
+    );
+}
+
 /// F1 [crash]: reading a field declared by an interface member of a union
 /// (`x.name` on `Dog | Named`) type-checks, then the VM aborts with
 /// `expected map, got instance`. SHOULD dispatch on the runtime class -> "Rex".
@@ -9576,9 +9662,12 @@ fn union_fuzz_f04_string_plus_int_is_type_error_not_vm_crash() {
         "#,
     );
     assert!(
-        !errors.is_empty(),
-        "`string + int` must be rejected by the type-checker (it currently infers `string` \
-         but the VM aborts with `cannot apply binary operation: string + int`); got no errors"
+        errors
+            .iter()
+            .any(|e| e.starts_with("[E0004]") && e.contains("Add")),
+        "`string + int` must be rejected with an InvalidBinaryOp (E0004) naming `Add` \
+         (it used to infer `string` and abort the VM); got:\n  {}",
+        errors.join("\n  ")
     );
 }
 
@@ -9808,10 +9897,13 @@ fn union_fuzz_f11_conflicting_union_field_read_is_rejected() {
         "#,
     );
     assert!(
-        !errors.is_empty(),
+        errors
+            .iter()
+            .any(|e| e.starts_with("[E0001]") && e.contains("bool")),
         "reading a field with conflicting types across union-interface members must be \
-         rejected — it currently type-checks even against a `bool` target (soundness hole); \
-         got no compile errors"
+         rejected with a type mismatch (E0001) against the `bool` target — it used to \
+         type-check unsoundly against any target; got:\n  {}",
+        errors.join("\n  ")
     );
 }
 
@@ -9880,6 +9972,14 @@ fn union_fuzz_f13_exhaustiveness_witness_does_not_leak_user_prefix() {
           return describe(d)
         }
         "#,
+    );
+    // First require the E0062 non-exhaustive-match diagnostic to actually fire,
+    // so the no-`user.` check below can't pass vacuously if exhaustiveness ever
+    // stops being reported.
+    assert!(
+        errors.iter().any(|e| e.starts_with("[E0062]")),
+        "expected an E0062 non-exhaustive-match error; got:\n  {}",
+        errors.join("\n  ")
     );
     assert!(
         errors.iter().all(|e| !e.contains("user.")),

--- a/baml_language/crates/baml_tests/tests/interfaces.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces.rs
@@ -9523,6 +9523,36 @@ async fn union_fuzz_pr_reflection_nested_union_arg_order_insensitive() {
     assert_eq!(output.result.unwrap(), BexExternalValue::Int(11));
 }
 
+/// Calling a method that two interfaces both declare, on a *union* of classes
+/// that inherit it, must report the same E0121 ambiguity (with the `.as<I>`
+/// hint) the single-class receiver does — not collapse to a misleading
+/// `unknown | unknown is not a function` (E0006) leaking the internal sentinel.
+#[test]
+fn union_fuzz_pr_ambiguous_inherited_method_in_class_union_is_e0121() {
+    let errors = collect_compile_errors(
+        r#"
+        interface A { function f(self) -> string { return "a" } }
+        interface B { function f(self) -> string { return "b" } }
+        class C { implements A {} implements B {} }
+        class D { implements A {} implements B {} }
+        function g(x: C | D) -> string { return x.f() }
+        function main() -> string { return g(C {}) }
+        "#,
+    );
+    assert!(
+        errors.iter().any(|e| e.starts_with("[E0121]")),
+        "ambiguous inherited method on a class union must be E0121; got:\n  {}",
+        errors.join("\n  ")
+    );
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e.contains("unknown |") || e.contains("is not a function")),
+        "must not leak the internal `unknown | unknown` not-a-function form (E0006); got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
 /// A function-typed interface *field* in a union must keep its declared
 /// signature: the union-member resolver used to prepend a phantom `self` to any
 /// function-typed member, turning `(int) -> string` into

--- a/baml_language/crates/baml_tests/tests/interfaces.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces.rs
@@ -9622,6 +9622,77 @@ fn union_fuzz_pr_concrete_arm_not_callable_despite_recovery_arm() {
     );
 }
 
+/// Calling a method on a union of interfaces where some class implements two of
+/// them (the method declared by both) is ambiguous for that class — a value of
+/// the union could be that class — so reject with E0121 rather than silently
+/// dispatching to the first interface's default ("from-A").
+#[test]
+fn union_fuzz_pr_shared_implementor_method_in_iface_union_is_e0121() {
+    let errors = collect_compile_errors(
+        r#"
+        interface A { function m(self) -> string { return "from-A" } }
+        interface B { function m(self) -> string { return "from-B" } }
+        class C { implements A {} implements B {} }
+        function call(x: A | B) -> string { return x.m() }
+        function main() -> string { let c: A = C {}; return call(c) }
+        "#,
+    );
+    assert!(
+        errors.iter().any(|e| e.starts_with("[E0121]")),
+        "a union of interfaces with a shared ambiguous implementor must be E0121; got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+/// A union with the *same* interface that is unambiguous (only one implementor
+/// per interface) must still compile and dispatch.
+#[tokio::test]
+async fn union_fuzz_pr_disjoint_implementors_iface_union_dispatches() {
+    let output = baml_test!(
+        r#"
+        interface A { function m(self) -> string { return "a" } }
+        interface B { function m(self) -> string { return "b" } }
+        class Dog { implements A {} }
+        class Cat { implements B {} }
+        function call(x: A | B) -> string { return x.m() }
+        function main() -> string {
+          let d: A = Dog {}
+          let c: B = Cat {}
+          return call(d) + call(c)
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("ab".into())
+    );
+}
+
+/// Reflection generic-arg equivalence must use a one-to-one matching of union
+/// members: `Box<int | int>` must NOT be treated as `Box<int | string>` just
+/// because both `int`s on the left match the single `int` on the right.
+#[tokio::test]
+async fn union_fuzz_pr_reflection_duplicate_union_members_not_equivalent() {
+    let output = baml_test!(
+        r#"
+        interface Box<T> { function get(self) -> T }
+        class UBox {
+          value: int
+          implements Box<int | int> { function get(self) -> int | int { return self.value } }
+        }
+        function main() -> int {
+          let ub = reflect.type_of<UBox>()
+          let a = 0
+          // UBox implements Box<int | int>, NOT Box<int | string>.
+          if ub.implements(reflect.type_of<Box<int | int>>()) { a = a + 1 }
+          if ub.implements(reflect.type_of<Box<int | string>>()) { a = a + 10 }
+          return a
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
+}
+
 /// F1 [crash]: reading a field declared by an interface member of a union
 /// (`x.name` on `Dog | Named`) type-checks, then the VM aborts with
 /// `expected map, got instance`. SHOULD dispatch on the runtime class -> "Rex".

--- a/baml_language/crates/baml_tests/tests/interfaces.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces.rs
@@ -9425,3 +9425,599 @@ async fn wf3_blanket_implementor_identity_is_bare_class_pins() {
         BexExternalValue::String("Box".into())
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group: union-fuzz findings (workflow_scratch_files/FINDINGS.md, 2026-06-01)
+//
+// 17 union-focused interface bugs found by the `baml-interface-union-fuzz`
+// workflow. Each `union_fuzz_fNN_*` test asserts the DESIRED behavior, so it
+// FAILS today and turns GREEN once the bug is fixed (no edit required). The
+// runnable `.baml` repro for each finding lives under
+// `workflow_scratch_files/cat_<category>/`. Severities: crash > wrong-result >
+// spurious-compile-error > missing-error > bad-diagnostic.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Regression guard (user-reported): a method present on every member of a
+/// *class-only* union (`A | B`, both declaring `execute`) dispatches on the
+/// runtime class. This already worked, but is pinned alongside the interface
+/// union fixes so the shared union-dispatch path stays green.
+#[tokio::test]
+async fn union_fuzz_class_only_union_method_dispatch() {
+    let output = baml_test!(
+        r#"
+        class A {
+          name: string
+          function execute(self) -> string { return "A executes and gets " + self.name }
+        }
+        class B {
+          name: string
+          function execute(self) -> string { return "B executes and gets " + self.name }
+        }
+        function process(input: A | B) -> string { return input.execute() }
+        function main() -> string {
+          return process(A { name: "Alice" }) + " | " + process(B { name: "Bob" })
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("A executes and gets Alice | B executes and gets Bob".into())
+    );
+}
+
+/// F1 [crash]: reading a field declared by an interface member of a union
+/// (`x.name` on `Dog | Named`) type-checks, then the VM aborts with
+/// `expected map, got instance`. SHOULD dispatch on the runtime class -> "Rex".
+/// Repro: `cat_concrete_iface_union/concrete_iface_union_9_field_union_vm_crash.baml`
+#[tokio::test]
+async fn union_fuzz_f01_field_read_on_iface_union_member() {
+    let output = baml_test!(
+        r#"
+        interface Named {
+          name: string
+        }
+        class Dog {
+          name: string
+          implements Named {}
+        }
+        function readName(x: Dog | Named) -> string {
+          return x.name
+        }
+        function main() -> string {
+          return readName(Dog { name: "Rex" })
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("Rex".into())
+    );
+}
+
+/// F2 [crash]: generic-interface match narrowing ignores the type argument — a
+/// `StrSlot` (only `Slot<string>`) matches the `let a: Slot<int>` arm, so
+/// `a.value + 1` runs integer add on a string and panics (`tagged_int_add`).
+/// SHOULD NOT match the `Slot<int>` arm; falls through -> 0.
+/// Repro: `cat_generic_iface_union/generic_iface_union_2d_unsound.baml`
+#[tokio::test]
+async fn union_fuzz_f02_generic_match_narrowing_ignores_type_arg_crash() {
+    let output = baml_test!(
+        r#"
+        interface Slot<T> { value: T }
+
+        class IntSlot {
+          n: int
+          implements Slot<int> { value as n }
+        }
+        class StrSlot {
+          s: string
+          implements Slot<string> { value as s }
+        }
+
+        function addOne(x: Slot<int> | Slot<string>) -> int {
+          return match (x) {
+            let a: Slot<int> => a.value + 1,
+            let b: Slot<string> => 0,
+          }
+        }
+
+        function main() -> int {
+          let b: Slot<int> | Slot<string> = StrSlot { s: "not a number" }
+          return addOne(b)
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(0));
+}
+
+/// F3 [crash]: a same-named field with CONFLICTING types across two union
+/// interfaces (`Animal.id: string`, `Vehicle.id: int`) used to type-check
+/// against any target and then abort the VM (`expected map, got instance`).
+/// The sound result is that `u.id` has type `string | int` (the value is an
+/// Animal OR a Vehicle, not genuinely ambiguous), so reading it into a `string`
+/// must be a clean compile-time type error (E0001) — never a VM crash.
+/// Repro: `cat_iface_iface_union/iface_iface_union_7_same_field_diff_type.baml`
+#[test]
+fn union_fuzz_f03_conflicting_union_field_is_ambiguous_error() {
+    assert_compile_error_code(
+        r#"
+        interface Animal { id: string }
+        interface Vehicle { id: int }
+        class Dog { id: string  implements Animal {} }
+        class Car { id: int  implements Vehicle {} }
+        function pick(b: bool) -> Animal | Vehicle {
+          if b { return Dog { id: "rex" } } else { return Car { id: 7 } }
+        }
+        function main() -> string {
+          let u: Animal | Vehicle = pick(false)
+          let v: string = u.id
+          return v
+        }
+        "#,
+        "E0001",
+    );
+}
+
+/// F4 [crash]: `string + int` type-checks (inferred as `string`) but the VM
+/// aborts with `cannot apply binary operation: string + int`. The two phases
+/// must agree — the type-checker SHOULD reject it. (Symmetric arithmetic hole;
+/// surfaced via interface projection in the sibling repro, not interface-only.)
+/// Repro: `cat_as_projection_union/as_projection_union_20_plain_int_concat.baml`
+#[test]
+fn union_fuzz_f04_string_plus_int_is_type_error_not_vm_crash() {
+    let errors = collect_compile_errors(
+        r#"
+        function plainPlus() -> string {
+          return "age=" + 4
+        }
+        function main() -> string {
+          return plainPlus()
+        }
+        "#,
+    );
+    assert!(
+        !errors.is_empty(),
+        "`string + int` must be rejected by the type-checker (it currently infers `string` \
+         but the VM aborts with `cannot apply binary operation: string + int`); got no errors"
+    );
+}
+
+/// F5 [wrong-result]: matching a union of the SAME generic interface at two
+/// instantiations ignores the type argument — a `StrSlot` (only `Slot<string>`)
+/// is captured by the `let a: Slot<int>` arm instead of falling through.
+/// SHOULD return "other". (EXIT=0 wrong-result face of F2.)
+/// Repro: `cat_generic_iface_union/generic_iface_union_5c_nonunion.baml`
+#[tokio::test]
+async fn union_fuzz_f05_generic_match_narrowing_wrong_result() {
+    let output = baml_test!(
+        r#"
+        interface Slot<T> { value: T }
+        class IntSlot { n: int  implements Slot<int> { value as n } }
+        class StrSlot { s: string  implements Slot<string> { value as s } }
+        function go(x: Slot<int> | Slot<string>) -> string {
+          return match (x) {
+            let a: Slot<int> => "int",
+            _ => "other",
+          }
+        }
+        function main() -> string {
+          let b: Slot<int> | Slot<string> = StrSlot { s: "z" }
+          return go(b)
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("other".into())
+    );
+}
+
+/// F6 [wrong-result]: reflection generic-arg matching is union-ORDER-sensitive —
+/// `Box<int | string>` answers correctly but the reversed `Box<string | int>`
+/// answers wrong across all three reflection APIs. Union member order is
+/// semantically irrelevant, so all six probes SHOULD answer 1 -> 111111
+/// (currently 111000).
+/// Repro: `cat_reflection_union/reflection_union_10c_order_breadth.baml`
+#[tokio::test]
+async fn union_fuzz_f06_reflection_generic_union_arg_order_insensitive() {
+    let output = baml_test!(
+        r#"
+        interface Box<T> {
+          function get(self) -> T
+        }
+        class UBox {
+          value: int
+          implements Box<int | string> {
+            function get(self) -> int | string { return self.value }
+          }
+        }
+        function main() -> int {
+          let ub = reflect.type_of<UBox>()
+          let fwd = reflect.type_of<Box<int | string>>()
+          let rev = reflect.type_of<Box<string | int>>()
+          let d1 = 0
+          if ub.implements(fwd) { d1 = 1 }
+          let d2 = 0
+          if fwd.implemented_by(ub) { d2 = 1 }
+          let d3 = 0
+          if fwd.implementors().length() == 1 { d3 = 1 }
+          let d4 = 0
+          if ub.implements(rev) { d4 = 1 }
+          let d5 = 0
+          if rev.implemented_by(ub) { d5 = 1 }
+          let d6 = 0
+          if rev.implementors().length() == 1 { d6 = 1 }
+          return d1*100000 + d2*10000 + d3*1000 + d4*100 + d5*10 + d6
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(111111));
+}
+
+/// F7 [spurious-compile-error]: a method present on EVERY member of a union that
+/// contains an interface is rejected as `` `unknown | unknown` is not a function ``
+/// (E0006) — the interface arm's method type resolves to the `Ty::Unknown`
+/// sentinel. SHOULD compile and dispatch on the runtime class -> "Woof".
+/// (Currently panics at compile until fixed.)
+/// Repro: `cat_collection_union/collection_union_9_union_direct_call.baml`
+#[tokio::test]
+async fn union_fuzz_f07_shared_method_on_iface_union_is_callable() {
+    let output = baml_test!(
+        r#"
+        interface Animal {
+          function speak(self) -> string
+        }
+        class Dog {
+          implements Animal {
+            function speak(self) -> string { return "Woof" }
+          }
+        }
+        interface Vehicle {
+          function speak(self) -> string
+        }
+        class Car {
+          implements Vehicle {
+            function speak(self) -> string { return "Vroom" }
+          }
+        }
+        function main() -> string {
+          let v: Animal | Vehicle = Dog {};
+          return v.speak();
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("Woof".into())
+    );
+}
+
+/// F8 [spurious-compile-error]: an interface-bounded generic identity
+/// `identity<T extends Animal>(a: T) -> T { return a }` is rejected with the
+/// self-contradictory `expected T, got T` (E0001). Reflexive `T <: T` always
+/// holds; a bound only constrains `T`, it doesn't change its identity.
+/// SHOULD compile and the caller gets the concrete class back -> "fetched/Woof!".
+/// Repro: `cat_bounds_basic/bounds_basic_8_return_bound_type.baml`
+#[tokio::test]
+async fn union_fuzz_f08_interface_bounded_generic_identity_compiles() {
+    let output = baml_test!(
+        r#"
+        interface Animal {
+          function speak(self) -> string
+        }
+        class Dog {
+          implements Animal {
+            function speak(self) -> string { return "Woof!" }
+          }
+          function fetch(self) -> string { return "fetched" }
+        }
+        function identity<T extends Animal>(a: T) -> T {
+          return a
+        }
+        function main() -> string {
+          let d = identity<Dog>(Dog {})
+          return d.fetch() + "/" + d.speak()
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("fetched/Woof!".into())
+    );
+}
+
+/// F9 [spurious-compile-error]: an interface match arm over an optional union of
+/// implementors `(Dog | Cat)?` is rejected (E0001 `expected Dog | Cat | null,
+/// got Animal`), though the same arm over the non-optional union is accepted.
+/// SHOULD compile: `let a: Animal` covers every non-null member -> "Meow".
+/// Repro: `cat_optional_union/optional_union_4_method_on_optional_union.baml`
+#[tokio::test]
+async fn union_fuzz_f09_interface_arm_over_optional_union_compiles() {
+    let output = baml_test!(
+        r#"
+        interface Animal {
+          function speak(self) -> string
+        }
+        class Dog {
+          name: string
+          implements Animal {
+            function speak(self) -> string { return "Woof" }
+          }
+        }
+        class Cat {
+          implements Animal {
+            function speak(self) -> string { return "Meow" }
+          }
+        }
+        function main() -> string {
+          let v: (Dog | Cat)? = Cat {}
+          match (v) {
+            let a: Animal => a.speak()
+            null => "none"
+          }
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("Meow".into())
+    );
+}
+
+/// F10 [spurious-compile-error]: a direct member call on an out-of-body
+/// primitive impl only resolves for `int`; `string`/`float`/`bool` are rejected
+/// (E0007 `type string has no member debug`) even though the impl exists and is
+/// visible via upcast/`.as<>`/reflection. SHOULD return "str".
+/// Repro: `cat_out_of_body_union/out_of_body_union_9_string_direct_baseline.baml`
+#[tokio::test]
+async fn union_fuzz_f10_out_of_body_primitive_string_direct_call() {
+    let output = baml_test!(
+        r#"
+        interface Debuggable { function debug(self) -> string }
+        implements Debuggable for string { function debug(self) -> string { return "str" } }
+        function main() -> string {
+          let s: string = "hi"
+          return s.debug()
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("str".into())
+    );
+}
+
+/// F11 [missing-error]: the soundness face of F3 — reading a conflicting
+/// union-interface field type-checks against ANY target, including `bool`
+/// (`Animal.id: string` / `Vehicle.id: int` read into `let v: bool`), so the
+/// field has no single well-defined type. SHOULD be rejected at compile time.
+/// Repro: `cat_iface_iface_union/iface_iface_union_7_same_field_diff_type.baml`
+#[test]
+fn union_fuzz_f11_conflicting_union_field_read_is_rejected() {
+    let errors = collect_compile_errors(
+        r#"
+        interface Animal { id: string }
+        interface Vehicle { id: int }
+        class Dog { id: string  implements Animal {} }
+        class Car { id: int  implements Vehicle {} }
+        function readBool(u: Animal | Vehicle) -> bool {
+          let v: bool = u.id
+          return v
+        }
+        function main() -> bool { return readBool(Dog { id: "x" }) }
+        "#,
+    );
+    assert!(
+        !errors.is_empty(),
+        "reading a field with conflicting types across union-interface members must be \
+         rejected — it currently type-checks even against a `bool` target (soundness hole); \
+         got no compile errors"
+    );
+}
+
+/// F12 [bad-diagnostic]: the diagnostic face of F7 — the rejected interface-union
+/// method call leaks compiler internals: the `unknown` inference sentinel, the
+/// `throws never` bottom marker (BAML has no `never` keyword), and the
+/// method-as-value `(self: Cat) -> string` form. The message SHOULD name the real
+/// receiver/method (or, per F7, the call should compile) — never these internals.
+/// Repro: `cat_collection_union/collection_union_4_field_array.baml`
+#[test]
+fn union_fuzz_f12_iface_union_call_diagnostic_does_not_leak_internals() {
+    let errors = collect_compile_errors(
+        r#"
+        interface Animal {
+          function speak(self) -> string
+        }
+        class Dog {
+          implements Animal {
+            function speak(self) -> string { return "Woof" }
+          }
+        }
+        class Cat {
+          implements Animal {
+            function speak(self) -> string { return "Meow" }
+          }
+        }
+        function describe(x: Animal | Cat) -> string {
+          return x.speak()
+        }
+        function main() -> string {
+          let a: Animal = Dog {}
+          return describe(a)
+        }
+        "#,
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|e| !e.contains("throws never") && !e.contains("(self:")),
+        "method-call diagnostic must not leak compiler internals \
+         (`throws never`, `(self: ...)`, the `unknown` inference sentinel); got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+/// F13 [bad-diagnostic]: the reserved internal `user.` package prefix leaks into
+/// the E0062 non-exhaustive-match `missing:` class-pattern witnesses
+/// (`user.Dog { owner: user.Person { ... } }`). User-facing output must never
+/// contain `user.`.
+/// Repro: `cat_match_union_exhaustive/match_union_exhaustive_11_nested_user_leak.baml`
+#[test]
+fn union_fuzz_f13_exhaustiveness_witness_does_not_leak_user_prefix() {
+    let errors = collect_compile_errors(
+        r#"
+        class Person { name: string }
+        class Dog { owner: Person }
+        class Cat { lives: int }
+        function describe(x: Dog | Cat) -> string {
+          match (x) {
+            Dog { owner: Person { name: "Alice" } } => "alice's dog"
+          }
+        }
+        function main() -> string {
+          let p: Person = Person { name: "Bob" }
+          let d: Dog = Dog { owner: p }
+          return describe(d)
+        }
+        "#,
+    );
+    assert!(
+        errors.iter().all(|e| !e.contains("user.")),
+        "diagnostics must not leak the internal `user.` package prefix; got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+/// F14 [bad-diagnostic]: the E0062 `missing:` witness renders interface union
+/// members as a bare `_` (no `Ty::Interface` arm in the witness renderer), e.g.
+/// `Animal | Vehicle` covered only by `Dog`/`Car` reports `missing: _, _`. The
+/// non-exhaustiveness verdict is correct (interfaces are open-world), but the
+/// witness SHOULD name the uncovered interface(s).
+/// Repro: `cat_match_union_exhaustive/match_union_exhaustive_7_concrete_destructure_both_covers.baml`
+#[test]
+fn union_fuzz_f14_exhaustiveness_witness_names_interface_members() {
+    let errors = collect_compile_errors(
+        r#"
+        interface Animal { function speak(self) -> string }
+        interface Vehicle { function drive(self) -> string }
+        class Dog { name: string  implements Animal { function speak(self) -> string { return "Woof" } } }
+        class Car { model: string  implements Vehicle { function drive(self) -> string { return "Vroom" } } }
+        function describe(x: Animal | Vehicle) -> string {
+          match (x) {
+            Dog { name } => "dog " + name
+            Car { model } => "car " + model
+          }
+        }
+        function main() -> string {
+          let c: Car = Car { model: "T" }
+          return describe(c)
+        }
+        "#,
+    );
+    assert!(
+        errors.iter().any(|e| {
+            e.starts_with("[E0062]")
+                && e.split("missing:")
+                    .nth(1)
+                    .is_some_and(|w| w.contains("Animal") || w.contains("Vehicle"))
+        }),
+        "E0062 `missing:` witness should name the uncovered interface(s) (Animal/Vehicle), \
+         not render them as bare `_`; got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+/// F15 [bad-diagnostic]: an interface-union method-not-found wrongly blames a
+/// member that DOES satisfy the interface — `x.debug()` on `int | Dog` emits an
+/// E0007 against `int` even though `implements Debuggable for int` exists. It
+/// should reject (Dog genuinely lacks `debug`) but blame ONLY `Dog`.
+/// Repro: `cat_out_of_body_union/out_of_body_union_10_wrong_blame_int_with_impl.baml`
+#[test]
+fn union_fuzz_f15_union_method_blame_skips_satisfying_member() {
+    let errors = collect_compile_errors(
+        r#"
+        interface Debuggable { function debug(self) -> string }
+        implements Debuggable for int { function debug(self) -> string { return "int" } }
+        class Dog { name: string }
+        function main() -> string {
+          let x: int | Dog = 7
+          return x.debug()
+        }
+        "#,
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("Dog") && e.contains("debug")),
+        "must still reject — `Dog` lacks `debug`; got:\n  {}",
+        errors.join("\n  ")
+    );
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e.contains("`int`") && e.contains("debug")),
+        "must NOT blame `int` — it satisfies Debuggable via `implements Debuggable for int`; \
+         got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+/// F16 [bad-diagnostic]: an unqualified ambiguous interface-field access on a
+/// UNION value gives a false E0007 `no member` instead of the E0131 ambiguity
+/// diagnostic (with the `.as<Named>`/`.as<Labeled>` hint) that the equivalent
+/// single-class case already emits.
+/// Repro: `cat_as_projection_union/as_projection_union_22_unqualified_ambiguous.baml`
+#[test]
+fn union_fuzz_f16_unqualified_ambiguous_union_field_is_e0131() {
+    assert_compile_error_code(
+        r#"
+        interface Named { name: string }
+        interface Labeled { name: string }
+        class Person {
+          full: string
+          handle: string
+          implements Named { name as full }
+          implements Labeled { name as handle }
+        }
+        class Company {
+          legal: string
+          brand: string
+          implements Named { name as legal }
+          implements Labeled { name as brand }
+        }
+        function rawName(x: Person | Company) -> string {
+          return x.name
+        }
+        function main() -> string {
+          return rawName(Person { full: "Ada", handle: "ada99" })
+        }
+        "#,
+        "E0131",
+    );
+}
+
+/// F17 [bad-diagnostic]: a failed `.as<Cargo<int>>` projection drops the `<int>`
+/// type argument from the message (`does not implement interface Cargo`), which
+/// is misleading because the type DOES implement `Cargo`, just at `<string>`.
+/// The diagnostic SHOULD name the full `Cargo<int>`.
+/// Repro: `cat_as_projection_union/as_projection_union_10_generic_mismatch.baml`
+#[test]
+fn union_fuzz_f17_projection_failure_names_full_generic_interface() {
+    assert_compile_error_contains(
+        r#"
+        interface Cargo<T> { payload: T }
+        class Box<T> {
+          inner: T
+          implements Cargo<T> { payload as inner }
+        }
+        function takeInt(x: Box<int> | Box<string>) -> int {
+          return x.as<Cargo<int>>.payload
+        }
+        function main() -> int {
+          let b: Box<int> | Box<string> = Box<string> { inner: "oops" }
+          return takeInt(b)
+        }
+        "#,
+        "Cargo<int>",
+    );
+}

--- a/baml_language/crates/baml_tests/tests/interfaces.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces.rs
@@ -9581,6 +9581,47 @@ async fn union_fuzz_pr_function_typed_interface_field_in_union() {
     );
 }
 
+/// Reading an interface-member field through an *optional* union (`(Dog |
+/// Named)?` via `?.`) must dispatch on the runtime class like the non-optional
+/// union does — the field lowering used to match only a bare `Union`, so the
+/// `Optional`-wrapped union fell through and crashed the VM
+/// (`expected map, got instance`).
+#[tokio::test]
+async fn union_fuzz_pr_optional_union_interface_field() {
+    let output = baml_test!(
+        r#"
+        interface Named { name: string }
+        class Dog { name: string  implements Named {} }
+        function readName(x: (Dog | Named)?) -> string? { return x?.name }
+        function main() -> string? { return readName(Dog { name: "Rex" }) }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("Rex".into())
+    );
+}
+
+/// A concrete non-function arm in a union callee must still be reported as
+/// not-callable even when another arm is in recovery (`int | <unresolved>`).
+/// The E0006-suppression added for ambiguous-method unions must only fire when
+/// *every* non-function arm is already in recovery, not on any recovery arm.
+#[test]
+fn union_fuzz_pr_concrete_arm_not_callable_despite_recovery_arm() {
+    let errors = collect_compile_errors(
+        r#"
+        function f(x: int | DoesNotExist) -> string { return x() }
+        function main() -> string { return "ok" }
+        "#,
+    );
+    assert!(
+        errors.iter().any(|e| e.starts_with("[E0006]")),
+        "the concrete `int` arm of an `int | <recovery>` callee must still be \
+         reported not-callable (E0006); got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
 /// F1 [crash]: reading a field declared by an interface member of a union
 /// (`x.name` on `Dog | Named`) type-checks, then the VM aborts with
 /// `expected map, got instance`. SHOULD dispatch on the runtime class -> "Rex".

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -102,11 +102,26 @@ fn ty_args_equivalent(a: &[baml_type::Ty], b: &[baml_type::Ty]) -> bool {
 fn ty_equivalent(a: &baml_type::Ty, b: &baml_type::Ty) -> bool {
     use baml_type::Ty;
     match (a, b) {
-        // Unordered-set comparison of union members (recursive). Equal lengths +
-        // every `a` member matching some `b` member is set equality for the
-        // deduplicated unions the compiler produces.
+        // Order-insensitive comparison of union members via a one-to-one
+        // matching: each `a` member must pair with a *distinct* equivalent `b`
+        // member. A plain `all(|x| any(|y| ...))` would wrongly accept
+        // `int | int` as equivalent to `int | string` (both members of the left
+        // match the single `int` on the right), so consume each matched member.
         (Ty::Union(am, _), Ty::Union(bm, _)) => {
-            am.len() == bm.len() && am.iter().all(|x| bm.iter().any(|y| ty_equivalent(x, y)))
+            if am.len() != bm.len() {
+                return false;
+            }
+            let mut used = vec![false; bm.len()];
+            'next_a: for x in am {
+                for (j, y) in bm.iter().enumerate() {
+                    if !used[j] && ty_equivalent(x, y) {
+                        used[j] = true;
+                        continue 'next_a;
+                    }
+                }
+                return false;
+            }
+            true
         }
         // Recurse into nested generic instantiations (`Box<Slot<int | string>>`).
         (Ty::Class(an, aa, _), Ty::Class(bn, ba, _)) => an == bn && ty_args_equivalent(aa, ba),

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -110,6 +110,21 @@ fn ty_equivalent(a: &baml_type::Ty, b: &baml_type::Ty) -> bool {
         }
         // Recurse into nested generic instantiations (`Box<Slot<int | string>>`).
         (Ty::Class(an, aa, _), Ty::Class(bn, ba, _)) => an == bn && ty_args_equivalent(aa, ba),
+        // Recurse through container/optional wrappers so a union nested inside
+        // them is still compared order-insensitively (`Box<(int | string)?>` ==
+        // `Box<(string | int)?>`); otherwise the wrapper would fall to the
+        // structural `==` below and defeat the union-set comparison.
+        (Ty::Optional(ai, _), Ty::Optional(bi, _)) | (Ty::List(ai, _), Ty::List(bi, _)) => {
+            ty_equivalent(ai, bi)
+        }
+        (
+            Ty::Map {
+                key: ak, value: av, ..
+            },
+            Ty::Map {
+                key: bk, value: bv, ..
+            },
+        ) => ty_equivalent(ak, bk) && ty_equivalent(av, bv),
         _ => a == b,
     }
 }

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -45,7 +45,7 @@ impl BamlClassTypeValue for PackageBamlImpl {
                     *impl_class == class_name
                         && (iface_args.is_empty()
                             || impl_args.is_empty()
-                            || *impl_args == iface_args)
+                            || ty_args_equivalent(impl_args, &iface_args))
                 })
             })
     }
@@ -77,13 +77,40 @@ impl BamlClassTypeValue for PackageBamlImpl {
             // Keep only implementors recorded at the requested instantiation
             // (any, when the request or implementor entry carries no type args).
             .filter(|(_, impl_args)| {
-                iface_args.is_empty() || impl_args.is_empty() || *impl_args == iface_args
+                iface_args.is_empty()
+                    || impl_args.is_empty()
+                    || ty_args_equivalent(impl_args, &iface_args)
             })
             .map(|(name, _)| {
                 let ty = baml_type::Ty::Class(name, Vec::new(), baml_type::TyAttr::default());
                 Value::object(vm.tlab.alloc(Object::Type(Box::new(ty))))
             })
             .collect()
+    }
+}
+
+/// Compare two generic-argument lists for *semantic* equivalence. Union
+/// arguments are compared as unordered sets, so `Box<int | string>` and
+/// `Box<string | int>` are the same instantiation (union member order is
+/// semantically irrelevant — the type checker already treats `int | string`
+/// and `string | int` as identical). Falls back to structural `==` for
+/// non-union leaves.
+fn ty_args_equivalent(a: &[baml_type::Ty], b: &[baml_type::Ty]) -> bool {
+    a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| ty_equivalent(x, y))
+}
+
+fn ty_equivalent(a: &baml_type::Ty, b: &baml_type::Ty) -> bool {
+    use baml_type::Ty;
+    match (a, b) {
+        // Unordered-set comparison of union members (recursive). Equal lengths +
+        // every `a` member matching some `b` member is set equality for the
+        // deduplicated unions the compiler produces.
+        (Ty::Union(am, _), Ty::Union(bm, _)) => {
+            am.len() == bm.len() && am.iter().all(|x| bm.iter().any(|y| ty_equivalent(x, y)))
+        }
+        // Recurse into nested generic instantiations (`Box<Slot<int | string>>`).
+        (Ty::Class(an, aa, _), Ty::Class(bn, ba, _)) => an == bn && ty_args_equivalent(aa, ba),
+        _ => a == b,
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes 17 bugs in BEP-044 interface **unions**, found by a union-focused fuzz of the language. Each was pinned as a failing `union_fuzz_fNN_*` test in `crates/baml_tests/tests/interfaces.rs` and is now green. A class-only union method-dispatch case is also pinned as a regression guard.

Two root causes dominated:
- **`unknown | unknown is not a function`** — a method present on every member of a union containing an interface was rejected because the union-member probe resolved interface members to the `Ty::Unknown` sentinel.
- **VM crashes (`expected map, got instance`, `tagged_int_add`)** — reading a field / narrowing a generic-interface match arm on a union dispatched incorrectly at runtime.

## Fixes

| ID | Severity | Fix |
|----|----------|-----|
| F7/F12 | spurious-error / diagnostic | TIR resolves interface union members through the real interface machinery (side effects suppressed); MIR dispatches the call on the runtime class across all members' implementors. No more `unknown \| unknown`. |
| F1/F3/F11 | crash / soundness | MIR dispatches a union field read on the runtime class. Conflicting field types across union interfaces read soundly as `T \| U` (misuse → E0001); a genuinely ambiguous field view → E0131. |
| F2/F5 | crash / wrong-result | A generic-interface match arm (`Slot<int>`) respects its type argument at runtime instead of matching every implementor of the bare interface. |
| F4 | crash | `string + <non-object primitive>` (int/float/bigint/bool/null) is a type error, not an inferred `string` that aborts the VM. `string + uint8array` stays valid. |
| F6 | wrong-result | Reflection compares generic union args as unordered sets (`Box<int\|string>` == `Box<string\|int>`). |
| F8 | spurious-error | A bounded type variable is a subtype of itself (`<T extends I>(a: T) -> T { return a }` compiles). |
| F9 | spurious-error | A match arm overlapping any member of an optional/union scrutinee is accepted (`let a: Animal` over `(Dog \| Cat)?`). |
| F10/F15 | spurious-error / diagnostic | Out-of-body `implements I for <primitive>` resolves for every primitive (not just `int`); union method-not-found blames only the genuinely-lacking member. |
| F13/F14/F16/F17 | diagnostic | No `user.` package-prefix leak in match witnesses; uncovered interface members named instead of `_`; ambiguous union field → E0131; projection errors keep generic args (`Cargo<int>`). |

Snapshot + LSP expectation updates reflect the corrected diagnostics (no `user.` leak; `string + int` now E0004).

## Test plan

- `cargo test -p baml_tests` — **2058 passed, 0 failed**
- `cargo test -p baml_lsp2_actions_tests` — **369 passed, 0 failed**
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt` — clean

Merged latest `canary` (salsa-memoization hang fix); the one conflict in `lower.rs` was resolved by keeping the generic-interface pattern routing on top of canary's borrowed-`resolved_aliases` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches MIR lowering, TIR inference, VM reflection, and pattern/match codegen for interfaces and unions—areas that previously caused VM crashes and silent wrong dispatch; regressions would affect runtime behavior and type soundness.
> 
> **Overview**
> Fixes **BEP-044 interface unions** end-to-end: TIR no longer collapses interface arms to `unknown | unknown` for callable unions; MIR adds runtime class-tag dispatch for methods and fields when the receiver is a union (including optional-wrapped unions and interface members), including inherited defaults and interface field views. **Generic interface** `is`/match patterns and fast type-tag switches now respect type arguments so `Slot<int>` cannot capture `Slot<string>` values.
> 
> TIR also gains union-member resolution with diagnostic rollback, E0121/E0131 for ambiguous shared implementors, out-of-body primitive members, bounded-generic `T <: T`, match-arm overlap over optional unions, and stricter `string +` rules for non-object primitives. VM reflection compares generic args with order-insensitive union equivalence. Diagnostics and exhaustiveness witnesses drop `user.` prefixes and show user-facing type names. Large `union_fuzz_fNN_*` regression tests plus snapshot/LSP updates; `.gitignore` adds `workflow_scratch_files/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b535f94a74d5b15bc1bd7e2213e9abf031f259f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime dispatch and field reads for unions that contain interface members; tightened generic-interface runtime matching and narrowed type-match behavior.
  * Reduced spurious diagnostics during union-call inference; improved subtype/pattern-overlap checking and rejected invalid string+int concatenation.
  * Made missing-case diagnostics and witness rendering use user-facing type names and avoid leaking internal prefixes.

* **Tests**
  * Added a large regression suite covering union/interface dispatch, generic-interface scenarios, diagnostics, and runtime behaviors.

* **Chores**
  * Ignored local workflow scratch files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->