### PR TITLE
feat: add default client arg to LLM functions

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/companions.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/companions.rs
@@ -12,7 +12,7 @@ use baml_base::Name;
 
 use crate::{
     DeclarativeMeta,
-    ast::{FunctionBodyDef, FunctionDef, FunctionDefaults, Param, SpannedTypeExpr, TypeExpr},
+    ast::{FunctionBodyDef, FunctionDef, Param, SpannedTypeExpr, TypeExpr},
     lower_cst::{synthesize_llm_builtin_call, synthesize_llm_parse_call},
 };
 
@@ -77,7 +77,8 @@ fn llm_parse(parent: &FunctionDef) -> Option<FunctionDef> {
 
     let name = Name::new(format!("{}$parse", parent.name));
 
-    // Parse takes a single `json: string` parameter instead of the parent's params.
+    // Parse takes a `json: string` parameter instead of the parent's prompt
+    // params, but keeps the LLM client's default override for API consistency.
     let json_param = Param {
         name: Name::new("json"),
         type_expr: Some(SpannedTypeExpr {
@@ -93,13 +94,17 @@ fn llm_parse(parent: &FunctionDef) -> Option<FunctionDef> {
     let return_type = parent.return_type.clone();
 
     let (body, source_map) = synthesize_llm_parse_call(parent.name.as_str(), parent.span);
+    let mut params = vec![json_param];
+    if let Some(client_param) = parent.params.iter().find(|p| p.name.as_str() == "client") {
+        params.push(client_param.clone());
+    }
 
     Some(FunctionDef {
         name,
         generic_params: parent.generic_params.clone(),
         generic_param_bounds: parent.generic_param_bounds.clone(),
-        params: vec![json_param],
-        defaults: FunctionDefaults::empty(),
+        params,
+        defaults: parent.defaults.clone(),
         return_type,
         throws: None,
         body: Some(FunctionBodyDef::Expr(body, source_map)),
@@ -126,17 +131,27 @@ fn make_llm_companion(
         },
         span: parent.span,
     };
-    let param_names: Vec<Name> = parent.params.iter().map(|p| p.name.clone()).collect();
+    let param_names: Vec<Name> = parent
+        .params
+        .iter()
+        .filter(|p| p.name.as_str() != "client")
+        .map(|p| p.name.clone())
+        .collect();
     // Extract client name from parent's LLM declarative meta.
-    let client_name = match &parent.declarative_meta {
-        Some(DeclarativeMeta::Llm(llm)) => llm.client.as_ref().map(|n| n.as_str().to_string()),
+    let client_arg_name = match &parent.declarative_meta {
+        Some(DeclarativeMeta::Llm(_))
+            if parent.params.iter().any(|p| p.name.as_str() == "client") =>
+        {
+            Some("client")
+        }
+        Some(DeclarativeMeta::Llm(llm)) => llm.client.as_ref().map(smol_str::SmolStr::as_str),
         _ => None,
     };
     let (body, source_map) = synthesize_llm_builtin_call(
         target,
         parent.name.as_str(),
         &param_names,
-        client_name.as_deref(),
+        client_arg_name,
         Vec::new(),
         parent.span,
     );

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -345,6 +345,14 @@ mod tests {
         items
     }
 
+    fn parse_and_lower_with_diagnostics(
+        source: &str,
+    ) -> (Vec<Item>, Vec<crate::LoweringDiagnostic>) {
+        let root = parse(source);
+        let (items, diags, _env_var_refs) = lower_file(&root);
+        (items, diags)
+    }
+
     fn first_function(items: Vec<Item>) -> crate::ast::FunctionDef {
         items
             .into_iter()
@@ -356,6 +364,53 @@ mod tests {
                 }
             })
             .expect("expected a FunctionDef")
+    }
+
+    #[test]
+    fn llm_function_user_client_param_is_reserved() {
+        let source = r##"
+client<llm> GPT4 {
+  provider "openai"
+  options {
+    model "gpt-4o"
+    api_key "test"
+  }
+}
+
+function Extract(client: string, text: string) -> string {
+  client GPT4
+  prompt #"{{ text }}"#
+}
+"##;
+
+        let (items, diags) = parse_and_lower_with_diagnostics(source);
+        assert!(
+            diags.iter().any(|diag| matches!(
+                diag,
+                crate::LoweringDiagnostic::ReservedLlmClientParam {
+                    function_name,
+                    param_name,
+                    ..
+                } if function_name == "Extract" && param_name == "client"
+            )),
+            "expected reserved LLM client param diagnostic, got: {diags:#?}"
+        );
+
+        let function = items
+            .into_iter()
+            .find_map(|item| match item {
+                Item::Function(function) if function.name.as_str() == "Extract" => Some(function),
+                _ => None,
+            })
+            .expect("expected Extract function");
+        let param_names: Vec<&str> = function.params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(param_names, vec!["text", "client"]);
+        let default_id = function.params[1].default.expect("expected client default");
+        let default_expr = &function.defaults.exprs.exprs[default_id.expr()];
+        assert!(
+            matches!(default_expr, Expr::Path(path) if path.len() == 1 && path[0].as_str() == "GPT4"),
+            "expected compiler-injected client default to reference GPT4, got {default_expr:#?}"
+        );
     }
 
     #[test]

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -19,7 +19,7 @@ use crate::{
         FieldDef, FunctionBodyDef, FunctionDef, FunctionDefaults, GeneratorDef, ImplementsBlockDef,
         ImplementsForDef, InterfaceDef, InterfaceFieldLinkDef, Interpolation, Item, LetDef,
         LetOrigin, LlmBodyDef, MethodSigDef, Param, RawAttribute, RawAttributeArg, RawPrompt,
-        SpannedTypeExpr, TemplateStringDef, TestDef, TypeAliasDef, VariantDef,
+        SpannedTypeExpr, TemplateStringDef, TestDef, TypeAliasDef, TypeExpr, VariantDef,
     },
     companions::expand_companions,
     lower_expr_body, lower_type_expr,
@@ -272,7 +272,7 @@ fn lower_function(
         .collect();
     let parameter_context = format!("function `{}`", name.as_str());
 
-    let (params, defaults) = func
+    let (mut params, mut defaults) = func
         .param_list()
         .map(|pl| {
             lower_params_with_defaults(
@@ -314,8 +314,17 @@ fn lower_function(
 
     let (body, declarative_meta) = if let Some(llm) = func.llm_body() {
         let llm_body_def = lower_llm_body(&llm);
-        let param_names: Vec<Name> = params.iter().map(|p| p.name.clone()).collect();
+        reject_reserved_llm_client_params(&mut params, name.as_str(), diags);
         let client_name = llm_body_def.client.as_ref().map(|n| n.as_str().to_string());
+        if let Some(client_name) = client_name.as_deref() {
+            append_default_client_param(&mut params, &mut defaults, client_name, llm_body_def.span);
+        }
+        let param_names: Vec<Name> = params
+            .iter()
+            .filter(|p| p.name.as_str() != "client")
+            .map(|p| p.name.clone())
+            .collect();
+        let client_arg_name = client_name.as_ref().map(|_| "client");
         // Pass the LLM function's declared return type as the explicit `<T>`
         // type argument to `baml.llm.call_llm_function<T>`. This is required
         // for the runtime type-arg threading: without it, `T` falls back to
@@ -330,7 +339,7 @@ fn lower_function(
             "call_llm_function",
             name.as_str(),
             &param_names,
-            client_name.as_deref(),
+            client_arg_name,
             call_type_args,
             llm_body_def.span,
         );
@@ -521,6 +530,107 @@ pub(crate) fn lower_param(
     })
 }
 
+pub(crate) fn append_default_client_param(
+    params: &mut Vec<Param>,
+    defaults: &mut FunctionDefaults,
+    client_name: &str,
+    span: text_size::TextRange,
+) {
+    let default_expr = alloc_client_override_default_expr(defaults, client_name, span);
+    params.push(Param {
+        name: Name::new("client"),
+        type_expr: Some(SpannedTypeExpr {
+            expr: TypeExpr::Path {
+                segments: vec![Name::new("baml"), Name::new("llm"), Name::new("Client")],
+                generic_args: vec![],
+                attrs: vec![],
+            },
+            span,
+        }),
+        default: Some(crate::ast::DefaultExprId::new(default_expr)),
+        span,
+        name_span: span,
+    });
+}
+
+fn reject_reserved_llm_client_params(
+    params: &mut Vec<Param>,
+    function_name: &str,
+    diags: &mut Vec<LoweringDiagnostic>,
+) {
+    let mut reserved_spans = Vec::new();
+    params.retain(|param| {
+        if param.name.as_str() == "client" {
+            reserved_spans.push(param.name_span);
+            false
+        } else {
+            true
+        }
+    });
+
+    for span in reserved_spans {
+        diags.push(LoweringDiagnostic::ReservedLlmClientParam {
+            function_name: function_name.to_string(),
+            param_name: "client".to_string(),
+            span,
+        });
+    }
+}
+
+fn alloc_client_override_default_expr(
+    defaults: &mut FunctionDefaults,
+    client_name: &str,
+    span: text_size::TextRange,
+) -> ExprId {
+    fn alloc(defaults: &mut FunctionDefaults, expr: Expr, span: text_size::TextRange) -> ExprId {
+        let id = defaults.exprs.exprs.alloc(expr);
+        defaults.source_map.expr_spans.alloc(span);
+        id
+    }
+
+    if client_name.contains('/') {
+        // Shorthand clients are not backed by a synthesized top-level let binding,
+        // so defaults have to carry the inline Client value.
+        let name_lit = alloc(
+            defaults,
+            Expr::Literal(crate::ast::Literal::String(client_name.to_string())),
+            span,
+        );
+        let client_type = alloc(
+            defaults,
+            Expr::Path(vec![
+                Name::new("baml"),
+                Name::new("llm"),
+                Name::new("ClientType"),
+                Name::new("Primitive"),
+            ]),
+            span,
+        );
+        let sub_clients = alloc(defaults, Expr::Array { elements: vec![] }, span);
+        let retry = alloc(defaults, Expr::Null, span);
+        let counter = alloc(defaults, Expr::Literal(crate::ast::Literal::Int(0)), span);
+        alloc(
+            defaults,
+            Expr::Object {
+                type_name: Some(TypePath::from_dotted("baml.llm.Client")),
+                type_args: vec![],
+                fields: vec![
+                    (Name::new("name"), name_lit),
+                    (Name::new("client_type"), client_type),
+                    (Name::new("sub_clients"), sub_clients),
+                    (Name::new("retry"), retry),
+                    (Name::new("counter"), counter),
+                ],
+                spreads: vec![],
+            },
+            span,
+        )
+    } else {
+        // Named client declarations already lower to a top-level client let binding.
+        alloc(defaults, Expr::Path(vec![Name::new(client_name)]), span)
+    }
+}
+
 fn lower_llm_body(llm_body: &ast::LlmFunctionBody) -> LlmBodyDef {
     let span = llm_body.syntax().text_range();
 
@@ -549,8 +659,9 @@ fn lower_llm_body(llm_body: &ast::LlmFunctionBody) -> LlmBodyDef {
 /// an inline `Client { name, client_type: ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }`.
 /// When `client_name` is `None`, `Expr::Null` is used as a fallback.
 ///
-/// Only `call_llm_function` passes a client; companion builtins (`render_prompt`, `build_request`)
-/// use `client_name = None` and keep their existing 2-argument signature.
+/// LLM functions and request/render/stream companions pass a client as the first argument.
+/// After default-client parameter synthesis, call sites pass `client_name = Some("client")`
+/// so explicit `client=` overrides flow through the generated body.
 ///
 /// All synthetic spans point to `span`.
 pub fn synthesize_llm_builtin_call(

--- a/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
@@ -37,6 +37,14 @@ pub enum LoweringDiagnostic {
     /// A parameter default was parsed in a context that does not support defaults.
     UnsupportedParameterDefault { context: String, span: TextRange },
 
+    /// A user-authored LLM function declared `client`, which is reserved for
+    /// the compiler-injected client override parameter.
+    ReservedLlmClientParam {
+        function_name: String,
+        param_name: String,
+        span: TextRange,
+    },
+
     /// An enum variant has no name token.
     MissingVariantName { enum_name: String, span: TextRange },
 
@@ -162,6 +170,18 @@ impl LoweringDiagnostic {
                 format!("parameter defaults are not supported in {context}"),
                 *span,
                 "default value is not allowed here",
+            ),
+            LoweringDiagnostic::ReservedLlmClientParam {
+                function_name,
+                param_name,
+                span,
+            } => (
+                DiagnosticId::InvalidSyntax,
+                format!(
+                    "LLM function `{function_name}` cannot declare a parameter named `{param_name}`; `client` is reserved for the compiler-injected LLM client override"
+                ),
+                *span,
+                "`client` is reserved here",
             ),
             LoweringDiagnostic::MissingVariantName { enum_name, span } => (
                 DiagnosticId::MissingName,

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -457,13 +457,23 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                 // --- $stream companion ---
                 // Calls baml.llm.stream_llm_function(CLIENT, "FuncName", map { args })
                 {
-                    let param_names: Vec<Name> =
-                        func.params.iter().map(|p| p.name.clone()).collect();
+                    let param_names: Vec<Name> = func
+                        .params
+                        .iter()
+                        .filter(|p| p.name.as_str() != "client")
+                        .map(|p| p.name.clone())
+                        .collect();
+                    let client_arg_name = if func.params.iter().any(|p| p.name.as_str() == "client")
+                    {
+                        Some("client")
+                    } else {
+                        client_name.as_deref()
+                    };
                     let (body, source_map) = ast::synthesize_llm_builtin_call(
                         "stream_llm_function",
                         func.name.as_str(),
                         &param_names,
-                        client_name.as_deref(),
+                        client_arg_name,
                         Vec::new(),
                         span,
                     );
@@ -488,7 +498,13 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
 
                 // --- $parse_stream companion ---
                 // Requires a client (calls CLIENT.__make_stream).
-                if let Some(ref client_name) = client_name {
+                if let Some(client_arg_name) = func
+                    .params
+                    .iter()
+                    .find(|p| p.name.as_str() == "client")
+                    .map(|_| "client")
+                    .or(client_name.as_deref())
+                {
                     let sse_param = ast::Param {
                         name: Name::new("sse"),
                         type_expr: Some(ast::SpannedTypeExpr {
@@ -508,15 +524,24 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                         name_span,
                     };
 
-                    let (body, source_map) =
-                        ast::synthesize_llm_make_stream_call(func.name.as_str(), client_name, span);
+                    let (body, source_map) = ast::synthesize_llm_make_stream_call(
+                        func.name.as_str(),
+                        client_arg_name,
+                        span,
+                    );
+                    let mut params = vec![sse_param];
+                    if let Some(client_param) =
+                        func.params.iter().find(|p| p.name.as_str() == "client")
+                    {
+                        params.push(client_param.clone());
+                    }
 
                     let companion = ast::FunctionDef {
                         name: SmolStr::new(format!("{}$parse_stream", func.name)),
                         generic_params: func.generic_params.clone(),
                         generic_param_bounds: func.generic_param_bounds.clone(),
-                        params: vec![sse_param],
-                        defaults: ast::FunctionDefaults::empty(),
+                        params,
+                        defaults: func.defaults.clone(),
                         return_type: Some(stream_return_type),
                         throws: None,
                         body: Some(ast::FunctionBodyDef::Expr(body, source_map)),

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/functions_v2/duplicate_names.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/functions_v2/duplicate_names.baml
@@ -118,14 +118,3 @@ function Bar(a: string, b: int | bool) -> int {
 //    │     
 //    │     Note: Error code: E0001
 // ───╯
-// error: type mismatch: expected baml.llm.Client, got () -> unknown throws never
-//    ╭─[ functions_v2_duplicate_names.baml:4:2 ]
-//    │
-//  4 │ ╭─▶ }
-//    ┆ ┆   
-//  9 │ ├─▶ }
-//    │ │       
-//    │ ╰─────── type mismatch: expected baml.llm.Client, got () -> unknown throws never
-//    │     
-//    │     Note: Error code: E0001
-// ───╯

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -831,6 +831,111 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_llm_functions_and_companions_get_default_client_argument() {
+        let root = Path::new("/tmp/llm_default_client_arg");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("main.baml").as_path(),
+            r##"
+client<llm> GPT4 {
+  provider "openai"
+  options {
+    model "gpt-4o"
+    api_key "test"
+  }
+}
+
+class Resume { name string }
+
+function ExtractResume(resume: string) -> Resume {
+  client GPT4
+  prompt #"Extract resume from {{resume}}"#
+}
+"##,
+        );
+
+        let pool = build_symbol_pool(&db);
+
+        for (bare, expected_prefix) in [
+            ("ExtractResume", &["resume"][..]),
+            ("ExtractResume$render_prompt", &["resume"][..]),
+            ("ExtractResume$build_request", &["resume"][..]),
+            ("ExtractResume$build_request_stream", &["resume"][..]),
+            ("ExtractResume$stream", &["resume"][..]),
+            ("ExtractResume$parse", &["json"][..]),
+            ("ExtractResume$parse_stream", &["sse"][..]),
+        ] {
+            let key = cg::Name {
+                pkg: Name::new("user"),
+                namespace_path: vec![],
+                name: Name::new(bare),
+            };
+            let Some(cg::Symbol::Function(func)) = pool.get(&key) else {
+                panic!("missing function {bare}");
+            };
+
+            let arg_names: Vec<&str> = func.arguments.iter().map(|a| a.name.as_str()).collect();
+            let mut expected_names = expected_prefix.to_vec();
+            expected_names.push("client");
+            assert_eq!(arg_names, expected_names, "arguments for {bare}");
+
+            let client_arg = func.arguments.last().expect("client argument");
+            assert_eq!(client_arg.name.as_str(), "client");
+            assert_eq!(
+                client_arg.default,
+                Some(cg::FunctionArgumentDefault::Expression {
+                    source: Some("GPT4".to_string()),
+                }),
+                "client default for {bare}",
+            );
+            match &client_arg.ty {
+                cg::Ty::Class(name, args) => {
+                    assert_eq!(name.to_string(), "baml.llm.Client");
+                    assert!(args.is_empty());
+                }
+                other => panic!("client type for {bare} should be baml.llm.Client, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_llm_function_user_client_param_is_compiler_error() {
+        let root = Path::new("/tmp/llm_reserved_client_arg");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("main.baml").as_path(),
+            r##"
+client<llm> GPT4 {
+  provider "openai"
+  options {
+    model "gpt-4o"
+    api_key "test"
+  }
+}
+
+function Extract(client: string, text: string) -> string {
+  client GPT4
+  prompt #"{{ text }}"#
+}
+"##,
+        );
+
+        let diagnostics = crate::collect_compiler2_diagnostics(&db);
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag.message
+                    .contains("cannot declare a parameter named `client`")
+                    && diag
+                        .message
+                        .contains("reserved for the compiler-injected LLM client override")
+            }),
+            "expected reserved `client` compiler error, got: {diagnostics:#?}"
+        );
+    }
+
     /// Smoke test: `///` on classes / fields / enums / variants must reach the
     /// `SymbolPool`. Pre-existing failure mode here was that the symbol pool
     /// was built but every `docstring` was `None` despite the AST carrying

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
@@ -42,112 +42,222 @@ function type_reflection.$init_test_ns_type_reflection_type_reflection(registry:
     return
 }
 
-function type_reflection.GetBar() -> type_reflection.Bar {
-    load_type type_reflection.Bar
+function type_reflection.GetBar(client: baml.llm.Client) -> type_reflection.Bar {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_type type_reflection.Bar
+    load_var client
     load_const "GetBar"
     alloc_map 0
     call baml.llm.call_llm_function
     return
 }
 
-function type_reflection.GetBar$build_request() -> baml.http.Request {
+function type_reflection.GetBar$build_request(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "GetBar"
     alloc_map 0
     call baml.llm.build_request
     return
 }
 
-function type_reflection.GetBar$build_request_stream() -> baml.http.Request {
+function type_reflection.GetBar$build_request_stream(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "GetBar"
     alloc_map 0
     call baml.llm.build_request_stream
     return
 }
 
-function type_reflection.GetBar$parse(json: string) -> type_reflection.Bar {
+function type_reflection.GetBar$parse(json: string, client: baml.llm.Client) -> type_reflection.Bar {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
     load_const "GetBar"
     load_var json
     call baml.llm.parse
     return
 }
 
-function type_reflection.GetBar$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | type_reflection.Bar$stream, type_reflection.Bar> {
-    load_var sse
+function type_reflection.GetBar$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | type_reflection.Bar$stream, type_reflection.Bar> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "GetBar"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function type_reflection.GetBar$render_prompt() -> baml.llm.PromptAst {
+function type_reflection.GetBar$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "GetBar"
     alloc_map 0
     call baml.llm.render_prompt
     return
 }
 
-function type_reflection.GetBar$stream() -> baml.llm.Stream<null | type_reflection.Bar$stream, type_reflection.Bar> {
+function type_reflection.GetBar$stream(client: baml.llm.Client) -> baml.llm.Stream<null | type_reflection.Bar$stream, type_reflection.Bar> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "GetBar"
     alloc_map 0
     call baml.llm.stream_llm_function
     return
 }
 
-function type_reflection.GetFoo() -> type_reflection.Foo {
-    load_type type_reflection.Foo
+function type_reflection.GetFoo(client: baml.llm.Client) -> type_reflection.Foo {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_type type_reflection.Foo
+    load_var client
     load_const "GetFoo"
     alloc_map 0
     call baml.llm.call_llm_function
     return
 }
 
-function type_reflection.GetFoo$build_request() -> baml.http.Request {
+function type_reflection.GetFoo$build_request(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "GetFoo"
     alloc_map 0
     call baml.llm.build_request
     return
 }
 
-function type_reflection.GetFoo$build_request_stream() -> baml.http.Request {
+function type_reflection.GetFoo$build_request_stream(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "GetFoo"
     alloc_map 0
     call baml.llm.build_request_stream
     return
 }
 
-function type_reflection.GetFoo$parse(json: string) -> type_reflection.Foo {
+function type_reflection.GetFoo$parse(json: string, client: baml.llm.Client) -> type_reflection.Foo {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
     load_const "GetFoo"
     load_var json
     call baml.llm.parse
     return
 }
 
-function type_reflection.GetFoo$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | type_reflection.Foo$stream, type_reflection.Foo> {
-    load_var sse
+function type_reflection.GetFoo$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | type_reflection.Foo$stream, type_reflection.Foo> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "GetFoo"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function type_reflection.GetFoo$render_prompt() -> baml.llm.PromptAst {
+function type_reflection.GetFoo$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "GetFoo"
     alloc_map 0
     call baml.llm.render_prompt
     return
 }
 
-function type_reflection.GetFoo$stream() -> baml.llm.Stream<null | type_reflection.Foo$stream, type_reflection.Foo> {
+function type_reflection.GetFoo$stream(client: baml.llm.Client) -> baml.llm.Stream<null | type_reflection.Foo$stream, type_reflection.Foo> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.type_reflection.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "GetFoo"
     alloc_map 0
     call baml.llm.stream_llm_function

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__03_hir.snap
@@ -2,35 +2,35 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.CommentAfterArrow() -> string  [llm] {
-  baml.llm.call_llm_function(TestClient, "CommentAfterArrow", map {  })
+function user.CommentAfterArrow(client: baml.llm.Client = TestClient) -> string  [llm] {
+  baml.llm.call_llm_function(client, "CommentAfterArrow", map {  })
 }
-function user.CommentAfterArrow$build_request() -> baml.http.Request  [expr] {
-  baml.llm.build_request(TestClient, "CommentAfterArrow", map {  })
+function user.CommentAfterArrow$build_request(client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "CommentAfterArrow", map {  })
 }
-function user.CommentAfterArrow$build_request_stream() -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(TestClient, "CommentAfterArrow", map {  })
+function user.CommentAfterArrow$build_request_stream(client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "CommentAfterArrow", map {  })
 }
-function user.CommentAfterArrow$parse(json: string) -> string  [expr] {
+function user.CommentAfterArrow$parse(json: string, client: baml.llm.Client = TestClient) -> string  [expr] {
   baml.llm.parse("CommentAfterArrow", json)
 }
-function user.CommentAfterArrow$render_prompt() -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(TestClient, "CommentAfterArrow", map {  })
+function user.CommentAfterArrow$render_prompt(client: baml.llm.Client = TestClient) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "CommentAfterArrow", map {  })
 }
-function user.FunctionWithComments(a: string, b: int) -> string  [llm] {
-  baml.llm.call_llm_function(TestClient, "FunctionWithComments", map { "a": a, "b": b })
+function user.FunctionWithComments(a: string, b: int, client: baml.llm.Client = TestClient) -> string  [llm] {
+  baml.llm.call_llm_function(client, "FunctionWithComments", map { "a": a, "b": b })
 }
-function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http.Request  [expr] {
-  baml.llm.build_request(TestClient, "FunctionWithComments", map { "a": a, "b": b })
+function user.FunctionWithComments$build_request(a: string, b: int, client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "FunctionWithComments", map { "a": a, "b": b })
 }
-function user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(TestClient, "FunctionWithComments", map { "a": a, "b": b })
+function user.FunctionWithComments$build_request_stream(a: string, b: int, client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "FunctionWithComments", map { "a": a, "b": b })
 }
-function user.FunctionWithComments$parse(json: string) -> string  [expr] {
+function user.FunctionWithComments$parse(json: string, client: baml.llm.Client = TestClient) -> string  [expr] {
   baml.llm.parse("FunctionWithComments", json)
 }
-function user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(TestClient, "FunctionWithComments", map { "a": a, "b": b })
+function user.FunctionWithComments$render_prompt(a: string, b: int, client: baml.llm.Client = TestClient) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "FunctionWithComments", map { "a": a, "b": b })
 }
 function user.TestClient$new() -> ?  [expr] {
   baml.llm.PrimitiveClient { name: "TestClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: null, base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } }

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__04_5_mir.snap
@@ -2,162 +2,282 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.CommentAfterArrow() -> string {
+fn user.CommentAfterArrow(client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
-    let _1: map<string, unknown>
-    let _2: type
-
-    bb0: {
-        _1 = {  };
-        _2 = load_type(string);
-        _0 = call const fn baml.llm.call_llm_function<copy _2>(const fn user.TestClient, const "CommentAfterArrow", copy _1) -> [bb1];
-    }
-
-    bb1: {
-        return;
-    }
-}
-
-fn user.CommentAfterArrow$build_request() -> baml.http.Request {
-    // Locals:
-    let _0: baml.http.Request // _0 // return
-    let _1: map<string, unknown>
-
-    bb0: {
-        _1 = {  };
-        _0 = call const fn baml.llm.build_request(const fn user.TestClient, const "CommentAfterArrow", copy _1) -> [bb1];
-    }
-
-    bb1: {
-        return;
-    }
-}
-
-fn user.CommentAfterArrow$build_request_stream() -> baml.http.Request {
-    // Locals:
-    let _0: baml.http.Request // _0 // return
-    let _1: map<string, unknown>
-
-    bb0: {
-        _1 = {  };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.TestClient, const "CommentAfterArrow", copy _1) -> [bb1];
-    }
-
-    bb1: {
-        return;
-    }
-}
-
-fn user.CommentAfterArrow$parse(json: string) -> string {
-    // Locals:
-    let _0: string // _0 // return
-    let _1: string // json // param
-
-    bb0: {
-        _0 = call const fn baml.llm.parse(const "CommentAfterArrow", copy _1) -> [bb1];
-    }
-
-    bb1: {
-        return;
-    }
-}
-
-fn user.CommentAfterArrow$render_prompt() -> baml.llm.PromptAst {
-    // Locals:
-    let _0: baml.llm.PromptAst // _0 // return
-    let _1: map<string, unknown>
-
-    bb0: {
-        _1 = {  };
-        _0 = call const fn baml.llm.render_prompt(const fn user.TestClient, const "CommentAfterArrow", copy _1) -> [bb1];
-    }
-
-    bb1: {
-        return;
-    }
-}
-
-fn user.FunctionWithComments(a: string, b: int) -> string {
-    // Locals:
-    let _0: string // _0 // return
-    let _1: string // a // param
-    let _2: int // b // param
+    let _1: baml.llm.Client // client // param
+    let _2: bool
     let _3: map<string, unknown>
     let _4: type
 
     bb0: {
-        _3 = { const "a": copy _1, const "b": copy _2 };
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
+    }
+
+    bb1: {
+        _1 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _3 = {  };
         _4 = load_type(string);
-        _0 = call const fn baml.llm.call_llm_function<copy _4>(const fn user.TestClient, const "FunctionWithComments", copy _3) -> [bb1];
+        _0 = call const fn baml.llm.call_llm_function<copy _4>(copy _1, const "CommentAfterArrow", copy _3) -> [bb3];
     }
 
-    bb1: {
+    bb3: {
         return;
     }
 }
 
-fn user.FunctionWithComments$build_request(a: string, b: int) -> baml.http.Request {
+fn user.CommentAfterArrow$build_request(client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
-    let _1: string // a // param
-    let _2: int // b // param
+    let _1: baml.llm.Client // client // param
+    let _2: bool
     let _3: map<string, unknown>
 
     bb0: {
-        _3 = { const "a": copy _1, const "b": copy _2 };
-        _0 = call const fn baml.llm.build_request(const fn user.TestClient, const "FunctionWithComments", copy _3) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _1 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _3 = {  };
+        _0 = call const fn baml.llm.build_request(copy _1, const "CommentAfterArrow", copy _3) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request {
+fn user.CommentAfterArrow$build_request_stream(client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
-    let _1: string // a // param
-    let _2: int // b // param
+    let _1: baml.llm.Client // client // param
+    let _2: bool
     let _3: map<string, unknown>
 
     bb0: {
-        _3 = { const "a": copy _1, const "b": copy _2 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.TestClient, const "FunctionWithComments", copy _3) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _1 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _3 = {  };
+        _0 = call const fn baml.llm.build_request_stream(copy _1, const "CommentAfterArrow", copy _3) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.FunctionWithComments$parse(json: string) -> string {
+fn user.CommentAfterArrow$parse(json: string, client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "FunctionWithComments", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "CommentAfterArrow", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.PromptAst {
+fn user.CommentAfterArrow$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst {
+    // Locals:
+    let _0: baml.llm.PromptAst // _0 // return
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: map<string, unknown>
+
+    bb0: {
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
+    }
+
+    bb1: {
+        _1 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _3 = {  };
+        _0 = call const fn baml.llm.render_prompt(copy _1, const "CommentAfterArrow", copy _3) -> [bb3];
+    }
+
+    bb3: {
+        return;
+    }
+}
+
+fn user.FunctionWithComments(a: string, b: int, client: baml.llm.Client) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: string // a // param
+    let _2: int // b // param
+    let _3: baml.llm.Client // client // param
+    let _4: bool
+    let _5: map<string, unknown>
+    let _6: type
+
+    bb0: {
+        _4 = copy _3 == const <omitted>;
+        branch copy _4 -> [bb1, bb2];
+    }
+
+    bb1: {
+        _3 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "a": copy _1, const "b": copy _2 };
+        _6 = load_type(string);
+        _0 = call const fn baml.llm.call_llm_function<copy _6>(copy _3, const "FunctionWithComments", copy _5) -> [bb3];
+    }
+
+    bb3: {
+        return;
+    }
+}
+
+fn user.FunctionWithComments$build_request(a: string, b: int, client: baml.llm.Client) -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: string // a // param
+    let _2: int // b // param
+    let _3: baml.llm.Client // client // param
+    let _4: bool
+    let _5: map<string, unknown>
+
+    bb0: {
+        _4 = copy _3 == const <omitted>;
+        branch copy _4 -> [bb1, bb2];
+    }
+
+    bb1: {
+        _3 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "a": copy _1, const "b": copy _2 };
+        _0 = call const fn baml.llm.build_request(copy _3, const "FunctionWithComments", copy _5) -> [bb3];
+    }
+
+    bb3: {
+        return;
+    }
+}
+
+fn user.FunctionWithComments$build_request_stream(a: string, b: int, client: baml.llm.Client) -> baml.http.Request {
+    // Locals:
+    let _0: baml.http.Request // _0 // return
+    let _1: string // a // param
+    let _2: int // b // param
+    let _3: baml.llm.Client // client // param
+    let _4: bool
+    let _5: map<string, unknown>
+
+    bb0: {
+        _4 = copy _3 == const <omitted>;
+        branch copy _4 -> [bb1, bb2];
+    }
+
+    bb1: {
+        _3 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "a": copy _1, const "b": copy _2 };
+        _0 = call const fn baml.llm.build_request_stream(copy _3, const "FunctionWithComments", copy _5) -> [bb3];
+    }
+
+    bb3: {
+        return;
+    }
+}
+
+fn user.FunctionWithComments$parse(json: string, client: baml.llm.Client) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+
+    bb0: {
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
+    }
+
+    bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "FunctionWithComments", copy _1) -> [bb3];
+    }
+
+    bb3: {
+        return;
+    }
+}
+
+fn user.FunctionWithComments$render_prompt(a: string, b: int, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // a // param
     let _2: int // b // param
-    let _3: map<string, unknown>
+    let _3: baml.llm.Client // client // param
+    let _4: bool
+    let _5: map<string, unknown>
 
     bb0: {
-        _3 = { const "a": copy _1, const "b": copy _2 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.TestClient, const "FunctionWithComments", copy _3) -> [bb1];
+        _4 = copy _3 == const <omitted>;
+        branch copy _4 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "a": copy _1, const "b": copy _2 };
+        _0 = call const fn baml.llm.render_prompt(copy _3, const "FunctionWithComments", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__04_tir.snap
@@ -5,45 +5,45 @@ source: crates/baml_tests/src/generated_tests.rs
 function user.TestClient$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "TestClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: null, base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : baml.llm.PrimitiveClient
 }
-function user.FunctionWithComments(a: string, b: int) -> string throws never {
-  baml.llm.call_llm_function<T>(TestClient, "FunctionWithComments", map { "a": a, "b": b }) : string
+function user.FunctionWithComments(a: string, b: int, client: baml.llm.Client = TestClient) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "FunctionWithComments", map { "a": a, "b": b }) : string
 }
-function user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(TestClient, "FunctionWithComments", map { "a": a, "b": b }) : baml.llm.PromptAst
+function user.FunctionWithComments$render_prompt(a: string, b: int, client: baml.llm.Client = TestClient) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "FunctionWithComments", map { "a": a, "b": b }) : baml.llm.PromptAst
 }
-function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http.Request throws never {
-  baml.llm.build_request(TestClient, "FunctionWithComments", map { "a": a, "b": b }) : baml.http.Request
+function user.FunctionWithComments$build_request(a: string, b: int, client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "FunctionWithComments", map { "a": a, "b": b }) : baml.http.Request
 }
-function user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(TestClient, "FunctionWithComments", map { "a": a, "b": b }) : baml.http.Request
+function user.FunctionWithComments$build_request_stream(a: string, b: int, client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "FunctionWithComments", map { "a": a, "b": b }) : baml.http.Request
 }
-function user.FunctionWithComments$parse(json: string) -> string throws never {
+function user.FunctionWithComments$parse(json: string, client: baml.llm.Client = TestClient) -> string throws never {
   baml.llm.parse<TFinal>("FunctionWithComments", json) : string
 }
-function user.CommentAfterArrow() -> string throws never {
-  baml.llm.call_llm_function<T>(TestClient, "CommentAfterArrow", map {  }) : string
+function user.CommentAfterArrow(client: baml.llm.Client = TestClient) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "CommentAfterArrow", map {  }) : string
 }
-function user.CommentAfterArrow$render_prompt() -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(TestClient, "CommentAfterArrow", map {  }) : baml.llm.PromptAst
+function user.CommentAfterArrow$render_prompt(client: baml.llm.Client = TestClient) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "CommentAfterArrow", map {  }) : baml.llm.PromptAst
 }
-function user.CommentAfterArrow$build_request() -> baml.http.Request throws never {
-  baml.llm.build_request(TestClient, "CommentAfterArrow", map {  }) : baml.http.Request
+function user.CommentAfterArrow$build_request(client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "CommentAfterArrow", map {  }) : baml.http.Request
 }
-function user.CommentAfterArrow$build_request_stream() -> baml.http.Request throws never {
-  baml.llm.build_request_stream(TestClient, "CommentAfterArrow", map {  }) : baml.http.Request
+function user.CommentAfterArrow$build_request_stream(client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "CommentAfterArrow", map {  }) : baml.http.Request
 }
-function user.CommentAfterArrow$parse(json: string) -> string throws never {
+function user.CommentAfterArrow$parse(json: string, client: baml.llm.Client = TestClient) -> string throws never {
   baml.llm.parse<TFinal>("CommentAfterArrow", json) : string
 }
-function user.FunctionWithComments$stream(a: string, b: int) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(TestClient, "FunctionWithComments", map { "a": a, "b": b }) : baml.llm.Stream<null | string, string>
+function user.FunctionWithComments$stream(a: string, b: int, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "FunctionWithComments", map { "a": a, "b": b }) : baml.llm.Stream<null | string, string>
 }
-function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  TestClient.__make_stream(sse, "FunctionWithComments") : unknown
+function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "FunctionWithComments") : baml.llm.Stream<null | string, string>
 }
-function user.CommentAfterArrow$stream() -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(TestClient, "CommentAfterArrow", map {  }) : baml.llm.Stream<null | string, string>
+function user.CommentAfterArrow$stream(client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "CommentAfterArrow", map {  }) : baml.llm.Stream<null | string, string>
 }
-function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  TestClient.__make_stream(sse, "CommentAfterArrow") : unknown
+function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "CommentAfterArrow") : baml.llm.Stream<null | string, string>
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__06_codegen.snap
@@ -8,65 +8,128 @@ function $init() -> null {
     return
 }
 
-function user.CommentAfterArrow() -> string {
-    load_type string
+function user.CommentAfterArrow(client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_type string
+    load_var client
     load_const "CommentAfterArrow"
     alloc_map 0
     call baml.llm.call_llm_function
     return
 }
 
-function user.CommentAfterArrow$build_request() -> baml.http.Request {
+function user.CommentAfterArrow$build_request(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "CommentAfterArrow"
     alloc_map 0
     call baml.llm.build_request
     return
 }
 
-function user.CommentAfterArrow$build_request_stream() -> baml.http.Request {
+function user.CommentAfterArrow$build_request_stream(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "CommentAfterArrow"
     alloc_map 0
     call baml.llm.build_request_stream
     return
 }
 
-function user.CommentAfterArrow$parse(json: string) -> string {
+function user.CommentAfterArrow$parse(json: string, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
     load_const "CommentAfterArrow"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> {
-    load_var sse
+function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "CommentAfterArrow"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.CommentAfterArrow$render_prompt() -> baml.llm.PromptAst {
+function user.CommentAfterArrow$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "CommentAfterArrow"
     alloc_map 0
     call baml.llm.render_prompt
     return
 }
 
-function user.CommentAfterArrow$stream() -> baml.llm.Stream<null | string, string> {
+function user.CommentAfterArrow$stream(client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "CommentAfterArrow"
     alloc_map 0
     call baml.llm.stream_llm_function
     return
 }
 
-function user.FunctionWithComments(a: string, b: int) -> string {
-    load_type string
+function user.FunctionWithComments(a: string, b: int, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_type string
+    load_var client
     load_const "FunctionWithComments"
     load_var2 1 2
     load_const "a"
@@ -76,8 +139,16 @@ function user.FunctionWithComments(a: string, b: int) -> string {
     return
 }
 
-function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http.Request {
+function user.FunctionWithComments$build_request(a: string, b: int, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "FunctionWithComments"
     load_var2 1 2
     load_const "a"
@@ -87,8 +158,16 @@ function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http
     return
 }
 
-function user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request {
+function user.FunctionWithComments$build_request_stream(a: string, b: int, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "FunctionWithComments"
     load_var2 1 2
     load_const "a"
@@ -98,23 +177,46 @@ function user.FunctionWithComments$build_request_stream(a: string, b: int) -> ba
     return
 }
 
-function user.FunctionWithComments$parse(json: string) -> string {
+function user.FunctionWithComments$parse(json: string, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
     load_const "FunctionWithComments"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> {
-    load_var sse
+function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "FunctionWithComments"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.PromptAst {
+function user.FunctionWithComments$render_prompt(a: string, b: int, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "FunctionWithComments"
     load_var2 1 2
     load_const "a"
@@ -124,8 +226,16 @@ function user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.
     return
 }
 
-function user.FunctionWithComments$stream(a: string, b: int) -> baml.llm.Stream<null | string, string> {
+function user.FunctionWithComments$stream(a: string, b: int, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "FunctionWithComments"
     load_var2 1 2
     load_const "a"

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__03_hir.snap
@@ -2,20 +2,20 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === HIR2 ===
-function user.ExtractAny() -> baml.json.json  [llm] {
-  baml.llm.call_llm_function(TestClient, "ExtractAny", map {  })
+function user.ExtractAny(client: baml.llm.Client = TestClient) -> baml.json.json  [llm] {
+  baml.llm.call_llm_function(client, "ExtractAny", map {  })
 }
-function user.ExtractAny$build_request() -> baml.http.Request  [expr] {
-  baml.llm.build_request(TestClient, "ExtractAny", map {  })
+function user.ExtractAny$build_request(client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "ExtractAny", map {  })
 }
-function user.ExtractAny$build_request_stream() -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(TestClient, "ExtractAny", map {  })
+function user.ExtractAny$build_request_stream(client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "ExtractAny", map {  })
 }
-function user.ExtractAny$parse(json: string) -> baml.json.json  [expr] {
+function user.ExtractAny$parse(json: string, client: baml.llm.Client = TestClient) -> baml.json.json  [expr] {
   baml.llm.parse("ExtractAny", json)
 }
-function user.ExtractAny$render_prompt() -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(TestClient, "ExtractAny", map {  })
+function user.ExtractAny$render_prompt(client: baml.llm.Client = TestClient) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "ExtractAny", map {  })
 }
 function user.TestClient$new() -> ?  [expr] {
   baml.llm.PrimitiveClient { name: "TestClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4o-mini", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: "test-key", provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } }

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__04_5_mir.snap
@@ -2,78 +2,138 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.ExtractAny() -> baml.json.json {
+fn user.ExtractAny(client: baml.llm.Client) -> baml.json.json {
     // Locals:
     let _0: baml.json.json // _0 // return
-    let _1: map<string, unknown>
-    let _2: type
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: map<string, unknown>
+    let _4: type
 
     bb0: {
-        _1 = {  };
-        _2 = load_type(baml.json.json);
-        _0 = call const fn baml.llm.call_llm_function<copy _2>(const fn user.TestClient, const "ExtractAny", copy _1) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _1 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _3 = {  };
+        _4 = load_type(baml.json.json);
+        _0 = call const fn baml.llm.call_llm_function<copy _4>(copy _1, const "ExtractAny", copy _3) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ExtractAny$build_request() -> baml.http.Request {
+fn user.ExtractAny$build_request(client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
-    let _1: map<string, unknown>
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: map<string, unknown>
 
     bb0: {
-        _1 = {  };
-        _0 = call const fn baml.llm.build_request(const fn user.TestClient, const "ExtractAny", copy _1) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _1 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _3 = {  };
+        _0 = call const fn baml.llm.build_request(copy _1, const "ExtractAny", copy _3) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ExtractAny$build_request_stream() -> baml.http.Request {
+fn user.ExtractAny$build_request_stream(client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
-    let _1: map<string, unknown>
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: map<string, unknown>
 
     bb0: {
-        _1 = {  };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.TestClient, const "ExtractAny", copy _1) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _1 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _3 = {  };
+        _0 = call const fn baml.llm.build_request_stream(copy _1, const "ExtractAny", copy _3) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ExtractAny$parse(json: string) -> baml.json.json {
+fn user.ExtractAny$parse(json: string, client: baml.llm.Client) -> baml.json.json {
     // Locals:
     let _0: baml.json.json // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "ExtractAny", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "ExtractAny", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ExtractAny$render_prompt() -> baml.llm.PromptAst {
+fn user.ExtractAny$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
-    let _1: map<string, unknown>
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: map<string, unknown>
 
     bb0: {
-        _1 = {  };
-        _0 = call const fn baml.llm.render_prompt(const fn user.TestClient, const "ExtractAny", copy _1) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _1 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _3 = {  };
+        _0 = call const fn baml.llm.render_prompt(copy _1, const "ExtractAny", copy _3) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__04_tir.snap
@@ -5,24 +5,24 @@ source: crates/baml_tests/src/generated_tests.rs
 function user.TestClient$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "TestClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4o-mini", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: "test-key", provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : baml.llm.PrimitiveClient
 }
-function user.ExtractAny() -> baml.json.json throws never {
-  baml.llm.call_llm_function<T>(TestClient, "ExtractAny", map {  }) : baml.json.json
+function user.ExtractAny(client: baml.llm.Client = TestClient) -> baml.json.json throws never {
+  baml.llm.call_llm_function<T>(client, "ExtractAny", map {  }) : baml.json.json
 }
-function user.ExtractAny$render_prompt() -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(TestClient, "ExtractAny", map {  }) : baml.llm.PromptAst
+function user.ExtractAny$render_prompt(client: baml.llm.Client = TestClient) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "ExtractAny", map {  }) : baml.llm.PromptAst
 }
-function user.ExtractAny$build_request() -> baml.http.Request throws never {
-  baml.llm.build_request(TestClient, "ExtractAny", map {  }) : baml.http.Request
+function user.ExtractAny$build_request(client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "ExtractAny", map {  }) : baml.http.Request
 }
-function user.ExtractAny$build_request_stream() -> baml.http.Request throws never {
-  baml.llm.build_request_stream(TestClient, "ExtractAny", map {  }) : baml.http.Request
+function user.ExtractAny$build_request_stream(client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "ExtractAny", map {  }) : baml.http.Request
 }
-function user.ExtractAny$parse(json: string) -> baml.json.json throws never {
+function user.ExtractAny$parse(json: string, client: baml.llm.Client = TestClient) -> baml.json.json throws never {
   baml.llm.parse<TFinal>("ExtractAny", json) : baml.json.json
 }
-function user.ExtractAny$stream() -> baml.llm.Stream<null | baml.json.json$stream, baml.json.json> throws never {
-  baml.llm.stream_llm_function(TestClient, "ExtractAny", map {  }) : baml.llm.Stream<null | baml.json.json$stream, baml.json.json>
+function user.ExtractAny$stream(client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | baml.json.json$stream, baml.json.json> throws never {
+  baml.llm.stream_llm_function(client, "ExtractAny", map {  }) : baml.llm.Stream<null | baml.json.json$stream, baml.json.json>
 }
-function user.ExtractAny$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | baml.json.json$stream, baml.json.json> throws never {
-  TestClient.__make_stream(sse, "ExtractAny") : unknown
+function user.ExtractAny$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | baml.json.json$stream, baml.json.json> throws never {
+  client.__make_stream(sse, "ExtractAny") : baml.llm.Stream<null | baml.json.json$stream, baml.json.json>
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__06_codegen.snap
@@ -8,56 +8,111 @@ function $init() -> null {
     return
 }
 
-function user.ExtractAny() -> baml.json.json {
-    load_type baml.json.json
+function user.ExtractAny(client: baml.llm.Client) -> baml.json.json {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_type baml.json.json
+    load_var client
     load_const "ExtractAny"
     alloc_map 0
     call baml.llm.call_llm_function
     return
 }
 
-function user.ExtractAny$build_request() -> baml.http.Request {
+function user.ExtractAny$build_request(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "ExtractAny"
     alloc_map 0
     call baml.llm.build_request
     return
 }
 
-function user.ExtractAny$build_request_stream() -> baml.http.Request {
+function user.ExtractAny$build_request_stream(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "ExtractAny"
     alloc_map 0
     call baml.llm.build_request_stream
     return
 }
 
-function user.ExtractAny$parse(json: string) -> baml.json.json {
+function user.ExtractAny$parse(json: string, client: baml.llm.Client) -> baml.json.json {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
     load_const "ExtractAny"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.ExtractAny$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | baml.json.json$stream, baml.json.json> {
-    load_var sse
+function user.ExtractAny$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | baml.json.json$stream, baml.json.json> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "ExtractAny"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.ExtractAny$render_prompt() -> baml.llm.PromptAst {
+function user.ExtractAny$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "ExtractAny"
     alloc_map 0
     call baml.llm.render_prompt
     return
 }
 
-function user.ExtractAny$stream() -> baml.llm.Stream<null | baml.json.json$stream, baml.json.json> {
+function user.ExtractAny$stream(client: baml.llm.Client) -> baml.llm.Stream<null | baml.json.json$stream, baml.json.json> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "ExtractAny"
     alloc_map 0
     call baml.llm.stream_llm_function

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__03_hir.snap
@@ -1,52 +1,51 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 11667
 ---
 === HIR2 ===
-function user.GenerateImage(prompt: string) -> image  [llm] {
-  baml.llm.call_llm_function(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt })
+function user.GenerateImage(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> image  [llm] {
+  baml.llm.call_llm_function(client, "GenerateImage", map { "prompt": prompt })
 }
-function user.GenerateImage$build_request(prompt: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt })
+function user.GenerateImage$build_request(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "GenerateImage", map { "prompt": prompt })
 }
-function user.GenerateImage$build_request_stream(prompt: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt })
+function user.GenerateImage$build_request_stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "GenerateImage", map { "prompt": prompt })
 }
-function user.GenerateImage$parse(json: string) -> image  [expr] {
+function user.GenerateImage$parse(json: string, client: baml.llm.Client = OpenAIImageResponses) -> image  [expr] {
   baml.llm.parse("GenerateImage", json)
 }
-function user.GenerateImage$render_prompt(prompt: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt })
+function user.GenerateImage$render_prompt(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "GenerateImage", map { "prompt": prompt })
 }
-function user.GenerateImageSet(prompt: string) -> image[]  [llm] {
-  baml.llm.call_llm_function(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt })
+function user.GenerateImageSet(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> image[]  [llm] {
+  baml.llm.call_llm_function(client, "GenerateImageSet", map { "prompt": prompt })
 }
-function user.GenerateImageSet$build_request(prompt: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt })
+function user.GenerateImageSet$build_request(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "GenerateImageSet", map { "prompt": prompt })
 }
-function user.GenerateImageSet$build_request_stream(prompt: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt })
+function user.GenerateImageSet$build_request_stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "GenerateImageSet", map { "prompt": prompt })
 }
-function user.GenerateImageSet$parse(json: string) -> image[]  [expr] {
+function user.GenerateImageSet$parse(json: string, client: baml.llm.Client = OpenAIImageResponses) -> image[]  [expr] {
   baml.llm.parse("GenerateImageSet", json)
 }
-function user.GenerateImageSet$render_prompt(prompt: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt })
+function user.GenerateImageSet$render_prompt(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "GenerateImageSet", map { "prompt": prompt })
 }
-function user.GenerateMixedImageNarrative(prompt: string) -> image | string[]  [llm] {
-  baml.llm.call_llm_function(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt })
+function user.GenerateMixedImageNarrative(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> image | string[]  [llm] {
+  baml.llm.call_llm_function(client, "GenerateMixedImag...", map { "prompt": prompt })
 }
-function user.GenerateMixedImageNarrative$build_request(prompt: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt })
+function user.GenerateMixedImageNarrative$build_request(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "GenerateMixedImag...", map { "prompt": prompt })
 }
-function user.GenerateMixedImageNarrative$build_request_stream(prompt: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt })
+function user.GenerateMixedImageNarrative$build_request_stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "GenerateMixedImag...", map { "prompt": prompt })
 }
-function user.GenerateMixedImageNarrative$parse(json: string) -> image | string[]  [expr] {
+function user.GenerateMixedImageNarrative$parse(json: string, client: baml.llm.Client = OpenAIImageResponses) -> image | string[]  [expr] {
   baml.llm.parse("GenerateMixedImag...", json)
 }
-function user.GenerateMixedImageNarrative$render_prompt(prompt: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt })
+function user.GenerateMixedImageNarrative$render_prompt(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "GenerateMixedImag...", map { "prompt": prompt })
 }
 function user.OpenAIImageResponses$new() -> ?  [expr] {
   baml.llm.PrimitiveClient { name: "OpenAIImageResponses", provider: "openai-responses", options: baml.llm.PrimitiveClientOptions { model: "gpt-4.1", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: baml.env.get_or_panic("OPENAI_API_KEY"), provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map { "tools": [] } } }

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__04_5_mir.snap
@@ -2,242 +2,422 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.GenerateImage(prompt: string) -> image {
+fn user.GenerateImage(prompt: string, client: baml.llm.Client) -> image {
     // Locals:
     let _0: image // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
-    let _3: type
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
+    let _5: type
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _3 = load_type(image);
-        _0 = call const fn baml.llm.call_llm_function<copy _3>(const fn user.OpenAIImageResponses, const "GenerateImage", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _5 = load_type(image);
+        _0 = call const fn baml.llm.call_llm_function<copy _5>(copy _2, const "GenerateImage", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImage$build_request(prompt: string) -> baml.http.Request {
+fn user.GenerateImage$build_request(prompt: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.build_request(const fn user.OpenAIImageResponses, const "GenerateImage", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.build_request(copy _2, const "GenerateImage", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImage$build_request_stream(prompt: string) -> baml.http.Request {
+fn user.GenerateImage$build_request_stream(prompt: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.OpenAIImageResponses, const "GenerateImage", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(copy _2, const "GenerateImage", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImage$parse(json: string) -> image {
+fn user.GenerateImage$parse(json: string, client: baml.llm.Client) -> image {
     // Locals:
     let _0: image // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "GenerateImage", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "GenerateImage", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImage$render_prompt(prompt: string) -> baml.llm.PromptAst {
+fn user.GenerateImage$render_prompt(prompt: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.OpenAIImageResponses, const "GenerateImage", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.render_prompt(copy _2, const "GenerateImage", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImageSet(prompt: string) -> image[] {
+fn user.GenerateImageSet(prompt: string, client: baml.llm.Client) -> image[] {
     // Locals:
     let _0: image[] // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
-    let _3: type
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
+    let _5: type
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _3 = load_type(image[]);
-        _0 = call const fn baml.llm.call_llm_function<copy _3>(const fn user.OpenAIImageResponses, const "GenerateImageSet", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _5 = load_type(image[]);
+        _0 = call const fn baml.llm.call_llm_function<copy _5>(copy _2, const "GenerateImageSet", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImageSet$build_request(prompt: string) -> baml.http.Request {
+fn user.GenerateImageSet$build_request(prompt: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.build_request(const fn user.OpenAIImageResponses, const "GenerateImageSet", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.build_request(copy _2, const "GenerateImageSet", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImageSet$build_request_stream(prompt: string) -> baml.http.Request {
+fn user.GenerateImageSet$build_request_stream(prompt: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.OpenAIImageResponses, const "GenerateImageSet", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(copy _2, const "GenerateImageSet", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImageSet$parse(json: string) -> image[] {
+fn user.GenerateImageSet$parse(json: string, client: baml.llm.Client) -> image[] {
     // Locals:
     let _0: image[] // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "GenerateImageSet", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "GenerateImageSet", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateImageSet$render_prompt(prompt: string) -> baml.llm.PromptAst {
+fn user.GenerateImageSet$render_prompt(prompt: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.OpenAIImageResponses, const "GenerateImageSet", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.render_prompt(copy _2, const "GenerateImageSet", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateMixedImageNarrative(prompt: string) -> (image | string)[] {
+fn user.GenerateMixedImageNarrative(prompt: string, client: baml.llm.Client) -> (image | string)[] {
     // Locals:
     let _0: (image | string)[] // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
-    let _3: type
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
+    let _5: type
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _3 = load_type(image | string[]);
-        _0 = call const fn baml.llm.call_llm_function<copy _3>(const fn user.OpenAIImageResponses, const "GenerateMixedImageNarrative", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _5 = load_type(image | string[]);
+        _0 = call const fn baml.llm.call_llm_function<copy _5>(copy _2, const "GenerateMixedImageNarrative", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateMixedImageNarrative$build_request(prompt: string) -> baml.http.Request {
+fn user.GenerateMixedImageNarrative$build_request(prompt: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.build_request(const fn user.OpenAIImageResponses, const "GenerateMixedImageNarrative", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.build_request(copy _2, const "GenerateMixedImageNarrative", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateMixedImageNarrative$build_request_stream(prompt: string) -> baml.http.Request {
+fn user.GenerateMixedImageNarrative$build_request_stream(prompt: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.OpenAIImageResponses, const "GenerateMixedImageNarrative", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(copy _2, const "GenerateMixedImageNarrative", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateMixedImageNarrative$parse(json: string) -> (image | string)[] {
+fn user.GenerateMixedImageNarrative$parse(json: string, client: baml.llm.Client) -> (image | string)[] {
     // Locals:
     let _0: (image | string)[] // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "GenerateMixedImageNarrative", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "GenerateMixedImageNarrative", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateMixedImageNarrative$render_prompt(prompt: string) -> baml.llm.PromptAst {
+fn user.GenerateMixedImageNarrative$render_prompt(prompt: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // prompt // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "prompt": copy _1 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.OpenAIImageResponses, const "GenerateMixedImageNarrative", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.OpenAIImageResponses;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "prompt": copy _1 };
+        _0 = call const fn baml.llm.render_prompt(copy _2, const "GenerateMixedImageNarrative", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__04_tir.snap
@@ -5,66 +5,66 @@ source: crates/baml_tests/src/generated_tests.rs
 function user.OpenAIImageResponses$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "OpenAIImageResponses", provider: "openai-responses", options: baml.llm.PrimitiveClientOptions { model: "gpt-4.1", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: baml.env.get_or_panic("OPENAI_API_KEY"), provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map { "tools": [] } } } : baml.llm.PrimitiveClient
 }
-function user.GenerateImage(prompt: string) -> image throws never {
-  baml.llm.call_llm_function<T>(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt }) : image
+function user.GenerateImage(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> image throws never {
+  baml.llm.call_llm_function<T>(client, "GenerateImage", map { "prompt": prompt }) : image
 }
-function user.GenerateImage$render_prompt(prompt: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt }) : baml.llm.PromptAst
+function user.GenerateImage$render_prompt(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GenerateImage", map { "prompt": prompt }) : baml.llm.PromptAst
 }
-function user.GenerateImage$build_request(prompt: string) -> baml.http.Request throws never {
-  baml.llm.build_request(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt }) : baml.http.Request
+function user.GenerateImage$build_request(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GenerateImage", map { "prompt": prompt }) : baml.http.Request
 }
-function user.GenerateImage$build_request_stream(prompt: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt }) : baml.http.Request
+function user.GenerateImage$build_request_stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GenerateImage", map { "prompt": prompt }) : baml.http.Request
 }
-function user.GenerateImage$parse(json: string) -> image throws never {
+function user.GenerateImage$parse(json: string, client: baml.llm.Client = OpenAIImageResponses) -> image throws never {
   baml.llm.parse<TFinal>("GenerateImage", json) : image
 }
-function user.GenerateImageSet(prompt: string) -> image[] throws never {
-  baml.llm.call_llm_function<T>(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt }) : image[]
+function user.GenerateImageSet(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> image[] throws never {
+  baml.llm.call_llm_function<T>(client, "GenerateImageSet", map { "prompt": prompt }) : image[]
 }
-function user.GenerateImageSet$render_prompt(prompt: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt }) : baml.llm.PromptAst
+function user.GenerateImageSet$render_prompt(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GenerateImageSet", map { "prompt": prompt }) : baml.llm.PromptAst
 }
-function user.GenerateImageSet$build_request(prompt: string) -> baml.http.Request throws never {
-  baml.llm.build_request(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt }) : baml.http.Request
+function user.GenerateImageSet$build_request(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GenerateImageSet", map { "prompt": prompt }) : baml.http.Request
 }
-function user.GenerateImageSet$build_request_stream(prompt: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt }) : baml.http.Request
+function user.GenerateImageSet$build_request_stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GenerateImageSet", map { "prompt": prompt }) : baml.http.Request
 }
-function user.GenerateImageSet$parse(json: string) -> image[] throws never {
+function user.GenerateImageSet$parse(json: string, client: baml.llm.Client = OpenAIImageResponses) -> image[] throws never {
   baml.llm.parse<TFinal>("GenerateImageSet", json) : image[]
 }
-function user.GenerateMixedImageNarrative(prompt: string) -> (image | string)[] throws never {
-  baml.llm.call_llm_function<T>(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt }) : (image | string)[]
+function user.GenerateMixedImageNarrative(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> (image | string)[] throws never {
+  baml.llm.call_llm_function<T>(client, "GenerateMixedImag...", map { "prompt": prompt }) : (image | string)[]
 }
-function user.GenerateMixedImageNarrative$render_prompt(prompt: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt }) : baml.llm.PromptAst
+function user.GenerateMixedImageNarrative$render_prompt(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GenerateMixedImag...", map { "prompt": prompt }) : baml.llm.PromptAst
 }
-function user.GenerateMixedImageNarrative$build_request(prompt: string) -> baml.http.Request throws never {
-  baml.llm.build_request(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt }) : baml.http.Request
+function user.GenerateMixedImageNarrative$build_request(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GenerateMixedImag...", map { "prompt": prompt }) : baml.http.Request
 }
-function user.GenerateMixedImageNarrative$build_request_stream(prompt: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt }) : baml.http.Request
+function user.GenerateMixedImageNarrative$build_request_stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GenerateMixedImag...", map { "prompt": prompt }) : baml.http.Request
 }
-function user.GenerateMixedImageNarrative$parse(json: string) -> (image | string)[] throws never {
+function user.GenerateMixedImageNarrative$parse(json: string, client: baml.llm.Client = OpenAIImageResponses) -> (image | string)[] throws never {
   baml.llm.parse<TFinal>("GenerateMixedImag...", json) : (image | string)[]
 }
-function user.GenerateImage$stream(prompt: string) -> baml.llm.Stream<image, image> throws never {
-  baml.llm.stream_llm_function(OpenAIImageResponses, "GenerateImage", map { "prompt": prompt }) : baml.llm.Stream<image, image>
+function user.GenerateImage$stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.Stream<image, image> throws never {
+  baml.llm.stream_llm_function(client, "GenerateImage", map { "prompt": prompt }) : baml.llm.Stream<image, image>
 }
-function user.GenerateImage$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<image, image> throws never {
-  OpenAIImageResponses.__make_stream(sse, "GenerateImage") : unknown
+function user.GenerateImage$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.Stream<image, image> throws never {
+  client.__make_stream(sse, "GenerateImage") : baml.llm.Stream<image, image>
 }
-function user.GenerateImageSet$stream(prompt: string) -> baml.llm.Stream<image[], image[]> throws never {
-  baml.llm.stream_llm_function(OpenAIImageResponses, "GenerateImageSet", map { "prompt": prompt }) : baml.llm.Stream<image[], image[]>
+function user.GenerateImageSet$stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.Stream<image[], image[]> throws never {
+  baml.llm.stream_llm_function(client, "GenerateImageSet", map { "prompt": prompt }) : baml.llm.Stream<image[], image[]>
 }
-function user.GenerateImageSet$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<image[], image[]> throws never {
-  OpenAIImageResponses.__make_stream(sse, "GenerateImageSet") : unknown
+function user.GenerateImageSet$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.Stream<image[], image[]> throws never {
+  client.__make_stream(sse, "GenerateImageSet") : baml.llm.Stream<image[], image[]>
 }
-function user.GenerateMixedImageNarrative$stream(prompt: string) -> baml.llm.Stream<(image | string)[], (image | string)[]> throws never {
-  baml.llm.stream_llm_function(OpenAIImageResponses, "GenerateMixedImag...", map { "prompt": prompt }) : baml.llm.Stream<(image | string)[], (image | string)[]>
+function user.GenerateMixedImageNarrative$stream(prompt: string, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.Stream<(image | string)[], (image | string)[]> throws never {
+  baml.llm.stream_llm_function(client, "GenerateMixedImag...", map { "prompt": prompt }) : baml.llm.Stream<(image | string)[], (image | string)[]>
 }
-function user.GenerateMixedImageNarrative$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<(image | string)[], (image | string)[]> throws never {
-  OpenAIImageResponses.__make_stream(sse, "GenerateMixedImag...") : unknown
+function user.GenerateMixedImageNarrative$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = OpenAIImageResponses) -> baml.llm.Stream<(image | string)[], (image | string)[]> throws never {
+  client.__make_stream(sse, "GenerateMixedImag...") : baml.llm.Stream<(image | string)[], (image | string)[]>
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__06_codegen.snap
@@ -8,9 +8,17 @@ function $init() -> null {
     return
 }
 
-function user.GenerateImage(prompt: string) -> image {
+function user.GenerateImage(prompt: string, client: baml.llm.Client) -> image {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
     load_type image
-    load_global user.OpenAIImageResponses
+    load_var client
     load_const "GenerateImage"
     load_var prompt
     load_const "prompt"
@@ -19,8 +27,16 @@ function user.GenerateImage(prompt: string) -> image {
     return
 }
 
-function user.GenerateImage$build_request(prompt: string) -> baml.http.Request {
+function user.GenerateImage$build_request(prompt: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateImage"
     load_var prompt
     load_const "prompt"
@@ -29,8 +45,16 @@ function user.GenerateImage$build_request(prompt: string) -> baml.http.Request {
     return
 }
 
-function user.GenerateImage$build_request_stream(prompt: string) -> baml.http.Request {
+function user.GenerateImage$build_request_stream(prompt: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateImage"
     load_var prompt
     load_const "prompt"
@@ -39,23 +63,46 @@ function user.GenerateImage$build_request_stream(prompt: string) -> baml.http.Re
     return
 }
 
-function user.GenerateImage$parse(json: string) -> image {
+function user.GenerateImage$parse(json: string, client: baml.llm.Client) -> image {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
     load_const "GenerateImage"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.GenerateImage$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<image, image> {
-    load_var sse
+function user.GenerateImage$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<image, image> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "GenerateImage"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.GenerateImage$render_prompt(prompt: string) -> baml.llm.PromptAst {
+function user.GenerateImage$render_prompt(prompt: string, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateImage"
     load_var prompt
     load_const "prompt"
@@ -64,8 +111,16 @@ function user.GenerateImage$render_prompt(prompt: string) -> baml.llm.PromptAst 
     return
 }
 
-function user.GenerateImage$stream(prompt: string) -> baml.llm.Stream<image, image> {
+function user.GenerateImage$stream(prompt: string, client: baml.llm.Client) -> baml.llm.Stream<image, image> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateImage"
     load_var prompt
     load_const "prompt"
@@ -74,9 +129,17 @@ function user.GenerateImage$stream(prompt: string) -> baml.llm.Stream<image, ima
     return
 }
 
-function user.GenerateImageSet(prompt: string) -> image[] {
+function user.GenerateImageSet(prompt: string, client: baml.llm.Client) -> image[] {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
     load_type image[]
-    load_global user.OpenAIImageResponses
+    load_var client
     load_const "GenerateImageSet"
     load_var prompt
     load_const "prompt"
@@ -85,8 +148,16 @@ function user.GenerateImageSet(prompt: string) -> image[] {
     return
 }
 
-function user.GenerateImageSet$build_request(prompt: string) -> baml.http.Request {
+function user.GenerateImageSet$build_request(prompt: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateImageSet"
     load_var prompt
     load_const "prompt"
@@ -95,8 +166,16 @@ function user.GenerateImageSet$build_request(prompt: string) -> baml.http.Reques
     return
 }
 
-function user.GenerateImageSet$build_request_stream(prompt: string) -> baml.http.Request {
+function user.GenerateImageSet$build_request_stream(prompt: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateImageSet"
     load_var prompt
     load_const "prompt"
@@ -105,23 +184,46 @@ function user.GenerateImageSet$build_request_stream(prompt: string) -> baml.http
     return
 }
 
-function user.GenerateImageSet$parse(json: string) -> image[] {
+function user.GenerateImageSet$parse(json: string, client: baml.llm.Client) -> image[] {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
     load_const "GenerateImageSet"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.GenerateImageSet$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<image[], image[]> {
-    load_var sse
+function user.GenerateImageSet$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<image[], image[]> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "GenerateImageSet"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.GenerateImageSet$render_prompt(prompt: string) -> baml.llm.PromptAst {
+function user.GenerateImageSet$render_prompt(prompt: string, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateImageSet"
     load_var prompt
     load_const "prompt"
@@ -130,8 +232,16 @@ function user.GenerateImageSet$render_prompt(prompt: string) -> baml.llm.PromptA
     return
 }
 
-function user.GenerateImageSet$stream(prompt: string) -> baml.llm.Stream<image[], image[]> {
+function user.GenerateImageSet$stream(prompt: string, client: baml.llm.Client) -> baml.llm.Stream<image[], image[]> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateImageSet"
     load_var prompt
     load_const "prompt"
@@ -140,9 +250,17 @@ function user.GenerateImageSet$stream(prompt: string) -> baml.llm.Stream<image[]
     return
 }
 
-function user.GenerateMixedImageNarrative(prompt: string) -> (image | string)[] {
-    load_type image | string[]
+function user.GenerateMixedImageNarrative(prompt: string, client: baml.llm.Client) -> (image | string)[] {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_type image | string[]
+    load_var client
     load_const "GenerateMixedImageNarrative"
     load_var prompt
     load_const "prompt"
@@ -151,8 +269,16 @@ function user.GenerateMixedImageNarrative(prompt: string) -> (image | string)[] 
     return
 }
 
-function user.GenerateMixedImageNarrative$build_request(prompt: string) -> baml.http.Request {
+function user.GenerateMixedImageNarrative$build_request(prompt: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateMixedImageNarrative"
     load_var prompt
     load_const "prompt"
@@ -161,8 +287,16 @@ function user.GenerateMixedImageNarrative$build_request(prompt: string) -> baml.
     return
 }
 
-function user.GenerateMixedImageNarrative$build_request_stream(prompt: string) -> baml.http.Request {
+function user.GenerateMixedImageNarrative$build_request_stream(prompt: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateMixedImageNarrative"
     load_var prompt
     load_const "prompt"
@@ -171,23 +305,46 @@ function user.GenerateMixedImageNarrative$build_request_stream(prompt: string) -
     return
 }
 
-function user.GenerateMixedImageNarrative$parse(json: string) -> (image | string)[] {
+function user.GenerateMixedImageNarrative$parse(json: string, client: baml.llm.Client) -> (image | string)[] {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
     load_const "GenerateMixedImageNarrative"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.GenerateMixedImageNarrative$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<(image | string)[], (image | string)[]> {
-    load_var sse
+function user.GenerateMixedImageNarrative$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<(image | string)[], (image | string)[]> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "GenerateMixedImageNarrative"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.GenerateMixedImageNarrative$render_prompt(prompt: string) -> baml.llm.PromptAst {
+function user.GenerateMixedImageNarrative$render_prompt(prompt: string, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateMixedImageNarrative"
     load_var prompt
     load_const "prompt"
@@ -196,8 +353,16 @@ function user.GenerateMixedImageNarrative$render_prompt(prompt: string) -> baml.
     return
 }
 
-function user.GenerateMixedImageNarrative$stream(prompt: string) -> baml.llm.Stream<(image | string)[], (image | string)[]> {
+function user.GenerateMixedImageNarrative$stream(prompt: string, client: baml.llm.Client) -> baml.llm.Stream<(image | string)[], (image | string)[]> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.OpenAIImageResponses
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateMixedImageNarrative"
     load_var prompt
     load_const "prompt"

--- a/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__03_hir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 18316
 ---
 === HIR2 ===
 class user.SearchService {
@@ -8,20 +7,20 @@ class user.SearchService {
 }
 type user.NarrowSearcher = (query: string, filter?: string?) -> string[]
 type user.Searcher = (query: string, max_results?: int) -> int
-function user.AskDocs(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> string  [llm] {
-  baml.llm.call_llm_function(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter })
+function user.AskDocs(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> string  [llm] {
+  baml.llm.call_llm_function(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter })
 }
-function user.AskDocs$build_request(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> baml.http.Request  [expr] {
-  baml.llm.build_request(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter })
+function user.AskDocs$build_request(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter })
 }
-function user.AskDocs$build_request_stream(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter })
+function user.AskDocs$build_request_stream(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter })
 }
-function user.AskDocs$parse(json: string) -> string  [expr] {
+function user.AskDocs$parse(json: string, client: baml.llm.Client = TestClient) -> string  [expr] {
   baml.llm.parse("AskDocs", json)
 }
-function user.AskDocs$render_prompt(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter })
+function user.AskDocs$render_prompt(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter })
 }
 function user.DefaultFilter() -> string  [expr] {
   {  } "none"

--- a/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__04_5_mir.snap
@@ -2,20 +2,22 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.AskDocs(query: string, max_results: int, filter: string) -> string {
+fn user.AskDocs(query: string, max_results: int, filter: string, client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // query // param
     let _2: int // max_results // param
     let _3: string // filter // param
-    let _4: bool
+    let _4: baml.llm.Client // client // param
     let _5: bool
-    let _6: map<string, unknown>
-    let _7: type
+    let _6: bool
+    let _7: bool
+    let _8: map<string, unknown>
+    let _9: type
 
     bb0: {
-        _4 = copy _2 == const <omitted>;
-        branch copy _4 -> [bb1, bb2];
+        _5 = copy _2 == const <omitted>;
+        branch copy _5 -> [bb1, bb2];
     }
 
     bb1: {
@@ -24,8 +26,8 @@ fn user.AskDocs(query: string, max_results: int, filter: string) -> string {
     }
 
     bb2: {
-        _5 = copy _3 == const <omitted>;
-        branch copy _5 -> [bb3, bb4];
+        _6 = copy _3 == const <omitted>;
+        branch copy _6 -> [bb3, bb4];
     }
 
     bb3: {
@@ -33,29 +35,41 @@ fn user.AskDocs(query: string, max_results: int, filter: string) -> string {
     }
 
     bb4: {
-        _6 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 };
-        _7 = load_type(string);
-        _0 = call const fn baml.llm.call_llm_function<copy _7>(const fn user.TestClient, const "AskDocs", copy _6) -> [bb5];
+        _7 = copy _4 == const <omitted>;
+        branch copy _7 -> [bb5, bb6];
     }
 
     bb5: {
+        _4 = const fn user.TestClient;
+        goto -> bb6;
+    }
+
+    bb6: {
+        _8 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 };
+        _9 = load_type(string);
+        _0 = call const fn baml.llm.call_llm_function<copy _9>(copy _4, const "AskDocs", copy _8) -> [bb7];
+    }
+
+    bb7: {
         return;
     }
 }
 
-fn user.AskDocs$build_request(query: string, max_results: int, filter: string) -> baml.http.Request {
+fn user.AskDocs$build_request(query: string, max_results: int, filter: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // query // param
     let _2: int // max_results // param
     let _3: string // filter // param
-    let _4: bool
+    let _4: baml.llm.Client // client // param
     let _5: bool
-    let _6: map<string, unknown>
+    let _6: bool
+    let _7: bool
+    let _8: map<string, unknown>
 
     bb0: {
-        _4 = copy _2 == const <omitted>;
-        branch copy _4 -> [bb1, bb2];
+        _5 = copy _2 == const <omitted>;
+        branch copy _5 -> [bb1, bb2];
     }
 
     bb1: {
@@ -64,8 +78,8 @@ fn user.AskDocs$build_request(query: string, max_results: int, filter: string) -
     }
 
     bb2: {
-        _5 = copy _3 == const <omitted>;
-        branch copy _5 -> [bb3, bb4];
+        _6 = copy _3 == const <omitted>;
+        branch copy _6 -> [bb3, bb4];
     }
 
     bb3: {
@@ -73,28 +87,40 @@ fn user.AskDocs$build_request(query: string, max_results: int, filter: string) -
     }
 
     bb4: {
-        _6 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 };
-        _0 = call const fn baml.llm.build_request(const fn user.TestClient, const "AskDocs", copy _6) -> [bb5];
+        _7 = copy _4 == const <omitted>;
+        branch copy _7 -> [bb5, bb6];
     }
 
     bb5: {
+        _4 = const fn user.TestClient;
+        goto -> bb6;
+    }
+
+    bb6: {
+        _8 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 };
+        _0 = call const fn baml.llm.build_request(copy _4, const "AskDocs", copy _8) -> [bb7];
+    }
+
+    bb7: {
         return;
     }
 }
 
-fn user.AskDocs$build_request_stream(query: string, max_results: int, filter: string) -> baml.http.Request {
+fn user.AskDocs$build_request_stream(query: string, max_results: int, filter: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // query // param
     let _2: int // max_results // param
     let _3: string // filter // param
-    let _4: bool
+    let _4: baml.llm.Client // client // param
     let _5: bool
-    let _6: map<string, unknown>
+    let _6: bool
+    let _7: bool
+    let _8: map<string, unknown>
 
     bb0: {
-        _4 = copy _2 == const <omitted>;
-        branch copy _4 -> [bb1, bb2];
+        _5 = copy _2 == const <omitted>;
+        branch copy _5 -> [bb1, bb2];
     }
 
     bb1: {
@@ -103,8 +129,8 @@ fn user.AskDocs$build_request_stream(query: string, max_results: int, filter: st
     }
 
     bb2: {
-        _5 = copy _3 == const <omitted>;
-        branch copy _5 -> [bb3, bb4];
+        _6 = copy _3 == const <omitted>;
+        branch copy _6 -> [bb3, bb4];
     }
 
     bb3: {
@@ -112,42 +138,66 @@ fn user.AskDocs$build_request_stream(query: string, max_results: int, filter: st
     }
 
     bb4: {
-        _6 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.TestClient, const "AskDocs", copy _6) -> [bb5];
+        _7 = copy _4 == const <omitted>;
+        branch copy _7 -> [bb5, bb6];
     }
 
     bb5: {
+        _4 = const fn user.TestClient;
+        goto -> bb6;
+    }
+
+    bb6: {
+        _8 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 };
+        _0 = call const fn baml.llm.build_request_stream(copy _4, const "AskDocs", copy _8) -> [bb7];
+    }
+
+    bb7: {
         return;
     }
 }
 
-fn user.AskDocs$parse(json: string) -> string {
+fn user.AskDocs$parse(json: string, client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "AskDocs", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "AskDocs", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.AskDocs$render_prompt(query: string, max_results: int, filter: string) -> baml.llm.PromptAst {
+fn user.AskDocs$render_prompt(query: string, max_results: int, filter: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // query // param
     let _2: int // max_results // param
     let _3: string // filter // param
-    let _4: bool
+    let _4: baml.llm.Client // client // param
     let _5: bool
-    let _6: map<string, unknown>
+    let _6: bool
+    let _7: bool
+    let _8: map<string, unknown>
 
     bb0: {
-        _4 = copy _2 == const <omitted>;
-        branch copy _4 -> [bb1, bb2];
+        _5 = copy _2 == const <omitted>;
+        branch copy _5 -> [bb1, bb2];
     }
 
     bb1: {
@@ -156,8 +206,8 @@ fn user.AskDocs$render_prompt(query: string, max_results: int, filter: string) -
     }
 
     bb2: {
-        _5 = copy _3 == const <omitted>;
-        branch copy _5 -> [bb3, bb4];
+        _6 = copy _3 == const <omitted>;
+        branch copy _6 -> [bb3, bb4];
     }
 
     bb3: {
@@ -165,11 +215,21 @@ fn user.AskDocs$render_prompt(query: string, max_results: int, filter: string) -
     }
 
     bb4: {
-        _6 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.TestClient, const "AskDocs", copy _6) -> [bb5];
+        _7 = copy _4 == const <omitted>;
+        branch copy _7 -> [bb5, bb6];
     }
 
     bb5: {
+        _4 = const fn user.TestClient;
+        goto -> bb6;
+    }
+
+    bb6: {
+        _8 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 };
+        _0 = call const fn baml.llm.render_prompt(copy _4, const "AskDocs", copy _8) -> [bb7];
+    }
+
+    bb7: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__04_tir.snap
@@ -55,19 +55,19 @@ function user.HostEntry(query: string, max_results: int = 10, filter: string? = 
       }
   }
 }
-function user.AskDocs(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> string throws never {
-  baml.llm.call_llm_function<T>(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : string
+function user.AskDocs(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : string
 }
-function user.AskDocs$render_prompt(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : baml.llm.PromptAst
+function user.AskDocs$render_prompt(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : baml.llm.PromptAst
 }
-function user.AskDocs$build_request(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> baml.http.Request throws never {
-  baml.llm.build_request(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : baml.http.Request
+function user.AskDocs$build_request(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : baml.http.Request
 }
-function user.AskDocs$build_request_stream(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : baml.http.Request
+function user.AskDocs$build_request_stream(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : baml.http.Request
 }
-function user.AskDocs$parse(json: string) -> string throws never {
+function user.AskDocs$parse(json: string, client: baml.llm.Client = TestClient) -> string throws never {
   baml.llm.parse<TFinal>("AskDocs", json) : string
 }
 class user.SearchService {
@@ -91,11 +91,11 @@ function user.SearchService.from_json(j: baml.json.json) -> user.SearchService t
 }
 type user.Searcher$stream = unknown
 type user.NarrowSearcher$stream = unknown
-function user.AskDocs$stream(query: string, max_results: int = 10, filter: string = DefaultFilter()) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(TestClient, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : baml.llm.Stream<null | string, string>
+function user.AskDocs$stream(query: string, max_results: int = 10, filter: string = DefaultFilter(), client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "AskDocs", map { "query": query, "max_results": max_results, "filter": filter }) : baml.llm.Stream<null | string, string>
 }
-function user.AskDocs$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  TestClient.__make_stream(sse, "AskDocs") : unknown
+function user.AskDocs$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "AskDocs") : baml.llm.Stream<null | string, string>
 }
 class user.SearchService$stream {
   base: null | string

--- a/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__06_codegen.snap
@@ -8,7 +8,7 @@ function $init() -> null {
     return
 }
 
-function user.AskDocs(query: string, max_results: int, filter: string) -> string {
+function user.AskDocs(query: string, max_results: int, filter: string, client: baml.llm.Client) -> string {
     load_var max_results
     load_const <omitted>
     cmp_op ==
@@ -25,8 +25,16 @@ function user.AskDocs(query: string, max_results: int, filter: string) -> string
     store_var filter
 
   L1:
-    load_type string
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L2
     load_global user.TestClient
+    store_var client
+
+  L2:
+    load_type string
+    load_var client
     load_const "AskDocs"
     load_var2 1 2
     load_var filter
@@ -38,7 +46,7 @@ function user.AskDocs(query: string, max_results: int, filter: string) -> string
     return
 }
 
-function user.AskDocs$build_request(query: string, max_results: int, filter: string) -> baml.http.Request {
+function user.AskDocs$build_request(query: string, max_results: int, filter: string, client: baml.llm.Client) -> baml.http.Request {
     load_var max_results
     load_const <omitted>
     cmp_op ==
@@ -55,7 +63,15 @@ function user.AskDocs$build_request(query: string, max_results: int, filter: str
     store_var filter
 
   L1:
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L2
     load_global user.TestClient
+    store_var client
+
+  L2:
+    load_var client
     load_const "AskDocs"
     load_var2 1 2
     load_var filter
@@ -67,7 +83,7 @@ function user.AskDocs$build_request(query: string, max_results: int, filter: str
     return
 }
 
-function user.AskDocs$build_request_stream(query: string, max_results: int, filter: string) -> baml.http.Request {
+function user.AskDocs$build_request_stream(query: string, max_results: int, filter: string, client: baml.llm.Client) -> baml.http.Request {
     load_var max_results
     load_const <omitted>
     cmp_op ==
@@ -84,7 +100,15 @@ function user.AskDocs$build_request_stream(query: string, max_results: int, filt
     store_var filter
 
   L1:
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L2
     load_global user.TestClient
+    store_var client
+
+  L2:
+    load_var client
     load_const "AskDocs"
     load_var2 1 2
     load_var filter
@@ -96,22 +120,37 @@ function user.AskDocs$build_request_stream(query: string, max_results: int, filt
     return
 }
 
-function user.AskDocs$parse(json: string) -> string {
+function user.AskDocs$parse(json: string, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
     load_const "AskDocs"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.AskDocs$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> {
-    load_var sse
+function user.AskDocs$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "AskDocs"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.AskDocs$render_prompt(query: string, max_results: int, filter: string) -> baml.llm.PromptAst {
+function user.AskDocs$render_prompt(query: string, max_results: int, filter: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     load_var max_results
     load_const <omitted>
     cmp_op ==
@@ -128,7 +167,15 @@ function user.AskDocs$render_prompt(query: string, max_results: int, filter: str
     store_var filter
 
   L1:
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L2
     load_global user.TestClient
+    store_var client
+
+  L2:
+    load_var client
     load_const "AskDocs"
     load_var2 1 2
     load_var filter
@@ -140,7 +187,7 @@ function user.AskDocs$render_prompt(query: string, max_results: int, filter: str
     return
 }
 
-function user.AskDocs$stream(query: string, max_results: int, filter: string) -> baml.llm.Stream<null | string, string> {
+function user.AskDocs$stream(query: string, max_results: int, filter: string, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
     load_var max_results
     load_const <omitted>
     cmp_op ==
@@ -157,7 +204,15 @@ function user.AskDocs$stream(query: string, max_results: int, filter: string) ->
     store_var filter
 
   L1:
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L2
     load_global user.TestClient
+    store_var client
+
+  L2:
+    load_var client
     load_const "AskDocs"
     load_var2 1 2
     load_var filter

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__03_hir.snap
@@ -5,20 +5,20 @@ source: crates/baml_tests/src/generated_tests.rs
 function user.TestClient$new() -> ?  [expr] {
   baml.llm.PrimitiveClient { name: "TestClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4o-mini", base_url: "http://localhost:...", allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: "test-key", provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } }
 }
-function user.TestFunc(input: string) -> string  [llm] {
-  baml.llm.call_llm_function(TestClient, "TestFunc", map { "input": input })
+function user.TestFunc(input: string, client: baml.llm.Client = TestClient) -> string  [llm] {
+  baml.llm.call_llm_function(client, "TestFunc", map { "input": input })
 }
-function user.TestFunc$build_request(input: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(TestClient, "TestFunc", map { "input": input })
+function user.TestFunc$build_request(input: string, client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "TestFunc", map { "input": input })
 }
-function user.TestFunc$build_request_stream(input: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(TestClient, "TestFunc", map { "input": input })
+function user.TestFunc$build_request_stream(input: string, client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "TestFunc", map { "input": input })
 }
-function user.TestFunc$parse(json: string) -> string  [expr] {
+function user.TestFunc$parse(json: string, client: baml.llm.Client = TestClient) -> string  [expr] {
   baml.llm.parse("TestFunc", json)
 }
-function user.TestFunc$render_prompt(input: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(TestClient, "TestFunc", map { "input": input })
+function user.TestFunc$render_prompt(input: string, client: baml.llm.Client = TestClient) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "TestFunc", map { "input": input })
 }
 function user.call_stream_inferred() -> baml.llm.Stream  [expr] {
   {  } baml.llm.stream_llm_function(TestClient, "TestFunc", map { "input": "world" })

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__04_5_mir.snap
@@ -24,82 +24,142 @@ fn user.TestClient$new() -> null {
     }
 }
 
-fn user.TestFunc(input: string) -> string {
+fn user.TestFunc(input: string, client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // input // param
-    let _2: map<string, unknown>
-    let _3: type
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
+    let _5: type
 
     bb0: {
-        _2 = { const "input": copy _1 };
-        _3 = load_type(string);
-        _0 = call const fn baml.llm.call_llm_function<copy _3>(const fn user.TestClient, const "TestFunc", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "input": copy _1 };
+        _5 = load_type(string);
+        _0 = call const fn baml.llm.call_llm_function<copy _5>(copy _2, const "TestFunc", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.TestFunc$build_request(input: string) -> baml.http.Request {
+fn user.TestFunc$build_request(input: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // input // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "input": copy _1 };
-        _0 = call const fn baml.llm.build_request(const fn user.TestClient, const "TestFunc", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "input": copy _1 };
+        _0 = call const fn baml.llm.build_request(copy _2, const "TestFunc", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.TestFunc$build_request_stream(input: string) -> baml.http.Request {
+fn user.TestFunc$build_request_stream(input: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // input // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "input": copy _1 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.TestClient, const "TestFunc", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "input": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(copy _2, const "TestFunc", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.TestFunc$parse(json: string) -> string {
+fn user.TestFunc$parse(json: string, client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "TestFunc", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "TestFunc", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.TestFunc$render_prompt(input: string) -> baml.llm.PromptAst {
+fn user.TestFunc$render_prompt(input: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // input // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "input": copy _1 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.TestClient, const "TestFunc", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.TestClient;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "input": copy _1 };
+        _0 = call const fn baml.llm.render_prompt(copy _2, const "TestFunc", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__04_tir.snap
@@ -5,19 +5,19 @@ source: crates/baml_tests/src/generated_tests.rs
 function user.TestClient$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "TestClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4o-mini", base_url: "http://localhost:...", allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: "test-key", provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : baml.llm.PrimitiveClient
 }
-function user.TestFunc(input: string) -> string throws never {
-  baml.llm.call_llm_function<T>(TestClient, "TestFunc", map { "input": input }) : string
+function user.TestFunc(input: string, client: baml.llm.Client = TestClient) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "TestFunc", map { "input": input }) : string
 }
-function user.TestFunc$render_prompt(input: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(TestClient, "TestFunc", map { "input": input }) : baml.llm.PromptAst
+function user.TestFunc$render_prompt(input: string, client: baml.llm.Client = TestClient) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "TestFunc", map { "input": input }) : baml.llm.PromptAst
 }
-function user.TestFunc$build_request(input: string) -> baml.http.Request throws never {
-  baml.llm.build_request(TestClient, "TestFunc", map { "input": input }) : baml.http.Request
+function user.TestFunc$build_request(input: string, client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "TestFunc", map { "input": input }) : baml.http.Request
 }
-function user.TestFunc$build_request_stream(input: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(TestClient, "TestFunc", map { "input": input }) : baml.http.Request
+function user.TestFunc$build_request_stream(input: string, client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "TestFunc", map { "input": input }) : baml.http.Request
 }
-function user.TestFunc$parse(json: string) -> string throws never {
+function user.TestFunc$parse(json: string, client: baml.llm.Client = TestClient) -> string throws never {
   baml.llm.parse<TFinal>("TestFunc", json) : string
 }
 function user.call_stream_inferred() -> baml.llm.Stream<null | string, string> throws never {
@@ -25,9 +25,9 @@ function user.call_stream_inferred() -> baml.llm.Stream<null | string, string> t
     baml.llm.stream_llm_function(TestClient, "TestFunc", map { "input": "world" }) : baml.llm.Stream<null | string, string>
   }
 }
-function user.TestFunc$stream(input: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(TestClient, "TestFunc", map { "input": input }) : baml.llm.Stream<null | string, string>
+function user.TestFunc$stream(input: string, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "TestFunc", map { "input": input }) : baml.llm.Stream<null | string, string>
 }
-function user.TestFunc$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  TestClient.__make_stream(sse, "TestFunc") : unknown
+function user.TestFunc$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "TestFunc") : baml.llm.Stream<null | string, string>
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__06_codegen.snap
@@ -31,9 +31,17 @@ function user.TestClient$new() -> null {
     return
 }
 
-function user.TestFunc(input: string) -> string {
-    load_type string
+function user.TestFunc(input: string, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_type string
+    load_var client
     load_const "TestFunc"
     load_var input
     load_const "input"
@@ -42,8 +50,16 @@ function user.TestFunc(input: string) -> string {
     return
 }
 
-function user.TestFunc$build_request(input: string) -> baml.http.Request {
+function user.TestFunc$build_request(input: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "TestFunc"
     load_var input
     load_const "input"
@@ -52,8 +68,16 @@ function user.TestFunc$build_request(input: string) -> baml.http.Request {
     return
 }
 
-function user.TestFunc$build_request_stream(input: string) -> baml.http.Request {
+function user.TestFunc$build_request_stream(input: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "TestFunc"
     load_var input
     load_const "input"
@@ -62,23 +86,46 @@ function user.TestFunc$build_request_stream(input: string) -> baml.http.Request 
     return
 }
 
-function user.TestFunc$parse(json: string) -> string {
+function user.TestFunc$parse(json: string, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
     load_const "TestFunc"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.TestFunc$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> {
-    load_var sse
+function user.TestFunc$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "TestFunc"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.TestFunc$render_prompt(input: string) -> baml.llm.PromptAst {
+function user.TestFunc$render_prompt(input: string, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "TestFunc"
     load_var input
     load_const "input"
@@ -87,8 +134,16 @@ function user.TestFunc$render_prompt(input: string) -> baml.llm.PromptAst {
     return
 }
 
-function user.TestFunc$stream(input: string) -> baml.llm.Stream<null | string, string> {
+function user.TestFunc$stream(input: string, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.TestClient
+    store_var client
+
+  L0:
+    load_var client
     load_const "TestFunc"
     load_var input
     load_const "input"

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__03_hir.snap
@@ -10,35 +10,35 @@ class user.Sentiment {
 function user.$init_test_main(registry: testing.TestCollector) -> ?  [expr] {
   { registry.register_test_set("test", (testset: testing.TestCollector) -> void { { let topics = ["happy", "sad"]; for sentiments in topics { testset.register_test_set(sentiments, (testset: testing.TestCollector) -> { { let req = baml.http.fetch("http://localhost:..." Add sentiments); let data = req.text(); let tests = GenerateTests$parse(data); for ex in tests { testset.register_test(ex, () -> { { let result = ClassifySentiment("hi"); assert.equal(result.feeling, "positive") } }, null) } } null }, null) }; testset.register_test_set("vibes", (testset: testing.TestCollector) -> { { let topics = ["happy", "sad"]; for sentiments in topics { testset.register_test_set(sentiments, (testset: testing.TestCollector) -> { { let tests = GenerateTests(5, sentiments); for ex in tests { testset.register_test(ex, () -> { { let result = ClassifySentiment("hi"); assert.equal(result.feeling, "positive") } }, null) } } null }, null) } } null }, null) } null }, null) } null
 }
-function user.ClassifySentiment(text: string) -> user.Sentiment  [llm] {
-  baml.llm.call_llm_function(GPT4o, "ClassifySentiment", map { "text": text })
+function user.ClassifySentiment(text: string, client: baml.llm.Client = GPT4o) -> user.Sentiment  [llm] {
+  baml.llm.call_llm_function(client, "ClassifySentiment", map { "text": text })
 }
-function user.ClassifySentiment$build_request(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4o, "ClassifySentiment", map { "text": text })
+function user.ClassifySentiment$build_request(text: string, client: baml.llm.Client = GPT4o) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "ClassifySentiment", map { "text": text })
 }
-function user.ClassifySentiment$build_request_stream(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4o, "ClassifySentiment", map { "text": text })
+function user.ClassifySentiment$build_request_stream(text: string, client: baml.llm.Client = GPT4o) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "ClassifySentiment", map { "text": text })
 }
-function user.ClassifySentiment$parse(json: string) -> user.Sentiment  [expr] {
+function user.ClassifySentiment$parse(json: string, client: baml.llm.Client = GPT4o) -> user.Sentiment  [expr] {
   baml.llm.parse("ClassifySentiment", json)
 }
-function user.ClassifySentiment$render_prompt(text: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4o, "ClassifySentiment", map { "text": text })
+function user.ClassifySentiment$render_prompt(text: string, client: baml.llm.Client = GPT4o) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "ClassifySentiment", map { "text": text })
 }
-function user.ClassifySentiment2(text: string) -> string  [llm] {
-  baml.llm.call_llm_function(GPT4o, "ClassifySentiment2", map { "text": text })
+function user.ClassifySentiment2(text: string, client: baml.llm.Client = GPT4o) -> string  [llm] {
+  baml.llm.call_llm_function(client, "ClassifySentiment2", map { "text": text })
 }
-function user.ClassifySentiment2$build_request(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4o, "ClassifySentiment2", map { "text": text })
+function user.ClassifySentiment2$build_request(text: string, client: baml.llm.Client = GPT4o) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "ClassifySentiment2", map { "text": text })
 }
-function user.ClassifySentiment2$build_request_stream(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4o, "ClassifySentiment2", map { "text": text })
+function user.ClassifySentiment2$build_request_stream(text: string, client: baml.llm.Client = GPT4o) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "ClassifySentiment2", map { "text": text })
 }
-function user.ClassifySentiment2$parse(json: string) -> string  [expr] {
+function user.ClassifySentiment2$parse(json: string, client: baml.llm.Client = GPT4o) -> string  [expr] {
   baml.llm.parse("ClassifySentiment2", json)
 }
-function user.ClassifySentiment2$render_prompt(text: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4o, "ClassifySentiment2", map { "text": text })
+function user.ClassifySentiment2$render_prompt(text: string, client: baml.llm.Client = GPT4o) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "ClassifySentiment2", map { "text": text })
 }
 function user.Foo() -> string | image  [expr] {
   { let x = "foo"; let y = 2; { let i = 0; while i Lt y { x = "hi:  " Add x } } } x
@@ -46,20 +46,20 @@ function user.Foo() -> string | image  [expr] {
 function user.GPT4o$new() -> ?  [expr] {
   baml.llm.PrimitiveClient { name: "GPT4o", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4o", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: baml.env.get_or_panic("OPENAI_API_KEY"), provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } }
 }
-function user.GenerateTests(count: int, topic: string) -> string[]  [llm] {
-  baml.llm.call_llm_function(GPT4o, "GenerateTests", map { "count": count, "topic": topic })
+function user.GenerateTests(count: int, topic: string, client: baml.llm.Client = GPT4o) -> string[]  [llm] {
+  baml.llm.call_llm_function(client, "GenerateTests", map { "count": count, "topic": topic })
 }
-function user.GenerateTests$build_request(count: int, topic: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4o, "GenerateTests", map { "count": count, "topic": topic })
+function user.GenerateTests$build_request(count: int, topic: string, client: baml.llm.Client = GPT4o) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "GenerateTests", map { "count": count, "topic": topic })
 }
-function user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4o, "GenerateTests", map { "count": count, "topic": topic })
+function user.GenerateTests$build_request_stream(count: int, topic: string, client: baml.llm.Client = GPT4o) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "GenerateTests", map { "count": count, "topic": topic })
 }
-function user.GenerateTests$parse(json: string) -> string[]  [expr] {
+function user.GenerateTests$parse(json: string, client: baml.llm.Client = GPT4o) -> string[]  [expr] {
   baml.llm.parse("GenerateTests", json)
 }
-function user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4o, "GenerateTests", map { "count": count, "topic": topic })
+function user.GenerateTests$render_prompt(count: int, topic: string, client: baml.llm.Client = GPT4o) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "GenerateTests", map { "count": count, "topic": topic })
 }
 function user.from_json(j: baml.json.json) -> user.Sentiment  [expr] {
   user.Sentiment { feeling: baml.json.from_json(baml.json.field(j, "feeling")), confidence: baml.json.from_json(baml.json.field(j, "confidence")), reasoning: baml.json.from_json(baml.json.field(j, "reasoning")) }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
@@ -117,7 +117,7 @@ fn .<lambda(<lambda($init_test_main, 0)>, 1)>(testset: testing.TestCollector) ->
 
     bb2: {
         _7 = copy _5;
-        _6 = call const fn user.GenerateTests$parse(copy _7) -> [bb3];
+        _6 = call const fn user.GenerateTests$parse(copy _7, const <omitted>) -> [bb3];
     }
 
     bb3: {
@@ -165,7 +165,7 @@ fn .<lambda(<lambda(<lambda($init_test_main, 0)>, 1)>, 2)>() -> null {
     let _3: string
 
     bb0: {
-        _1 = call const fn user.ClassifySentiment(const "hi") -> [bb1];
+        _1 = call const fn user.ClassifySentiment(const "hi", const <omitted>) -> [bb1];
     }
 
     bb1: {
@@ -255,7 +255,7 @@ fn .<lambda(<lambda(<lambda($init_test_main, 0)>, 3)>, 4)>(testset: testing.Test
 
     bb0: {
         _3 = copy capture[0];
-        _2 = call const fn user.GenerateTests(const 5_i64, copy _3) -> [bb1];
+        _2 = call const fn user.GenerateTests(const 5_i64, copy _3, const <omitted>) -> [bb1];
     }
 
     bb1: {
@@ -303,7 +303,7 @@ fn .<lambda(<lambda(<lambda(<lambda($init_test_main, 0)>, 3)>, 4)>, 5)>() -> nul
     let _3: string
 
     bb0: {
-        _1 = call const fn user.ClassifySentiment(const "hi") -> [bb1];
+        _1 = call const fn user.ClassifySentiment(const "hi", const <omitted>) -> [bb1];
     }
 
     bb1: {
@@ -321,162 +321,282 @@ fn .<lambda(<lambda(<lambda(<lambda($init_test_main, 0)>, 3)>, 4)>, 5)>() -> nul
     }
 }
 
-fn user.ClassifySentiment(text: string) -> Sentiment {
+fn user.ClassifySentiment(text: string, client: baml.llm.Client) -> Sentiment {
     // Locals:
     let _0: Sentiment // _0 // return
     let _1: string // text // param
-    let _2: map<string, unknown>
-    let _3: type
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
+    let _5: type
 
     bb0: {
-        _2 = { const "text": copy _1 };
-        _3 = load_type(Sentiment);
-        _0 = call const fn baml.llm.call_llm_function<copy _3>(const fn user.GPT4o, const "ClassifySentiment", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "text": copy _1 };
+        _5 = load_type(Sentiment);
+        _0 = call const fn baml.llm.call_llm_function<copy _5>(copy _2, const "ClassifySentiment", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment$build_request(text: string) -> baml.http.Request {
+fn user.ClassifySentiment$build_request(text: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // text // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "text": copy _1 };
-        _0 = call const fn baml.llm.build_request(const fn user.GPT4o, const "ClassifySentiment", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "text": copy _1 };
+        _0 = call const fn baml.llm.build_request(copy _2, const "ClassifySentiment", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment$build_request_stream(text: string) -> baml.http.Request {
+fn user.ClassifySentiment$build_request_stream(text: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // text // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "text": copy _1 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.GPT4o, const "ClassifySentiment", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "text": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(copy _2, const "ClassifySentiment", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment$parse(json: string) -> Sentiment {
+fn user.ClassifySentiment$parse(json: string, client: baml.llm.Client) -> Sentiment {
     // Locals:
     let _0: Sentiment // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "ClassifySentiment", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "ClassifySentiment", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment$render_prompt(text: string) -> baml.llm.PromptAst {
+fn user.ClassifySentiment$render_prompt(text: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // text // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "text": copy _1 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.GPT4o, const "ClassifySentiment", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "text": copy _1 };
+        _0 = call const fn baml.llm.render_prompt(copy _2, const "ClassifySentiment", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment2(text: string) -> string {
+fn user.ClassifySentiment2(text: string, client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // text // param
-    let _2: map<string, unknown>
-    let _3: type
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
+    let _5: type
 
     bb0: {
-        _2 = { const "text": copy _1 };
-        _3 = load_type(string);
-        _0 = call const fn baml.llm.call_llm_function<copy _3>(const fn user.GPT4o, const "ClassifySentiment2", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "text": copy _1 };
+        _5 = load_type(string);
+        _0 = call const fn baml.llm.call_llm_function<copy _5>(copy _2, const "ClassifySentiment2", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment2$build_request(text: string) -> baml.http.Request {
+fn user.ClassifySentiment2$build_request(text: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // text // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "text": copy _1 };
-        _0 = call const fn baml.llm.build_request(const fn user.GPT4o, const "ClassifySentiment2", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "text": copy _1 };
+        _0 = call const fn baml.llm.build_request(copy _2, const "ClassifySentiment2", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment2$build_request_stream(text: string) -> baml.http.Request {
+fn user.ClassifySentiment2$build_request_stream(text: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // text // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "text": copy _1 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.GPT4o, const "ClassifySentiment2", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "text": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(copy _2, const "ClassifySentiment2", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment2$parse(json: string) -> string {
+fn user.ClassifySentiment2$parse(json: string, client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "ClassifySentiment2", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "ClassifySentiment2", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.ClassifySentiment2$render_prompt(text: string) -> baml.llm.PromptAst {
+fn user.ClassifySentiment2$render_prompt(text: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // text // param
-    let _2: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = { const "text": copy _1 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.GPT4o, const "ClassifySentiment2", copy _2) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = { const "text": copy _1 };
+        _0 = call const fn baml.llm.render_prompt(copy _2, const "ClassifySentiment2", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
@@ -554,86 +674,146 @@ fn user.GPT4o$new() -> null {
     }
 }
 
-fn user.GenerateTests(count: int, topic: string) -> string[] {
+fn user.GenerateTests(count: int, topic: string, client: baml.llm.Client) -> string[] {
     // Locals:
     let _0: string[] // _0 // return
     let _1: int // count // param
     let _2: string // topic // param
-    let _3: map<string, unknown>
-    let _4: type
+    let _3: baml.llm.Client // client // param
+    let _4: bool
+    let _5: map<string, unknown>
+    let _6: type
 
     bb0: {
-        _3 = { const "count": copy _1, const "topic": copy _2 };
-        _4 = load_type(string[]);
-        _0 = call const fn baml.llm.call_llm_function<copy _4>(const fn user.GPT4o, const "GenerateTests", copy _3) -> [bb1];
+        _4 = copy _3 == const <omitted>;
+        branch copy _4 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "count": copy _1, const "topic": copy _2 };
+        _6 = load_type(string[]);
+        _0 = call const fn baml.llm.call_llm_function<copy _6>(copy _3, const "GenerateTests", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateTests$build_request(count: int, topic: string) -> baml.http.Request {
+fn user.GenerateTests$build_request(count: int, topic: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: int // count // param
     let _2: string // topic // param
-    let _3: map<string, unknown>
+    let _3: baml.llm.Client // client // param
+    let _4: bool
+    let _5: map<string, unknown>
 
     bb0: {
-        _3 = { const "count": copy _1, const "topic": copy _2 };
-        _0 = call const fn baml.llm.build_request(const fn user.GPT4o, const "GenerateTests", copy _3) -> [bb1];
+        _4 = copy _3 == const <omitted>;
+        branch copy _4 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "count": copy _1, const "topic": copy _2 };
+        _0 = call const fn baml.llm.build_request(copy _3, const "GenerateTests", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request {
+fn user.GenerateTests$build_request_stream(count: int, topic: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: int // count // param
     let _2: string // topic // param
-    let _3: map<string, unknown>
+    let _3: baml.llm.Client // client // param
+    let _4: bool
+    let _5: map<string, unknown>
 
     bb0: {
-        _3 = { const "count": copy _1, const "topic": copy _2 };
-        _0 = call const fn baml.llm.build_request_stream(const fn user.GPT4o, const "GenerateTests", copy _3) -> [bb1];
+        _4 = copy _3 == const <omitted>;
+        branch copy _4 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "count": copy _1, const "topic": copy _2 };
+        _0 = call const fn baml.llm.build_request_stream(copy _3, const "GenerateTests", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateTests$parse(json: string) -> string[] {
+fn user.GenerateTests$parse(json: string, client: baml.llm.Client) -> string[] {
     // Locals:
     let _0: string[] // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "GenerateTests", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _2 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "GenerateTests", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm.PromptAst {
+fn user.GenerateTests$render_prompt(count: int, topic: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: int // count // param
     let _2: string // topic // param
-    let _3: map<string, unknown>
+    let _3: baml.llm.Client // client // param
+    let _4: bool
+    let _5: map<string, unknown>
 
     bb0: {
-        _3 = { const "count": copy _1, const "topic": copy _2 };
-        _0 = call const fn baml.llm.render_prompt(const fn user.GPT4o, const "GenerateTests", copy _3) -> [bb1];
+        _4 = copy _3 == const <omitted>;
+        branch copy _4 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = const fn user.GPT4o;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "count": copy _1, const "topic": copy _2 };
+        _0 = call const fn baml.llm.render_prompt(copy _3, const "GenerateTests", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_tir.snap
@@ -16,34 +16,34 @@ function user.Sentiment.to_json(self: user.Sentiment) -> baml.json.json throws b
 function user.Sentiment.from_json(j: baml.json.json) -> user.Sentiment throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   Sentiment { feeling: baml.json.from_json<string>(baml.json.field(j, "feeling")), confidence: baml.json.from_json<float>(baml.json.field(j, "confidence")), reasoning: baml.json.from_json<string>(baml.json.field(j, "reasoning")) } : user.Sentiment
 }
-function user.ClassifySentiment(text: string) -> user.Sentiment throws never {
-  baml.llm.call_llm_function<T>(GPT4o, "ClassifySentiment", map { "text": text }) : user.Sentiment
+function user.ClassifySentiment(text: string, client: baml.llm.Client = GPT4o) -> user.Sentiment throws never {
+  baml.llm.call_llm_function<T>(client, "ClassifySentiment", map { "text": text }) : user.Sentiment
 }
-function user.ClassifySentiment$render_prompt(text: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4o, "ClassifySentiment", map { "text": text }) : baml.llm.PromptAst
+function user.ClassifySentiment$render_prompt(text: string, client: baml.llm.Client = GPT4o) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "ClassifySentiment", map { "text": text }) : baml.llm.PromptAst
 }
-function user.ClassifySentiment$build_request(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4o, "ClassifySentiment", map { "text": text }) : baml.http.Request
+function user.ClassifySentiment$build_request(text: string, client: baml.llm.Client = GPT4o) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "ClassifySentiment", map { "text": text }) : baml.http.Request
 }
-function user.ClassifySentiment$build_request_stream(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4o, "ClassifySentiment", map { "text": text }) : baml.http.Request
+function user.ClassifySentiment$build_request_stream(text: string, client: baml.llm.Client = GPT4o) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "ClassifySentiment", map { "text": text }) : baml.http.Request
 }
-function user.ClassifySentiment$parse(json: string) -> user.Sentiment throws never {
+function user.ClassifySentiment$parse(json: string, client: baml.llm.Client = GPT4o) -> user.Sentiment throws never {
   baml.llm.parse<TFinal>("ClassifySentiment", json) : user.Sentiment
 }
-function user.GenerateTests(count: int, topic: string) -> string[] throws never {
-  baml.llm.call_llm_function<T>(GPT4o, "GenerateTests", map { "count": count, "topic": topic }) : string[]
+function user.GenerateTests(count: int, topic: string, client: baml.llm.Client = GPT4o) -> string[] throws never {
+  baml.llm.call_llm_function<T>(client, "GenerateTests", map { "count": count, "topic": topic }) : string[]
 }
-function user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4o, "GenerateTests", map { "count": count, "topic": topic }) : baml.llm.PromptAst
+function user.GenerateTests$render_prompt(count: int, topic: string, client: baml.llm.Client = GPT4o) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GenerateTests", map { "count": count, "topic": topic }) : baml.llm.PromptAst
 }
-function user.GenerateTests$build_request(count: int, topic: string) -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4o, "GenerateTests", map { "count": count, "topic": topic }) : baml.http.Request
+function user.GenerateTests$build_request(count: int, topic: string, client: baml.llm.Client = GPT4o) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GenerateTests", map { "count": count, "topic": topic }) : baml.http.Request
 }
-function user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4o, "GenerateTests", map { "count": count, "topic": topic }) : baml.http.Request
+function user.GenerateTests$build_request_stream(count: int, topic: string, client: baml.llm.Client = GPT4o) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GenerateTests", map { "count": count, "topic": topic }) : baml.http.Request
 }
-function user.GenerateTests$parse(json: string) -> string[] throws never {
+function user.GenerateTests$parse(json: string, client: baml.llm.Client = GPT4o) -> string[] throws never {
   baml.llm.parse<TFinal>("GenerateTests", json) : string[]
 }
 function user.Foo() -> string | image throws never {
@@ -60,19 +60,19 @@ function user.Foo() -> string | image throws never {
     x : string
   }
 }
-function user.ClassifySentiment2(text: string) -> string throws never {
-  baml.llm.call_llm_function<T>(GPT4o, "ClassifySentiment2", map { "text": text }) : string
+function user.ClassifySentiment2(text: string, client: baml.llm.Client = GPT4o) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "ClassifySentiment2", map { "text": text }) : string
 }
-function user.ClassifySentiment2$render_prompt(text: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4o, "ClassifySentiment2", map { "text": text }) : baml.llm.PromptAst
+function user.ClassifySentiment2$render_prompt(text: string, client: baml.llm.Client = GPT4o) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "ClassifySentiment2", map { "text": text }) : baml.llm.PromptAst
 }
-function user.ClassifySentiment2$build_request(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4o, "ClassifySentiment2", map { "text": text }) : baml.http.Request
+function user.ClassifySentiment2$build_request(text: string, client: baml.llm.Client = GPT4o) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "ClassifySentiment2", map { "text": text }) : baml.http.Request
 }
-function user.ClassifySentiment2$build_request_stream(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4o, "ClassifySentiment2", map { "text": text }) : baml.http.Request
+function user.ClassifySentiment2$build_request_stream(text: string, client: baml.llm.Client = GPT4o) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "ClassifySentiment2", map { "text": text }) : baml.http.Request
 }
-function user.ClassifySentiment2$parse(json: string) -> string throws never {
+function user.ClassifySentiment2$parse(json: string, client: baml.llm.Client = GPT4o) -> string throws never {
   baml.llm.parse<TFinal>("ClassifySentiment2", json) : string
 }
 function user.$init_test_main(registry: testing.TestCollector) -> ? throws never {
@@ -108,21 +108,21 @@ class user.Sentiment$stream {
   confidence: null | float
   reasoning: null | string
 }
-function user.ClassifySentiment$stream(text: string) -> baml.llm.Stream<null | user.Sentiment$stream, user.Sentiment> throws never {
-  baml.llm.stream_llm_function(GPT4o, "ClassifySentiment", map { "text": text }) : baml.llm.Stream<null | user.Sentiment$stream, user.Sentiment>
+function user.ClassifySentiment$stream(text: string, client: baml.llm.Client = GPT4o) -> baml.llm.Stream<null | user.Sentiment$stream, user.Sentiment> throws never {
+  baml.llm.stream_llm_function(client, "ClassifySentiment", map { "text": text }) : baml.llm.Stream<null | user.Sentiment$stream, user.Sentiment>
 }
-function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | user.Sentiment$stream, user.Sentiment> throws never {
-  GPT4o.__make_stream(sse, "ClassifySentiment") : unknown
+function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4o) -> baml.llm.Stream<null | user.Sentiment$stream, user.Sentiment> throws never {
+  client.__make_stream(sse, "ClassifySentiment") : baml.llm.Stream<null | user.Sentiment$stream, user.Sentiment>
 }
-function user.GenerateTests$stream(count: int, topic: string) -> baml.llm.Stream<string[], string[]> throws never {
-  baml.llm.stream_llm_function(GPT4o, "GenerateTests", map { "count": count, "topic": topic }) : baml.llm.Stream<string[], string[]>
+function user.GenerateTests$stream(count: int, topic: string, client: baml.llm.Client = GPT4o) -> baml.llm.Stream<string[], string[]> throws never {
+  baml.llm.stream_llm_function(client, "GenerateTests", map { "count": count, "topic": topic }) : baml.llm.Stream<string[], string[]>
 }
-function user.GenerateTests$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string[], string[]> throws never {
-  GPT4o.__make_stream(sse, "GenerateTests") : unknown
+function user.GenerateTests$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4o) -> baml.llm.Stream<string[], string[]> throws never {
+  client.__make_stream(sse, "GenerateTests") : baml.llm.Stream<string[], string[]>
 }
-function user.ClassifySentiment2$stream(text: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(GPT4o, "ClassifySentiment2", map { "text": text }) : baml.llm.Stream<null | string, string>
+function user.ClassifySentiment2$stream(text: string, client: baml.llm.Client = GPT4o) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "ClassifySentiment2", map { "text": text }) : baml.llm.Stream<null | string, string>
 }
-function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  GPT4o.__make_stream(sse, "ClassifySentiment2") : unknown
+function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4o) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "ClassifySentiment2") : baml.llm.Stream<null | string, string>
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
@@ -27,9 +27,17 @@ function user.$init_test_main(registry: testing.TestCollector) -> null {
     return
 }
 
-function user.ClassifySentiment(text: string) -> Sentiment {
-    load_type Sentiment
+function user.ClassifySentiment(text: string, client: baml.llm.Client) -> Sentiment {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_type Sentiment
+    load_var client
     load_const "ClassifySentiment"
     load_var text
     load_const "text"
@@ -38,8 +46,16 @@ function user.ClassifySentiment(text: string) -> Sentiment {
     return
 }
 
-function user.ClassifySentiment$build_request(text: string) -> baml.http.Request {
+function user.ClassifySentiment$build_request(text: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "ClassifySentiment"
     load_var text
     load_const "text"
@@ -48,8 +64,16 @@ function user.ClassifySentiment$build_request(text: string) -> baml.http.Request
     return
 }
 
-function user.ClassifySentiment$build_request_stream(text: string) -> baml.http.Request {
+function user.ClassifySentiment$build_request_stream(text: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "ClassifySentiment"
     load_var text
     load_const "text"
@@ -58,23 +82,46 @@ function user.ClassifySentiment$build_request_stream(text: string) -> baml.http.
     return
 }
 
-function user.ClassifySentiment$parse(json: string) -> Sentiment {
+function user.ClassifySentiment$parse(json: string, client: baml.llm.Client) -> Sentiment {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.GPT4o
+    store_var client
+
+  L0:
     load_const "ClassifySentiment"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | Sentiment$stream, Sentiment> {
-    load_var sse
+function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | Sentiment$stream, Sentiment> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "ClassifySentiment"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.ClassifySentiment$render_prompt(text: string) -> baml.llm.PromptAst {
+function user.ClassifySentiment$render_prompt(text: string, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "ClassifySentiment"
     load_var text
     load_const "text"
@@ -83,8 +130,16 @@ function user.ClassifySentiment$render_prompt(text: string) -> baml.llm.PromptAs
     return
 }
 
-function user.ClassifySentiment$stream(text: string) -> baml.llm.Stream<null | Sentiment$stream, Sentiment> {
+function user.ClassifySentiment$stream(text: string, client: baml.llm.Client) -> baml.llm.Stream<null | Sentiment$stream, Sentiment> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "ClassifySentiment"
     load_var text
     load_const "text"
@@ -93,9 +148,17 @@ function user.ClassifySentiment$stream(text: string) -> baml.llm.Stream<null | S
     return
 }
 
-function user.ClassifySentiment2(text: string) -> string {
-    load_type string
+function user.ClassifySentiment2(text: string, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_type string
+    load_var client
     load_const "ClassifySentiment2"
     load_var text
     load_const "text"
@@ -104,8 +167,16 @@ function user.ClassifySentiment2(text: string) -> string {
     return
 }
 
-function user.ClassifySentiment2$build_request(text: string) -> baml.http.Request {
+function user.ClassifySentiment2$build_request(text: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "ClassifySentiment2"
     load_var text
     load_const "text"
@@ -114,8 +185,16 @@ function user.ClassifySentiment2$build_request(text: string) -> baml.http.Reques
     return
 }
 
-function user.ClassifySentiment2$build_request_stream(text: string) -> baml.http.Request {
+function user.ClassifySentiment2$build_request_stream(text: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "ClassifySentiment2"
     load_var text
     load_const "text"
@@ -124,23 +203,46 @@ function user.ClassifySentiment2$build_request_stream(text: string) -> baml.http
     return
 }
 
-function user.ClassifySentiment2$parse(json: string) -> string {
+function user.ClassifySentiment2$parse(json: string, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.GPT4o
+    store_var client
+
+  L0:
     load_const "ClassifySentiment2"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> {
-    load_var sse
+function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "ClassifySentiment2"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.ClassifySentiment2$render_prompt(text: string) -> baml.llm.PromptAst {
+function user.ClassifySentiment2$render_prompt(text: string, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "ClassifySentiment2"
     load_var text
     load_const "text"
@@ -149,8 +251,16 @@ function user.ClassifySentiment2$render_prompt(text: string) -> baml.llm.PromptA
     return
 }
 
-function user.ClassifySentiment2$stream(text: string) -> baml.llm.Stream<null | string, string> {
+function user.ClassifySentiment2$stream(text: string, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "ClassifySentiment2"
     load_var text
     load_const "text"
@@ -214,9 +324,17 @@ function user.GPT4o$new() -> null {
     return
 }
 
-function user.GenerateTests(count: int, topic: string) -> string[] {
-    load_type string[]
+function user.GenerateTests(count: int, topic: string, client: baml.llm.Client) -> string[] {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_type string[]
+    load_var client
     load_const "GenerateTests"
     load_var2 1 2
     load_const "count"
@@ -226,8 +344,16 @@ function user.GenerateTests(count: int, topic: string) -> string[] {
     return
 }
 
-function user.GenerateTests$build_request(count: int, topic: string) -> baml.http.Request {
+function user.GenerateTests$build_request(count: int, topic: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateTests"
     load_var2 1 2
     load_const "count"
@@ -237,8 +363,16 @@ function user.GenerateTests$build_request(count: int, topic: string) -> baml.htt
     return
 }
 
-function user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request {
+function user.GenerateTests$build_request_stream(count: int, topic: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateTests"
     load_var2 1 2
     load_const "count"
@@ -248,23 +382,46 @@ function user.GenerateTests$build_request_stream(count: int, topic: string) -> b
     return
 }
 
-function user.GenerateTests$parse(json: string) -> string[] {
+function user.GenerateTests$parse(json: string, client: baml.llm.Client) -> string[] {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.GPT4o
+    store_var client
+
+  L0:
     load_const "GenerateTests"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.GenerateTests$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<string[], string[]> {
-    load_var sse
+function user.GenerateTests$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<string[], string[]> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "GenerateTests"
-    load_const null
-    call_indirect
+    call baml.llm.Client.__make_stream
     return
 }
 
-function user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm.PromptAst {
+function user.GenerateTests$render_prompt(count: int, topic: string, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateTests"
     load_var2 1 2
     load_const "count"
@@ -274,8 +431,16 @@ function user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm
     return
 }
 
-function user.GenerateTests$stream(count: int, topic: string) -> baml.llm.Stream<string[], string[]> {
+function user.GenerateTests$stream(count: int, topic: string, client: baml.llm.Client) -> baml.llm.Stream<string[], string[]> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_global user.GPT4o
+    store_var client
+
+  L0:
+    load_var client
     load_const "GenerateTests"
     load_var2 1 2
     load_const "count"

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__03_hir.snap
@@ -5,20 +5,20 @@ source: crates/baml_tests/src/generated_tests.rs
 class user.Resume {
   name: string
 }
-function user.TypeBuilderFn(from_text: string) -> user.Resume  [llm] {
-  baml.llm.call_llm_function(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text })
+function user.TypeBuilderFn(from_text: string, client: baml.llm.Client = ...) -> user.Resume  [llm] {
+  baml.llm.call_llm_function(client, "TypeBuilderFn", map { "from_text": from_text })
 }
-function user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text })
+function user.TypeBuilderFn$build_request(from_text: string, client: baml.llm.Client = ...) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "TypeBuilderFn", map { "from_text": from_text })
 }
-function user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text })
+function user.TypeBuilderFn$build_request_stream(from_text: string, client: baml.llm.Client = ...) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "TypeBuilderFn", map { "from_text": from_text })
 }
-function user.TypeBuilderFn$parse(json: string) -> user.Resume  [expr] {
+function user.TypeBuilderFn$parse(json: string, client: baml.llm.Client = ...) -> user.Resume  [expr] {
   baml.llm.parse("TypeBuilderFn", json)
 }
-function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text })
+function user.TypeBuilderFn$render_prompt(from_text: string, client: baml.llm.Client = ...) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "TypeBuilderFn", map { "from_text": from_text })
 }
 function user.from_json(j: baml.json.json) -> user.Resume  [expr] {
   user.Resume { name: baml.json.from_json(baml.json.field(j, "name")) }

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__04_5_mir.snap
@@ -2,98 +2,152 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.TypeBuilderFn(from_text: string) -> Resume {
+fn user.TypeBuilderFn(from_text: string, client: baml.llm.Client) -> Resume {
     // Locals:
     let _0: Resume // _0 // return
     let _1: string // from_text // param
-    let _2: baml.llm.Client
-    let _3: baml.llm.Client[]
-    let _4: map<string, unknown>
-    let _5: type
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: baml.llm.Client[]
+    let _5: map<string, unknown>
+    let _6: type
 
     bb0: {
-        _3 = [];
-        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
-        _4 = { const "from_text": copy _1 };
-        _5 = load_type(Resume);
-        _0 = call const fn baml.llm.call_llm_function<copy _5>(copy _2, const "TypeBuilderFn", copy _4) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _4 = [];
+        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _4, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "from_text": copy _1 };
+        _6 = load_type(Resume);
+        _0 = call const fn baml.llm.call_llm_function<copy _6>(copy _2, const "TypeBuilderFn", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Request {
+fn user.TypeBuilderFn$build_request(from_text: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // from_text // param
-    let _2: baml.llm.Client
-    let _3: baml.llm.Client[]
-    let _4: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: baml.llm.Client[]
+    let _5: map<string, unknown>
 
     bb0: {
-        _3 = [];
-        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
-        _4 = { const "from_text": copy _1 };
-        _0 = call const fn baml.llm.build_request(copy _2, const "TypeBuilderFn", copy _4) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _4 = [];
+        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _4, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "from_text": copy _1 };
+        _0 = call const fn baml.llm.build_request(copy _2, const "TypeBuilderFn", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http.Request {
+fn user.TypeBuilderFn$build_request_stream(from_text: string, client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
     let _1: string // from_text // param
-    let _2: baml.llm.Client
-    let _3: baml.llm.Client[]
-    let _4: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: baml.llm.Client[]
+    let _5: map<string, unknown>
 
     bb0: {
-        _3 = [];
-        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
-        _4 = { const "from_text": copy _1 };
-        _0 = call const fn baml.llm.build_request_stream(copy _2, const "TypeBuilderFn", copy _4) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _4 = [];
+        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _4, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "from_text": copy _1 };
+        _0 = call const fn baml.llm.build_request_stream(copy _2, const "TypeBuilderFn", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.TypeBuilderFn$parse(json: string) -> Resume {
+fn user.TypeBuilderFn$parse(json: string, client: baml.llm.Client) -> Resume {
     // Locals:
     let _0: Resume // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: baml.llm.Client[]
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "TypeBuilderFn", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _4 = [];
+        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _4, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "TypeBuilderFn", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptAst {
+fn user.TypeBuilderFn$render_prompt(from_text: string, client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
     let _1: string // from_text // param
-    let _2: baml.llm.Client
-    let _3: baml.llm.Client[]
-    let _4: map<string, unknown>
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: baml.llm.Client[]
+    let _5: map<string, unknown>
 
     bb0: {
-        _3 = [];
-        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
-        _4 = { const "from_text": copy _1 };
-        _0 = call const fn baml.llm.render_prompt(copy _2, const "TypeBuilderFn", copy _4) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _4 = [];
+        _2 = baml.llm.Client { const "openai/gpt-4o-mini", const baml.llm.ClientType.Primitive, copy _4, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _5 = { const "from_text": copy _1 };
+        _0 = call const fn baml.llm.render_prompt(copy _2, const "TypeBuilderFn", copy _5) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__04_tir.snap
@@ -2,19 +2,19 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.TypeBuilderFn(from_text: string) -> user.Resume throws never {
-  baml.llm.call_llm_function<T>(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text }) : user.Resume
+function user.TypeBuilderFn(from_text: string, client: baml.llm.Client = ...) -> user.Resume throws never {
+  baml.llm.call_llm_function<T>(client, "TypeBuilderFn", map { "from_text": from_text }) : user.Resume
 }
-function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text }) : baml.llm.PromptAst
+function user.TypeBuilderFn$render_prompt(from_text: string, client: baml.llm.Client = ...) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "TypeBuilderFn", map { "from_text": from_text }) : baml.llm.PromptAst
 }
-function user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Request throws never {
-  baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text }) : baml.http.Request
+function user.TypeBuilderFn$build_request(from_text: string, client: baml.llm.Client = ...) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "TypeBuilderFn", map { "from_text": from_text }) : baml.http.Request
 }
-function user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text }) : baml.http.Request
+function user.TypeBuilderFn$build_request_stream(from_text: string, client: baml.llm.Client = ...) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "TypeBuilderFn", map { "from_text": from_text }) : baml.http.Request
 }
-function user.TypeBuilderFn$parse(json: string) -> user.Resume throws never {
+function user.TypeBuilderFn$parse(json: string, client: baml.llm.Client = ...) -> user.Resume throws never {
   baml.llm.parse<TFinal>("TypeBuilderFn", json) : user.Resume
 }
 class user.Resume {
@@ -26,11 +26,11 @@ function user.Resume.to_json(self: user.Resume) -> baml.json.json throws baml.js
 function user.Resume.from_json(j: baml.json.json) -> user.Resume throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   Resume { name: baml.json.from_json<string>(baml.json.field(j, "name")) } : user.Resume
 }
-function user.TypeBuilderFn$stream(from_text: string) -> baml.llm.Stream<null | user.Resume$stream, user.Resume> throws never {
-  baml.llm.stream_llm_function(baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "TypeBuilderFn", map { "from_text": from_text }) : baml.llm.Stream<null | user.Resume$stream, user.Resume>
+function user.TypeBuilderFn$stream(from_text: string, client: baml.llm.Client = ...) -> baml.llm.Stream<null | user.Resume$stream, user.Resume> throws never {
+  baml.llm.stream_llm_function(client, "TypeBuilderFn", map { "from_text": from_text }) : baml.llm.Stream<null | user.Resume$stream, user.Resume>
 }
-function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | user.Resume$stream, user.Resume> throws never {
-  baml.llm.Client { name: "openai/gpt-4o-mini", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "TypeBuilderFn") : baml.llm.Stream<null | user.Resume$stream, user.Resume>
+function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = ...) -> baml.llm.Stream<null | user.Resume$stream, user.Resume> throws never {
+  client.__make_stream(sse, "TypeBuilderFn") : baml.llm.Stream<null | user.Resume$stream, user.Resume>
 }
 class user.Resume$stream {
   name: null | string

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 30228
 ---
 function user.Resume.from_json(j: baml.json.json) -> Resume {
     load_var j
@@ -23,8 +22,11 @@ function user.Resume.to_json(self: Resume) -> baml.json.json {
     return
 }
 
-function user.TypeBuilderFn(from_text: string) -> Resume {
-    load_type Resume
+function user.TypeBuilderFn(from_text: string, client: baml.llm.Client) -> Resume {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o-mini"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -32,6 +34,11 @@ function user.TypeBuilderFn(from_text: string) -> Resume {
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_type Resume
+    load_var client
     load_const "TypeBuilderFn"
     load_var from_text
     load_const "from_text"
@@ -40,7 +47,11 @@ function user.TypeBuilderFn(from_text: string) -> Resume {
     return
 }
 
-function user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Request {
+function user.TypeBuilderFn$build_request(from_text: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o-mini"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -48,6 +59,10 @@ function user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Reques
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_var client
     load_const "TypeBuilderFn"
     load_var from_text
     load_const "from_text"
@@ -56,7 +71,11 @@ function user.TypeBuilderFn$build_request(from_text: string) -> baml.http.Reques
     return
 }
 
-function user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http.Request {
+function user.TypeBuilderFn$build_request_stream(from_text: string, client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o-mini"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -64,6 +83,10 @@ function user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_var client
     load_const "TypeBuilderFn"
     load_var from_text
     load_const "from_text"
@@ -72,14 +95,32 @@ function user.TypeBuilderFn$build_request_stream(from_text: string) -> baml.http
     return
 }
 
-function user.TypeBuilderFn$parse(json: string) -> Resume {
+function user.TypeBuilderFn$parse(json: string, client: baml.llm.Client) -> Resume {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_const "openai/gpt-4o-mini"
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
+    alloc_array 0
+    load_const null
+    load_const 0
+    init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
     load_const "TypeBuilderFn"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | Resume$stream, Resume> {
+function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | Resume$stream, Resume> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o-mini"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -87,13 +128,20 @@ function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream) -> baml.llm.S
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
-    load_var sse
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "TypeBuilderFn"
     call baml.llm.Client.__make_stream
     return
 }
 
-function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptAst {
+function user.TypeBuilderFn$render_prompt(from_text: string, client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o-mini"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -101,6 +149,10 @@ function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptA
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_var client
     load_const "TypeBuilderFn"
     load_var from_text
     load_const "from_text"
@@ -109,7 +161,11 @@ function user.TypeBuilderFn$render_prompt(from_text: string) -> baml.llm.PromptA
     return
 }
 
-function user.TypeBuilderFn$stream(from_text: string) -> baml.llm.Stream<null | Resume$stream, Resume> {
+function user.TypeBuilderFn$stream(from_text: string, client: baml.llm.Client) -> baml.llm.Stream<null | Resume$stream, Resume> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o-mini"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -117,6 +173,10 @@ function user.TypeBuilderFn$stream(from_text: string) -> baml.llm.Stream<null | 
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_var client
     load_const "TypeBuilderFn"
     load_var from_text
     load_const "from_text"

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__03_hir.snap
@@ -6,20 +6,20 @@ class user.TopLevelClass {
   a: string
 }
 enum user.TopLevelEnum {A, B}
-function user.Fn() -> string  [llm] {
-  baml.llm.call_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  })
+function user.Fn(client: baml.llm.Client = ...) -> string  [llm] {
+  baml.llm.call_llm_function(client, "Fn", map {  })
 }
-function user.Fn$build_request() -> baml.http.Request  [expr] {
-  baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  })
+function user.Fn$build_request(client: baml.llm.Client = ...) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "Fn", map {  })
 }
-function user.Fn$build_request_stream() -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  })
+function user.Fn$build_request_stream(client: baml.llm.Client = ...) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "Fn", map {  })
 }
-function user.Fn$parse(json: string) -> string  [expr] {
+function user.Fn$parse(json: string, client: baml.llm.Client = ...) -> string  [expr] {
   baml.llm.parse("Fn", json)
 }
-function user.Fn$render_prompt() -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  })
+function user.Fn$render_prompt(client: baml.llm.Client = ...) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "Fn", map {  })
 }
 function user.from_json(j: baml.json.json) -> user.TopLevelClass  [expr] {
   user.TopLevelClass { a: baml.json.from_json(baml.json.field(j, "a")) }

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__04_5_mir.snap
@@ -2,94 +2,148 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === MIR2 ===
-fn user.Fn() -> string {
+fn user.Fn(client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
-    let _1: baml.llm.Client
-    let _2: baml.llm.Client[]
-    let _3: map<string, unknown>
-    let _4: type
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: baml.llm.Client[]
+    let _4: map<string, unknown>
+    let _5: type
 
     bb0: {
-        _2 = [];
-        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _2, const null, const 0_i64 };
-        _3 = {  };
-        _4 = load_type(string);
-        _0 = call const fn baml.llm.call_llm_function<copy _4>(copy _1, const "Fn", copy _3) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = [];
+        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = {  };
+        _5 = load_type(string);
+        _0 = call const fn baml.llm.call_llm_function<copy _5>(copy _1, const "Fn", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.Fn$build_request() -> baml.http.Request {
+fn user.Fn$build_request(client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
-    let _1: baml.llm.Client
-    let _2: baml.llm.Client[]
-    let _3: map<string, unknown>
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: baml.llm.Client[]
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = [];
-        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _2, const null, const 0_i64 };
-        _3 = {  };
-        _0 = call const fn baml.llm.build_request(copy _1, const "Fn", copy _3) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = [];
+        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = {  };
+        _0 = call const fn baml.llm.build_request(copy _1, const "Fn", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.Fn$build_request_stream() -> baml.http.Request {
+fn user.Fn$build_request_stream(client: baml.llm.Client) -> baml.http.Request {
     // Locals:
     let _0: baml.http.Request // _0 // return
-    let _1: baml.llm.Client
-    let _2: baml.llm.Client[]
-    let _3: map<string, unknown>
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: baml.llm.Client[]
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = [];
-        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _2, const null, const 0_i64 };
-        _3 = {  };
-        _0 = call const fn baml.llm.build_request_stream(copy _1, const "Fn", copy _3) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = [];
+        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = {  };
+        _0 = call const fn baml.llm.build_request_stream(copy _1, const "Fn", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.Fn$parse(json: string) -> string {
+fn user.Fn$parse(json: string, client: baml.llm.Client) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // json // param
+    let _2: baml.llm.Client // client // param
+    let _3: bool
+    let _4: baml.llm.Client[]
 
     bb0: {
-        _0 = call const fn baml.llm.parse(const "Fn", copy _1) -> [bb1];
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
+        _4 = [];
+        _2 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _4, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = call const fn baml.llm.parse(const "Fn", copy _1) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }
 
-fn user.Fn$render_prompt() -> baml.llm.PromptAst {
+fn user.Fn$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst {
     // Locals:
     let _0: baml.llm.PromptAst // _0 // return
-    let _1: baml.llm.Client
-    let _2: baml.llm.Client[]
-    let _3: map<string, unknown>
+    let _1: baml.llm.Client // client // param
+    let _2: bool
+    let _3: baml.llm.Client[]
+    let _4: map<string, unknown>
 
     bb0: {
-        _2 = [];
-        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _2, const null, const 0_i64 };
-        _3 = {  };
-        _0 = call const fn baml.llm.render_prompt(copy _1, const "Fn", copy _3) -> [bb1];
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb2];
     }
 
     bb1: {
+        _3 = [];
+        _1 = baml.llm.Client { const "openai/gpt-4o", const baml.llm.ClientType.Primitive, copy _3, const null, const 0_i64 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = {  };
+        _0 = call const fn baml.llm.render_prompt(copy _1, const "Fn", copy _4) -> [bb3];
+    }
+
+    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__04_tir.snap
@@ -2,19 +2,19 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.Fn() -> string throws never {
-  baml.llm.call_llm_function<T>(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  }) : string
+function user.Fn(client: baml.llm.Client = ...) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "Fn", map {  }) : string
 }
-function user.Fn$render_prompt() -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  }) : baml.llm.PromptAst
+function user.Fn$render_prompt(client: baml.llm.Client = ...) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "Fn", map {  }) : baml.llm.PromptAst
 }
-function user.Fn$build_request() -> baml.http.Request throws never {
-  baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  }) : baml.http.Request
+function user.Fn$build_request(client: baml.llm.Client = ...) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "Fn", map {  }) : baml.http.Request
 }
-function user.Fn$build_request_stream() -> baml.http.Request throws never {
-  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  }) : baml.http.Request
+function user.Fn$build_request_stream(client: baml.llm.Client = ...) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "Fn", map {  }) : baml.http.Request
 }
-function user.Fn$parse(json: string) -> string throws never {
+function user.Fn$parse(json: string, client: baml.llm.Client = ...) -> string throws never {
   baml.llm.parse<TFinal>("Fn", json) : string
 }
 class user.TopLevelClass {
@@ -27,11 +27,11 @@ function user.TopLevelClass.from_json(j: baml.json.json) -> user.TopLevelClass t
   TopLevelClass { a: baml.json.from_json<string>(baml.json.field(j, "a")) } : user.TopLevelClass
 }
 enum user.TopLevelEnum
-function user.Fn$stream() -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "Fn", map {  }) : baml.llm.Stream<null | string, string>
+function user.Fn$stream(client: baml.llm.Client = ...) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "Fn", map {  }) : baml.llm.Stream<null | string, string>
 }
-function user.Fn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "Fn") : baml.llm.Stream<null | string, string>
+function user.Fn$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = ...) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "Fn") : baml.llm.Stream<null | string, string>
 }
 class user.TopLevelClass$stream {
   a: null | string

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__06_codegen.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 30572
 ---
-function user.Fn() -> string {
-    load_type string
+function user.Fn(client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -11,13 +13,22 @@ function user.Fn() -> string {
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_type string
+    load_var client
     load_const "Fn"
     alloc_map 0
     call baml.llm.call_llm_function
     return
 }
 
-function user.Fn$build_request() -> baml.http.Request {
+function user.Fn$build_request(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -25,13 +36,21 @@ function user.Fn$build_request() -> baml.http.Request {
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_var client
     load_const "Fn"
     alloc_map 0
     call baml.llm.build_request
     return
 }
 
-function user.Fn$build_request_stream() -> baml.http.Request {
+function user.Fn$build_request_stream(client: baml.llm.Client) -> baml.http.Request {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -39,20 +58,42 @@ function user.Fn$build_request_stream() -> baml.http.Request {
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_var client
     load_const "Fn"
     alloc_map 0
     call baml.llm.build_request_stream
     return
 }
 
-function user.Fn$parse(json: string) -> string {
+function user.Fn$parse(json: string, client: baml.llm.Client) -> string {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_const "openai/gpt-4o"
+    load_const baml.llm.ClientType.Primitive
+    alloc_variant baml.llm.ClientType
+    alloc_array 0
+    load_const null
+    load_const 0
+    init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
     load_const "Fn"
     load_var json
     call baml.llm.parse
     return
 }
 
-function user.Fn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> {
+function user.Fn$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -60,13 +101,20 @@ function user.Fn$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null 
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
-    load_var sse
+    store_var client
+
+  L0:
+    load_var2 2 1
     load_const "Fn"
     call baml.llm.Client.__make_stream
     return
 }
 
-function user.Fn$render_prompt() -> baml.llm.PromptAst {
+function user.Fn$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -74,13 +122,21 @@ function user.Fn$render_prompt() -> baml.llm.PromptAst {
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_var client
     load_const "Fn"
     alloc_map 0
     call baml.llm.render_prompt
     return
 }
 
-function user.Fn$stream() -> baml.llm.Stream<null | string, string> {
+function user.Fn$stream(client: baml.llm.Client) -> baml.llm.Stream<null | string, string> {
+    load_var client
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
     load_const "openai/gpt-4o"
     load_const baml.llm.ClientType.Primitive
     alloc_variant baml.llm.ClientType
@@ -88,6 +144,10 @@ function user.Fn$stream() -> baml.llm.Stream<null | string, string> {
     load_const null
     load_const 0
     init_instance baml.llm.Client .name, .client_type, .sub_clients, .retry, .counter
+    store_var client
+
+  L0:
+    load_var client
     load_const "Fn"
     alloc_map 0
     call baml.llm.stream_llm_function

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/basic_types/baml_tests__diagnostic_errors__basic_types__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/basic_types/baml_tests__diagnostic_errors__basic_types__03_hir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 26183
 ---
 === HIR2 ===
 class user.ClassAttributes {
@@ -27,65 +26,65 @@ function user.to_json(self: ?) -> baml.json.json  [expr] {
 function user.to_json(self: ?) -> baml.json.json  [expr] {
   map { "money": self.money.to_json(), "currency": self.currency.to_json(), "name": self.name.to_json(), "summary": self.summary.to_json(), "details": self.details?.to_json(), "state": self.state.to_json(), "multiple": self.multiple?.to_json() }
 }
-function user.GetMixedList() -> int | string[]  [llm] {
-  baml.llm.call_llm_function(GPT4, "GetMixedList", map {  })
+function user.GetMixedList(client: baml.llm.Client = GPT4) -> int | string[]  [llm] {
+  baml.llm.call_llm_function(client, "GetMixedList", map {  })
 }
-function user.GetMixedList$build_request() -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4, "GetMixedList", map {  })
+function user.GetMixedList$build_request(client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "GetMixedList", map {  })
 }
-function user.GetMixedList$build_request_stream() -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4, "GetMixedList", map {  })
+function user.GetMixedList$build_request_stream(client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "GetMixedList", map {  })
 }
-function user.GetMixedList$parse(json: string) -> int | string[]  [expr] {
+function user.GetMixedList$parse(json: string, client: baml.llm.Client = GPT4) -> int | string[]  [expr] {
   baml.llm.parse("GetMixedList", json)
 }
-function user.GetMixedList$render_prompt() -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4, "GetMixedList", map {  })
+function user.GetMixedList$render_prompt(client: baml.llm.Client = GPT4) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "GetMixedList", map {  })
 }
-function user.GetMixedMap() -> map<string, int | string>  [llm] {
-  baml.llm.call_llm_function(GPT4, "GetMixedMap", map {  })
+function user.GetMixedMap(client: baml.llm.Client = GPT4) -> map<string, int | string>  [llm] {
+  baml.llm.call_llm_function(client, "GetMixedMap", map {  })
 }
-function user.GetMixedMap$build_request() -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4, "GetMixedMap", map {  })
+function user.GetMixedMap$build_request(client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "GetMixedMap", map {  })
 }
-function user.GetMixedMap$build_request_stream() -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4, "GetMixedMap", map {  })
+function user.GetMixedMap$build_request_stream(client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "GetMixedMap", map {  })
 }
-function user.GetMixedMap$parse(json: string) -> map<string, int | string>  [expr] {
+function user.GetMixedMap$parse(json: string, client: baml.llm.Client = GPT4) -> map<string, int | string>  [expr] {
   baml.llm.parse("GetMixedMap", json)
 }
-function user.GetMixedMap$render_prompt() -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4, "GetMixedMap", map {  })
+function user.GetMixedMap$render_prompt(client: baml.llm.Client = GPT4) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "GetMixedMap", map {  })
 }
-function user.GetStatus() -> user.Status  [llm] {
-  baml.llm.call_llm_function(GPT4, "GetStatus", map {  })
+function user.GetStatus(client: baml.llm.Client = GPT4) -> user.Status  [llm] {
+  baml.llm.call_llm_function(client, "GetStatus", map {  })
 }
-function user.GetStatus$build_request() -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4, "GetStatus", map {  })
+function user.GetStatus$build_request(client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "GetStatus", map {  })
 }
-function user.GetStatus$build_request_stream() -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4, "GetStatus", map {  })
+function user.GetStatus$build_request_stream(client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "GetStatus", map {  })
 }
-function user.GetStatus$parse(json: string) -> user.Status  [expr] {
+function user.GetStatus$parse(json: string, client: baml.llm.Client = GPT4) -> user.Status  [expr] {
   baml.llm.parse("GetStatus", json)
 }
-function user.GetStatus$render_prompt() -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4, "GetStatus", map {  })
+function user.GetStatus$render_prompt(client: baml.llm.Client = GPT4) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "GetStatus", map {  })
 }
-function user.GetUser(id: int) -> user.User  [llm] {
-  baml.llm.call_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id })
+function user.GetUser(id: int, client: baml.llm.Client = ...) -> user.User  [llm] {
+  baml.llm.call_llm_function(client, "GetUser", map { "id": id })
 }
-function user.GetUser$build_request(id: int) -> baml.http.Request  [expr] {
-  baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id })
+function user.GetUser$build_request(id: int, client: baml.llm.Client = ...) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "GetUser", map { "id": id })
 }
-function user.GetUser$build_request_stream(id: int) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id })
+function user.GetUser$build_request_stream(id: int, client: baml.llm.Client = ...) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "GetUser", map { "id": id })
 }
-function user.GetUser$parse(json: string) -> user.User  [expr] {
+function user.GetUser$parse(json: string, client: baml.llm.Client = ...) -> user.User  [expr] {
   baml.llm.parse("GetUser", json)
 }
-function user.GetUser$render_prompt(id: int) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id })
+function user.GetUser$render_prompt(id: int, client: baml.llm.Client = ...) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "GetUser", map { "id": id })
 }
 class user.User {
   id: int

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/basic_types/baml_tests__diagnostic_errors__basic_types__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/basic_types/baml_tests__diagnostic_errors__basic_types__04_tir.snap
@@ -38,106 +38,109 @@ class user.FieldAttributes$stream {
 class user.ClassAttributes$stream {
   name: null | string
 }
-function user.GetUser(id: int) -> user.User throws never {
-  baml.llm.call_llm_function<T>(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id }) : user.User
+function user.GetUser(id: int, client: baml.llm.Client = ...) -> user.User throws never {
+  baml.llm.call_llm_function<T>(client, "GetUser", map { "id": id }) : user.User
 }
-function user.GetUser$render_prompt(id: int) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id }) : baml.llm.PromptAst
+function user.GetUser$render_prompt(id: int, client: baml.llm.Client = ...) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GetUser", map { "id": id }) : baml.llm.PromptAst
 }
-function user.GetUser$build_request(id: int) -> baml.http.Request throws never {
-  baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id }) : baml.http.Request
+function user.GetUser$build_request(id: int, client: baml.llm.Client = ...) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GetUser", map { "id": id }) : baml.http.Request
 }
-function user.GetUser$build_request_stream(id: int) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id }) : baml.http.Request
+function user.GetUser$build_request_stream(id: int, client: baml.llm.Client = ...) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GetUser", map { "id": id }) : baml.http.Request
 }
-function user.GetUser$parse(json: string) -> user.User throws never {
+function user.GetUser$parse(json: string, client: baml.llm.Client = ...) -> user.User throws never {
   baml.llm.parse<TFinal>("GetUser", json) : user.User
 }
-function user.GetStatus() -> user.Status throws never {
-  baml.llm.call_llm_function<T>(GPT4, "GetStatus", map {  }) : user.Status
+function user.GetStatus(client: baml.llm.Client = GPT4) -> user.Status throws never {
+  baml.llm.call_llm_function<T>(client, "GetStatus", map {  }) : user.Status
   !! 127..173: unresolved name: GPT4
 }
-function user.GetStatus$render_prompt() -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4, "GetStatus", map {  }) : baml.llm.PromptAst
+function user.GetStatus$render_prompt(client: baml.llm.Client = GPT4) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GetStatus", map {  }) : baml.llm.PromptAst
   !! 95..173: unresolved name: GPT4
 }
-function user.GetStatus$build_request() -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4, "GetStatus", map {  }) : baml.http.Request
+function user.GetStatus$build_request(client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GetStatus", map {  }) : baml.http.Request
   !! 95..173: unresolved name: GPT4
 }
-function user.GetStatus$build_request_stream() -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4, "GetStatus", map {  }) : baml.http.Request
+function user.GetStatus$build_request_stream(client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GetStatus", map {  }) : baml.http.Request
   !! 95..173: unresolved name: GPT4
 }
-function user.GetStatus$parse(json: string) -> user.Status throws never {
+function user.GetStatus$parse(json: string, client: baml.llm.Client = GPT4) -> user.Status throws never {
   baml.llm.parse<TFinal>("GetStatus", json) : user.Status
+  !! 95..173: unresolved name: GPT4
 }
-function user.GetMixedList() -> (int | string)[] throws never {
-  baml.llm.call_llm_function<T>(GPT4, "GetMixedList", map {  }) : (int | string)[]
+function user.GetMixedList(client: baml.llm.Client = GPT4) -> (int | string)[] throws never {
+  baml.llm.call_llm_function<T>(client, "GetMixedList", map {  }) : (int | string)[]
   !! 258..308: unresolved name: GPT4
 }
-function user.GetMixedList$render_prompt() -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4, "GetMixedList", map {  }) : baml.llm.PromptAst
+function user.GetMixedList$render_prompt(client: baml.llm.Client = GPT4) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GetMixedList", map {  }) : baml.llm.PromptAst
   !! 173..308: unresolved name: GPT4
 }
-function user.GetMixedList$build_request() -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4, "GetMixedList", map {  }) : baml.http.Request
+function user.GetMixedList$build_request(client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GetMixedList", map {  }) : baml.http.Request
   !! 173..308: unresolved name: GPT4
 }
-function user.GetMixedList$build_request_stream() -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4, "GetMixedList", map {  }) : baml.http.Request
+function user.GetMixedList$build_request_stream(client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GetMixedList", map {  }) : baml.http.Request
   !! 173..308: unresolved name: GPT4
 }
-function user.GetMixedList$parse(json: string) -> (int | string)[] throws never {
+function user.GetMixedList$parse(json: string, client: baml.llm.Client = GPT4) -> (int | string)[] throws never {
   baml.llm.parse<TFinal>("GetMixedList", json) : (int | string)[]
+  !! 173..308: unresolved name: GPT4
 }
-function user.GetMixedMap() -> map<string, int | string> throws never {
-  baml.llm.call_llm_function<T>(GPT4, "GetMixedMap", map {  }) : map<string, int | string>
+function user.GetMixedMap(client: baml.llm.Client = GPT4) -> map<string, int | string> throws never {
+  baml.llm.call_llm_function<T>(client, "GetMixedMap", map {  }) : map<string, int | string>
   !! 361..410: unresolved name: GPT4
 }
-function user.GetMixedMap$render_prompt() -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4, "GetMixedMap", map {  }) : baml.llm.PromptAst
+function user.GetMixedMap$render_prompt(client: baml.llm.Client = GPT4) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GetMixedMap", map {  }) : baml.llm.PromptAst
   !! 308..410: unresolved name: GPT4
 }
-function user.GetMixedMap$build_request() -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4, "GetMixedMap", map {  }) : baml.http.Request
+function user.GetMixedMap$build_request(client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GetMixedMap", map {  }) : baml.http.Request
   !! 308..410: unresolved name: GPT4
 }
-function user.GetMixedMap$build_request_stream() -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4, "GetMixedMap", map {  }) : baml.http.Request
+function user.GetMixedMap$build_request_stream(client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GetMixedMap", map {  }) : baml.http.Request
   !! 308..410: unresolved name: GPT4
 }
-function user.GetMixedMap$parse(json: string) -> map<string, int | string> throws never {
+function user.GetMixedMap$parse(json: string, client: baml.llm.Client = GPT4) -> map<string, int | string> throws never {
   baml.llm.parse<TFinal>("GetMixedMap", json) : map<string, int | string>
-}
-function user.GetUser$stream(id: int) -> baml.llm.Stream<null | user.User$stream, user.User> throws never {
-  baml.llm.stream_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "GetUser", map { "id": id }) : baml.llm.Stream<null | user.User$stream, user.User>
-}
-function user.GetUser$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | user.User$stream, user.User> throws never {
-  baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "GetUser") : baml.llm.Stream<null | user.User$stream, user.User>
-}
-function user.GetStatus$stream() -> baml.llm.Stream<null | user.Status, user.Status> throws never {
-  baml.llm.stream_llm_function(GPT4, "GetStatus", map {  }) : baml.llm.Stream<null | user.Status, user.Status>
-  !! 95..173: unresolved name: GPT4
-}
-function user.GetStatus$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | user.Status, user.Status> throws never {
-  GPT4.__make_stream(sse, "GetStatus") : unknown
-  !! 95..173: unresolved name: GPT4
-}
-function user.GetMixedList$stream() -> baml.llm.Stream<(int | string)[], (int | string)[]> throws never {
-  baml.llm.stream_llm_function(GPT4, "GetMixedList", map {  }) : baml.llm.Stream<(int | string)[], (int | string)[]>
-  !! 173..308: unresolved name: GPT4
-}
-function user.GetMixedList$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<(int | string)[], (int | string)[]> throws never {
-  GPT4.__make_stream(sse, "GetMixedList") : unknown
-  !! 173..308: unresolved name: GPT4
-}
-function user.GetMixedMap$stream() -> baml.llm.Stream<map<string, int | string>, map<string, int | string>> throws never {
-  baml.llm.stream_llm_function(GPT4, "GetMixedMap", map {  }) : baml.llm.Stream<map<string, int | string>, map<string, int | string>>
   !! 308..410: unresolved name: GPT4
 }
-function user.GetMixedMap$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<map<string, int | string>, map<string, int | string>> throws never {
-  GPT4.__make_stream(sse, "GetMixedMap") : unknown
+function user.GetUser$stream(id: int, client: baml.llm.Client = ...) -> baml.llm.Stream<null | user.User$stream, user.User> throws never {
+  baml.llm.stream_llm_function(client, "GetUser", map { "id": id }) : baml.llm.Stream<null | user.User$stream, user.User>
+}
+function user.GetUser$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = ...) -> baml.llm.Stream<null | user.User$stream, user.User> throws never {
+  client.__make_stream(sse, "GetUser") : baml.llm.Stream<null | user.User$stream, user.User>
+}
+function user.GetStatus$stream(client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | user.Status, user.Status> throws never {
+  baml.llm.stream_llm_function(client, "GetStatus", map {  }) : baml.llm.Stream<null | user.Status, user.Status>
+  !! 95..173: unresolved name: GPT4
+}
+function user.GetStatus$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | user.Status, user.Status> throws never {
+  client.__make_stream(sse, "GetStatus") : baml.llm.Stream<null | user.Status, user.Status>
+  !! 95..173: unresolved name: GPT4
+}
+function user.GetMixedList$stream(client: baml.llm.Client = GPT4) -> baml.llm.Stream<(int | string)[], (int | string)[]> throws never {
+  baml.llm.stream_llm_function(client, "GetMixedList", map {  }) : baml.llm.Stream<(int | string)[], (int | string)[]>
+  !! 173..308: unresolved name: GPT4
+}
+function user.GetMixedList$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4) -> baml.llm.Stream<(int | string)[], (int | string)[]> throws never {
+  client.__make_stream(sse, "GetMixedList") : baml.llm.Stream<(int | string)[], (int | string)[]>
+  !! 173..308: unresolved name: GPT4
+}
+function user.GetMixedMap$stream(client: baml.llm.Client = GPT4) -> baml.llm.Stream<map<string, int | string>, map<string, int | string>> throws never {
+  baml.llm.stream_llm_function(client, "GetMixedMap", map {  }) : baml.llm.Stream<map<string, int | string>, map<string, int | string>>
+  !! 308..410: unresolved name: GPT4
+}
+function user.GetMixedMap$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4) -> baml.llm.Stream<map<string, int | string>, map<string, int | string>> throws never {
+  client.__make_stream(sse, "GetMixedMap") : baml.llm.Stream<map<string, int | string>, map<string, int | string>>
   !! 308..410: unresolved name: GPT4
 }
 class user.User {

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/control_flow/baml_tests__diagnostic_errors__control_flow__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/control_flow/baml_tests__diagnostic_errors__control_flow__03_hir.snap
@@ -11,20 +11,20 @@ function user.Headers() -> string  [expr] {
 function user.IfElseWithHeaders(flag: bool) -> string  [expr] {
   { // [1] Check flag } if (flag) { // [1] True branch } "yes" else { // [1] False branch } "no"
 }
-function user.LlmFunction(input: string) -> string  [llm] {
-  baml.llm.call_llm_function(TestClient, "LlmFunction", map { "input": input })
+function user.LlmFunction(input: string, client: baml.llm.Client = TestClient) -> string  [llm] {
+  baml.llm.call_llm_function(client, "LlmFunction", map { "input": input })
 }
-function user.LlmFunction$build_request(input: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(TestClient, "LlmFunction", map { "input": input })
+function user.LlmFunction$build_request(input: string, client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "LlmFunction", map { "input": input })
 }
-function user.LlmFunction$build_request_stream(input: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(TestClient, "LlmFunction", map { "input": input })
+function user.LlmFunction$build_request_stream(input: string, client: baml.llm.Client = TestClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "LlmFunction", map { "input": input })
 }
-function user.LlmFunction$parse(json: string) -> string  [expr] {
+function user.LlmFunction$parse(json: string, client: baml.llm.Client = TestClient) -> string  [expr] {
   baml.llm.parse("LlmFunction", json)
 }
-function user.LlmFunction$render_prompt(input: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(TestClient, "LlmFunction", map { "input": input })
+function user.LlmFunction$render_prompt(input: string, client: baml.llm.Client = TestClient) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "LlmFunction", map { "input": input })
 }
 function user.MatchExpression(x: int) -> string  [expr] {
   {  } match (x) { 1 => { // [1] One } "one", 2 => { // [1] Two } "two", _ => { // [1] Default } "other" }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/control_flow/baml_tests__diagnostic_errors__control_flow__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/control_flow/baml_tests__diagnostic_errors__control_flow__04_tir.snap
@@ -121,24 +121,24 @@ function user.NestedControlFlow(x: int) -> string throws never {
 function user.TestClient$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "TestClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : baml.llm.PrimitiveClient
 }
-function user.LlmFunction(input: string) -> string throws never {
-  baml.llm.call_llm_function<T>(TestClient, "LlmFunction", map { "input": input }) : string
+function user.LlmFunction(input: string, client: baml.llm.Client = TestClient) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "LlmFunction", map { "input": input }) : string
 }
-function user.LlmFunction$render_prompt(input: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(TestClient, "LlmFunction", map { "input": input }) : baml.llm.PromptAst
+function user.LlmFunction$render_prompt(input: string, client: baml.llm.Client = TestClient) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "LlmFunction", map { "input": input }) : baml.llm.PromptAst
 }
-function user.LlmFunction$build_request(input: string) -> baml.http.Request throws never {
-  baml.llm.build_request(TestClient, "LlmFunction", map { "input": input }) : baml.http.Request
+function user.LlmFunction$build_request(input: string, client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "LlmFunction", map { "input": input }) : baml.http.Request
 }
-function user.LlmFunction$build_request_stream(input: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(TestClient, "LlmFunction", map { "input": input }) : baml.http.Request
+function user.LlmFunction$build_request_stream(input: string, client: baml.llm.Client = TestClient) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "LlmFunction", map { "input": input }) : baml.http.Request
 }
-function user.LlmFunction$parse(json: string) -> string throws never {
+function user.LlmFunction$parse(json: string, client: baml.llm.Client = TestClient) -> string throws never {
   baml.llm.parse<TFinal>("LlmFunction", json) : string
 }
-function user.LlmFunction$stream(input: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(TestClient, "LlmFunction", map { "input": input }) : baml.llm.Stream<null | string, string>
+function user.LlmFunction$stream(input: string, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "LlmFunction", map { "input": input }) : baml.llm.Stream<null | string, string>
 }
-function user.LlmFunction$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  TestClient.__make_stream(sse, "LlmFunction") : unknown
+function user.LlmFunction$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = TestClient) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "LlmFunction") : baml.llm.Stream<null | string, string>
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__03_hir.snap
@@ -565,20 +565,20 @@ function user.SameLineClient$new() -> ?  [expr] {
 function user.StringProviderClient$new() -> ?  [expr] {
   baml.llm.PrimitiveClient { name: "StringProviderClient", provider: "openai-generic", options: baml.llm.PrimitiveClientOptions { model: "mistralai/mistral...", base_url: "https://openroute...", allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } }
 }
-function user.TestTarget() -> string  [llm] {
-  baml.llm.call_llm_function(BasicClient, "TestTarget", map {  })
+function user.TestTarget(client: baml.llm.Client = BasicClient) -> string  [llm] {
+  baml.llm.call_llm_function(client, "TestTarget", map {  })
 }
-function user.TestTarget$build_request() -> baml.http.Request  [expr] {
-  baml.llm.build_request(BasicClient, "TestTarget", map {  })
+function user.TestTarget$build_request(client: baml.llm.Client = BasicClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "TestTarget", map {  })
 }
-function user.TestTarget$build_request_stream() -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(BasicClient, "TestTarget", map {  })
+function user.TestTarget$build_request_stream(client: baml.llm.Client = BasicClient) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "TestTarget", map {  })
 }
-function user.TestTarget$parse(json: string) -> string  [expr] {
+function user.TestTarget$parse(json: string, client: baml.llm.Client = BasicClient) -> string  [expr] {
   baml.llm.parse("TestTarget", json)
 }
-function user.TestTarget$render_prompt() -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(BasicClient, "TestTarget", map {  })
+function user.TestTarget$render_prompt(client: baml.llm.Client = BasicClient) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "TestTarget", map {  })
 }
 function user.ThisIsAnExtremelyLongClientNameThatDefinitelyExceedsTheDefaultLineLimitOfOneHundredColumns$new() -> ?  [expr] {
   baml.llm.PrimitiveClient { name: "ThisIsAnExtremely...", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } }
@@ -653,80 +653,80 @@ function user.F() -> int  [expr] {
 function user.FinalExpr(a: int, b: int) -> int  [expr] {
   {  } a Add b
 }
-function user.LlmBasic(name: string) -> string  [llm] {
-  baml.llm.call_llm_function(GPT4, "LlmBasic", map { "name": name })
+function user.LlmBasic(name: string, client: baml.llm.Client = GPT4) -> string  [llm] {
+  baml.llm.call_llm_function(client, "LlmBasic", map { "name": name })
 }
-function user.LlmBasic$build_request(name: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4, "LlmBasic", map { "name": name })
+function user.LlmBasic$build_request(name: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "LlmBasic", map { "name": name })
 }
-function user.LlmBasic$build_request_stream(name: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4, "LlmBasic", map { "name": name })
+function user.LlmBasic$build_request_stream(name: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "LlmBasic", map { "name": name })
 }
-function user.LlmBasic$parse(json: string) -> string  [expr] {
+function user.LlmBasic$parse(json: string, client: baml.llm.Client = GPT4) -> string  [expr] {
   baml.llm.parse("LlmBasic", json)
 }
-function user.LlmBasic$render_prompt(name: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4, "LlmBasic", map { "name": name })
+function user.LlmBasic$render_prompt(name: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "LlmBasic", map { "name": name })
 }
-function user.LlmMultiLine(text: string) -> string  [llm] {
-  baml.llm.call_llm_function(GPT4, "LlmMultiLine", map { "text": text })
+function user.LlmMultiLine(text: string, client: baml.llm.Client = GPT4) -> string  [llm] {
+  baml.llm.call_llm_function(client, "LlmMultiLine", map { "text": text })
 }
-function user.LlmMultiLine$build_request(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4, "LlmMultiLine", map { "text": text })
+function user.LlmMultiLine$build_request(text: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "LlmMultiLine", map { "text": text })
 }
-function user.LlmMultiLine$build_request_stream(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4, "LlmMultiLine", map { "text": text })
+function user.LlmMultiLine$build_request_stream(text: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "LlmMultiLine", map { "text": text })
 }
-function user.LlmMultiLine$parse(json: string) -> string  [expr] {
+function user.LlmMultiLine$parse(json: string, client: baml.llm.Client = GPT4) -> string  [expr] {
   baml.llm.parse("LlmMultiLine", json)
 }
-function user.LlmMultiLine$render_prompt(text: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4, "LlmMultiLine", map { "text": text })
+function user.LlmMultiLine$render_prompt(text: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "LlmMultiLine", map { "text": text })
 }
-function user.LlmReversedOrder(text: string) -> string  [llm] {
-  baml.llm.call_llm_function(GPT4, "LlmReversedOrder", map { "text": text })
+function user.LlmReversedOrder(text: string, client: baml.llm.Client = GPT4) -> string  [llm] {
+  baml.llm.call_llm_function(client, "LlmReversedOrder", map { "text": text })
 }
-function user.LlmReversedOrder$build_request(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4, "LlmReversedOrder", map { "text": text })
+function user.LlmReversedOrder$build_request(text: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "LlmReversedOrder", map { "text": text })
 }
-function user.LlmReversedOrder$build_request_stream(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4, "LlmReversedOrder", map { "text": text })
+function user.LlmReversedOrder$build_request_stream(text: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "LlmReversedOrder", map { "text": text })
 }
-function user.LlmReversedOrder$parse(json: string) -> string  [expr] {
+function user.LlmReversedOrder$parse(json: string, client: baml.llm.Client = GPT4) -> string  [expr] {
   baml.llm.parse("LlmReversedOrder", json)
 }
-function user.LlmReversedOrder$render_prompt(text: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4, "LlmReversedOrder", map { "text": text })
+function user.LlmReversedOrder$render_prompt(text: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "LlmReversedOrder", map { "text": text })
 }
-function user.LlmStringClient(text: string) -> string  [llm] {
-  baml.llm.call_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text })
+function user.LlmStringClient(text: string, client: baml.llm.Client = ...) -> string  [llm] {
+  baml.llm.call_llm_function(client, "LlmStringClient", map { "text": text })
 }
-function user.LlmStringClient$build_request(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text })
+function user.LlmStringClient$build_request(text: string, client: baml.llm.Client = ...) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "LlmStringClient", map { "text": text })
 }
-function user.LlmStringClient$build_request_stream(text: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text })
+function user.LlmStringClient$build_request_stream(text: string, client: baml.llm.Client = ...) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "LlmStringClient", map { "text": text })
 }
-function user.LlmStringClient$parse(json: string) -> string  [expr] {
+function user.LlmStringClient$parse(json: string, client: baml.llm.Client = ...) -> string  [expr] {
   baml.llm.parse("LlmStringClient", json)
 }
-function user.LlmStringClient$render_prompt(text: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text })
+function user.LlmStringClient$render_prompt(text: string, client: baml.llm.Client = ...) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "LlmStringClient", map { "text": text })
 }
-function user.LlmWithLongSignature(first_context: string, second_context: string, third_context: string, user_query: string) -> string  [llm] {
-  baml.llm.call_llm_function(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
+function user.LlmWithLongSignature(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> string  [llm] {
+  baml.llm.call_llm_function(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
 }
-function user.LlmWithLongSignature$build_request(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
+function user.LlmWithLongSignature$build_request(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
 }
-function user.LlmWithLongSignature$build_request_stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
+function user.LlmWithLongSignature$build_request_stream(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
 }
-function user.LlmWithLongSignature$parse(json: string) -> string  [expr] {
+function user.LlmWithLongSignature$parse(json: string, client: baml.llm.Client = GPT4) -> string  [expr] {
   baml.llm.parse("LlmWithLongSignature", json)
 }
-function user.LlmWithLongSignature$render_prompt(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
+function user.LlmWithLongSignature$render_prompt(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query })
 }
 function user.LongNameWithLongReturnType_ExceedsTheLineLimit(x: int) -> map<string, map<string, int | string | bool | float | null>>  [expr] {
   {  } map { "a": map { "b": 1 } }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__04_tir.snap
@@ -927,19 +927,19 @@ function user.TriviaLongValueClient$new() -> ? throws never {
 function user.TriviaLongValueClientBlock$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "TriviaLongValueCl...", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "some-extremely-lo...", base_url: "https://some-real...", allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : baml.llm.PrimitiveClient
 }
-function user.TestTarget() -> string throws never {
-  baml.llm.call_llm_function<T>(BasicClient, "TestTarget", map {  }) : string
+function user.TestTarget(client: baml.llm.Client = BasicClient) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "TestTarget", map {  }) : string
 }
-function user.TestTarget$render_prompt() -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(BasicClient, "TestTarget", map {  }) : baml.llm.PromptAst
+function user.TestTarget$render_prompt(client: baml.llm.Client = BasicClient) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "TestTarget", map {  }) : baml.llm.PromptAst
 }
-function user.TestTarget$build_request() -> baml.http.Request throws never {
-  baml.llm.build_request(BasicClient, "TestTarget", map {  }) : baml.http.Request
+function user.TestTarget$build_request(client: baml.llm.Client = BasicClient) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "TestTarget", map {  }) : baml.http.Request
 }
-function user.TestTarget$build_request_stream() -> baml.http.Request throws never {
-  baml.llm.build_request_stream(BasicClient, "TestTarget", map {  }) : baml.http.Request
+function user.TestTarget$build_request_stream(client: baml.llm.Client = BasicClient) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "TestTarget", map {  }) : baml.http.Request
 }
-function user.TestTarget$parse(json: string) -> string throws never {
+function user.TestTarget$parse(json: string, client: baml.llm.Client = BasicClient) -> string throws never {
   baml.llm.parse<TFinal>("TestTarget", json) : string
 }
 function user.C$new() -> ? throws never {
@@ -954,11 +954,11 @@ function user.CommaClient$new() -> ? throws never {
 function user.SameLineClient$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "SameLineClient", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : baml.llm.PrimitiveClient
 }
-function user.TestTarget$stream() -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(BasicClient, "TestTarget", map {  }) : baml.llm.Stream<null | string, string>
+function user.TestTarget$stream(client: baml.llm.Client = BasicClient) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "TestTarget", map {  }) : baml.llm.Stream<null | string, string>
 }
-function user.TestTarget$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  BasicClient.__make_stream(sse, "TestTarget") : unknown
+function user.TestTarget$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = BasicClient) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "TestTarget") : baml.llm.Stream<null | string, string>
 }
 enum user.Minimal
 enum user.TwoVariants
@@ -1242,96 +1242,100 @@ function user.DeepNestLongExpr(a: int, b: int, c: int, d: int) -> int throws nev
       }
   }
 }
-function user.LlmBasic(name: string) -> string throws never {
-  baml.llm.call_llm_function<T>(GPT4, "LlmBasic", map { "name": name }) : string
+function user.LlmBasic(name: string, client: baml.llm.Client = GPT4) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "LlmBasic", map { "name": name }) : string
   !! 11146..11203: unresolved name: GPT4
 }
-function user.LlmBasic$render_prompt(name: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4, "LlmBasic", map { "name": name }) : baml.llm.PromptAst
+function user.LlmBasic$render_prompt(name: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "LlmBasic", map { "name": name }) : baml.llm.PromptAst
   !! 11069..11203: unresolved name: GPT4
 }
-function user.LlmBasic$build_request(name: string) -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4, "LlmBasic", map { "name": name }) : baml.http.Request
+function user.LlmBasic$build_request(name: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "LlmBasic", map { "name": name }) : baml.http.Request
   !! 11069..11203: unresolved name: GPT4
 }
-function user.LlmBasic$build_request_stream(name: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4, "LlmBasic", map { "name": name }) : baml.http.Request
+function user.LlmBasic$build_request_stream(name: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "LlmBasic", map { "name": name }) : baml.http.Request
   !! 11069..11203: unresolved name: GPT4
 }
-function user.LlmBasic$parse(json: string) -> string throws never {
+function user.LlmBasic$parse(json: string, client: baml.llm.Client = GPT4) -> string throws never {
   baml.llm.parse<TFinal>("LlmBasic", json) : string
+  !! 11069..11203: unresolved name: GPT4
 }
-function user.LlmMultiLine(text: string) -> string throws never {
-  baml.llm.call_llm_function<T>(GPT4, "LlmMultiLine", map { "text": text }) : string
+function user.LlmMultiLine(text: string, client: baml.llm.Client = GPT4) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "LlmMultiLine", map { "text": text }) : string
   !! 11306..11428: unresolved name: GPT4
 }
-function user.LlmMultiLine$render_prompt(text: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4, "LlmMultiLine", map { "text": text }) : baml.llm.PromptAst
+function user.LlmMultiLine$render_prompt(text: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "LlmMultiLine", map { "text": text }) : baml.llm.PromptAst
   !! 11203..11428: unresolved name: GPT4
 }
-function user.LlmMultiLine$build_request(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4, "LlmMultiLine", map { "text": text }) : baml.http.Request
+function user.LlmMultiLine$build_request(text: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "LlmMultiLine", map { "text": text }) : baml.http.Request
   !! 11203..11428: unresolved name: GPT4
 }
-function user.LlmMultiLine$build_request_stream(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4, "LlmMultiLine", map { "text": text }) : baml.http.Request
+function user.LlmMultiLine$build_request_stream(text: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "LlmMultiLine", map { "text": text }) : baml.http.Request
   !! 11203..11428: unresolved name: GPT4
 }
-function user.LlmMultiLine$parse(json: string) -> string throws never {
+function user.LlmMultiLine$parse(json: string, client: baml.llm.Client = GPT4) -> string throws never {
   baml.llm.parse<TFinal>("LlmMultiLine", json) : string
+  !! 11203..11428: unresolved name: GPT4
 }
-function user.LlmStringClient(text: string) -> string throws never {
-  baml.llm.call_llm_function<T>(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text }) : string
+function user.LlmStringClient(text: string, client: baml.llm.Client = ...) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "LlmStringClient", map { "text": text }) : string
 }
-function user.LlmStringClient$render_prompt(text: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text }) : baml.llm.PromptAst
+function user.LlmStringClient$render_prompt(text: string, client: baml.llm.Client = ...) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "LlmStringClient", map { "text": text }) : baml.llm.PromptAst
 }
-function user.LlmStringClient$build_request(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text }) : baml.http.Request
+function user.LlmStringClient$build_request(text: string, client: baml.llm.Client = ...) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "LlmStringClient", map { "text": text }) : baml.http.Request
 }
-function user.LlmStringClient$build_request_stream(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text }) : baml.http.Request
+function user.LlmStringClient$build_request_stream(text: string, client: baml.llm.Client = ...) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "LlmStringClient", map { "text": text }) : baml.http.Request
 }
-function user.LlmStringClient$parse(json: string) -> string throws never {
+function user.LlmStringClient$parse(json: string, client: baml.llm.Client = ...) -> string throws never {
   baml.llm.parse<TFinal>("LlmStringClient", json) : string
 }
-function user.LlmReversedOrder(text: string) -> string throws never {
-  baml.llm.call_llm_function<T>(GPT4, "LlmReversedOrder", map { "text": text }) : string
+function user.LlmReversedOrder(text: string, client: baml.llm.Client = GPT4) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "LlmReversedOrder", map { "text": text }) : string
   !! 11706..11763: unresolved name: GPT4
 }
-function user.LlmReversedOrder$render_prompt(text: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4, "LlmReversedOrder", map { "text": text }) : baml.llm.PromptAst
+function user.LlmReversedOrder$render_prompt(text: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "LlmReversedOrder", map { "text": text }) : baml.llm.PromptAst
   !! 11593..11763: unresolved name: GPT4
 }
-function user.LlmReversedOrder$build_request(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4, "LlmReversedOrder", map { "text": text }) : baml.http.Request
+function user.LlmReversedOrder$build_request(text: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "LlmReversedOrder", map { "text": text }) : baml.http.Request
   !! 11593..11763: unresolved name: GPT4
 }
-function user.LlmReversedOrder$build_request_stream(text: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4, "LlmReversedOrder", map { "text": text }) : baml.http.Request
+function user.LlmReversedOrder$build_request_stream(text: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "LlmReversedOrder", map { "text": text }) : baml.http.Request
   !! 11593..11763: unresolved name: GPT4
 }
-function user.LlmReversedOrder$parse(json: string) -> string throws never {
+function user.LlmReversedOrder$parse(json: string, client: baml.llm.Client = GPT4) -> string throws never {
   baml.llm.parse<TFinal>("LlmReversedOrder", json) : string
+  !! 11593..11763: unresolved name: GPT4
 }
-function user.LlmWithLongSignature(first_context: string, second_context: string, third_context: string, user_query: string) -> string throws never {
-  baml.llm.call_llm_function<T>(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : string
+function user.LlmWithLongSignature(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : string
   !! 11948..12099: unresolved name: GPT4
 }
-function user.LlmWithLongSignature$render_prompt(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.llm.PromptAst
+function user.LlmWithLongSignature$render_prompt(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.llm.PromptAst
   !! 11763..12099: unresolved name: GPT4
 }
-function user.LlmWithLongSignature$build_request(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.http.Request
+function user.LlmWithLongSignature$build_request(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.http.Request
   !! 11763..12099: unresolved name: GPT4
 }
-function user.LlmWithLongSignature$build_request_stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.http.Request
+function user.LlmWithLongSignature$build_request_stream(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.http.Request
   !! 11763..12099: unresolved name: GPT4
 }
-function user.LlmWithLongSignature$parse(json: string) -> string throws never {
+function user.LlmWithLongSignature$parse(json: string, client: baml.llm.Client = GPT4) -> string throws never {
   baml.llm.parse<TFinal>("LlmWithLongSignature", json) : string
+  !! 11763..12099: unresolved name: GPT4
 }
 function user.ExtraWhitespace(a: int, b: int) -> int throws never {
   { : int
@@ -1363,42 +1367,42 @@ function user.NoColonComplexTypes(items: int[], mapping: map<string, int>) -> st
     "done" : "done"
   }
 }
-function user.LlmBasic$stream(name: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(GPT4, "LlmBasic", map { "name": name }) : baml.llm.Stream<null | string, string>
+function user.LlmBasic$stream(name: string, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "LlmBasic", map { "name": name }) : baml.llm.Stream<null | string, string>
   !! 11069..11203: unresolved name: GPT4
 }
-function user.LlmBasic$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  GPT4.__make_stream(sse, "LlmBasic") : unknown
+function user.LlmBasic$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "LlmBasic") : baml.llm.Stream<null | string, string>
   !! 11069..11203: unresolved name: GPT4
 }
-function user.LlmMultiLine$stream(text: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(GPT4, "LlmMultiLine", map { "text": text }) : baml.llm.Stream<null | string, string>
+function user.LlmMultiLine$stream(text: string, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "LlmMultiLine", map { "text": text }) : baml.llm.Stream<null | string, string>
   !! 11203..11428: unresolved name: GPT4
 }
-function user.LlmMultiLine$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  GPT4.__make_stream(sse, "LlmMultiLine") : unknown
+function user.LlmMultiLine$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "LlmMultiLine") : baml.llm.Stream<null | string, string>
   !! 11203..11428: unresolved name: GPT4
 }
-function user.LlmStringClient$stream(text: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }, "LlmStringClient", map { "text": text }) : baml.llm.Stream<null | string, string>
+function user.LlmStringClient$stream(text: string, client: baml.llm.Client = ...) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "LlmStringClient", map { "text": text }) : baml.llm.Stream<null | string, string>
 }
-function user.LlmStringClient$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.Client { name: "openai/gpt-4o", client_type: baml.llm.ClientType.Primitive, sub_clients: [], retry: null, counter: 0 }.__make_stream(sse, "LlmStringClient") : baml.llm.Stream<null | string, string>
+function user.LlmStringClient$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = ...) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "LlmStringClient") : baml.llm.Stream<null | string, string>
 }
-function user.LlmReversedOrder$stream(text: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(GPT4, "LlmReversedOrder", map { "text": text }) : baml.llm.Stream<null | string, string>
+function user.LlmReversedOrder$stream(text: string, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "LlmReversedOrder", map { "text": text }) : baml.llm.Stream<null | string, string>
   !! 11593..11763: unresolved name: GPT4
 }
-function user.LlmReversedOrder$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  GPT4.__make_stream(sse, "LlmReversedOrder") : unknown
+function user.LlmReversedOrder$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "LlmReversedOrder") : baml.llm.Stream<null | string, string>
   !! 11593..11763: unresolved name: GPT4
 }
-function user.LlmWithLongSignature$stream(first_context: string, second_context: string, third_context: string, user_query: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(GPT4, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.llm.Stream<null | string, string>
+function user.LlmWithLongSignature$stream(first_context: string, second_context: string, third_context: string, user_query: string, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "LlmWithLongSignature", map { "first_context": first_context, "second_context": second_context, "third_context": third_context, "user_query": user_query }) : baml.llm.Stream<null | string, string>
   !! 11763..12099: unresolved name: GPT4
 }
-function user.LlmWithLongSignature$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  GPT4.__make_stream(sse, "LlmWithLongSignature") : unknown
+function user.LlmWithLongSignature$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "LlmWithLongSignature") : baml.llm.Stream<null | string, string>
   !! 11763..12099: unresolved name: GPT4
 }
 function user.MyFunction(a: int, b: int) -> int throws never {

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_function/baml_tests__diagnostic_errors__simple_function__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_function/baml_tests__diagnostic_errors__simple_function__03_hir.snap
@@ -6,20 +6,20 @@ class user.User {
   name: string
   age: int
 }
-function user.HelloWorld(name: string) -> string  [llm] {
-  baml.llm.call_llm_function(GPT4, "HelloWorld", map { "name": name })
+function user.HelloWorld(name: string, client: baml.llm.Client = GPT4) -> string  [llm] {
+  baml.llm.call_llm_function(client, "HelloWorld", map { "name": name })
 }
-function user.HelloWorld$build_request(name: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request(GPT4, "HelloWorld", map { "name": name })
+function user.HelloWorld$build_request(name: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request(client, "HelloWorld", map { "name": name })
 }
-function user.HelloWorld$build_request_stream(name: string) -> baml.http.Request  [expr] {
-  baml.llm.build_request_stream(GPT4, "HelloWorld", map { "name": name })
+function user.HelloWorld$build_request_stream(name: string, client: baml.llm.Client = GPT4) -> baml.http.Request  [expr] {
+  baml.llm.build_request_stream(client, "HelloWorld", map { "name": name })
 }
-function user.HelloWorld$parse(json: string) -> string  [expr] {
+function user.HelloWorld$parse(json: string, client: baml.llm.Client = GPT4) -> string  [expr] {
   baml.llm.parse("HelloWorld", json)
 }
-function user.HelloWorld$render_prompt(name: string) -> baml.llm.PromptAst  [expr] {
-  baml.llm.render_prompt(GPT4, "HelloWorld", map { "name": name })
+function user.HelloWorld$render_prompt(name: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst  [expr] {
+  baml.llm.render_prompt(client, "HelloWorld", map { "name": name })
 }
 function user.from_json(j: baml.json.json) -> user.User  [expr] {
   user.User { name: baml.json.from_json(baml.json.field(j, "name")), age: baml.json.from_json(baml.json.field(j, "age")) }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_function/baml_tests__diagnostic_errors__simple_function__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_function/baml_tests__diagnostic_errors__simple_function__04_tir.snap
@@ -2,24 +2,25 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
-function user.HelloWorld(name: string) -> string throws never {
-  baml.llm.call_llm_function<T>(GPT4, "HelloWorld", map { "name": name }) : string
+function user.HelloWorld(name: string, client: baml.llm.Client = GPT4) -> string throws never {
+  baml.llm.call_llm_function<T>(client, "HelloWorld", map { "name": name }) : string
   !! 43..104: unresolved name: GPT4
 }
-function user.HelloWorld$render_prompt(name: string) -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(GPT4, "HelloWorld", map { "name": name }) : baml.llm.PromptAst
+function user.HelloWorld$render_prompt(name: string, client: baml.llm.Client = GPT4) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "HelloWorld", map { "name": name }) : baml.llm.PromptAst
   !! 0..104: unresolved name: GPT4
 }
-function user.HelloWorld$build_request(name: string) -> baml.http.Request throws never {
-  baml.llm.build_request(GPT4, "HelloWorld", map { "name": name }) : baml.http.Request
+function user.HelloWorld$build_request(name: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "HelloWorld", map { "name": name }) : baml.http.Request
   !! 0..104: unresolved name: GPT4
 }
-function user.HelloWorld$build_request_stream(name: string) -> baml.http.Request throws never {
-  baml.llm.build_request_stream(GPT4, "HelloWorld", map { "name": name }) : baml.http.Request
+function user.HelloWorld$build_request_stream(name: string, client: baml.llm.Client = GPT4) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "HelloWorld", map { "name": name }) : baml.http.Request
   !! 0..104: unresolved name: GPT4
 }
-function user.HelloWorld$parse(json: string) -> string throws never {
+function user.HelloWorld$parse(json: string, client: baml.llm.Client = GPT4) -> string throws never {
   baml.llm.parse<TFinal>("HelloWorld", json) : string
+  !! 0..104: unresolved name: GPT4
 }
 class user.User {
   name: string
@@ -31,12 +32,12 @@ function user.User.to_json(self: user.User) -> baml.json.json throws baml.json.J
 function user.User.from_json(j: baml.json.json) -> user.User throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   User { name: baml.json.from_json<string>(baml.json.field(j, "name")), age: baml.json.from_json<int>(baml.json.field(j, "age")) } : user.User
 }
-function user.HelloWorld$stream(name: string) -> baml.llm.Stream<null | string, string> throws never {
-  baml.llm.stream_llm_function(GPT4, "HelloWorld", map { "name": name }) : baml.llm.Stream<null | string, string>
+function user.HelloWorld$stream(name: string, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  baml.llm.stream_llm_function(client, "HelloWorld", map { "name": name }) : baml.llm.Stream<null | string, string>
   !! 0..104: unresolved name: GPT4
 }
-function user.HelloWorld$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | string, string> throws never {
-  GPT4.__make_stream(sse, "HelloWorld") : unknown
+function user.HelloWorld$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = GPT4) -> baml.llm.Stream<null | string, string> throws never {
+  client.__make_stream(sse, "HelloWorld") : baml.llm.Stream<null | string, string>
   !! 0..104: unresolved name: GPT4
 }
 class user.User$stream {

--- a/baml_language/crates/baml_tests/src/compiler2_hir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_hir.rs
@@ -242,11 +242,20 @@ mod tests {
             .find(|f| f.name == Name::new("greet"));
         let func = func.expect("function 'greet' should be in item tree");
 
-        assert_eq!(func.params.len(), 1, "greet should have 1 param");
+        assert_eq!(
+            func.params.len(),
+            2,
+            "LLM function should have user params plus default client param"
+        );
         assert_eq!(
             func.params[0].name,
             Name::new("name"),
             "param name should be 'name'"
+        );
+        assert_eq!(
+            func.params[1].name,
+            Name::new("client"),
+            "LLM function should append default client param"
         );
         assert!(
             func.return_type.is_some(),
@@ -280,10 +289,10 @@ mod tests {
             let bindings = &index.scope_bindings[i];
             assert_eq!(
                 bindings.params.len(),
-                2,
-                "function 'add' should have 2 params"
+                3,
+                "LLM function 'add' should have 2 user params plus default client param"
             );
-            // params are in order: a=0, b=1
+            // params are in order: a=0, b=1, client=2
             assert!(
                 bindings
                     .params
@@ -296,11 +305,17 @@ mod tests {
                     .iter()
                     .any(|(n, idx)| n == &Name::new("b") && *idx == 1)
             );
+            assert!(
+                bindings
+                    .params
+                    .iter()
+                    .any(|(n, idx)| n == &Name::new("client") && *idx == 2)
+            );
 
             // scope_bindings_query also works using the pre-interned ScopeId
             let scope_id = index.scope_ids[i];
             let bindings2 = baml_compiler2_hir::scope_bindings_query(&db, scope_id);
-            assert_eq!(bindings2.params.len(), 2);
+            assert_eq!(bindings2.params.len(), 3);
         } else {
             panic!("No Function scope found in index");
         }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
@@ -140,6 +140,63 @@ function f() -> string {
 }
 
 #[test]
+fn llm_client_override_argument_is_callable_on_function_and_build_request() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r##"
+client<llm> DefaultClient {
+  provider "openai"
+  options {
+    model "gpt-4o-mini"
+    api_key "default-key"
+  }
+}
+
+client<llm> OverrideClient {
+  provider "openai"
+  options {
+    model "gpt-4o-mini"
+    api_key "override-key"
+  }
+}
+
+function Ask(input: string) -> string {
+  client DefaultClient
+  prompt #"{{ input }}"#
+}
+
+function call_overrides() -> string {
+  let answer = Ask("hello", client = OverrideClient)
+  let request_url = Ask$build_request("hello", client = OverrideClient).url
+  answer + request_url
+}
+"##,
+    );
+    let tir = render_tir(&db, file);
+
+    assert!(
+        tir.contains("function user.Ask(input: string, client: baml.llm.Client = DefaultClient)"),
+        "{tir}"
+    );
+    assert!(
+        tir.contains(
+            "function user.Ask$build_request(input: string, client: baml.llm.Client = DefaultClient) -> baml.http.Request"
+        ),
+        "{tir}"
+    );
+    assert!(
+        tir.contains(r#"Ask("hello", client = OverrideClient) : string"#),
+        "{tir}"
+    );
+    assert!(
+        tir.contains(r#"Ask$build_request("hello", client = OverrideClient).url : string"#),
+        "{tir}"
+    );
+    assert!(!tir.contains("!!"), "unexpected diagnostics:\n{tir}");
+}
+
+#[test]
 fn raw_generic_constructor_infers_typevar_from_field_value() {
     let mut db = make_db();
     let file = db.add_file(

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__stream_expansion__stream_companion_preserves_generic_args_for_llm_return_type.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__stream_expansion__stream_companion_preserves_generic_args_for_llm_return_type.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/compiler2_tir/stream_expansion.rs
+assertion_line: 453
 expression: "render_tir(&db, file)"
 ---
 class user.Box {
@@ -14,27 +15,27 @@ function user.Box.from_json(j: baml.json.json) -> user.Box<unknown> throws baml.
 function user.Dummy$new() -> ? throws never {
   baml.llm.PrimitiveClient { name: "Dummy", provider: "openai", options: baml.llm.PrimitiveClientOptions { model: "gpt-4", base_url: null, allowed_role_metadata: null, finish_reason_allow_list: null, finish_reason_deny_list: null, supports_streaming: null, default_role: null, allowed_roles: null, remap_roles: null, api_key: null, provider_options: null, media_url_handler: null, headers: map {  }, query_params: map {  }, request_body: map {  } } } : baml.llm.PrimitiveClient
 }
-function user.GetBoxedInt() -> user.Box<int> throws never {
-  baml.llm.call_llm_function<T>(Dummy, "GetBoxedInt", map {  }) : user.Box<int>
+function user.GetBoxedInt(client: baml.llm.Client = Dummy) -> user.Box<int> throws never {
+  baml.llm.call_llm_function<T>(client, "GetBoxedInt", map {  }) : user.Box<int>
 }
-function user.GetBoxedInt$render_prompt() -> baml.llm.PromptAst throws never {
-  baml.llm.render_prompt(Dummy, "GetBoxedInt", map {  }) : baml.llm.PromptAst
+function user.GetBoxedInt$render_prompt(client: baml.llm.Client = Dummy) -> baml.llm.PromptAst throws never {
+  baml.llm.render_prompt(client, "GetBoxedInt", map {  }) : baml.llm.PromptAst
 }
-function user.GetBoxedInt$build_request() -> baml.http.Request throws never {
-  baml.llm.build_request(Dummy, "GetBoxedInt", map {  }) : baml.http.Request
+function user.GetBoxedInt$build_request(client: baml.llm.Client = Dummy) -> baml.http.Request throws never {
+  baml.llm.build_request(client, "GetBoxedInt", map {  }) : baml.http.Request
 }
-function user.GetBoxedInt$build_request_stream() -> baml.http.Request throws never {
-  baml.llm.build_request_stream(Dummy, "GetBoxedInt", map {  }) : baml.http.Request
+function user.GetBoxedInt$build_request_stream(client: baml.llm.Client = Dummy) -> baml.http.Request throws never {
+  baml.llm.build_request_stream(client, "GetBoxedInt", map {  }) : baml.http.Request
 }
-function user.GetBoxedInt$parse(json: string) -> user.Box<int> throws never {
+function user.GetBoxedInt$parse(json: string, client: baml.llm.Client = Dummy) -> user.Box<int> throws never {
   baml.llm.parse<TFinal>("GetBoxedInt", json) : user.Box<int>
 }
 class user.Box$stream {
   value: null | T
 }
-function user.GetBoxedInt$stream() -> baml.llm.Stream<null | user.Box$stream<int>, user.Box<int>> throws never {
-  baml.llm.stream_llm_function(Dummy, "GetBoxedInt", map {  }) : baml.llm.Stream<null | user.Box$stream<int>, user.Box<int>>
+function user.GetBoxedInt$stream(client: baml.llm.Client = Dummy) -> baml.llm.Stream<null | user.Box$stream<int>, user.Box<int>> throws never {
+  baml.llm.stream_llm_function(client, "GetBoxedInt", map {  }) : baml.llm.Stream<null | user.Box$stream<int>, user.Box<int>>
 }
-function user.GetBoxedInt$parse_stream(sse: baml.http.SseStream) -> baml.llm.Stream<null | user.Box$stream<int>, user.Box<int>> throws never {
-  Dummy.__make_stream(sse, "GetBoxedInt") : unknown
+function user.GetBoxedInt$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client = Dummy) -> baml.llm.Stream<null | user.Box$stream<int>, user.Box<int>> throws never {
+  client.__make_stream(sse, "GetBoxedInt") : baml.llm.Stream<null | user.Box$stream<int>, user.Box<int>>
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -92,7 +92,7 @@ use bex_heap::{BexHeap, TlabHolder};
 use bex_vm::{BexVm, SpanNotification, VmExecState, vm::InterfaceImplementors};
 use bex_vm_types::{
     FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SharedGlobals, SysOp, Value,
-    VmGlobals,
+    ValueKind, VmGlobals,
 };
 pub use conversion::test_arg_to_external;
 // Re-export CancellationToken for callers.
@@ -2745,6 +2745,7 @@ impl BexEngine {
                                 // Convert VM args to fully owned values for the event
                                 let external_args: Vec<BexExternalValue> = args
                                     .iter()
+                                    .filter(|v| !matches!(v.kind(), ValueKind::OmittedArg))
                                     .map(|v| self.vm_value_to_owned(thread.proof(), *v))
                                     .collect();
 

--- a/baml_language/sdks/python/rust/codegen_python/src/lib.rs
+++ b/baml_language/sdks/python/rust/codegen_python/src/lib.rs
@@ -1919,6 +1919,75 @@ mod tests {
     }
 
     #[test]
+    fn llm_default_client_argument_renders_in_function_and_companion_signatures() {
+        let mut pool: SymbolPool = HashMap::new();
+        let client_ty = Ty::Class(cg_name("baml", &["llm"], "Client"), vec![]);
+        let client_default = Some(FunctionArgumentDefault::Expression {
+            source: Some("GPT4".to_string()),
+        });
+        let make_args = |first_name: &str, first_ty: Ty| {
+            vec![
+                FunctionArgument {
+                    name: BaseName::new(first_name),
+                    docstring: None,
+                    ty: first_ty,
+                    default: None,
+                },
+                FunctionArgument {
+                    name: BaseName::new("client"),
+                    docstring: None,
+                    ty: client_ty.clone(),
+                    default: client_default.clone(),
+                },
+            ]
+        };
+
+        pool.insert(
+            cg_name("user", &["lorem"], "extract_resume"),
+            Symbol::Function(Function {
+                generic_params: Vec::new(),
+                name: BaseName::new("extract_resume"),
+                docstring: None,
+                arguments: make_args("resume", Ty::String),
+                return_type: Ty::String,
+                throws: None,
+                watchers: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        pool.insert(
+            cg_name("user", &["lorem"], "extract_resume$build_request"),
+            Symbol::Function(Function {
+                generic_params: Vec::new(),
+                name: BaseName::new("extract_resume$build_request"),
+                docstring: None,
+                arguments: make_args("resume", Ty::String),
+                return_type: Ty::Class(cg_name("baml", &["http"], "Request"), vec![]),
+                throws: None,
+                watchers: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(py.contains(
+            "extract_resume       = _define_function(\"user.lorem.extract_resume\", \"sync\",  [\"resume\", \"client\"], 1)\n"
+        ));
+        assert!(py.contains(
+            "extract_resume__build_request       = _define_function(\"user.lorem.extract_resume$build_request\", \"sync\",  [\"resume\", \"client\"], 1)\n"
+        ));
+
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(pyi.contains(
+            "def extract_resume(resume: str, *, client: baml.llm.Client = ...) -> str: ...\n"
+        ));
+        assert!(pyi.contains(
+            "def extract_resume__build_request(resume: str, *, client: baml.llm.Client = ...) -> baml.http.Request: ...\n"
+        ));
+    }
+
+    #[test]
     fn empty_collection_defaults_do_not_require_unset_import_in_pyi() {
         let mut pool: SymbolPool = HashMap::new();
         let key = cg_name("user", &["lorem"], "defaults");


### PR DESCRIPTION
- add a default `client` arg to every LLM function and all LLM companion functions: `$build_request()`, `$build_request_stream()``$render_prompt()`, `$parse()`, `$parse_stream()`, `$stream()`
- if the user attempts to define a `client` arg on their LLM function, compiler now errors
