### PR TITLE
perf(vm): CPython-style movement superinstructions + lazy faulting PC

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -1153,8 +1153,13 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         // are never affected:
         //  - StoreVar(slot); LoadVar(slot)  -> StoreVarLoadVar(slot)   (store-keep)
         //  - LoadVar(a);     LoadVar(slot)  -> LoadVar2(a, slot)       (load pair)
+        //
+        // Skip fusion when a sequence point is pending: the rewrite happens in
+        // place on the previous instruction, so it would swallow the new op's
+        // sequence point / line entry (the standalone `emit` path below records
+        // it). Cheap correctness guard for debugger stepping & line attribution.
         let n = self.bytecode.instructions.len();
-        if n > self.current_block_start {
+        if n > self.current_block_start && !self.pending_sequence_point {
             match self.bytecode.instructions[n - 1] {
                 Instruction::StoreVar(prev) if prev == slot => {
                     self.bytecode.instructions[n - 1] = Instruction::StoreVarLoadVar(slot);
@@ -1178,8 +1183,9 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
     /// In-place rewrite confined to the current basic block, like
     /// [`Self::emit_load_var`].
     fn emit_store_var(&mut self, slot: usize) {
+        // See `emit_load_var`: don't fuse across a pending sequence point.
         let n = self.bytecode.instructions.len();
-        if n > self.current_block_start {
+        if n > self.current_block_start && !self.pending_sequence_point {
             if let Instruction::StoreVar(a) = self.bytecode.instructions[n - 1] {
                 self.bytecode.instructions[n - 1] = Instruction::StoreVar2(a, slot);
                 self.set_var_operand(n - 1, slot);

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -1148,19 +1148,45 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
     }
 
     fn emit_load_var(&mut self, slot: usize) {
-        if matches!(
-            self.bytecode.instructions.last(),
-            Some(Instruction::StoreVar(prev_slot)) if *prev_slot == slot
-        ) {
-            let last_idx = self.bytecode.instructions.len() - 1;
-            if last_idx >= self.current_block_start {
-                self.bytecode.instructions[last_idx] = Instruction::StoreVarLoadVar(slot);
-                self.set_var_operand(last_idx, slot);
-                return;
+        // Superinstruction peepholes (CPython-style, operand-movement only),
+        // confined to the current basic block so jump targets / block addresses
+        // are never affected:
+        //  - StoreVar(slot); LoadVar(slot)  -> StoreVarLoadVar(slot)   (store-keep)
+        //  - LoadVar(a);     LoadVar(slot)  -> LoadVar2(a, slot)       (load pair)
+        let n = self.bytecode.instructions.len();
+        if n > self.current_block_start {
+            match self.bytecode.instructions[n - 1] {
+                Instruction::StoreVar(prev) if prev == slot => {
+                    self.bytecode.instructions[n - 1] = Instruction::StoreVarLoadVar(slot);
+                    self.set_var_operand(n - 1, slot);
+                    return;
+                }
+                Instruction::LoadVar(a) => {
+                    self.bytecode.instructions[n - 1] = Instruction::LoadVar2(a, slot);
+                    return;
+                }
+                _ => {}
             }
         }
 
         let inst = self.emit(Instruction::LoadVar(slot));
+        self.set_var_operand(inst, slot);
+    }
+
+    /// Emit a store to a (non-captured) local slot, folding `StoreVar(a);
+    /// StoreVar(slot)` into `StoreVar2(a, slot)` (`STORE_FAST_STORE_FAST`).
+    /// In-place rewrite confined to the current basic block, like
+    /// [`Self::emit_load_var`].
+    fn emit_store_var(&mut self, slot: usize) {
+        let n = self.bytecode.instructions.len();
+        if n > self.current_block_start {
+            if let Instruction::StoreVar(a) = self.bytecode.instructions[n - 1] {
+                self.bytecode.instructions[n - 1] = Instruction::StoreVar2(a, slot);
+                self.set_var_operand(n - 1, slot);
+                return;
+            }
+        }
+        let inst = self.emit(Instruction::StoreVar(slot));
         self.set_var_operand(inst, slot);
     }
 
@@ -1908,9 +1934,9 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                             // Captured local: store through the cell.
                             self.emit(Instruction::StoreDeref(slot));
                         } else {
-                            // Normal local: direct slot store.
-                            let inst = self.emit(Instruction::StoreVar(slot));
-                            self.set_var_operand(inst, slot);
+                            // Normal local: direct slot store (folds a preceding
+                            // StoreVar into StoreVar2).
+                            self.emit_store_var(slot);
                         }
                     }
                     LocalStoreBehavior::KeepOnStack => {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/assignments.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/assignments.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 140
 ---
 function assignments.$init_test_ns_assignments_assignments(registry: testing.TestCollector) -> null {
     load_var registry
@@ -147,7 +146,8 @@ function assignments.array_element_field() -> int {
     load_const 30
     init_instance user.assignments.Item .count
     alloc_array 3
-    store_var_load_var items
+    store_var items
+    load_var items
     load_const 1
     load_array_element
     copy 0
@@ -186,7 +186,8 @@ function assignments.cross_block_param_mutation(c: bool, p: int) -> int {
 
 function assignments.cross_block_soundness(c: bool) -> int {
     load_const 1
-    store_var_load_var a
+    store_var a
+    load_var a
     store_var b
     load_var c
     pop_jump_if_false L0
@@ -213,7 +214,8 @@ function assignments.cross_block_transitive_param_mutation(c: bool, p: int) -> i
 
 function assignments.mutable_in_arg(x: int) -> int {
     load_const 3
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 
@@ -221,7 +223,8 @@ function assignments.nested_field_compound() -> int {
     load_const 10
     init_instance user.assignments.Inner .value
     init_instance user.assignments.Outer .inner
-    store_var_load_var o
+    store_var o
+    load_var o
     load_field .inner
     copy 0
     load_field .value
@@ -238,7 +241,8 @@ function assignments.nested_field_simple() -> int {
     load_const 10
     init_instance user.assignments.Inner .value
     init_instance user.assignments.Outer .inner
-    store_var_load_var o
+    store_var o
+    load_var o
     load_field .inner
     load_const 42
     store_field .value

--- a/baml_language/crates/baml_tests/snapshots/baml_src/bigints.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/bigints.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 140
 ---
 function bigints.$init_test_ns_bigints_bigints(registry: testing.TestCollector) -> null {
     load_var registry
@@ -680,8 +679,7 @@ function bigints.$init_test_ns_bigints_bigints(registry: testing.TestCollector) 
 }
 
 function bigints.BigintBox.set(self: bigints.BigintBox, x: void) -> void {
-    load_var self
-    load_var x
+    load_var2 1 2
     store_field .v
     load_var x
     return
@@ -741,8 +739,7 @@ function bigints.bigint_compound_assign_nonliteral_fn() -> bigint {
     store_var x
     call user.bigints.bigint_nonliteral_inc
     store_var _4
-    load_var x
-    load_var _4
+    load_var2 1 2
     add_bigint
     store_var_load_var x
     load_const 1
@@ -822,8 +819,7 @@ function bigints.bigint_mul_preflight_fn() -> bigint {
     load_const 200000000n
     call baml.Bigint.pow
     store_var b
-    load_var a
-    load_var b
+    load_var2 1 2
     mul_bigint
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/bigints.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/bigints.snap
@@ -697,10 +697,12 @@ function bigints.bigint_box_caller() -> bigint {
 
 function bigints.bigint_compound_assign_add_fn() -> bigint {
     load_const 0n
-    store_var_load_var x
+    store_var x
+    load_var x
     load_const 1
     add_bigint
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 
@@ -718,20 +720,24 @@ function bigints.bigint_compound_assign_lambda_fn() -> bigint {
 
 function bigints.bigint_compound_assign_mul_fn() -> bigint {
     load_const 5n
-    store_var_load_var x
+    store_var x
+    load_var x
     load_const 2
     mul_bigint
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 
 function bigints.bigint_compound_assign_nonliteral_fn() -> bigint {
     load_const 100n
-    store_var_load_var x
+    store_var x
+    load_var x
     load_const 7
     unary_op -
     add_bigint
-    store_var_load_var x
+    store_var x
+    load_var x
     load_const 2
     load_const 3
     add_int
@@ -741,10 +747,12 @@ function bigints.bigint_compound_assign_nonliteral_fn() -> bigint {
     store_var _4
     load_var2 1 2
     add_bigint
-    store_var_load_var x
+    store_var x
+    load_var x
     load_const 1
     sub_bigint
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/byte_strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/byte_strings.snap
@@ -209,7 +209,8 @@ function byte_strings.byte_strings_index_read_direct() -> int {
 function byte_strings.byte_strings_index_write() -> int? {
     load_const b"\x00\x00"
     call baml.deep_copy
-    store_var_load_var data
+    store_var data
+    load_var data
     load_const 0
     load_const 255
     store_array_element
@@ -222,7 +223,8 @@ function byte_strings.byte_strings_index_write() -> int? {
 function byte_strings.byte_strings_index_write_out_of_range() -> int {
     load_const b"\x00"
     call baml.deep_copy
-    store_var_load_var data
+    store_var data
+    load_var data
     load_const 0
     load_const 256
     store_array_element

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
@@ -30,7 +30,8 @@ function cancel_cascade.cancel_from_handle_then_await_catches_cancelled() -> int
     spawn
     store_var _3
     load_var _3
-    store_var_load_var f
+    store_var f
+    load_var f
     call baml.future.Future.cancel
     pop 1
     load_var f
@@ -68,7 +69,8 @@ function cancel_cascade.cancelled_child_future_state_is_cancelled() -> baml.futu
     spawn
     store_var _6
     load_var _6
-    store_var_load_var waiter
+    store_var waiter
+    load_var waiter
     call baml.future.Future.cancel
     pop 1
     load_var waiter

--- a/baml_language/crates/baml_tests/snapshots/baml_src/classes.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/classes.snap
@@ -187,7 +187,8 @@ function classes.default_point() -> classes.PointXYZW {
 function classes.field_assignment_fn() -> int {
     load_const 0
     init_instance user.classes.Data .value
-    store_var_load_var d
+    store_var d
+    load_var d
     load_const 42
     store_field .value
     load_var d
@@ -198,7 +199,8 @@ function classes.field_assignment_fn() -> int {
 function classes.field_compound_assignment_fn() -> int {
     load_const 5
     init_instance user.classes.Counter .value
-    store_var_load_var c
+    store_var c
+    load_var c
     copy 0
     load_field .value
     load_const 10
@@ -233,7 +235,8 @@ function classes.multiple_spreads_fn() -> classes.PointXYZW {
 function classes.mutable_self_method_fn() -> int {
     load_const 1
     init_instance user.classes.MutableNumber .value
-    store_var_load_var a
+    store_var a
+    load_var a
     load_const 2
     init_instance user.classes.MutableNumber .value
     call user.classes.MutableNumber.add
@@ -292,7 +295,8 @@ function classes.nested_field_assignment_fn() -> int {
     load_const 0
     init_instance user.classes.CInner .value
     init_instance user.classes.COuter .inner
-    store_var_load_var o
+    store_var o
+    load_var o
     load_field .inner
     load_const 99
     store_field .value
@@ -306,7 +310,8 @@ function classes.nested_field_compound_assignment_fn() -> int {
     load_const 5
     init_instance user.classes.CInner .value
     init_instance user.classes.COuter .inner
-    store_var_load_var o
+    store_var o
+    load_var o
     load_field .inner
     copy 0
     load_field .value

--- a/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
@@ -281,7 +281,8 @@ function closures.closures_generic_unwrap() -> int {
 function closures.closures_mutation_after_bind() -> int {
     load_const 0
     init_instance user.closures.ClsCounter .value
-    store_var_load_var c
+    store_var c
+    load_var c
     make_bound_method user.closures.ClsCounter.increment
     store_var inc
     load_var c

--- a/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
@@ -81,14 +81,12 @@ function closures.ClsCalculator.compute(self: closures.ClsCalculator, a: int, b:
     jump L1
 
   L0:
-    load_var a
-    load_var b
+    load_var2 2 3
     mul_int
     jump L2
 
   L1:
-    load_var a
-    load_var b
+    load_var2 2 3
     add_int
 
   L2:
@@ -149,14 +147,12 @@ function closures.ClsFormatter.format(self: closures.ClsFormatter, text: string)
 }
 
 function closures.ClsRangeCheck.is_valid(self: closures.ClsRangeCheck, n: int) -> bool {
-    load_var n
-    load_var self
+    load_var2 2 1
     load_field .min
     cmp_int_op >=
     jump_if_false L0
     pop 1
-    load_var n
-    load_var self
+    load_var2 2 1
     load_field .max
     cmp_int_op <=
 
@@ -184,8 +180,7 @@ function closures.ClsWorker.risky(self: closures.ClsWorker, value: int) -> int {
 }
 
 function closures.closures_apply(f: (int, int) -> int throws never, a: int, b: int) -> int {
-    load_var a
-    load_var b
+    load_var2 2 3
     load_var f
     call_indirect
     return
@@ -327,8 +322,7 @@ function closures.closures_strategy_swap() -> int[] {
     load_const 4
     call user.closures.closures_apply
     store_var _7
-    load_var _5
-    load_var _7
+    load_var2 1 2
     alloc_array 2
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/control_flow.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/control_flow.snap
@@ -226,8 +226,7 @@ function control_flow.concat_oks(items: (control_flow.Ok | control_flow.Err)[]) 
     return
 
   L2:
-    load_var items
-    load_var i
+    load_var2 1 3
     load_array_element
     store_var item
     load_var i
@@ -238,8 +237,7 @@ function control_flow.concat_oks(items: (control_flow.Ok | control_flow.Err)[]) 
     store_var_load_var _9
     is_type control_flow.Ok
     pop_jump_if_false L0
-    load_var acc
-    load_var _9
+    load_var2 2 5
     load_field .value
     bin_op +
     store_var acc
@@ -521,8 +519,7 @@ function control_flow.pick_first_ok(items: (control_flow.Ok | control_flow.Err)[
     load_const 3
     cmp_int_op <
     pop_jump_if_false L1
-    load_var items
-    load_var i
+    load_var2 1 3
     load_array_element
     store_var_load_var _9
     is_type control_flow.Ok

--- a/baml_language/crates/baml_tests/snapshots/baml_src/deep_copy.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/deep_copy.snap
@@ -106,7 +106,8 @@ function deep_copy.deep_copy_circular_helper() -> int {
     load_const 1
     alloc_array 0
     init_instance user.deep_copy.Node .value, .children
-    store_var_load_var a
+    store_var a
+    load_var a
     load_const 2
     load_var a
     alloc_array 1
@@ -269,7 +270,8 @@ function deep_copy.deep_equals_circular_helper() -> bool {
     load_const 1
     alloc_array 0
     init_instance user.deep_copy.Node .value, .children
-    store_var_load_var a1
+    store_var a1
+    load_var a1
     load_const 2
     load_var a1
     alloc_array 1
@@ -279,7 +281,8 @@ function deep_copy.deep_equals_circular_helper() -> bool {
     load_const 1
     alloc_array 0
     init_instance user.deep_copy.Node .value, .children
-    store_var_load_var a2
+    store_var a2
+    load_var a2
     load_const 2
     load_var a2
     alloc_array 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/deep_copy.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/deep_copy.snap
@@ -286,8 +286,7 @@ function deep_copy.deep_equals_circular_helper() -> bool {
     init_instance user.deep_copy.Node .value, .children
     alloc_array 1
     store_field .children
-    load_var a1
-    load_var a2
+    load_var2 1 2
     call baml.deep_equals
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/exceptions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/exceptions.snap
@@ -3369,8 +3369,7 @@ function exceptions.sequential_catches_both_recover_fn() -> int {
     store_var b
 
   L1:
-    load_var a
-    load_var b
+    load_var2 1 3
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/floats.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/floats.snap
@@ -1192,8 +1192,7 @@ function floats.float_random_distinct_values() -> bool {
     jump L2
 
   L1:
-    load_var max_seen
-    load_var min_seen
+    load_var2 2 1
     sub_float
     load_const 0.5
     cmp_float_op >
@@ -1202,16 +1201,14 @@ function floats.float_random_distinct_values() -> bool {
   L2:
     call baml.Float.random
     store_var r
-    load_var r
-    load_var min_seen
+    load_var2 4 1
     cmp_float_op <
     pop_jump_if_false L3
     load_var r
     store_var min_seen
 
   L3:
-    load_var r
-    load_var max_seen
+    load_var2 4 2
     cmp_float_op >
     pop_jump_if_false L4
     load_var r

--- a/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
@@ -84,8 +84,7 @@ function for_loops.for_loops_c_for_sum_to_ten() -> int {
     return
 
   L2:
-    load_var s
-    load_var i
+    load_var2 1 2
     add_int
     store_var s
     load_var i
@@ -100,8 +99,7 @@ function for_loops.for_loops_first_even(xs: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var xs
+    load_var2 2 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -113,8 +111,7 @@ function for_loops.for_loops_first_even(xs: int[]) -> int {
     jump L5
 
   L2:
-    load_var xs
-    load_var __for_idx
+    load_var2 1 2
     load_array_element
     store_var_load_var x
     load_const 2
@@ -145,13 +142,11 @@ function for_loops.for_loops_for_with_break(xs: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var xs
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L2
-    load_var xs
-    load_var __for_idx
+    load_var2 1 3
     load_array_element
     store_var_load_var x
     load_const 10
@@ -160,8 +155,7 @@ function for_loops.for_loops_for_with_break(xs: int[]) -> int {
     jump L2
 
   L1:
-    load_var result
-    load_var x
+    load_var2 2 4
     add_int
     store_var result
     load_var __for_idx
@@ -182,8 +176,7 @@ function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var xs
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -194,8 +187,7 @@ function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
     return
 
   L2:
-    load_var xs
-    load_var __for_idx
+    load_var2 1 3
     load_array_element
     store_var_load_var x
     load_const 10
@@ -204,8 +196,7 @@ function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
     jump L4
 
   L3:
-    load_var result
-    load_var x
+    load_var2 2 4
     add_int
     store_var result
 
@@ -222,8 +213,7 @@ function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var grid
+    load_var2 2 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -234,16 +224,14 @@ function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
     jump L8
 
   L2:
-    load_var grid
-    load_var __for_idx
+    load_var2 1 2
     load_array_element
     store_var _8
     load_const 0
     store_var __for_idx_1
 
   L3:
-    load_var __for_idx_1
-    load_var _8
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L4
@@ -257,8 +245,7 @@ function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
     jump L0
 
   L5:
-    load_var _8
-    load_var __for_idx_1
+    load_var2 3 4
     load_array_element
     load_const ""
     cmp_op ==
@@ -286,8 +273,7 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var arr_a
+    load_var2 4 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -298,16 +284,14 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
     return
 
   L2:
-    load_var arr_a
-    load_var __for_idx
+    load_var2 1 4
     load_array_element
     store_var a
     load_const 0
     store_var __for_idx_1
 
   L3:
-    load_var __for_idx_1
-    load_var arr_b
+    load_var2 6 2
     container_len
     cmp_int_op <
     pop_jump_if_false L4
@@ -321,10 +305,8 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
     jump L0
 
   L5:
-    load_var result
-    load_var a
-    load_var arr_b
-    load_var __for_idx_1
+    load_var2 3 5
+    load_var2 2 6
     load_array_element
     mul_int
     add_int
@@ -343,8 +325,7 @@ function for_loops.for_loops_render(xs: string[]) -> string {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var xs
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -355,8 +336,7 @@ function for_loops.for_loops_render(xs: string[]) -> string {
     return
 
   L2:
-    load_var xs
-    load_var __for_idx
+    load_var2 1 3
     load_array_element
     store_var_load_var x
     load_const ""
@@ -365,8 +345,7 @@ function for_loops.for_loops_render(xs: string[]) -> string {
     jump L4
 
   L3:
-    load_var result
-    load_var x
+    load_var2 2 4
     bin_op +
     store_var result
     jump L5
@@ -392,8 +371,7 @@ function for_loops.for_loops_sum(xs: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var xs
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -404,8 +382,7 @@ function for_loops.for_loops_sum(xs: int[]) -> int {
     return
 
   L2:
-    load_var result
-    load_var xs
+    load_var2 2 1
     load_var __for_idx
     load_array_element
     add_int
@@ -429,8 +406,7 @@ function for_loops.for_loops_sum_let_var() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -441,8 +417,7 @@ function for_loops.for_loops_sum_let_var() -> int {
     return
 
   L2:
-    load_var sum
-    load_var _3
+    load_var2 1 2
     load_var __for_idx
     load_array_element
     add_int
@@ -466,8 +441,7 @@ function for_loops.for_loops_sum_let_var_no_parens() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -478,8 +452,7 @@ function for_loops.for_loops_sum_let_var_no_parens() -> int {
     return
 
   L2:
-    load_var sum
-    load_var _3
+    load_var2 1 2
     load_var __for_idx
     load_array_element
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
@@ -408,8 +408,7 @@ function fs.fs_file_rw_write_bytes_fn() -> bool {
     load_const 0
     sys_op baml.fs.File.seek_from
     pop 1
-    load_var file
-    load_var bytes
+    load_var2 2 1
     sys_op baml.fs.File.write_bytes
     store_var n
     load_const "/tmp/baml_fs_file_write_bytes_src.bin"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/functions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/functions.snap
@@ -233,7 +233,8 @@ function functions.mutable_variables_fn() -> int {
     load_const 3
     store_var y
     load_const 5
-    store_var_load_var y
+    store_var y
+    load_var y
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/functions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/functions.snap
@@ -79,25 +79,21 @@ function functions.$init_test_ns_functions_functions(registry: testing.TestColle
 }
 
 function functions.add(a: int, b: int) -> int {
-    load_var a
-    load_var b
+    load_var2 1 2
     add_int
     return
 }
 
 function functions.call_twice(f: (int, int) -> int throws never, x: int, y: int) -> int {
-    load_var x
-    load_var y
+    load_var2 2 3
     load_var f
     call_indirect
     store_var _4
-    load_var x
-    load_var y
+    load_var2 2 3
     load_var f
     call_indirect
     store_var _5
-    load_var _4
-    load_var _5
+    load_var2 4 5
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
@@ -42,7 +42,8 @@ function future_methods.methods_after_cancel() -> baml.future.FutureState {
     spawn
     store_var _3
     load_var _3
-    store_var_load_var f
+    store_var f
+    load_var f
     call baml.future.Future.cancel
     pop 1
     load_var f
@@ -104,7 +105,8 @@ function future_methods.methods_on_pending_future() -> baml.future.FutureState {
     spawn
     store_var _3
     load_var _3
-    store_var_load_var f
+    store_var f
+    load_var f
     call baml.future.Future.is_settled
     pop 1
     load_var f

--- a/baml_language/crates/baml_tests/snapshots/baml_src/glob.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/glob.snap
@@ -336,8 +336,7 @@ function glob.scan_dot_pattern_matches_only_dot_files() -> string[] {
     load_const ".*"
     sys_op baml.glob.new
     store_var g
-    load_var g
-    load_var root
+    load_var2 3 1
     load_const true
     load_const null
     load_const null
@@ -444,8 +443,7 @@ function glob.scan_follows_symlinked_directory_checks() -> bool[] {
     load_const "**/*.txt"
     sys_op baml.glob.new
     store_var g
-    load_var g
-    load_var outer_root
+    load_var2 4 2
     load_const null
     load_const null
     load_const true
@@ -500,8 +498,7 @@ function glob.scan_matches_absolute_pattern_checks() -> bool[] {
     bin_op +
     sys_op baml.glob.new
     store_var g
-    load_var g
-    load_var root
+    load_var2 3 1
     load_const null
     load_const true
     load_const null
@@ -510,8 +507,7 @@ function glob.scan_matches_absolute_pattern_checks() -> bool[] {
     init_instance baml.glob.ScanOptions .cwd, .dot, .absolute, .follow_symlinks, .throw_error_on_broken_symlink, .only_files
     sys_op baml.glob.Glob.scan
     store_var result
-    load_var result
-    load_var root
+    load_var2 4 1
     load_const "/file.txt"
     bin_op +
     call baml.Array.includes
@@ -638,8 +634,7 @@ function glob.scan_opts_include_dot_absolute_and_dirs_checks() -> bool[] {
     load_const "**/*.txt"
     sys_op baml.glob.new
     store_var g
-    load_var g
-    load_var root
+    load_var2 3 1
     load_const true
     load_const true
     load_const null
@@ -648,20 +643,17 @@ function glob.scan_opts_include_dot_absolute_and_dirs_checks() -> bool[] {
     init_instance baml.glob.ScanOptions .cwd, .dot, .absolute, .follow_symlinks, .throw_error_on_broken_symlink, .only_files
     sys_op baml.glob.Glob.scan
     store_var result
-    load_var result
-    load_var root
+    load_var2 4 1
     load_const "/.hidden.txt"
     bin_op +
     call baml.Array.includes
     store_var _24
-    load_var result
-    load_var root
+    load_var2 4 1
     load_const "/dir.txt"
     bin_op +
     call baml.Array.includes
     store_var _27
-    load_var result
-    load_var root
+    load_var2 4 1
     load_const "/file.txt"
     bin_op +
     call baml.Array.includes
@@ -676,8 +668,7 @@ function glob.scan_opts_include_dot_absolute_and_dirs_checks() -> bool[] {
     container_len
     load_const 3
     cmp_int_op ==
-    load_var _24
-    load_var _27
+    load_var2 5 6
     load_var _30
     alloc_array 4
     return
@@ -755,8 +746,7 @@ function glob.scan_skips_broken_symlinks_by_default() -> string[] {
     load_const "*.txt"
     sys_op baml.glob.new
     store_var g
-    load_var g
-    load_var root
+    load_var2 3 1
     load_const null
     load_const null
     load_const true

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ints.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ints.snap
@@ -565,8 +565,7 @@ function ints.count_zeros_plus_ones(n: int) -> int {
     load_var n
     call baml.Int.count_ones
     store_var _3
-    load_var _2
-    load_var _3
+    load_var2 2 3
     add_int
     return
 }
@@ -587,8 +586,7 @@ function ints.int_random_distinct_values_in_wide_range() -> bool {
     jump L2
 
   L1:
-    load_var max_seen
-    load_var min_seen
+    load_var2 2 1
     sub_int
     load_const 500
     cmp_int_op >=
@@ -599,16 +597,14 @@ function ints.int_random_distinct_values_in_wide_range() -> bool {
     load_const 1000
     call baml.Int.random
     store_var r
-    load_var r
-    load_var min_seen
+    load_var2 4 1
     cmp_int_op <
     pop_jump_if_false L3
     load_var r
     store_var min_seen
 
   L3:
-    load_var r
-    load_var max_seen
+    load_var2 4 2
     cmp_int_op >
     pop_jump_if_false L4
     load_var r
@@ -627,21 +623,18 @@ function ints.int_random_full_range_returns_some_int() -> bool {
     store_var _2
     call baml.Int.max_value
     store_var _3
-    load_var _2
-    load_var _3
+    load_var2 2 3
     call baml.Int.random
     store_var r
     call baml.Int.min_value
     store_var _6
-    load_var r
-    load_var _6
+    load_var2 1 4
     cmp_int_op >=
     jump_if_false L0
     pop 1
     call baml.Int.max_value
     store_var _8
-    load_var r
-    load_var _8
+    load_var2 1 5
     cmp_int_op <=
 
   L0:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/is_operator.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/is_operator.snap
@@ -983,8 +983,7 @@ function is_operator.is_inside_array_literal_fn() -> bool[] {
     store_var _4
 
   L5:
-    load_var _2
-    load_var _4
+    load_var2 1 2
     alloc_array 2
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_auto_derive.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_auto_derive.snap
@@ -867,8 +867,7 @@ function json_auto_derive.optional_primitive_field_from_json_sum() -> int {
     store_var v2
 
   L5:
-    load_var v1
-    load_var v2
+    load_var2 5 7
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -221,8 +221,7 @@ function lambdas.lambdas_captures_loop_variable_accumulation() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _4
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -233,8 +232,7 @@ function lambdas.lambdas_captures_loop_variable_accumulation() -> int {
     return
 
   L2:
-    load_var _4
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     load_var sum
     make_closure .<lambda(lambdas_captures_loop_variable_accumulation, 0)>, 1
@@ -258,8 +256,7 @@ function lambdas.lambdas_captures_multiple_variables() -> int {
     store_deref ?1
     load_const 5
     store_deref ?2
-    load_var a
-    load_var b
+    load_var2 1 2
     make_closure .<lambda(lambdas_captures_multiple_variables, 0)>, 2
     call_indirect
     return
@@ -414,8 +411,7 @@ function lambdas.lambdas_issue_a_interleaved_capture_reads_writes() -> int {
     load_var get_x
     call_indirect
     store_var c
-    load_var a
-    load_var b
+    load_var2 4 5
     add_int
     load_var c
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
@@ -437,7 +437,8 @@ function lexical_scoping.rule2_block_outer_mutation_escapes() -> int {
     load_const 1
     store_var x
     load_const 2
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 
@@ -475,7 +476,8 @@ function lexical_scoping.rule2_pre_shadow_mutation_escapes_post_shadow_does_not(
     load_const 1
     store_var x
     load_const 2
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
@@ -257,8 +257,7 @@ function lexical_scoping.for_loop_restores_outer() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 2 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -269,8 +268,7 @@ function lexical_scoping.for_loop_restores_outer() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 1 2
     load_array_element
     store_var x
     load_var __for_idx
@@ -313,8 +311,7 @@ function lexical_scoping.match_and_catch_main() -> int {
     store_var _4
     call user.lexical_scoping.catch_base_uses_outer_lambda
     store_var _6
-    load_var _2
-    load_var _4
+    load_var2 1 2
     load_const 100
     mul_int
     add_int
@@ -454,8 +451,7 @@ function lexical_scoping.rule2_for_outer_mutation_escapes() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/maps.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/maps.snap
@@ -173,7 +173,8 @@ function maps.edit_map_key_helper() -> int {
     load_const 123
     load_const "hi"
     alloc_map 1
-    store_var_load_var map
+    store_var map
+    load_var map
     load_const "hi"
     load_const 42
     load_const 4
@@ -195,7 +196,8 @@ function maps.edit_map_key_helper() -> int {
 
 function maps.map_clear_already_empty_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     call baml.Map.clear
     pop 1
     load_var m
@@ -205,7 +207,8 @@ function maps.map_clear_already_empty_main() -> int {
 
 function maps.map_clear_makes_get_return_null_main() -> int? {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -221,7 +224,8 @@ function maps.map_clear_makes_get_return_null_main() -> int? {
 
 function maps.map_clear_removes_all_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -241,7 +245,8 @@ function maps.map_clear_removes_all_main() -> int {
 
 function maps.map_clear_then_reuse_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -282,7 +287,8 @@ function maps.map_delete_absent_main() -> int? {
 
 function maps.map_delete_already_deleted_main() -> int? {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -299,7 +305,8 @@ function maps.map_delete_already_deleted_main() -> int? {
 
 function maps.map_delete_does_not_affect_other_keys_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -334,7 +341,8 @@ function maps.map_delete_does_not_affect_other_keys_main() -> int {
 
 function maps.map_delete_returns_previous_main() -> int? {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 42
     call baml.Map.set
@@ -347,7 +355,8 @@ function maps.map_delete_returns_previous_main() -> int? {
 
 function maps.map_delete_shrinks_length_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -368,7 +377,8 @@ function maps.map_delete_shrinks_length_main() -> int {
 
 function maps.map_get_or_insert_does_not_overwrite_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "k"
     load_const 1
     call baml.Map.set
@@ -399,7 +409,8 @@ function maps.map_get_or_insert_does_not_overwrite_main() -> int {
 
 function maps.map_get_or_insert_grows_length_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.get_or_insert
@@ -424,7 +435,8 @@ function maps.map_get_or_insert_inserts_when_absent_main() -> int {
 
 function maps.map_get_or_insert_persists_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "k"
     load_const 7
     call baml.Map.get_or_insert
@@ -450,7 +462,8 @@ function maps.map_get_or_insert_persists_main() -> int {
 
 function maps.map_get_or_insert_returns_existing_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "k"
     load_const 1
     call baml.Map.set
@@ -464,7 +477,8 @@ function maps.map_get_or_insert_returns_existing_main() -> int {
 
 function maps.map_has_after_delete_main() -> bool {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -481,7 +495,8 @@ function maps.map_has_after_delete_main() -> bool {
 
 function maps.map_has_after_get_or_insert_main() -> bool {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "k"
     load_const 7
     call baml.Map.get_or_insert
@@ -512,7 +527,8 @@ function maps.map_set_first_insert_main() -> int? {
 
 function maps.map_set_grows_length_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -534,7 +550,8 @@ function maps.map_set_grows_length_main() -> int {
 
 function maps.map_set_replace_preserves_length_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -556,7 +573,8 @@ function maps.map_set_replace_preserves_length_main() -> int {
 
 function maps.map_set_replace_returns_previous_main() -> int? {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -570,7 +588,8 @@ function maps.map_set_replace_returns_previous_main() -> int? {
 
 function maps.map_set_then_get_main() -> int {
     alloc_map 0
-    store_var_load_var m
+    store_var m
+    load_var m
     load_const "a"
     load_const 1
     call baml.Map.set
@@ -603,7 +622,8 @@ function maps.use_map_contains_helper() -> string {
     load_const "world"
     load_const "hello"
     alloc_map 1
-    store_var_load_var map
+    store_var map
+    load_var map
     load_const "hello"
     call baml.Map.has
     pop_jump_if_false L0

--- a/baml_language/crates/baml_tests/snapshots/baml_src/match_basics.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/match_basics.snap
@@ -543,8 +543,7 @@ function match_basics.classify_string_typed_fallback(s: string) -> int {
 }
 
 function match_basics.classify_sum(a: int, b: int) -> string {
-    load_var a
-    load_var b
+    load_var2 1 2
     add_int
     load_const 0
     cmp_int_op ==
@@ -552,8 +551,7 @@ function match_basics.classify_sum(a: int, b: int) -> string {
     jump L3
 
   L0:
-    load_var a
-    load_var b
+    load_var2 1 2
     add_int
     load_const 1
     cmp_int_op ==
@@ -801,8 +799,7 @@ function match_basics.match_in_loop_helper() -> int {
     store_var _6
 
   L8:
-    load_var _5
-    load_var _6
+    load_var2 3 4
     bin_op +
     store_var sum
     load_var i

--- a/baml_language/crates/baml_tests/snapshots/baml_src/null_handling.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/null_handling.snap
@@ -264,8 +264,7 @@ function null_handling.nh_null_coalesce_lazy_non_null(value: int?) -> int {
     store_var ?2
     load_const 0
     store_deref ?2
-    load_var value
-    load_var value
+    load_var2 1 1
     load_const null
     cmp_op ==
     pop_jump_if_false L0
@@ -287,8 +286,7 @@ function null_handling.nh_null_coalesce_null_lhs(value: int?) -> int {
     store_var ?2
     load_const 0
     store_deref ?2
-    load_var value
-    load_var value
+    load_var2 1 1
     load_const null
     cmp_op ==
     pop_jump_if_false L0

--- a/baml_language/crates/baml_tests/snapshots/baml_src/optional_function_parameters.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/optional_function_parameters.snap
@@ -183,8 +183,7 @@ function optional_function_parameters.push_default(value: int, items: int[]) -> 
     store_var items
 
   L0:
-    load_var items
-    load_var value
+    load_var2 2 1
     call baml.Array.push
     pop 1
     load_var items
@@ -234,8 +233,7 @@ function optional_function_parameters.score(query: string, max_results: int, fil
     store_var filter_bonus
 
   L5:
-    load_var max_results
-    load_var chunk_size
+    load_var2 2 4
     add_int
     load_var filter_bonus
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -804,8 +804,7 @@ function patterns_new_runtime.from_array_boxes(boxes: patterns_new_runtime.BoxT<
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var boxes
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -816,8 +815,7 @@ function patterns_new_runtime.from_array_boxes(boxes: patterns_new_runtime.BoxT<
     return
 
   L2:
-    load_var total
-    load_var boxes
+    load_var2 2 1
     load_var __for_idx
     load_array_element
     load_field .value
@@ -1099,8 +1097,7 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _29
-    load_var _29
+    load_var2 5 5
     container_len
     load_const 1
     sub_int
@@ -1118,8 +1115,7 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _37
-    load_var _37
+    load_var2 7 7
     container_len
     load_const 2
     sub_int
@@ -1224,8 +1220,7 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L2
-    load_var _36
-    load_var _36
+    load_var2 5 5
     container_len
     load_const 3
     sub_int
@@ -1254,8 +1249,7 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L3
-    load_var _62
-    load_var _62
+    load_var2 7 7
     container_len
     load_const 1
     sub_int
@@ -1381,8 +1375,7 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _44
-    load_var _44
+    load_var2 8 8
     container_len
     load_const 1
     sub_int
@@ -1400,8 +1393,7 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _52
-    load_var _52
+    load_var2 10 10
     container_len
     load_const 1
     sub_int
@@ -1419,8 +1411,7 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _60
-    load_var _60
+    load_var2 12 12
     container_len
     load_const 2
     sub_int
@@ -1693,8 +1684,7 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -2337,16 +2327,14 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 2
     sub_int
     load_array_element
     is_type int[]
     pop_jump_if_false L0
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -2366,8 +2354,7 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     sub_int
     load_const 100
     mul_int
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 2
     sub_int
@@ -2377,8 +2364,7 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     load_const 10
     mul_int
     add_int
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -2502,16 +2488,14 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     load_array_element
     is_type int
     pop_jump_if_false L0
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 2
     sub_int
     load_array_element
     is_type int
     pop_jump_if_false L0
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -2530,8 +2514,7 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     load_array_element
     load_const 100
     mul_int
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 2
     sub_int
@@ -2539,8 +2522,7 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     load_const 10
     mul_int
     add_int
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -2646,8 +2628,7 @@ function patterns_new_runtime.score_suffix_rest(xs: int[]) -> int {
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L0
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -2667,8 +2648,7 @@ function patterns_new_runtime.score_suffix_rest(xs: int[]) -> int {
     sub_int
     load_const 10
     mul_int
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -2852,8 +2832,7 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
     load_array_element
     is_type int
     pop_jump_if_false L0
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -2878,8 +2857,7 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
     load_const 10
     mul_int
     add_int
-    load_var xs
-    load_var xs
+    load_var2 1 1
     container_len
     load_const 1
     sub_int
@@ -3027,8 +3005,7 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _19
-    load_var _19
+    load_var2 3 3
     container_len
     load_const 1
     sub_int
@@ -3128,8 +3105,7 @@ function patterns_new_runtime.test_empty_generic_destruct_contextual() -> int {
     init_instance<1> user.patterns_new_runtime.BoxT .value
     call user.patterns_new_runtime.classify_box_string
     store_var _5
-    load_var _3
-    load_var _5
+    load_var2 1 2
     add_int
     return
 }
@@ -3138,18 +3114,15 @@ function patterns_new_runtime.test_five_levels_or_flipped() -> int {
     load_const 0
     init_instance user.patterns_new_runtime.Atom1 .value
     store_var_load_var stuffer_atom
-    load_var stuffer_atom
-    load_var stuffer_atom
+    load_var2 1 1
     alloc_array 3
     init_instance user.patterns_new_runtime.Slot1 .atoms
     store_var_load_var stuffer_slot
-    load_var stuffer_slot
-    load_var stuffer_slot
+    load_var2 2 2
     alloc_array 3
     init_instance user.patterns_new_runtime.Row1 .slots
     store_var_load_var stuffer_row
-    load_var stuffer_slot
-    load_var stuffer_atom
+    load_var2 2 1
     load_const 42
     init_instance user.patterns_new_runtime.Atom1 .value
     load_var stuffer_atom
@@ -3186,8 +3159,7 @@ function patterns_new_runtime.test_for_class_binds_inner_zip() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _12
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3198,8 +3170,7 @@ function patterns_new_runtime.test_for_class_binds_inner_zip() -> int {
     return
 
   L2:
-    load_var product
-    load_var _12
+    load_var2 1 2
     load_var __for_idx
     load_array_element
     load_field .address
@@ -3238,8 +3209,7 @@ function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _12
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3276,15 +3246,13 @@ function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
     load_const null
     make_cell
     store_var zip
-    load_var _12
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     load_field .address
     load_field .coordinate
     load_field .zip
     store_deref ?4
-    load_var funcs
-    load_var zip
+    load_var2 1 4
     make_closure .<lambda(test_for_deep_class_capture_fresh, 0)>, 1
     call baml.Array.push
     pop 1
@@ -3316,8 +3284,7 @@ function patterns_new_runtime.test_for_deep_class_sums() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _12
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3328,8 +3295,7 @@ function patterns_new_runtime.test_for_deep_class_sums() -> int {
     return
 
   L2:
-    load_var total
-    load_var _12
+    load_var2 1 2
     load_var __for_idx
     load_array_element
     load_field .address
@@ -3362,8 +3328,7 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _9
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3374,14 +3339,12 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     return
 
   L2:
-    load_var _9
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     load_field .scores
     container_len
     store_var _16
-    load_var total
-    load_var _16
+    load_var2 1 4
     add_int
     store_var total
     load_var __for_idx
@@ -3406,8 +3369,7 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3441,8 +3403,7 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var_load_var _6
     store_var a
@@ -3451,8 +3412,7 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
     store_var b
     load_var _6
     store_deref ?6
-    load_var funcs
-    load_var b
+    load_var2 1 6
     make_closure .<lambda(test_for_let_chain_alias_capture, 0)>, 1
     call baml.Array.push
     pop 1
@@ -3475,8 +3435,7 @@ function patterns_new_runtime.test_for_let_chain_of_bindings() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3487,12 +3446,10 @@ function patterns_new_runtime.test_for_let_chain_of_bindings() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var _6
-    load_var total
-    load_var _6
+    load_var2 1 4
     load_var _6
     add_int
     add_int
@@ -3520,8 +3477,7 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3532,14 +3488,12 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var_load_var row
     container_len
     store_var _13
-    load_var total
-    load_var _13
+    load_var2 1 5
     load_const 100
     mul_int
     load_var row
@@ -3573,8 +3527,7 @@ function patterns_new_runtime.test_for_let_or_same_binding() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3585,8 +3538,7 @@ function patterns_new_runtime.test_for_let_or_same_binding() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var_load_var _6
     is_type int
@@ -3603,8 +3555,7 @@ function patterns_new_runtime.test_for_let_or_same_binding() -> int {
     store_var x
 
   L5:
-    load_var total
-    load_var x
+    load_var2 1 5
     add_int
     store_var total
     load_var __for_idx
@@ -3626,8 +3577,7 @@ function patterns_new_runtime.test_for_let_or_six_bindings() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3638,8 +3588,7 @@ function patterns_new_runtime.test_for_let_or_six_bindings() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var_load_var _6
     is_type int
@@ -3700,8 +3649,7 @@ function patterns_new_runtime.test_for_let_or_six_bindings() -> int {
     store_var x
 
   L13:
-    load_var total
-    load_var x
+    load_var2 1 5
     add_int
     store_var total
     load_var __for_idx
@@ -3726,8 +3674,7 @@ function patterns_new_runtime.test_for_nested_rest_irrefutable() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3770,8 +3717,7 @@ function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _6
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3808,12 +3754,10 @@ function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
     load_const null
     make_cell
     store_var row
-    load_var _6
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_deref ?4
-    load_var funcs
-    load_var row
+    load_var2 1 4
     make_closure .<lambda(test_for_rest_capture_fresh_cell, 0)>, 1
     call baml.Array.push
     pop 1
@@ -3840,8 +3784,7 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _6
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3852,13 +3795,11 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     return
 
   L2:
-    load_var _6
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     container_len
     store_var _12
-    load_var total
-    load_var _12
+    load_var2 1 4
     add_int
     store_var total
     load_var __for_idx
@@ -3883,8 +3824,7 @@ function patterns_new_runtime.test_for_rest_wildcard_irrefutable() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _6
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3920,8 +3860,7 @@ function patterns_new_runtime.test_generic_backfills_wrapped() -> int {
     alloc_array 1
     call user.patterns_new_runtime.from_array_boxes
     store_var _7
-    load_var _3
-    load_var _5
+    load_var2 2 3
     add_int
     load_var _7
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -3405,7 +3405,8 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
   L2:
     load_var2 2 3
     load_array_element
-    store_var_load_var _6
+    store_var _6
+    load_var _6
     store_var a
     load_const null
     make_cell
@@ -3490,7 +3491,8 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
   L2:
     load_var2 2 3
     load_array_element
-    store_var_load_var row
+    store_var row
+    load_var row
     container_len
     store_var _13
     load_var2 1 5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of.snap
@@ -195,22 +195,19 @@ function reflect_type_of.type_of_to_string_works_as_map_key_fn() -> int {
     load_type reflect_type_of.User
     call baml.TypeValue.to_string
     store_var _2
-    load_var m
-    load_var _2
+    load_var2 1 2
     load_const 1
     store_map_element
     load_type int
     call baml.TypeValue.to_string
     store_var _4
-    load_var m
-    load_var _4
+    load_var2 1 3
     load_const 2
     store_map_element
     load_type reflect_type_of.User
     call baml.TypeValue.to_string
     store_var _7
-    load_var m
-    load_var _7
+    load_var2 1 4
     load_map_element
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/soundness.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/soundness.snap
@@ -82,7 +82,8 @@ function soundness.copy_of_mutable_param_helper(x: int) -> int {
 function soundness.cross_block_field_mutation_helper() -> int {
     load_const 1
     init_instance user.soundness.SoundBox .v
-    store_var_load_var b
+    store_var b
+    load_var b
     load_field .v
     store_var t
     load_const 1
@@ -100,7 +101,8 @@ function soundness.cross_block_field_mutation_helper() -> int {
 
 function soundness.cross_block_let_mutation_true(c: bool) -> int {
     load_const 1
-    store_var_load_var a
+    store_var a
+    load_var a
     store_var b
     load_var c
     pop_jump_if_false L0
@@ -129,7 +131,8 @@ function soundness.multiple_defs_preserve_side_effects_helper() -> int {
     call user.soundness.sound_fail
     store_var x
     load_const 2
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_semantics.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_semantics.snap
@@ -67,8 +67,7 @@ function spawn_semantics.multiple_awaits_on_same_future_return_cached_value_fn()
     load_var f
     await
     store_var c
-    load_var a
-    load_var b
+    load_var2 3 4
     add_int
     load_var c
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
@@ -530,7 +530,8 @@ function type_error_repro.array_element_assignment_1d_body() -> string {
     load_const "b"
     load_const "c"
     alloc_array 3
-    store_var_load_var arr
+    store_var arr
+    load_var arr
     load_const 1
     load_const "z"
     store_array_element
@@ -554,7 +555,8 @@ function type_error_repro.array_element_assignment_2d_type_error_body() -> strin
     load_const ""
     alloc_array 3
     alloc_array 3
-    store_var_load_var cells
+    store_var cells
+    load_var cells
     load_const 1
     load_array_element
     load_const 2
@@ -583,7 +585,8 @@ function type_error_repro.array_write_with_variable_index_body() -> string {
     load_const "b"
     load_const "c"
     alloc_array 3
-    store_var_load_var arr
+    store_var arr
+    load_var arr
     load_const 1
     load_const "z"
     store_array_element
@@ -609,7 +612,8 @@ function type_error_repro.bytecode_1d_array_write_local_body() -> string {
     load_const "b"
     load_const "c"
     alloc_array 3
-    store_var_load_var arr
+    store_var arr
+    load_var arr
     load_const 1
     load_const "z"
     store_array_element
@@ -641,7 +645,8 @@ function type_error_repro.bytecode_2d_array_write_local_body() -> string {
     load_const "d"
     alloc_array 2
     alloc_array 2
-    store_var_load_var cells
+    store_var cells
+    load_var cells
     load_const 1
     load_array_element
     load_const 0
@@ -675,7 +680,8 @@ function type_error_repro.bytecode_2d_array_write_through_field_body() -> null {
 
 function type_error_repro.bytecode_map_write_local_body() -> int {
     alloc_map 0
-    store_var_load_var scores
+    store_var scores
+    load_var scores
     load_const "alice"
     load_const 100
     store_map_element
@@ -894,7 +900,8 @@ function type_error_repro.int_through_function_call_as_index_works_body() -> str
 
 function type_error_repro.map_write_local_variable_body() -> int {
     alloc_map 0
-    store_var_load_var scores
+    store_var scores
+    load_var scores
     load_const "alice"
     load_const 100
     store_map_element
@@ -959,7 +966,8 @@ function type_error_repro.nested_array_write_with_variables_body() -> string {
     load_const "i"
     alloc_array 3
     alloc_array 3
-    store_var_load_var cells
+    store_var cells
+    load_var cells
     load_const 1
     load_array_element
     load_const 2

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
@@ -197,8 +197,7 @@ function type_error_repro.BoardMinimal.play(self: type_error_repro.BoardMinimal,
     load_field .cells
     load_var row
     load_array_element
-    load_var col
-    load_var player
+    load_var2 4 2
     store_array_element
     load_const null
     return
@@ -265,8 +264,7 @@ function type_error_repro.BoardWrite.play(self: type_error_repro.BoardWrite, pla
     load_field .cells
     load_var row
     load_array_element
-    load_var col
-    load_var player
+    load_var2 4 2
     store_array_element
     load_const null
     return
@@ -275,8 +273,7 @@ function type_error_repro.BoardWrite.play(self: type_error_repro.BoardWrite, pla
 function type_error_repro.BytecodeContainer.set(self: type_error_repro.BytecodeContainer, idx: int, val: string) -> null {
     load_var self
     load_field .items
-    load_var idx
-    load_var val
+    load_var2 2 3
     store_array_element
     load_const null
     return
@@ -295,8 +292,7 @@ function type_error_repro.BytecodeGrid.set(self: type_error_repro.BytecodeGrid, 
     load_field .cells
     load_var row
     load_array_element
-    load_var col
-    load_var val
+    load_var2 3 4
     store_array_element
     load_const null
     return
@@ -305,8 +301,7 @@ function type_error_repro.BytecodeGrid.set(self: type_error_repro.BytecodeGrid, 
 function type_error_repro.BytecodeScores.set(self: type_error_repro.BytecodeScores, key: string, val: int) -> null {
     load_var self
     load_field .data
-    load_var key
-    load_var val
+    load_var2 2 3
     store_map_element
     load_const null
     return
@@ -332,8 +327,7 @@ function type_error_repro.ContainerSelf.new() -> type_error_repro.ContainerSelf 
 function type_error_repro.ContainerSelf.set(self: type_error_repro.ContainerSelf, idx: int, val: string) -> null {
     load_var self
     load_field .items
-    load_var idx
-    load_var val
+    load_var2 2 3
     store_array_element
     load_const null
     return
@@ -378,8 +372,7 @@ function type_error_repro.Cube.set(self: type_error_repro.Cube, x: int, y: int, 
     load_array_element
     load_var y
     load_array_element
-    load_var z
-    load_var val
+    load_var2 4 5
     store_array_element
     load_const null
     return
@@ -418,8 +411,7 @@ function type_error_repro.GridSelf.set(self: type_error_repro.GridSelf, row: int
     load_field .cells
     load_var row
     load_array_element
-    load_var col
-    load_var val
+    load_var2 3 4
     store_array_element
     load_const null
     return
@@ -448,8 +440,7 @@ function type_error_repro.OuterItems.set(self: type_error_repro.OuterItems, idx:
     load_var self
     load_field .inner
     load_field .items
-    load_var idx
-    load_var val
+    load_var2 2 3
     store_array_element
     load_const null
     return
@@ -481,8 +472,7 @@ function type_error_repro.Registry.set(self: type_error_repro.Registry, key: str
     load_field .data
     load_var key
     load_map_element
-    load_var idx
-    load_var val
+    load_var2 3 4
     store_array_element
     load_const null
     return
@@ -505,8 +495,7 @@ function type_error_repro.ScoresSelf.new() -> type_error_repro.ScoresSelf {
 function type_error_repro.ScoresSelf.set(self: type_error_repro.ScoresSelf, key: string, val: int) -> null {
     load_var self
     load_field .data
-    load_var key
-    load_var val
+    load_var2 2 3
     store_map_element
     load_const null
     return
@@ -724,8 +713,7 @@ function type_error_repro.bytecode_non_self_param_array_write_body() -> null {
 function type_error_repro.bytecode_set_item(c: type_error_repro.BytecodeContainerNonSelf, idx: int, val: string) -> null {
     load_var c
     load_field .items
-    load_var idx
-    load_var val
+    load_var2 2 3
     store_array_element
     load_const null
     return
@@ -881,8 +869,7 @@ function type_error_repro.class_method_nested_field_array_write_body() -> string
 }
 
 function type_error_repro.get_cell_for_nested_test(cells: string[][], row: int, col: int) -> string {
-    load_var cells
-    load_var row
+    load_var2 1 2
     load_array_element
     load_var col
     load_array_element
@@ -890,8 +877,7 @@ function type_error_repro.get_cell_for_nested_test(cells: string[][], row: int, 
 }
 
 function type_error_repro.get_element_for_int_through_call(arr: string[], idx: int) -> string {
-    load_var arr
-    load_var idx
+    load_var2 1 2
     load_array_element
     return
 }
@@ -1008,8 +994,7 @@ function type_error_repro.non_self_param_array_write_body() -> string {
 function type_error_repro.set_item_non_self(c: type_error_repro.ContainerNonSelf, idx: int, val: string) -> null {
     load_var c
     load_field .items
-    load_var idx
-    load_var val
+    load_var2 2 3
     store_array_element
     load_const null
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
@@ -184,8 +184,7 @@ function type_reflection.deep_equals_type_values_different_fn() -> bool {
     load_const "GetBar"
     sys_op baml.llm.get_return_type
     store_var b
-    load_var a
-    load_var b
+    load_var2 1 2
     call baml.deep_equals
     return
 }
@@ -197,8 +196,7 @@ function type_reflection.deep_equals_type_values_same_fn() -> bool {
     load_const "GetFoo"
     sys_op baml.llm.get_return_type
     store_var b
-    load_var a
-    load_var b
+    load_var2 1 2
     call baml.deep_equals
     return
 }
@@ -210,8 +208,7 @@ function type_reflection.eq_type_values_different_fn() -> bool {
     load_const "GetBar"
     sys_op baml.llm.get_return_type
     store_var b
-    load_var a
-    load_var b
+    load_var2 1 2
     cmp_op ==
     return
 }
@@ -223,8 +220,7 @@ function type_reflection.eq_type_values_same_fn() -> bool {
     load_const "GetFoo"
     sys_op baml.llm.get_return_type
     store_var b
-    load_var a
-    load_var b
+    load_var2 1 2
     cmp_op ==
     return
 }
@@ -236,8 +232,7 @@ function type_reflection.neq_type_values_different_fn() -> bool {
     load_const "GetBar"
     sys_op baml.llm.get_return_type
     store_var b
-    load_var a
-    load_var b
+    load_var2 1 2
     cmp_op !=
     return
 }
@@ -249,8 +244,7 @@ function type_reflection.neq_type_values_same_fn() -> bool {
     load_const "GetFoo"
     sys_op baml.llm.get_return_type
     store_var b
-    load_var a
-    load_var b
+    load_var2 1 2
     cmp_op !=
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
@@ -67,8 +67,7 @@ function typed_inputs.$init_test_ns_typed_inputs_typed_inputs(registry: testing.
 }
 
 function typed_inputs.add(a: int, b: int) -> int {
-    load_var a
-    load_var b
+    load_var2 1 2
     add_int
     return
 }
@@ -94,8 +93,7 @@ function typed_inputs.double(x: int) -> int {
 }
 
 function typed_inputs.get_value(m: map<string, int>, key: string) -> int {
-    load_var m
-    load_var key
+    load_var2 1 2
     load_map_element
     return
 }
@@ -151,8 +149,7 @@ function typed_inputs.sum(arr: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var arr
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -163,8 +160,7 @@ function typed_inputs.sum(arr: int[]) -> int {
     return
 
   L2:
-    load_var total
-    load_var arr
+    load_var2 2 1
     load_var __for_idx
     load_array_element
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
@@ -395,7 +395,8 @@ function watch.watch_catch_arm_fallthrough_fn() -> int {
     load_const null
     watch x
     load_const 5
-    store_var_load_var x
+    store_var x
+    load_var x
     store_var result
     unwatch x
 
@@ -584,7 +585,8 @@ function watch.watch_default_filter_fn() -> int {
     load_const 0
     store_var value
     load_const 6
-    store_var_load_var value
+    store_var value
+    load_var value
     unwatch value
     return
 }
@@ -603,7 +605,8 @@ function watch.watch_early_return_unwatches_fn() -> int {
 
   L0:
     load_const 99
-    store_var_load_var x
+    store_var x
+    load_var x
     unwatch x
     jump L2
 
@@ -730,7 +733,8 @@ function watch.watch_match_arm_fallthrough_entry(input: int) -> int {
     load_const null
     watch x
     load_const 5
-    store_var_load_var x
+    store_var x
+    load_var x
     store_var result
     unwatch x
 
@@ -876,7 +880,8 @@ function watch.watch_primitive_fn() -> int {
     load_const null
     watch value
     load_const 1
-    store_var_load_var value
+    store_var value
+    load_var value
     unwatch value
     return
 }
@@ -946,7 +951,8 @@ function watch.watch_switch_arm_fallthrough_entry(input: int) -> int {
     load_const null
     watch x
     load_const 5
-    store_var_load_var x
+    store_var x
+    load_var x
     store_var result
     unwatch x
     jump L5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
@@ -181,11 +181,9 @@ function watch.$init_test_ns_watch_watch(registry: testing.TestCollector) -> nul
 }
 
 function watch.WPointWithSet.set(self: watch.WPointWithSet, x: int, y: int) -> watch.WPointWithSet {
-    load_var self
-    load_var x
+    load_var2 1 2
     store_field .x
-    load_var self
-    load_var y
+    load_var2 1 3
     store_field .y
     load_var self
     return
@@ -341,13 +339,11 @@ function watch.watch_break_unwatches_fn() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L3
-    load_var _2
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var x
     load_const "x"
@@ -364,8 +360,7 @@ function watch.watch_break_unwatches_fn() -> int {
     load_const 9
     add_int
     store_var x
-    load_var total
-    load_var x
+    load_var2 1 4
     add_int
     store_var total
     unwatch x
@@ -485,8 +480,7 @@ function watch.watch_continue_unwatches_fn() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -497,8 +491,7 @@ function watch.watch_continue_unwatches_fn() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var x
     load_const "x"
@@ -515,8 +508,7 @@ function watch.watch_continue_unwatches_fn() -> int {
     load_const 10
     add_int
     store_var x
-    load_var total
-    load_var x
+    load_var2 1 4
     add_int
     store_var total
     unwatch x
@@ -556,20 +548,16 @@ function watch.watch_cyclic_graph_fn() -> int {
     load_const "v4"
     load_const null
     watch v4
-    load_var v1
-    load_var v2
+    load_var2 1 2
     alloc_array 1
     store_field .edges
-    load_var v2
-    load_var v3
+    load_var2 2 3
     alloc_array 1
     store_field .edges
-    load_var v3
-    load_var v4
+    load_var2 3 4
     alloc_array 1
     store_field .edges
-    load_var v4
-    load_var v1
+    load_var2 4 1
     alloc_array 1
     store_field .edges
     load_var v2
@@ -637,8 +625,7 @@ function watch.watch_for_throw_fails() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _1
+    load_var2 2 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -649,8 +636,7 @@ function watch.watch_for_throw_fails() -> int {
     return
 
   L2:
-    load_var _1
-    load_var __for_idx
+    load_var2 1 2
     load_array_element
     store_var x
     load_const "x"
@@ -831,8 +817,7 @@ function watch.watch_nested_object_added_fn() -> int {
     init_instance user.watch.WValue .value
     init_instance user.watch.WPointV .x, .y
     store_var p
-    load_var vec
-    load_var p
+    load_var2 1 2
     store_field .p
     load_var p
     load_field .x

--- a/baml_language/crates/baml_tests/snapshots/baml_src/while_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/while_loops.snap
@@ -164,8 +164,7 @@ function while_loops.while_loops_count_down(n: int) -> int {
   L0:
     load_const true
     pop_jump_if_false L1
-    load_var result
-    load_var n
+    load_var2 2 1
     add_int
     store_var result
     load_var n
@@ -195,8 +194,7 @@ function while_loops.while_loops_factorial_break(limit: int) -> int {
     jump L2
 
   L1:
-    load_var result
-    load_var limit
+    load_var2 2 1
     mul_int
     store_var result
     load_var limit
@@ -226,8 +224,7 @@ function while_loops.while_loops_factorial_continue(limit: int) -> int {
     return
 
   L2:
-    load_var result
-    load_var limit
+    load_var2 2 1
     mul_int
     store_var result
     load_var limit
@@ -267,8 +264,7 @@ function while_loops.while_loops_fib(n: int) -> int {
     load_const 1
     sub_int
     store_var n
-    load_var a
-    load_var b
+    load_var2 2 3
     add_int
     store_var t
     load_var a
@@ -280,8 +276,7 @@ function while_loops.while_loops_fib(n: int) -> int {
 
 function while_loops.while_loops_gcd(a: int, b: int) -> int {
   L0:
-    load_var a
-    load_var b
+    load_var2 1 2
     cmp_int_op !=
     pop_jump_if_false L1
     jump L2
@@ -291,22 +286,19 @@ function while_loops.while_loops_gcd(a: int, b: int) -> int {
     return
 
   L2:
-    load_var a
-    load_var b
+    load_var2 1 2
     cmp_int_op >
     pop_jump_if_false L3
     jump L4
 
   L3:
-    load_var b
-    load_var a
+    load_var2 2 1
     sub_int
     store_var b
     jump L0
 
   L4:
-    load_var a
-    load_var b
+    load_var2 1 2
     sub_int
     store_var a
     jump L0

--- a/baml_language/crates/baml_tests/snapshots/compiler2_emit/baml_tests__compiler2_emit__optional_defaults_emit_snapshot.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiler2_emit/baml_tests__compiler2_emit__optional_defaults_emit_snapshot.snap
@@ -12,8 +12,7 @@ function add(base: int, amount: int) -> int {
     store_var amount
 
   L0:
-    load_var base
-    load_var amount
+    load_var2 1 2
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____06_codegen.snap
@@ -2,8 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 function assert.contains(haystack: string, needle: string) -> null {
-    load_var haystack
-    load_var needle
+    load_var2 1 2
     call baml.String.includes
     unary_op !
     pop_jump_if_false L0
@@ -22,8 +21,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
-    load_var actual
-    load_var expected
+    load_var2 1 2
     cmp_op !=
     pop_jump_if_false L0
     jump L1

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -278,8 +278,7 @@ function baml.Float.to_json(self: baml.Float) -> baml.json.json {
 function baml.Float.to_radians(self: baml.Float) -> float {
     call baml.Float.pi
     store_var _3
-    load_var self
-    load_var _3
+    load_var2 1 2
     bin_op *
     load_const 180.0
     div_float
@@ -622,8 +621,7 @@ function baml.env.get_or_panic(key: string) -> string {
     load_var key
     sys_op baml.env.get
     store_var _2
-    load_var _2
-    load_var _2
+    load_var2 2 2
     load_const null
     cmp_op ==
     pop_jump_if_false L0
@@ -797,10 +795,8 @@ function baml.errors.HostCallable.to_json(self: baml.errors.HostCallable) -> bam
     load_field .category
     call baml.Int.to_json
     store_var _18
-    load_var _2
-    load_var _5
-    load_var _8
-    load_var _11
+    load_var2 2 3
+    load_var2 4 5
     load_var _18
     load_const "message"
     load_const "class_name"
@@ -1069,8 +1065,7 @@ function baml.errors.Timeout.to_json(self: baml.errors.Timeout) -> baml.json.jso
     store_var _5
 
   L2:
-    load_var _2
-    load_var _5
+    load_var2 2 3
     load_const "message"
     load_const "duration_ms"
     alloc_map 2
@@ -1462,12 +1457,9 @@ function baml.glob.ScanOptions.to_json(self: baml.glob.ScanOptions) -> baml.json
     store_var _37
 
   L17:
-    load_var _2
-    load_var _9
-    load_var _16
-    load_var _23
-    load_var _30
-    load_var _37
+    load_var2 2 3
+    load_var2 4 5
+    load_var2 6 7
     load_const "cwd"
     load_const "dot"
     load_const "absolute"
@@ -1911,10 +1903,8 @@ function baml.llm.AzureOpenAiOptions.to_json(self: baml.llm.AzureOpenAiOptions) 
     store_var _19
 
   L8:
-    load_var _2
-    load_var _9
-    load_var _16
-    load_var _19
+    load_var2 2 3
+    load_var2 4 5
     load_const "resource_name"
     load_const "deployment_id"
     load_const "api_version"
@@ -2199,16 +2189,11 @@ function baml.llm.BedrockOptions.to_json(self: baml.llm.BedrockOptions) -> baml.
     store_var _65
 
   L29:
-    load_var _2
-    load_var _9
-    load_var _16
-    load_var _23
-    load_var _30
-    load_var _37
-    load_var _44
-    load_var _51
-    load_var _58
-    load_var _65
+    load_var2 2 3
+    load_var2 4 5
+    load_var2 6 7
+    load_var2 8 9
+    load_var2 10 11
     load_const "region"
     load_const "endpoint_url"
     load_const "access_key_id"
@@ -2237,14 +2222,11 @@ function baml.llm.Client.__make_stream(self: baml.llm.Client, sse: baml.http.Sse
     sys_op baml.llm.PrimitiveClient.new_stream_accumulator
     store_var acc
     load_const null
-    load_var return_type
-    load_var stream_return_type
+    load_var2 5 6
     sys_op baml.llm.StreamCache.new
     store_var cache
-    load_var primitive
-    load_var acc
-    load_var sse
-    load_var cache
+    load_var2 4 7
+    load_var2 2 8
     load_type #0
     load_type #1
     init_instance<2> baml.llm.Stream ._client, ._acc, ._sse, ._cache
@@ -2293,10 +2275,8 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     load_var self
     load_field .counter
     store_var _28
-    load_var planner_state
-    load_var _27
-    load_var _28
-    load_var self
+    load_var2 2 10
+    load_var2 11 1
     load_field .sub_clients
     container_len
     call baml.llm.PlannerState.rr_pick_index
@@ -2323,8 +2303,7 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     store_var __for_idx
 
   L5:
-    load_var __for_idx
-    load_var _9
+    load_var2 6 5
     container_len
     cmp_int_op <
     pop_jump_if_false L6
@@ -2335,8 +2314,7 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     jump L12
 
   L7:
-    load_var _9
-    load_var __for_idx
+    load_var2 5 6
     load_array_element
     load_var planner_state
     call baml.llm.Client.build_plan_with_state
@@ -2345,8 +2323,7 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     store_var __for_idx_1
 
   L8:
-    load_var __for_idx_1
-    load_var _15
+    load_var2 8 7
     container_len
     cmp_int_op <
     pop_jump_if_false L9
@@ -2360,8 +2337,7 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     jump L5
 
   L10:
-    load_var steps
-    load_var _15
+    load_var2 4 7
     load_var __for_idx_1
     load_array_element
     call baml.Array.push
@@ -2402,8 +2378,7 @@ function baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_st
     jump L1
 
   L0:
-    load_var self
-    load_var planner_state
+    load_var2 1 2
     call baml.llm.Client.build_attempt_with_state
     jump L4
 
@@ -2421,8 +2396,7 @@ function baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_st
     store_var attempt
 
   L2:
-    load_var attempt
-    load_var r
+    load_var2 7 4
     load_field .max_retries
     cmp_int_op <=
     pop_jump_if_false L3
@@ -2444,8 +2418,7 @@ function baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_st
     load_var current_delay
     call baml.math.trunc
     store_var delay
-    load_var current_delay
-    load_var r
+    load_var2 6 4
     load_field .multiplier
     mul_float
     store_var_load_var next
@@ -2470,16 +2443,14 @@ function baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_st
     store_var current_delay
 
   L8:
-    load_var self
-    load_var planner_state
+    load_var2 1 2
     call baml.llm.Client.build_attempt_with_state
     store_var _26
     load_const 0
     store_var __for_idx
 
   L9:
-    load_var __for_idx
-    load_var _26
+    load_var2 11 10
     container_len
     cmp_int_op <
     pop_jump_if_false L10
@@ -2493,8 +2464,7 @@ function baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_st
     jump L2
 
   L11:
-    load_var result
-    load_var _26
+    load_var2 5 10
     load_var __for_idx
     load_array_element
     load_field .primitive_client
@@ -2561,8 +2531,7 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
     store_var __for_idx
 
   L5:
-    load_var __for_idx
-    load_var _35
+    load_var2 14 13
     container_len
     cmp_int_op <
     pop_jump_if_false L6
@@ -2575,11 +2544,9 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
 
   L7:
     load_type #0
-    load_var _35
-    load_var __for_idx
+    load_var2 13 14
     load_array_element
-    load_var context
-    load_var active_delay_ms
+    load_var2 2 3
     call baml.llm.Client.execute_oneshot
     jump L8
     load_var e
@@ -2599,20 +2566,17 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
     store_var primitive
     load_type #0
     store_var return_type
-    load_var primitive
-    load_var context
+    load_var2 4 2
     load_field .jinja_string
     load_var context
     load_field .args
     load_var return_type
     sys_op baml.llm.PrimitiveClient.render_prompt
     store_var prompt
-    load_var primitive
-    load_var prompt
+    load_var2 4 6
     sys_op baml.llm.PrimitiveClient.specialize_prompt
     store_var specialized
-    load_var primitive
-    load_var specialized
+    load_var2 4 7
     load_var return_type
     sys_op baml.llm.PrimitiveClient.build_request
     sys_op baml.http.send
@@ -2652,8 +2616,7 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
     load_var http_response
     sys_op baml.http.Response.text
     store_var body
-    load_var primitive
-    load_var body
+    load_var2 4 9
     load_type #0
     sys_op baml.llm.PrimitiveClient.parse
     jump L15
@@ -2730,8 +2693,7 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
     store_var __for_idx
 
   L5:
-    load_var __for_idx
-    load_var _22
+    load_var2 10 9
     container_len
     cmp_int_op <
     pop_jump_if_false L6
@@ -2745,11 +2707,9 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
   L7:
     load_type #0
     load_type #1
-    load_var _22
-    load_var __for_idx
+    load_var2 9 10
     load_array_element
-    load_var context
-    load_var active_delay_ms
+    load_var2 2 3
     call baml.llm.Client.execute_stream
     jump L8
     load_var e
@@ -2769,26 +2729,22 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
     store_var primitive
     load_type #1
     store_var return_type
-    load_var primitive
-    load_var context
+    load_var2 4 2
     load_field .jinja_string
     load_var context
     load_field .args
     load_var return_type
     sys_op baml.llm.PrimitiveClient.render_prompt
     store_var prompt
-    load_var primitive
-    load_var prompt
+    load_var2 4 6
     sys_op baml.llm.PrimitiveClient.specialize_prompt
     store_var specialized
-    load_var primitive
-    load_var specialized
+    load_var2 4 7
     load_var return_type
     sys_op baml.llm.PrimitiveClient.build_request_stream
     sys_op baml.http.fetch_sse
     store_var sse
-    load_var self
-    load_var sse
+    load_var2 1 8
     load_var context
     load_field .function_name
     call baml.llm.Client.__make_stream
@@ -2810,8 +2766,7 @@ function baml.llm.Client.execute_oneshot(self: baml.llm.Client, context: baml.ll
 
   L0:
     load_type #0
-    load_var self
-    load_var context
+    load_var2 1 2
     load_var inherited_delay_ms
     call baml.llm.Client.execute_once_oneshot
     jump L9
@@ -2827,8 +2782,7 @@ function baml.llm.Client.execute_oneshot(self: baml.llm.Client, context: baml.ll
     store_var attempt
 
   L2:
-    load_var attempt
-    load_var r
+    load_var2 7 5
     load_field .max_retries
     cmp_int_op <=
     pop_jump_if_false L3
@@ -2849,8 +2803,7 @@ function baml.llm.Client.execute_oneshot(self: baml.llm.Client, context: baml.ll
     load_var current_delay
     call baml.math.trunc
     store_var attempt_delay
-    load_var current_delay
-    load_var r
+    load_var2 6 5
     load_field .multiplier
     mul_float
     store_var_load_var next
@@ -2875,8 +2828,7 @@ function baml.llm.Client.execute_oneshot(self: baml.llm.Client, context: baml.ll
     store_var current_delay
 
   L7:
-    load_var attempt
-    load_var r
+    load_var2 7 5
     load_field .max_retries
     cmp_int_op ==
     pop_jump_if_false L8
@@ -2885,8 +2837,7 @@ function baml.llm.Client.execute_oneshot(self: baml.llm.Client, context: baml.ll
 
   L8:
     load_type #0
-    load_var self
-    load_var context
+    load_var2 1 2
     load_var attempt_delay
     call baml.llm.Client.execute_once_oneshot
     jump L9
@@ -2913,8 +2864,7 @@ function baml.llm.Client.execute_stream(self: baml.llm.Client, context: baml.llm
   L0:
     load_type #0
     load_type #1
-    load_var self
-    load_var context
+    load_var2 1 2
     load_var inherited_delay_ms
     call baml.llm.Client.execute_once_stream
     jump L9
@@ -2930,8 +2880,7 @@ function baml.llm.Client.execute_stream(self: baml.llm.Client, context: baml.llm
     store_var attempt
 
   L2:
-    load_var attempt
-    load_var r
+    load_var2 7 5
     load_field .max_retries
     cmp_int_op <=
     pop_jump_if_false L3
@@ -2952,8 +2901,7 @@ function baml.llm.Client.execute_stream(self: baml.llm.Client, context: baml.llm
     load_var current_delay
     call baml.math.trunc
     store_var attempt_delay
-    load_var current_delay
-    load_var r
+    load_var2 6 5
     load_field .multiplier
     mul_float
     store_var_load_var next
@@ -2978,8 +2926,7 @@ function baml.llm.Client.execute_stream(self: baml.llm.Client, context: baml.llm
     store_var current_delay
 
   L7:
-    load_var attempt
-    load_var r
+    load_var2 7 5
     load_field .max_retries
     cmp_int_op ==
     pop_jump_if_false L8
@@ -2989,8 +2936,7 @@ function baml.llm.Client.execute_stream(self: baml.llm.Client, context: baml.llm
   L8:
     load_type #0
     load_type #1
-    load_var self
-    load_var context
+    load_var2 1 2
     load_var attempt_delay
     call baml.llm.Client.execute_once_stream
     jump L9
@@ -3088,10 +3034,8 @@ function baml.llm.Client.to_json(self: baml.llm.Client) -> baml.json.json {
     load_field .counter
     call baml.Int.to_json
     store_var _20
-    load_var _2
-    load_var _5
-    load_var _10
-    load_var _13
+    load_var2 2 3
+    load_var2 4 5
     load_var _20
     load_const "name"
     load_const "client_type"
@@ -3257,10 +3201,8 @@ function baml.llm.MediaUrlHandler.to_json(self: baml.llm.MediaUrlHandler) -> bam
     store_var _23
 
   L11:
-    load_var _2
-    load_var _9
-    load_var _16
-    load_var _23
+    load_var2 2 3
+    load_var2 4 5
     load_const "image"
     load_const "audio"
     load_const "video"
@@ -3323,8 +3265,7 @@ function baml.llm.PlannerState.rr_local_offset(self: baml.llm.PlannerState, clie
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _4
+    load_var2 5 4
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -3335,8 +3276,7 @@ function baml.llm.PlannerState.rr_local_offset(self: baml.llm.PlannerState, clie
     return
 
   L2:
-    load_var _4
-    load_var __for_idx
+    load_var2 4 5
     load_array_element
     load_var client_name
     cmp_op ==
@@ -3355,8 +3295,7 @@ function baml.llm.PlannerState.rr_local_offset(self: baml.llm.PlannerState, clie
 }
 
 function baml.llm.PlannerState.rr_pick_index(self: baml.llm.PlannerState, client_name: string, counter: int, sub_client_count: int) -> int {
-    load_var self
-    load_var client_name
+    load_var2 1 2
     call baml.llm.PlannerState.rr_local_offset
     store_var local_offset
     load_var self
@@ -3364,8 +3303,7 @@ function baml.llm.PlannerState.rr_pick_index(self: baml.llm.PlannerState, client
     load_var client_name
     call baml.Array.push
     pop 1
-    load_var counter
-    load_var local_offset
+    load_var2 3 5
     add_int
     load_var sub_client_count
     mod_int
@@ -3901,10 +3839,8 @@ function baml.llm.VertexAiOptions.to_json(self: baml.llm.VertexAiOptions) -> bam
     store_var _23
 
   L11:
-    load_var _2
-    load_var _9
-    load_var _16
-    load_var _23
+    load_var2 2 3
+    load_var2 4 5
     load_const "credentials"
     load_const "credentials_content"
     load_const "location"
@@ -3926,13 +3862,11 @@ function baml.llm.build_request(client: baml.llm.Client, function_name: string, 
     load_var client
     call baml.llm.Client.to_primitive_client
     store_var primitive_client
-    load_var client
-    load_var function_name
+    load_var2 1 2
     load_var args
     call baml.llm.render_prompt
     store_var specialized_prompt
-    load_var primitive_client
-    load_var specialized_prompt
+    load_var2 5 6
     load_var return_type
     sys_op baml.llm.PrimitiveClient.build_request
     return
@@ -3945,13 +3879,11 @@ function baml.llm.build_request_stream(client: baml.llm.Client, function_name: s
     load_var client
     call baml.llm.Client.to_primitive_client
     store_var primitive_client
-    load_var client
-    load_var function_name
+    load_var2 1 2
     load_var args
     call baml.llm.render_prompt
     store_var specialized_prompt
-    load_var primitive_client
-    load_var specialized_prompt
+    load_var2 5 6
     load_var return_type
     sys_op baml.llm.PrimitiveClient.build_request_stream
     return
@@ -3962,10 +3894,8 @@ function baml.llm.call_llm_function(client: baml.llm.Client, function_name: stri
     sys_op baml.llm.get_jinja_template
     store_var jinja_string
     load_type #0
-    load_var client
-    load_var jinja_string
-    load_var args
-    load_var function_name
+    load_var2 1 4
+    load_var2 3 2
     init_instance baml.llm.ExecutionContext .jinja_string, .args, .function_name
     load_const 0
     call baml.llm.Client.execute_oneshot
@@ -3992,12 +3922,10 @@ function baml.llm.parse(function_name: string, json: string) -> unknown {
     sys_op baml.llm.get_stream_return_type
     store_var stream_return_type
     load_const null
-    load_var return_type
-    load_var stream_return_type
+    load_var2 3 4
     sys_op baml.llm.StreamCache.new
     store_var cache
-    load_var json
-    load_var cache
+    load_var2 2 5
     load_type #0
     load_type #1
     sys_op baml.llm.__sap_parse_final
@@ -4014,14 +3942,11 @@ function baml.llm.render_prompt(client: baml.llm.Client, function_name: string, 
     load_var client
     call baml.llm.Client.to_primitive_client
     store_var primitive_client
-    load_var primitive_client
-    load_var jinja_string
-    load_var args
-    load_var return_type
+    load_var2 6 4
+    load_var2 3 5
     sys_op baml.llm.PrimitiveClient.render_prompt
     store_var prompt
-    load_var primitive_client
-    load_var prompt
+    load_var2 6 7
     sys_op baml.llm.PrimitiveClient.specialize_prompt
     return
 }
@@ -4032,10 +3957,8 @@ function baml.llm.stream_llm_function(client: baml.llm.Client, function_name: st
     store_var jinja_string
     load_type #0
     load_type #1
-    load_var client
-    load_var jinja_string
-    load_var args
-    load_var function_name
+    load_var2 1 4
+    load_var2 3 2
     init_instance baml.llm.ExecutionContext .jinja_string, .args, .function_name
     load_const 0
     call baml.llm.Client.execute_stream
@@ -4699,10 +4622,8 @@ function baml.sys.ProcessOptions.to_json(self: baml.sys.ProcessOptions) -> baml.
     store_var _23
 
   L11:
-    load_var _2
-    load_var _9
-    load_var _16
-    load_var _23
+    load_var2 2 3
+    load_var2 4 5
     load_const "cwd"
     load_const "env"
     load_const "timeout_ms"

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
@@ -1,10 +1,8 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 4621
 ---
 function testing.$invoke_collector(collector: (testing.TestCollector) -> void throws unknown, c: testing.TestCollector) -> void {
-    load_var c
-    load_var collector
+    load_var2 2 1
     call_indirect
     return
 }
@@ -126,8 +124,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -140,8 +137,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
     throw
 
   L2:
-    load_var _3
-    load_var __for_idx
+    load_var2 3 4
     load_array_element
     store_var_load_var ts
     load_field .name
@@ -232,8 +228,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     store_var __for_idx
 
   L3:
-    load_var __for_idx
-    load_var _13
+    load_var2 9 8
     container_len
     cmp_int_op <
     pop_jump_if_false L4
@@ -261,16 +256,14 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     add_int
     call baml.unstable.string
     store_var _30
-    load_var _28
-    load_var _30
+    load_var2 12 13
     bin_op +
     store_var final_name
 
   L7:
     load_var self
     load_field .tests
-    load_var final_name
-    load_var body
+    load_var2 11 3
     load_var runner
     init_instance testing.TestRegistration .name, .body, .runner
     call baml.Array.push
@@ -279,8 +272,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     return
 
   L8:
-    load_var _13
-    load_var __for_idx
+    load_var2 8 9
     load_array_element
     store_var_load_var t
     load_field .name
@@ -347,8 +339,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     store_var __for_idx
 
   L3:
-    load_var __for_idx
-    load_var _13
+    load_var2 9 8
     container_len
     cmp_int_op <
     pop_jump_if_false L4
@@ -376,16 +367,14 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     add_int
     call baml.unstable.string
     store_var _30
-    load_var _28
-    load_var _30
+    load_var2 12 13
     bin_op +
     store_var final_name
 
   L7:
     load_var self
     load_field .testsets
-    load_var final_name
-    load_var collector
+    load_var2 11 3
     load_var runner
     init_instance testing.TestSetRegistration .name, .collector, .runner
     call baml.Array.push
@@ -394,8 +383,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     return
 
   L8:
-    load_var _13
-    load_var __for_idx
+    load_var2 8 9
     load_array_element
     store_var_load_var ts
     load_field .name
@@ -486,8 +474,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -502,8 +489,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     store_var __for_idx_1
 
   L2:
-    load_var __for_idx_1
-    load_var _28
+    load_var2 10 9
     container_len
     cmp_int_op <
     pop_jump_if_false L3
@@ -516,8 +502,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     throw
 
   L4:
-    load_var _28
-    load_var __for_idx_1
+    load_var2 9 10
     load_array_element
     store_var k
     load_var self
@@ -525,8 +510,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_var k
     load_map_element
     store_var sub
-    load_var name
-    load_var k
+    load_var2 2 11
     load_const "/"
     bin_op +
     call baml.String.starts_with
@@ -541,14 +525,12 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     jump L2
 
   L6:
-    load_var sub
-    load_var name
+    load_var2 12 2
     call testing.TestRegistry.expand_set
     jump L10
 
   L7:
-    load_var _3
-    load_var __for_idx
+    load_var2 3 4
     load_array_element
     store_var_load_var ts
     load_field .name
@@ -580,11 +562,9 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     store_var _19
     load_var self
     load_field .expansions
-    load_var name
-    load_var sub_collector
+    load_var2 2 7
     alloc_map 0
-    load_var _19
-    load_var start
+    load_var2 8 6
     sub_int
     init_instance testing.TestRegistry .collector, .expansions, .loading_time_ms
     call baml.Map.set
@@ -639,8 +619,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -655,8 +634,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     store_var __for_idx_1
 
   L2:
-    load_var __for_idx_1
-    load_var _13
+    load_var2 7 6
     container_len
     cmp_int_op <
     pop_jump_if_false L3
@@ -669,8 +647,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     throw
 
   L4:
-    load_var _13
-    load_var __for_idx_1
+    load_var2 6 7
     load_array_element
     store_var k
     load_var self
@@ -678,8 +655,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var k
     load_map_element
     store_var sub
-    load_var name
-    load_var k
+    load_var2 2 8
     load_const "/"
     bin_op +
     call baml.String.starts_with
@@ -694,14 +670,12 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     jump L2
 
   L6:
-    load_var sub
-    load_var name
+    load_var2 9 2
     call testing.TestRegistry.run_test
     jump L10
 
   L7:
-    load_var _3
-    load_var __for_idx
+    load_var2 3 4
     load_array_element
     store_var_load_var t
     load_field .name
@@ -739,8 +713,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -755,8 +728,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var __for_idx_1
 
   L2:
-    load_var __for_idx_1
-    load_var _12
+    load_var2 6 5
     container_len
     cmp_int_op <
     pop_jump_if_false L3
@@ -767,8 +739,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     return
 
   L4:
-    load_var _12
-    load_var __for_idx_1
+    load_var2 5 6
     load_array_element
     store_var ts
     load_var self
@@ -801,10 +772,8 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     load_var sub
     call testing.TestRegistry.serialize
     store_var _26
-    load_var items
-    load_var _25
-    load_var _26
-    load_var sub
+    load_var2 2 10
+    load_var2 11 9
     load_field .loading_time_ms
     init_instance testing.SerializedTestSet .name, .items, .loadingTimeMs
     call baml.Array.push
@@ -820,8 +789,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
   L8:
     load_var items
     load_const "test"
-    load_var _3
-    load_var __for_idx
+    load_var2 3 4
     load_array_element
     load_field .name
     init_instance testing.SerializedTest .type, .name
@@ -1000,8 +968,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
     jump L1
 
   L0:
-    load_var base_run
-    load_var runner
+    load_var2 3 2
     call_indirect
     call_indirect
     jump L2
@@ -1022,8 +989,7 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
     jump L1
 
   L0:
-    load_var run_children
-    load_var runner
+    load_var2 1 2
     call_indirect
     call_indirect
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/compiles/byte_string_literals/baml_tests__compiles__byte_string_literals__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/byte_string_literals/baml_tests__compiles__byte_string_literals__06_codegen.snap
@@ -77,7 +77,8 @@ function user.ByteStringLiteralAsArg() -> int {
 function user.ByteStringMutate() -> int? {
     load_const b"\x00\x00\x00"
     call baml.deep_copy
-    store_var_load_var data
+    store_var data
+    load_var data
     load_const 0
     load_const 42
     store_array_element

--- a/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
@@ -16,8 +16,7 @@ function user.sum_array(arr: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var arr
+    load_var2 4 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -30,8 +29,7 @@ function user.sum_array(arr: int[]) -> int {
     store_var __for_idx_1
 
   L2:
-    load_var __for_idx_1
-    load_var _12
+    load_var2 7 6
     container_len
     cmp_int_op <
     pop_jump_if_false L3
@@ -42,8 +40,7 @@ function user.sum_array(arr: int[]) -> int {
     return
 
   L4:
-    load_var _12
-    load_var __for_idx_1
+    load_var2 6 7
     load_array_element
     call_indirect
     pop 1
@@ -57,12 +54,10 @@ function user.sum_array(arr: int[]) -> int {
     load_const null
     make_cell
     store_var i
-    load_var arr
-    load_var __for_idx
+    load_var2 1 4
     load_array_element
     store_deref ?5
-    load_var total
-    load_var sum
+    load_var2 3 2
     load_var i
     make_closure .<lambda(sum_array, 0)>, 2
     call baml.Array.push

--- a/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 7540
 ---
 function user.Box.from_json(j: baml.json.json) -> Box<void> {
     load_var j
@@ -39,14 +38,12 @@ function user.Calculator.compute(self: Calculator, a: int, b: int) -> int {
     jump L1
 
   L0:
-    load_var a
-    load_var b
+    load_var2 2 3
     mul_int
     jump L2
 
   L1:
-    load_var a
-    load_var b
+    load_var2 2 3
     add_int
 
   L2:
@@ -263,14 +260,12 @@ function user.RangeCheck.from_json(j: baml.json.json) -> RangeCheck {
 }
 
 function user.RangeCheck.is_valid(self: RangeCheck, n: int) -> bool {
-    load_var n
-    load_var self
+    load_var2 2 1
     load_field .min
     cmp_int_op >=
     jump_if_false L0
     pop 1
-    load_var n
-    load_var self
+    load_var2 2 1
     load_field .max
     cmp_int_op <=
 
@@ -292,16 +287,14 @@ function user.RangeCheck.to_json(self: RangeCheck) -> baml.json.json {
 }
 
 function user.apply(f: (int, int) -> int throws never, a: int, b: int) -> int {
-    load_var a
-    load_var b
+    load_var2 2 3
     load_var f
     call_indirect
     return
 }
 
 function user.apply_to_each(items: Employee[], f: (Employee) -> string throws never) -> string[] {
-    load_var items
-    load_var f
+    load_var2 1 2
     call baml.Array.map
     return
 }
@@ -411,8 +404,7 @@ function user.test_strategy() -> int[] {
     load_const 4
     call user.apply
     store_var _7
-    load_var _5
-    load_var _7
+    load_var2 1 2
     alloc_array 2
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__06_codegen.snap
@@ -363,7 +363,8 @@ function user.test_generic_bind() -> int {
 function user.test_mutation_after_bind() -> int {
     load_const 0
     init_instance user.Counter .value
-    store_var_load_var c
+    store_var c
+    load_var c
     make_bound_method user.Counter.increment
     store_var inc
     load_var c

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__06_codegen.snap
@@ -68,8 +68,7 @@ function user.FunctionWithComments(a: string, b: int) -> string {
     load_type string
     load_global user.TestClient
     load_const "FunctionWithComments"
-    load_var a
-    load_var b
+    load_var2 1 2
     load_const "a"
     load_const "b"
     alloc_map 2
@@ -80,8 +79,7 @@ function user.FunctionWithComments(a: string, b: int) -> string {
 function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http.Request {
     load_global user.TestClient
     load_const "FunctionWithComments"
-    load_var a
-    load_var b
+    load_var2 1 2
     load_const "a"
     load_const "b"
     alloc_map 2
@@ -92,8 +90,7 @@ function user.FunctionWithComments$build_request(a: string, b: int) -> baml.http
 function user.FunctionWithComments$build_request_stream(a: string, b: int) -> baml.http.Request {
     load_global user.TestClient
     load_const "FunctionWithComments"
-    load_var a
-    load_var b
+    load_var2 1 2
     load_const "a"
     load_const "b"
     alloc_map 2
@@ -119,8 +116,7 @@ function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream) -> bam
 function user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.PromptAst {
     load_global user.TestClient
     load_const "FunctionWithComments"
-    load_var a
-    load_var b
+    load_var2 1 2
     load_const "a"
     load_const "b"
     alloc_map 2
@@ -131,8 +127,7 @@ function user.FunctionWithComments$render_prompt(a: string, b: int) -> baml.llm.
 function user.FunctionWithComments$stream(a: string, b: int) -> baml.llm.Stream<null | string, string> {
     load_global user.TestClient
     load_const "FunctionWithComments"
-    load_var a
-    load_var b
+    load_var2 1 2
     load_const "a"
     load_const "b"
     alloc_map 2

--- a/baml_language/crates/baml_tests/snapshots/compiles/host_callable_call/baml_tests__compiles__host_callable_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/host_callable_call/baml_tests__compiles__host_callable_call__06_codegen.snap
@@ -2,8 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 function user.call_with_callback(callback: (int) -> string throws never, x: int) -> string {
-    load_var x
-    load_var callback
+    load_var2 2 1
     call_indirect
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
@@ -323,8 +323,7 @@ function user.test_shadowing() -> string {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _5
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -335,16 +334,14 @@ function user.test_shadowing() -> string {
     return
 
   L2:
-    load_var _5
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var y
     load_const 0
     store_var i
 
   L3:
-    load_var i
-    load_var y
+    load_var2 5 4
     cmp_int_op <
     pop_jump_if_false L4
     jump L5

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__06_codegen.snap
@@ -51,8 +51,7 @@ function user.test_mixed() -> int {
     make_closure .<lambda(test_mixed, 1)>, 0
     call_indirect
     store_var _5
-    load_var _3
-    load_var _5
+    load_var2 1 2
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
@@ -58,8 +58,7 @@ function user.for_loop_restores_outer() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 2 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -70,8 +69,7 @@ function user.for_loop_restores_outer() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 1 2
     load_array_element
     store_var x
     load_var __for_idx

--- a/baml_language/crates/baml_tests/snapshots/compiles/literal_union_arithmetic/baml_tests__compiles__literal_union_arithmetic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/literal_union_arithmetic/baml_tests__compiles__literal_union_arithmetic__06_codegen.snap
@@ -30,8 +30,7 @@ function user.bothSidesUnion() -> int {
     store_var _2
 
   L5:
-    load_var _1
-    load_var _2
+    load_var2 1 2
     bin_op +
     return
 }
@@ -105,8 +104,7 @@ function user.loopMatchAccum() -> int {
     store_var _6
 
   L7:
-    load_var _5
-    load_var _6
+    load_var2 3 4
     bin_op +
     store_var sum
     load_var i

--- a/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 19199
 ---
 function $init() -> null {
     call $init_let_0
@@ -29,8 +28,7 @@ function user.AskDocs(query: string, max_results: int, filter: string) -> string
     load_type string
     load_global user.TestClient
     load_const "AskDocs"
-    load_var query
-    load_var max_results
+    load_var2 1 2
     load_var filter
     load_const "query"
     load_const "max_results"
@@ -59,8 +57,7 @@ function user.AskDocs$build_request(query: string, max_results: int, filter: str
   L1:
     load_global user.TestClient
     load_const "AskDocs"
-    load_var query
-    load_var max_results
+    load_var2 1 2
     load_var filter
     load_const "query"
     load_const "max_results"
@@ -89,8 +86,7 @@ function user.AskDocs$build_request_stream(query: string, max_results: int, filt
   L1:
     load_global user.TestClient
     load_const "AskDocs"
-    load_var query
-    load_var max_results
+    load_var2 1 2
     load_var filter
     load_const "query"
     load_const "max_results"
@@ -134,8 +130,7 @@ function user.AskDocs$render_prompt(query: string, max_results: int, filter: str
   L1:
     load_global user.TestClient
     load_const "AskDocs"
-    load_var query
-    load_var max_results
+    load_var2 1 2
     load_var filter
     load_const "query"
     load_const "max_results"
@@ -164,8 +159,7 @@ function user.AskDocs$stream(query: string, max_results: int, filter: string) ->
   L1:
     load_global user.TestClient
     load_const "AskDocs"
-    load_var query
-    load_var max_results
+    load_var2 1 2
     load_var filter
     load_const "query"
     load_const "max_results"
@@ -294,8 +288,7 @@ function user.SearchService.Run(self: SearchService, query: string, limit: int) 
     store_var limit
 
   L0:
-    load_var query
-    load_var limit
+    load_var2 2 3
     load_var self
     load_field .base
     call user.Search

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
@@ -85,10 +85,12 @@ function user.Point.to_json(self: Point) -> baml.json.json {
 
 function user.add_assign() -> int {
     load_const 10
-    store_var_load_var x
+    store_var x
+    load_var x
     load_const 5
     add_int
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 
@@ -328,10 +330,12 @@ function user.let_statements() -> int {
 
 function user.mul_assign() -> int {
     load_const 3
-    store_var_load_var x
+    store_var x
+    load_var x
     load_const 4
     mul_int
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 
@@ -454,7 +458,8 @@ function user.simple_assign() -> int {
     load_const 1
     store_var x
     load_const 5
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }
 
@@ -503,9 +508,11 @@ function user.simple_while_loop() -> int {
 
 function user.sub_assign() -> int {
     load_const 10
-    store_var_load_var x
+    store_var x
+    load_var x
     load_const 3
     sub_int
-    store_var_load_var x
+    store_var x
+    load_var x
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 21362
 ---
 function user.ConditionalLogic(age: int) -> string {
     load_var age
@@ -111,8 +110,7 @@ function user.assign_in_loop() -> int {
     return
 
   L2:
-    load_var sum
-    load_var i
+    load_var2 1 2
     add_int
     store_var sum
     load_var i
@@ -170,8 +168,7 @@ function user.c_style_for_loop() -> int {
     return
 
   L2:
-    load_var result
-    load_var i
+    load_var2 1 2
     add_int
     store_var result
     load_var i
@@ -275,8 +272,7 @@ function user.iterator_style_for_loop() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -287,8 +283,7 @@ function user.iterator_style_for_loop() -> int {
     return
 
   L2:
-    load_var result
-    load_var _2
+    load_var2 1 2
     load_var __for_idx
     load_array_element
     add_int
@@ -349,8 +344,7 @@ function user.multi_assign() -> int {
     store_var a
     load_const 20
     store_var b
-    load_var a
-    load_var b
+    load_var2 1 2
     add_int
     return
 }
@@ -378,8 +372,7 @@ function user.nested_for_loop() -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _2
+    load_var2 3 2
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -390,8 +383,7 @@ function user.nested_for_loop() -> int {
     return
 
   L2:
-    load_var _2
-    load_var __for_idx
+    load_var2 2 3
     load_array_element
     store_var i
     load_const 4
@@ -403,8 +395,7 @@ function user.nested_for_loop() -> int {
     store_var __for_idx_1
 
   L3:
-    load_var __for_idx_1
-    load_var _8
+    load_var2 6 5
     container_len
     cmp_int_op <
     pop_jump_if_false L4
@@ -418,10 +409,8 @@ function user.nested_for_loop() -> int {
     jump L0
 
   L5:
-    load_var result
-    load_var i
-    load_var _8
-    load_var __for_idx_1
+    load_var2 1 4
+    load_var2 5 6
     load_array_element
     mul_int
     add_int

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 22719
 ---
 function user.AppError.from_json(j: baml.json.json) -> AppError {
     load_var j
@@ -297,8 +296,7 @@ function user.for_let_ascription(items: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var items
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -309,8 +307,7 @@ function user.for_let_ascription(items: int[]) -> int {
     return
 
   L2:
-    load_var items
-    load_var __for_idx
+    load_var2 1 3
     load_array_element
     store_var n
     load_var sum
@@ -331,8 +328,7 @@ function user.for_let_fn_narrow(items: ((int) -> int throws never)[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var items
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -344,8 +340,7 @@ function user.for_let_fn_narrow(items: ((int) -> int throws never)[]) -> int {
 
   L2:
     load_const 0
-    load_var items
-    load_var __for_idx
+    load_var2 1 3
     load_array_element
     call_indirect
     load_var total
@@ -365,8 +360,7 @@ function user.for_let_with_narrow(items: int[]) -> int {
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var items
+    load_var2 3 1
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -377,8 +371,7 @@ function user.for_let_with_narrow(items: int[]) -> int {
     return
 
   L2:
-    load_var sum
-    load_var items
+    load_var2 2 1
     load_var __for_idx
     load_array_element
     add_int

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 28035
 ---
 function $init() -> null {
     call $init_let_0
@@ -219,8 +218,7 @@ function user.GenerateTests(count: int, topic: string) -> string[] {
     load_type string[]
     load_global user.GPT4o
     load_const "GenerateTests"
-    load_var count
-    load_var topic
+    load_var2 1 2
     load_const "count"
     load_const "topic"
     alloc_map 2
@@ -231,8 +229,7 @@ function user.GenerateTests(count: int, topic: string) -> string[] {
 function user.GenerateTests$build_request(count: int, topic: string) -> baml.http.Request {
     load_global user.GPT4o
     load_const "GenerateTests"
-    load_var count
-    load_var topic
+    load_var2 1 2
     load_const "count"
     load_const "topic"
     alloc_map 2
@@ -243,8 +240,7 @@ function user.GenerateTests$build_request(count: int, topic: string) -> baml.htt
 function user.GenerateTests$build_request_stream(count: int, topic: string) -> baml.http.Request {
     load_global user.GPT4o
     load_const "GenerateTests"
-    load_var count
-    load_var topic
+    load_var2 1 2
     load_const "count"
     load_const "topic"
     alloc_map 2
@@ -270,8 +266,7 @@ function user.GenerateTests$parse_stream(sse: baml.http.SseStream) -> baml.llm.S
 function user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm.PromptAst {
     load_global user.GPT4o
     load_const "GenerateTests"
-    load_var count
-    load_var topic
+    load_var2 1 2
     load_const "count"
     load_const "topic"
     alloc_map 2
@@ -282,8 +277,7 @@ function user.GenerateTests$render_prompt(count: int, topic: string) -> baml.llm
 function user.GenerateTests$stream(count: int, topic: string) -> baml.llm.Stream<string[], string[]> {
     load_global user.GPT4o
     load_const "GenerateTests"
-    load_var count
-    load_var topic
+    load_var2 1 2
     load_const "count"
     load_const "topic"
     alloc_map 2

--- a/baml_language/crates/baml_tests/snapshots/engine/baml_tests__engine__tests__optional_dropping_adapter_preserves_source_defaults_bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/engine/baml_tests__engine__tests__optional_dropping_adapter_preserves_source_defaults_bytecode.snap
@@ -18,8 +18,7 @@ function combine(x: int, a: int, b: int) -> int {
     store_var b
 
   L1:
-    load_var x
-    load_var a
+    load_var2 1 2
     add_int
     load_var b
     add_int

--- a/baml_language/crates/baml_tests/snapshots/engine/baml_tests__engine__tests__source_call_omitted_default_executes_in_callee_scope_bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/engine/baml_tests__engine__tests__source_call_omitted_default_executes_in_callee_scope_bytecode.snap
@@ -12,8 +12,7 @@ function add(base: int, amount: int) -> int {
     store_var amount
 
   L0:
-    load_var base
-    load_var amount
+    load_var2 1 2
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -1205,130 +1205,131 @@ function user.http_status(code: int) -> string {
 }
 
 function user.score(input: User | ErrorInfo, threshold: int) -> Report {
-  45   0    load_var 1              (input)
-       1    is_type 0               
-       2    pop_jump_if_false +2    (to 4)
-       3    jump +5                 (to 8)
+  45   0    load_var 1             (input)
+       1    is_type 0              
+       2    pop_jump_if_false +2   (to 4)
+       3    jump +5                (to 8)
 
-  47   4    load_var 1              (input)
-       5    load_field 1            (message)
-       6    store_var 3             (name)
+  47   4    load_var 1             (input)
+       5    load_field 1           (message)
+       6    store_var 3            (name)
 
-  45   7    jump +4                 (to 11)
+  45   7    jump +4                (to 11)
 
-  46   8    load_var 1              (input)
-       9    load_field 0            (name)
-       10   store_var 3             (name)
+  46   8    load_var 1             (input)
+       9    load_field 0           (name)
+       10   store_var 3            (name)
 
-  50   11   load_var 1              (input)
-       12   is_type 0               
-       13   pop_jump_if_false +2    (to 15)
-       14   jump +6                 (to 20)
+  50   11   load_var 1             (input)
+       12   is_type 0              
+       13   pop_jump_if_false +2   (to 15)
+       14   jump +6                (to 20)
 
-  52   15   load_var 1              (input)
-       16   load_field 0            (code)
-       17   unary_op -              
-       18   store_var 4             (age)
+  52   15   load_var 1             (input)
+       16   load_field 0           (code)
+       17   unary_op -             
+       18   store_var 4            (age)
 
-  50   19   jump +4                 (to 23)
+  50   19   jump +4                (to 23)
 
-  51   20   load_var 1              (input)
-       21   load_field 1            (age)
-       22   store_var 4             (age)
+  51   20   load_var 1             (input)
+       21   load_field 1           (age)
+       22   store_var 4            (age)
 
-  55   23   load_var 1              (input)
-       24   is_type 0               
-       25   pop_jump_if_false +2    (to 27)
-       26   jump +4                 (to 30)
+  55   23   load_var 1             (input)
+       24   is_type 0              
+       25   pop_jump_if_false +2   (to 27)
+       26   jump +4                (to 30)
 
-  62   27   load_var 2              (threshold)
-       28   store_var 5             (role_mult)
+  62   27   load_var 2             (threshold)
+       28   store_var 5            (role_mult)
 
-  55   29   jump +16                (to 45)
+  55   29   jump +16               (to 45)
 
-  56   30   load_var 1              (input)
-       31   load_field 2            (role)
-       32   discriminant            
-       33   jump_table 0            ([to 43, to 40, to 37, to 34], default to 92)
+  56   30   load_var 1             (input)
+       31   load_field 2           (role)
+       32   discriminant           
+       33   jump_table 0           ([to 43, to 40, to 37, to 34], default to 93)
 
-  60   34   load_var 2              (threshold)
-       35   store_var 5             (role_mult)
+  60   34   load_var 2             (threshold)
+       35   store_var 5            (role_mult)
 
-  56   36   jump +9                 (to 45)
+  56   36   jump +9                (to 45)
 
-  59   37   load_var 2              (threshold)
-       38   store_var 5             (role_mult)
+  59   37   load_var 2             (threshold)
+       38   store_var 5            (role_mult)
 
-  56   39   jump +6                 (to 45)
+  56   39   jump +6                (to 45)
 
-  58   40   load_var 2              (threshold)
-       41   store_var 5             (role_mult)
+  58   40   load_var 2             (threshold)
+       41   store_var 5            (role_mult)
 
-  56   42   jump +3                 (to 45)
+  56   42   jump +3                (to 45)
 
-  57   43   load_var 2              (threshold)
-       44   store_var 5             (role_mult)
+  57   43   load_var 2             (threshold)
+       44   store_var 5            (role_mult)
 
-  65   45   load_var 4              (age)
-       46   load_const 1            (2)
-       47   mul_int                 
-       48   load_var 5              (role_mult)
-       49   add_int                 
-       50   store_var_load_var 6    (base)
+  65   45   load_var 4             (age)
+       46   load_const 1           (2)
+       47   mul_int                
+       48   load_var 5             (role_mult)
+       49   add_int                
+       50   store_var_load_var 6   (base)
 
-  66   51   load_var 5              (role_mult)
-       52   cmp_int_op >            
-       53   pop_jump_if_false +2    (to 55)
-       54   jump +4                 (to 58)
+  66   51   load_var 5             (role_mult)
+       52   cmp_int_op >           
+       53   pop_jump_if_false +2   (to 55)
+       54   jump +4                (to 58)
 
-  69   55   load_var 6              (base)
-       56   store_var 7             (capped)
+  69   55   load_var 6             (base)
+       56   store_var 7            (capped)
 
-  66   57   jump +3                 (to 60)
+  66   57   jump +3                (to 60)
 
-  67   58   load_var 5              (role_mult)
-       59   store_var 7             (capped)
+  67   58   load_var 5             (role_mult)
+       59   store_var 7            (capped)
 
-  71   60   load_var2 7 5           
-       61   add_int                 
-       62   store_var_load_var 8    (total)
+  71   60   load_var2 7 5          
+       61   add_int                
+       62   store_var_load_var 8   (total)
 
-  73   63   load_var 2              (threshold)
-       64   cmp_int_op >            
-       65   load_const 2            (true)
-       66   cmp_op ==               
-       67   pop_jump_if_false +2    (to 69)
-       68   jump +4                 (to 72)
+  73   63   load_var 2             (threshold)
+       64   cmp_int_op >           
+       65   load_const 2           (true)
+       66   cmp_op ==              
+       67   pop_jump_if_false +2   (to 69)
+       68   jump +4                (to 72)
 
-  75   69   load_const 3            (" [LOW]")
-       70   store_var 9             (suffix)
+  75   69   load_const 3           (" [LOW]")
+       70   store_var 9            (suffix)
 
-  73   71   jump +3                 (to 74)
+  73   71   jump +3                (to 74)
 
-  74   72   load_const 4            (" [HIGH]")
-       73   store_var 9             (suffix)
+  74   72   load_const 4           (" [HIGH]")
+       73   store_var 9            (suffix)
 
-  79   74   load_var2 6 7           
-       75   load_var 8              (total)
-       76   alloc_array 3           
-       77   store_var_load_var 10   (scores)
+  79   74   load_var2 6 7          
+       75   load_var 8             (total)
+       76   alloc_array 3          
+       77   store_var 10           (scores)
 
-  80   78   load_const 5            (0)
-       79   load_var 8              (total)
-       80   store_array_element     
+  80   78   load_var 10            (scores)
+       79   load_const 5           (0)
+       80   load_var 8             (total)
+       81   store_array_element    
 
-  81   81   load_var 10             (scores)
-       82   load_const 5            (0)
-       83   load_array_element      
+  81   82   load_var 10            (scores)
+       83   load_const 5           (0)
+       84   load_array_element     
 
-  77   84   load_var2 3 9           
-       85   bin_op +                
+  77   85   load_var2 3 9          
+       86   bin_op +               
 
-  83   86   load_var2 6 5           
-       87   load_const 6            ("base")
-       88   load_const 7            ("role")
-       89   alloc_map 2             
-       90   init_instance 0         (user.Report .score, .label, .breakdown)
-       91   return                  
-       92   unreachable             
+  83   87   load_var2 6 5          
+       88   load_const 6           ("base")
+       89   load_const 7           ("role")
+       90   alloc_map 2            
+       91   init_instance 0        (user.Report .score, .label, .breakdown)
+       92   return                 
+       93   unreachable            
 }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -2,36 +2,34 @@
 source: crates/baml_tests/tests/bytecode_format/main.rs
 ---
 function assert.contains(haystack: string, needle: string) -> null {
-  32   0    load_var 1             (haystack)
-       1    load_var 2             (needle)
-       2    call 168 ntypeargs=0   (baml.String.includes)
-       3    unary_op !             
-       4    pop_jump_if_false +2   (to 6)
-       5    jump +3                (to 8)
-
-  35   6    load_const 0           (null)
-
-  32   7    jump +3                (to 10)
-
-  33   8    load_const 1           ("assertion failed: string does not contain expected substring")
-       9    call 284 ntypeargs=0   (baml.sys.panic)
-       10   return                 
-}
-
-function assert.equal(actual: unknown, expected: unknown) -> null {
-  23   0   load_var 1             (actual)
-       1   load_var 2             (expected)
-       2   cmp_op !=              
+  32   0   load_var2 1 2          
+       1   call 168 ntypeargs=0   (baml.String.includes)
+       2   unary_op !             
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
-  26   5   load_const 0           (null)
+  35   5   load_const 0           (null)
 
-  23   6   jump +3                (to 9)
+  32   6   jump +3                (to 9)
 
-  24   7   load_const 1           ("assertion failed: expected equal values")
+  33   7   load_const 1           ("assertion failed: string does not contain expected substring")
        8   call 284 ntypeargs=0   (baml.sys.panic)
        9   return                 
+}
+
+function assert.equal(actual: unknown, expected: unknown) -> null {
+  23   0   load_var2 1 2          
+       1   cmp_op !=              
+       2   pop_jump_if_false +2   (to 4)
+       3   jump +3                (to 6)
+
+  26   4   load_const 0           (null)
+
+  23   5   jump +3                (to 8)
+
+  24   6   load_const 1           ("assertion failed: expected equal values")
+       7   call 284 ntypeargs=0   (baml.sys.panic)
+       8   return                 
 }
 
 function assert.is_true(condition: bool) -> null {
@@ -66,10 +64,9 @@ function assert.not_null(value: unknown?) -> null {
 }
 
 function testing.$invoke_collector(collector: (testing.TestCollector) -> void throws unknown, c: testing.TestCollector) -> void {
-  73   0   load_var 2      (c)
-       1   load_var 1      (collector)
-       2   call_indirect   
-       3   return          
+  73   0   load_var2 2 1   
+       1   call_indirect   
+       2   return          
 }
 
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
@@ -187,37 +184,35 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        2    store_var 3            (_3)
        3    load_const 0           (0)
        4    store_var 4            (__for_idx)
-       5    load_var 4             (__for_idx)
-       6    load_var 3             (_3)
-       7    container_len          
-       8    cmp_int_op <           
-       9    pop_jump_if_false +2   (to 11)
-       10   jump +5                (to 15)
+       5    load_var2 4 3          
+       6    container_len          
+       7    cmp_int_op <           
+       8    pop_jump_if_false +2   (to 10)
+       9    jump +5                (to 14)
 
-  66   11   load_const 1           ("TestSet not found: ")
-       12   load_var 2             (name)
-       13   bin_op +               
-       14   throw                  
+  66   10   load_const 1           ("TestSet not found: ")
+       11   load_var 2             (name)
+       12   bin_op +               
+       13   throw                  
 
-  61   15   load_var 3             (_3)
-       16   load_var 4             (__for_idx)
-       17   load_array_element     
-       18   store_var_load_var 5   (ts)
+  61   14   load_var2 3 4          
+       15   load_array_element     
+       16   store_var_load_var 5   (ts)
 
-  62   19   load_field 0           (name)
-       20   load_var 2             (name)
-       21   cmp_op ==              
-       22   pop_jump_if_false +2   (to 24)
-       23   jump +6                (to 29)
+  62   17   load_field 0           (name)
+       18   load_var 2             (name)
+       19   cmp_op ==              
+       20   pop_jump_if_false +2   (to 22)
+       21   jump +6                (to 27)
 
-  61   24   load_var 4             (__for_idx)
-       25   load_const 2           (1)
-       26   add_int                
-       27   store_var 4            (__for_idx)
-       28   jump -23               (to 5)
+  61   22   load_var 4             (__for_idx)
+       23   load_const 2           (1)
+       24   add_int                
+       25   store_var 4            (__for_idx)
+       26   jump -21               (to 5)
 
-  63   29   load_var 5             (ts)
-       30   return                 
+  63   27   load_var 5             (ts)
+       28   return                 
 }
 
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
@@ -285,73 +280,69 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        24   store_var 8             (_13)
        25   load_const 2            (0)
        26   store_var 9             (__for_idx)
-       27   load_var 9              (__for_idx)
-       28   load_var 8              (_13)
-       29   container_len           
-       30   cmp_int_op <            
-       31   pop_jump_if_false +2    (to 33)
-       32   jump +32                (to 64)
+       27   load_var2 9 8           
+       28   container_len           
+       29   cmp_int_op <            
+       30   pop_jump_if_false +2    (to 32)
+       31   jump +30                (to 61)
 
-  45   33   load_var 6              (count)
-       34   load_const 2            (0)
-       35   cmp_int_op >            
-       36   pop_jump_if_false +2    (to 38)
-       37   jump +4                 (to 41)
-       38   load_var 5              (full_name)
-       39   store_var 11            (final_name)
-       40   jump +14                (to 54)
-       41   load_var 5              (full_name)
-       42   load_const 4            ("#")
-       43   bin_op +                
-       44   store_var 12            (_28)
-       45   load_var 6              (count)
-       46   load_const 5            (1)
-       47   add_int                 
-       48   call 383 ntypeargs=0    (baml.unstable.string)
-       49   store_var 13            (_30)
-       50   load_var 12             (_28)
-       51   load_var 13             (_30)
-       52   bin_op +                
-       53   store_var 11            (final_name)
+  45   32   load_var 6              (count)
+       33   load_const 2            (0)
+       34   cmp_int_op >            
+       35   pop_jump_if_false +2    (to 37)
+       36   jump +4                 (to 40)
+       37   load_var 5              (full_name)
+       38   store_var 11            (final_name)
+       39   jump +13                (to 52)
+       40   load_var 5              (full_name)
+       41   load_const 4            ("#")
+       42   bin_op +                
+       43   store_var 12            (_28)
+       44   load_var 6              (count)
+       45   load_const 5            (1)
+       46   add_int                 
+       47   call 383 ntypeargs=0    (baml.unstable.string)
+       48   store_var 13            (_30)
+       49   load_var2 12 13         
+       50   bin_op +                
+       51   store_var 11            (final_name)
 
-  46   54   load_var 1              (self)
-       55   load_field 1            (tests)
-       56   load_var 11             (final_name)
-       57   load_var 3              (body)
-       58   load_var 4              (runner)
-       59   init_instance 0         (testing.TestRegistration .name, .body, .runner)
-       60   call 15 ntypeargs=0     (baml.Array.push)
-       61   pop 1                   
+  46   52   load_var 1              (self)
+       53   load_field 1            (tests)
+       54   load_var2 11 3          
+       55   load_var 4              (runner)
+       56   init_instance 0         (testing.TestRegistration .name, .body, .runner)
+       57   call 15 ntypeargs=0     (baml.Array.push)
+       58   pop 1                   
 
-  38   62   load_const 6            (null)
-       63   return                  
+  38   59   load_const 6            (null)
+       60   return                  
 
-  42   64   load_var 8              (_13)
-       65   load_var 9              (__for_idx)
-       66   load_array_element      
-       67   store_var_load_var 10   (t)
+  42   61   load_var2 8 9           
+       62   load_array_element      
+       63   store_var_load_var 10   (t)
 
-  43   68   load_field 0            (name)
-       69   load_var 5              (full_name)
-       70   cmp_op ==               
-       71   jump_if_false +2        (to 73)
-       72   jump +6                 (to 78)
-       73   pop 1                   
-       74   load_var 10             (t)
-       75   load_field 0            (name)
-       76   load_var 7              (hash_prefix)
-       77   call 141 ntypeargs=0    (baml.String.starts_with)
-       78   pop_jump_if_false +5    (to 83)
-       79   load_var 6              (count)
+  43   64   load_field 0            (name)
+       65   load_var 5              (full_name)
+       66   cmp_op ==               
+       67   jump_if_false +2        (to 69)
+       68   jump +6                 (to 74)
+       69   pop 1                   
+       70   load_var 10             (t)
+       71   load_field 0            (name)
+       72   load_var 7              (hash_prefix)
+       73   call 141 ntypeargs=0    (baml.String.starts_with)
+       74   pop_jump_if_false +5    (to 79)
+       75   load_var 6              (count)
+       76   load_const 5            (1)
+       77   add_int                 
+       78   store_var 6             (count)
+
+  42   79   load_var 9              (__for_idx)
        80   load_const 5            (1)
        81   add_int                 
-       82   store_var 6             (count)
-
-  42   83   load_var 9              (__for_idx)
-       84   load_const 5            (1)
-       85   add_int                 
-       86   store_var 9             (__for_idx)
-       87   jump -60                (to 27)
+       82   store_var 9             (__for_idx)
+       83   jump -56                (to 27)
 }
 
 function testing.TestCollector.register_test_set(self: testing.TestCollector, name: string, collector: (testing.TestCollector) -> void throws unknown, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never)?) -> void {
@@ -385,73 +376,69 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        24   store_var 8             (_13)
        25   load_const 2            (0)
        26   store_var 9             (__for_idx)
-       27   load_var 9              (__for_idx)
-       28   load_var 8              (_13)
-       29   container_len           
-       30   cmp_int_op <            
-       31   pop_jump_if_false +2    (to 33)
-       32   jump +32                (to 64)
+       27   load_var2 9 8           
+       28   container_len           
+       29   cmp_int_op <            
+       30   pop_jump_if_false +2    (to 32)
+       31   jump +30                (to 61)
 
-  56   33   load_var 6              (count)
-       34   load_const 2            (0)
-       35   cmp_int_op >            
-       36   pop_jump_if_false +2    (to 38)
-       37   jump +4                 (to 41)
-       38   load_var 5              (full_name)
-       39   store_var 11            (final_name)
-       40   jump +14                (to 54)
-       41   load_var 5              (full_name)
-       42   load_const 4            ("#")
-       43   bin_op +                
-       44   store_var 12            (_28)
-       45   load_var 6              (count)
-       46   load_const 5            (1)
-       47   add_int                 
-       48   call 383 ntypeargs=0    (baml.unstable.string)
-       49   store_var 13            (_30)
-       50   load_var 12             (_28)
-       51   load_var 13             (_30)
-       52   bin_op +                
-       53   store_var 11            (final_name)
+  56   32   load_var 6              (count)
+       33   load_const 2            (0)
+       34   cmp_int_op >            
+       35   pop_jump_if_false +2    (to 37)
+       36   jump +4                 (to 40)
+       37   load_var 5              (full_name)
+       38   store_var 11            (final_name)
+       39   jump +13                (to 52)
+       40   load_var 5              (full_name)
+       41   load_const 4            ("#")
+       42   bin_op +                
+       43   store_var 12            (_28)
+       44   load_var 6              (count)
+       45   load_const 5            (1)
+       46   add_int                 
+       47   call 383 ntypeargs=0    (baml.unstable.string)
+       48   store_var 13            (_30)
+       49   load_var2 12 13         
+       50   bin_op +                
+       51   store_var 11            (final_name)
 
-  57   54   load_var 1              (self)
-       55   load_field 2            (testsets)
-       56   load_var 11             (final_name)
-       57   load_var 3              (collector)
-       58   load_var 4              (runner)
-       59   init_instance 0         (testing.TestSetRegistration .name, .collector, .runner)
-       60   call 15 ntypeargs=0     (baml.Array.push)
-       61   pop 1                   
+  57   52   load_var 1              (self)
+       53   load_field 2            (testsets)
+       54   load_var2 11 3          
+       55   load_var 4              (runner)
+       56   init_instance 0         (testing.TestSetRegistration .name, .collector, .runner)
+       57   call 15 ntypeargs=0     (baml.Array.push)
+       58   pop 1                   
 
-  49   62   load_const 6            (null)
-       63   return                  
+  49   59   load_const 6            (null)
+       60   return                  
 
-  53   64   load_var 8              (_13)
-       65   load_var 9              (__for_idx)
-       66   load_array_element      
-       67   store_var_load_var 10   (ts)
+  53   61   load_var2 8 9           
+       62   load_array_element      
+       63   store_var_load_var 10   (ts)
 
-  54   68   load_field 0            (name)
-       69   load_var 5              (full_name)
-       70   cmp_op ==               
-       71   jump_if_false +2        (to 73)
-       72   jump +6                 (to 78)
-       73   pop 1                   
-       74   load_var 10             (ts)
-       75   load_field 0            (name)
-       76   load_var 7              (hash_prefix)
-       77   call 141 ntypeargs=0    (baml.String.starts_with)
-       78   pop_jump_if_false +5    (to 83)
-       79   load_var 6              (count)
+  54   64   load_field 0            (name)
+       65   load_var 5              (full_name)
+       66   cmp_op ==               
+       67   jump_if_false +2        (to 69)
+       68   jump +6                 (to 74)
+       69   pop 1                   
+       70   load_var 10             (ts)
+       71   load_field 0            (name)
+       72   load_var 7              (hash_prefix)
+       73   call 141 ntypeargs=0    (baml.String.starts_with)
+       74   pop_jump_if_false +5    (to 79)
+       75   load_var 6              (count)
+       76   load_const 5            (1)
+       77   add_int                 
+       78   store_var 6             (count)
+
+  53   79   load_var 9              (__for_idx)
        80   load_const 5            (1)
        81   add_int                 
-       82   store_var 6             (count)
-
-  53   83   load_var 9              (__for_idx)
-       84   load_const 5            (1)
-       85   add_int                 
-       86   store_var 9             (__for_idx)
-       87   jump -60                (to 27)
+       82   store_var 9             (__for_idx)
+       83   jump -56                (to 27)
 }
 
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {
@@ -513,114 +500,105 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
 
   156   4    load_const 0           (0)
         5    store_var 4            (__for_idx)
-        6    load_var 4             (__for_idx)
-        7    load_var 3             (_3)
-        8    container_len          
-        9    cmp_int_op <           
-        10   pop_jump_if_false +2   (to 12)
-        11   jump +42               (to 53)
+        6    load_var2 4 3          
+        7    container_len          
+        8    cmp_int_op <           
+        9    pop_jump_if_false +2   (to 11)
+        10   jump +38               (to 48)
 
-  173   12   load_var 1             (self)
-        13   load_field 1           (expansions)
-        14   call 17 ntypeargs=0    (baml.Map.keys)
-        15   store_var 9            (_28)
+  173   11   load_var 1             (self)
+        12   load_field 1           (expansions)
+        13   call 17 ntypeargs=0    (baml.Map.keys)
+        14   store_var 9            (_28)
 
-  172   16   load_const 0           (0)
-        17   store_var 10           (__for_idx_1)
-        18   load_var 10            (__for_idx_1)
-        19   load_var 9             (_28)
-        20   container_len          
-        21   cmp_int_op <           
-        22   pop_jump_if_false +2   (to 24)
-        23   jump +5                (to 28)
+  172   15   load_const 0           (0)
+        16   store_var 10           (__for_idx_1)
+        17   load_var2 10 9         
+        18   container_len          
+        19   cmp_int_op <           
+        20   pop_jump_if_false +2   (to 22)
+        21   jump +5                (to 26)
 
-  179   24   load_const 1           ("TestSet not found for expansion: ")
-        25   load_var 2             (name)
-        26   bin_op +               
-        27   throw                  
+  179   22   load_const 1           ("TestSet not found for expansion: ")
+        23   load_var 2             (name)
+        24   bin_op +               
+        25   throw                  
 
-  172   28   load_var 9             (_28)
-        29   load_var 10            (__for_idx_1)
-        30   load_array_element     
-        31   store_var 11           (k)
+  172   26   load_var2 9 10         
+        27   load_array_element     
+        28   store_var 11           (k)
 
-  174   32   load_var 1             (self)
-        33   load_field 1           (expansions)
-        34   load_var 11            (k)
-        35   load_map_element       
-        36   store_var 12           (sub)
+  174   29   load_var 1             (self)
+        30   load_field 1           (expansions)
+        31   load_var 11            (k)
+        32   load_map_element       
+        33   store_var 12           (sub)
 
-  175   37   load_var 2             (name)
-        38   load_var 11            (k)
-        39   load_const 2           ("/")
-        40   bin_op +               
-        41   call 141 ntypeargs=0   (baml.String.starts_with)
-        42   pop_jump_if_false +2   (to 44)
-        43   jump +6                (to 49)
+  175   34   load_var2 2 11         
+        35   load_const 2           ("/")
+        36   bin_op +               
+        37   call 141 ntypeargs=0   (baml.String.starts_with)
+        38   pop_jump_if_false +2   (to 40)
+        39   jump +6                (to 45)
 
-  172   44   load_var 10            (__for_idx_1)
-        45   load_const 3           (1)
-        46   add_int                
-        47   store_var 10           (__for_idx_1)
-        48   jump -30               (to 18)
+  172   40   load_var 10            (__for_idx_1)
+        41   load_const 3           (1)
+        42   add_int                
+        43   store_var 10           (__for_idx_1)
+        44   jump -27               (to 17)
 
-  176   49   load_var 12            (sub)
-        50   load_var 2             (name)
-        51   call 520 ntypeargs=0   (testing.TestRegistry.expand_set)
-        52   jump +41               (to 93)
+  176   45   load_var2 12 2         
+        46   call 520 ntypeargs=0   (testing.TestRegistry.expand_set)
+        47   jump +38               (to 85)
 
-  156   53   load_var 3             (_3)
-        54   load_var 4             (__for_idx)
-        55   load_array_element     
-        56   store_var_load_var 5   (ts)
+  156   48   load_var2 3 4          
+        49   load_array_element     
+        50   store_var_load_var 5   (ts)
 
-  158   57   load_field 0           (name)
-        58   load_var 2             (name)
-        59   cmp_op ==              
-        60   pop_jump_if_false +2   (to 62)
-        61   jump +6                (to 67)
+  158   51   load_field 0           (name)
+        52   load_var 2             (name)
+        53   cmp_op ==              
+        54   pop_jump_if_false +2   (to 56)
+        55   jump +6                (to 61)
 
-  156   62   load_var 4             (__for_idx)
-        63   load_const 3           (1)
-        64   add_int                
-        65   store_var 4            (__for_idx)
-        66   jump -60               (to 6)
+  156   56   load_var 4             (__for_idx)
+        57   load_const 3           (1)
+        58   add_int                
+        59   store_var 4            (__for_idx)
+        60   jump -54               (to 6)
 
-  159   67   call 280 ntypeargs=0   (baml.sys.now_ms)
-        68   store_var 6            (start)
+  159   61   call 280 ntypeargs=0   (baml.sys.now_ms)
+        62   store_var 6            (start)
 
-  160   69   load_var 2             (name)
-        70   alloc_array 0          
-        71   alloc_array 0          
-        72   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
-        73   store_var_load_var 7   (sub_collector)
+  160   63   load_var 2             (name)
+        64   alloc_array 0          
+        65   alloc_array 0          
+        66   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
+        67   store_var_load_var 7   (sub_collector)
 
-  161   74   load_var 5             (ts)
-        75   load_field 1           (collector)
-        76   call_indirect          
-        77   pop 1                  
+  161   68   load_var 5             (ts)
+        69   load_field 1           (collector)
+        70   call_indirect          
+        71   pop 1                  
 
-  162   78   call 280 ntypeargs=0   (baml.sys.now_ms)
-        79   store_var 8            (_19)
+  162   72   call 280 ntypeargs=0   (baml.sys.now_ms)
+        73   store_var 8            (_19)
 
-  168   80   load_var 1             (self)
-        81   load_field 1           (expansions)
-        82   load_var 2             (name)
+  168   74   load_var 1             (self)
+        75   load_field 1           (expansions)
+        76   load_var2 2 7          
 
-  164   83   load_var 7             (sub_collector)
+  165   77   alloc_map 0            
 
-  165   84   alloc_map 0            
+  162   78   load_var2 8 6          
+        79   sub_int                
+        80   init_instance 1        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
+        81   call 18 ntypeargs=0    (baml.Map.set)
+        82   pop 1                  
 
-  162   85   load_var 8             (_19)
-        86   load_var 6             (start)
-        87   sub_int                
-        88   init_instance 1        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
-        89   call 18 ntypeargs=0    (baml.Map.set)
-        90   pop 1                  
-
-  169   91   load_var 1             (self)
-        92   call 515 ntypeargs=0   (testing.TestRegistry.serialize)
-        93   return                 
+  169   83   load_var 1             (self)
+        84   call 515 ntypeargs=0   (testing.TestRegistry.serialize)
+        85   return                 
 }
 
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
@@ -666,86 +644,80 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
 
   136   4    load_const 0           (0)
         5    store_var 4            (__for_idx)
-        6    load_var 4             (__for_idx)
-        7    load_var 3             (_3)
-        8    container_len          
-        9    cmp_int_op <           
-        10   pop_jump_if_false +2   (to 12)
-        11   jump +42               (to 53)
+        6    load_var2 4 3          
+        7    container_len          
+        8    cmp_int_op <           
+        9    pop_jump_if_false +2   (to 11)
+        10   jump +38               (to 48)
 
-  143   12   load_var 1             (self)
-        13   load_field 1           (expansions)
-        14   call 17 ntypeargs=0    (baml.Map.keys)
-        15   store_var 6            (_13)
+  143   11   load_var 1             (self)
+        12   load_field 1           (expansions)
+        13   call 17 ntypeargs=0    (baml.Map.keys)
+        14   store_var 6            (_13)
 
-  142   16   load_const 0           (0)
-        17   store_var 7            (__for_idx_1)
-        18   load_var 7             (__for_idx_1)
-        19   load_var 6             (_13)
-        20   container_len          
-        21   cmp_int_op <           
-        22   pop_jump_if_false +2   (to 24)
-        23   jump +5                (to 28)
+  142   15   load_const 0           (0)
+        16   store_var 7            (__for_idx_1)
+        17   load_var2 7 6          
+        18   container_len          
+        19   cmp_int_op <           
+        20   pop_jump_if_false +2   (to 22)
+        21   jump +5                (to 26)
 
-  150   24   load_const 1           ("Test not found: ")
-        25   load_var 2             (name)
-        26   bin_op +               
-        27   throw                  
+  150   22   load_const 1           ("Test not found: ")
+        23   load_var 2             (name)
+        24   bin_op +               
+        25   throw                  
 
-  142   28   load_var 6             (_13)
-        29   load_var 7             (__for_idx_1)
-        30   load_array_element     
-        31   store_var 8            (k)
+  142   26   load_var2 6 7          
+        27   load_array_element     
+        28   store_var 8            (k)
 
-  144   32   load_var 1             (self)
-        33   load_field 1           (expansions)
-        34   load_var 8             (k)
-        35   load_map_element       
-        36   store_var 9            (sub)
+  144   29   load_var 1             (self)
+        30   load_field 1           (expansions)
+        31   load_var 8             (k)
+        32   load_map_element       
+        33   store_var 9            (sub)
 
-  146   37   load_var 2             (name)
-        38   load_var 8             (k)
-        39   load_const 2           ("/")
-        40   bin_op +               
-        41   call 141 ntypeargs=0   (baml.String.starts_with)
+  146   34   load_var2 2 8          
+        35   load_const 2           ("/")
+        36   bin_op +               
+        37   call 141 ntypeargs=0   (baml.String.starts_with)
 
-  145   42   pop_jump_if_false +2   (to 44)
-        43   jump +6                (to 49)
+  145   38   pop_jump_if_false +2   (to 40)
+        39   jump +6                (to 45)
 
-  142   44   load_var 7             (__for_idx_1)
-        45   load_const 3           (1)
-        46   add_int                
-        47   store_var 7            (__for_idx_1)
-        48   jump -30               (to 18)
+  142   40   load_var 7             (__for_idx_1)
+        41   load_const 3           (1)
+        42   add_int                
+        43   store_var 7            (__for_idx_1)
+        44   jump -27               (to 17)
 
-  147   49   load_var 9             (sub)
-        50   load_var 2             (name)
-        51   call 519 ntypeargs=0   (testing.TestRegistry.run_test)
-        52   jump +20               (to 72)
+  147   45   load_var2 9 2          
+        46   call 519 ntypeargs=0   (testing.TestRegistry.run_test)
+        47   jump +19               (to 66)
 
-  136   53   load_var 3             (_3)
-        54   load_var 4             (__for_idx)
-        55   load_array_element     
-        56   store_var_load_var 5   (t)
+  136   48   load_var2 3 4          
+        49   load_array_element     
+        50   store_var_load_var 5   (t)
 
-  138   57   load_field 0           (name)
-        58   load_var 2             (name)
-        59   cmp_op ==              
-        60   pop_jump_if_false +2   (to 62)
-        61   jump +6                (to 67)
+  138   51   load_field 0           (name)
+        52   load_var 2             (name)
+        53   cmp_op ==              
+        54   pop_jump_if_false +2   (to 56)
+        55   jump +6                (to 61)
 
-  136   62   load_var 4             (__for_idx)
-        63   load_const 3           (1)
-        64   add_int                
-        65   store_var 4            (__for_idx)
-        66   jump -60               (to 6)
+  136   56   load_var 4             (__for_idx)
+        57   load_const 3           (1)
+        58   add_int                
+        59   store_var 4            (__for_idx)
+        60   jump -54               (to 6)
 
-  139   67   load_var 5             (t)
-        68   load_field 1           (body)
-        69   load_var 5             (t)
-        70   load_field 2           (runner)
-        71   call 526 ntypeargs=0   (testing.run_test)
-        72   return                 
+  139   61   load_var 5             (t)
+        62   load_field 1           (body)
+        63   load_var 5             (t)
+        64   load_field 2           (runner)
+        65   call 526 ntypeargs=0   (testing.run_test)
+        66   return                 
 }
 
 function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.SerializedTest | testing.SerializedTestSet)[] {
@@ -758,97 +730,91 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         5    store_var 3            (_3)
         6    load_const 0           (0)
         7    store_var 4            (__for_idx)
-        8    load_var 4             (__for_idx)
-        9    load_var 3             (_3)
-        10   container_len          
-        11   cmp_int_op <           
-        12   pop_jump_if_false +2   (to 14)
-        13   jump +58               (to 71)
+        8    load_var2 4 3          
+        9    container_len          
+        10   cmp_int_op <           
+        11   pop_jump_if_false +2   (to 13)
+        12   jump +54               (to 66)
 
-  116   14   load_var 1             (self)
-        15   load_field 0           (collector)
-        16   load_field 2           (testsets)
-        17   store_var 5            (_12)
-        18   load_const 0           (0)
-        19   store_var 6            (__for_idx_1)
-        20   load_var 6             (__for_idx_1)
-        21   load_var 5             (_12)
-        22   container_len          
-        23   cmp_int_op <           
-        24   pop_jump_if_false +2   (to 26)
-        25   jump +3                (to 28)
+  116   13   load_var 1             (self)
+        14   load_field 0           (collector)
+        15   load_field 2           (testsets)
+        16   store_var 5            (_12)
+        17   load_const 0           (0)
+        18   store_var 6            (__for_idx_1)
+        19   load_var2 6 5          
+        20   container_len          
+        21   cmp_int_op <           
+        22   pop_jump_if_false +2   (to 24)
+        23   jump +3                (to 26)
 
-  131   26   load_var 2             (items)
-        27   return                 
+  131   24   load_var 2             (items)
+        25   return                 
 
-  116   28   load_var 5             (_12)
-        29   load_var 6             (__for_idx_1)
-        30   load_array_element     
-        31   store_var 7            (ts)
+  116   26   load_var2 5 6          
+        27   load_array_element     
+        28   store_var 7            (ts)
 
-  117   32   load_var 1             (self)
-        33   load_field 1           (expansions)
-        34   load_var 7             (ts)
-        35   load_field 0           (name)
-        36   call 43 ntypeargs=0    (baml.Map.get)
-        37   store_var 8            (expanded)
+  117   29   load_var 1             (self)
+        30   load_field 1           (expansions)
+        31   load_var 7             (ts)
+        32   load_field 0           (name)
+        33   call 43 ntypeargs=0    (baml.Map.get)
+        34   store_var 8            (expanded)
 
-  118   38   load_var 8             (expanded)
-        39   is_type 1              
-        40   pop_jump_if_false +2   (to 42)
-        41   jump +9                (to 50)
+  118   35   load_var 8             (expanded)
+        36   is_type 1              
+        37   pop_jump_if_false +2   (to 39)
+        38   jump +9                (to 47)
 
-  127   42   load_var 2             (items)
-        43   load_const 2           ("lazyTestSet")
-        44   load_var 7             (ts)
-        45   load_field 0           (name)
-        46   init_instance 0        (testing.SerializedTest .type, .name)
-        47   call 15 ntypeargs=0    (baml.Array.push)
-        48   pop 1                  
-        49   jump +17               (to 66)
+  127   39   load_var 2             (items)
+        40   load_const 2           ("lazyTestSet")
+        41   load_var 7             (ts)
+        42   load_field 0           (name)
+        43   init_instance 0        (testing.SerializedTest .type, .name)
+        44   call 15 ntypeargs=0    (baml.Array.push)
+        45   pop 1                  
+        46   jump +15               (to 61)
 
-  118   50   load_var 8             (expanded)
-        51   store_var 9            (sub)
+  118   47   load_var 8             (expanded)
+        48   store_var 9            (sub)
 
-  121   52   load_var 7             (ts)
-        53   load_field 0           (name)
-        54   store_var 10           (_25)
+  121   49   load_var 7             (ts)
+        50   load_field 0           (name)
+        51   store_var 10           (_25)
 
-  122   55   load_var 9             (sub)
-        56   call 515 ntypeargs=0   (testing.TestRegistry.serialize)
-        57   store_var 11           (_26)
+  122   52   load_var 9             (sub)
+        53   call 515 ntypeargs=0   (testing.TestRegistry.serialize)
+        54   store_var 11           (_26)
 
-  120   58   load_var 2             (items)
-        59   load_var 10            (_25)
-        60   load_var 11            (_26)
+  120   55   load_var2 2 10         
+        56   load_var2 11 9         
 
-  123   61   load_var 9             (sub)
-        62   load_field 2           (loading_time_ms)
-        63   init_instance 1        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        64   call 15 ntypeargs=0    (baml.Array.push)
-        65   pop 1                  
+  123   57   load_field 2           (loading_time_ms)
+        58   init_instance 1        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
+        59   call 15 ntypeargs=0    (baml.Array.push)
+        60   pop 1                  
 
-  116   66   load_var 6             (__for_idx_1)
-        67   load_const 3           (1)
-        68   add_int                
-        69   store_var 6            (__for_idx_1)
-        70   jump -50               (to 20)
+  116   61   load_var 6             (__for_idx_1)
+        62   load_const 3           (1)
+        63   add_int                
+        64   store_var 6            (__for_idx_1)
+        65   jump -46               (to 19)
 
-  114   71   load_var 2             (items)
-        72   load_const 4           ("test")
+  114   66   load_var 2             (items)
+        67   load_const 4           ("test")
 
-  113   73   load_var 3             (_3)
+  113   68   load_var2 3 4          
+        69   load_array_element     
+        70   load_field 0           (name)
+        71   init_instance 2        (testing.SerializedTest .type, .name)
+        72   call 15 ntypeargs=0    (baml.Array.push)
+        73   pop 1                  
         74   load_var 4             (__for_idx)
-        75   load_array_element     
-        76   load_field 0           (name)
-        77   init_instance 2        (testing.SerializedTest .type, .name)
-        78   call 15 ntypeargs=0    (baml.Array.push)
-        79   pop 1                  
-        80   load_var 4             (__for_idx)
-        81   load_const 3           (1)
-        82   add_int                
-        83   store_var 4            (__for_idx)
-        84   jump -76               (to 8)
+        75   load_const 3           (1)
+        76   add_int                
+        77   store_var 4            (__for_idx)
+        78   jump -70               (to 8)
 }
 
 function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.json {
@@ -1016,18 +982,17 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         7    load_const 0           (null)
         8    cmp_op ==              
         9    pop_jump_if_false +2   (to 11)
-        10   jump +6                (to 16)
+        10   jump +5                (to 15)
 
-  203   11   load_var 3             (base_run)
-        12   load_var 2             (runner)
-        13   call_indirect          
+  203   11   load_var2 3 2          
+        12   call_indirect          
 
-  204   14   call_indirect          
-        15   jump +3                (to 18)
+  204   13   call_indirect          
+        14   jump +3                (to 17)
 
-  201   16   load_var 3             (base_run)
-        17   call_indirect          
-        18   return                 
+  201   15   load_var 3             (base_run)
+        16   call_indirect          
+        17   return                 
 }
 
 function testing.run_testset(run_children: () -> testing.TestSetReport throws never, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never)?) -> testing.TestSetReport {
@@ -1035,18 +1000,17 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
         1    load_const 0           (null)
         2    cmp_op ==              
         3    pop_jump_if_false +2   (to 5)
-        4    jump +6                (to 10)
+        4    jump +5                (to 9)
 
-  214   5    load_var 1             (run_children)
-        6    load_var 2             (runner)
-        7    call_indirect          
+  214   5    load_var2 1 2          
+        6    call_indirect          
 
-  215   8    call_indirect          
-        9    jump +3                (to 12)
+  215   7    call_indirect          
+        8    jump +3                (to 11)
 
-  212   10   load_var 1             (run_children)
-        11   call_indirect          
-        12   return                 
+  212   9    load_var 1             (run_children)
+        10   call_indirect          
+        11   return                 
 }
 
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
@@ -1158,23 +1122,22 @@ function user.User.promote(self: User, bonus: int) -> Report {
        4    bin_op +             
        5    store_field 1        (age)
 
-  10   6    load_var 1           (self)
-       7    load_var 2           (bonus)
-       8    call 3 ntypeargs=0   (user.score)
-       9    store_var 3          (base)
+  10   6    load_var2 1 2        
+       7    call 3 ntypeargs=0   (user.score)
+       8    store_var 3          (base)
 
-  11   10   load_var 3           (base)
-       11   load_field 0         (score)
-       12   load_var 2           (bonus)
-       13   add_int              
+  11   9    load_var 3           (base)
+       10   load_field 0         (score)
+       11   load_var 2           (bonus)
+       12   add_int              
 
-  14   14   load_var 3           (base)
-       15   load_field 1         (label)
+  14   13   load_var 3           (base)
+       14   load_field 1         (label)
 
-  15   16   load_var 3           (base)
-       17   load_field 2         (breakdown)
-       18   init_instance 0      (user.Report .score, .label, .breakdown)
-       19   return               
+  15   15   load_var 3           (base)
+       16   load_field 2         (breakdown)
+       17   init_instance 0      (user.Report .score, .label, .breakdown)
+       18   return               
 }
 
 function user.User.to_json(self: User) -> baml.json.json {
@@ -1286,7 +1249,7 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
   56   30   load_var 1              (input)
        31   load_field 2            (role)
        32   discriminant            
-       33   jump_table 0            ([to 43, to 40, to 37, to 34], default to 96)
+       33   jump_table 0            ([to 43, to 40, to 37, to 34], default to 92)
 
   60   34   load_var 2              (threshold)
        35   store_var 5             (role_mult)
@@ -1326,50 +1289,46 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
   67   58   load_var 5              (role_mult)
        59   store_var 7             (capped)
 
-  71   60   load_var 7              (capped)
-       61   load_var 5              (role_mult)
-       62   add_int                 
-       63   store_var_load_var 8    (total)
+  71   60   load_var2 7 5           
+       61   add_int                 
+       62   store_var_load_var 8    (total)
 
-  73   64   load_var 2              (threshold)
-       65   cmp_int_op >            
-       66   load_const 2            (true)
-       67   cmp_op ==               
-       68   pop_jump_if_false +2    (to 70)
-       69   jump +4                 (to 73)
+  73   63   load_var 2              (threshold)
+       64   cmp_int_op >            
+       65   load_const 2            (true)
+       66   cmp_op ==               
+       67   pop_jump_if_false +2    (to 69)
+       68   jump +4                 (to 72)
 
-  75   70   load_const 3            (" [LOW]")
-       71   store_var 9             (suffix)
+  75   69   load_const 3            (" [LOW]")
+       70   store_var 9             (suffix)
 
-  73   72   jump +3                 (to 75)
+  73   71   jump +3                 (to 74)
 
-  74   73   load_const 4            (" [HIGH]")
-       74   store_var 9             (suffix)
+  74   72   load_const 4            (" [HIGH]")
+       73   store_var 9             (suffix)
 
-  79   75   load_var 6              (base)
-       76   load_var 7              (capped)
-       77   load_var 8              (total)
-       78   alloc_array 3           
-       79   store_var_load_var 10   (scores)
+  79   74   load_var2 6 7           
+       75   load_var 8              (total)
+       76   alloc_array 3           
+       77   store_var_load_var 10   (scores)
 
-  80   80   load_const 5            (0)
-       81   load_var 8              (total)
-       82   store_array_element     
+  80   78   load_const 5            (0)
+       79   load_var 8              (total)
+       80   store_array_element     
 
-  81   83   load_var 10             (scores)
-       84   load_const 5            (0)
-       85   load_array_element      
+  81   81   load_var 10             (scores)
+       82   load_const 5            (0)
+       83   load_array_element      
 
-  77   86   load_var 3              (name)
-       87   load_var 9              (suffix)
-       88   bin_op +                
+  77   84   load_var2 3 9           
+       85   bin_op +                
 
-  83   89   load_var 6              (base)
-       90   load_var 5              (role_mult)
-       91   load_const 6            ("base")
-       92   load_const 7            ("role")
-       93   alloc_map 2             
-       94   init_instance 0         (user.Report .score, .label, .breakdown)
-       95   return                  
-       96   unreachable             
+  83   86   load_var2 6 5           
+       87   load_const 6            ("base")
+       88   load_const 7            ("role")
+       89   alloc_map 2             
+       90   init_instance 0         (user.Report .score, .label, .breakdown)
+       91   return                  
+       92   unreachable             
 }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -1279,139 +1279,143 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
   45   0     load_var 1              (input)
        1     is_type 0               
        2     pop_jump_if_false +2    (to 4)
-       3     jump +6                 (to 9)
+       3     jump +7                 (to 10)
        4     load_var 1              (input)
-       5     store_var_load_var 5    (e)
+       5     store_var 5             (e)
 
-  47   6     load_field 1            (message)
-       7     store_var 3             (name)
+  47   6     load_var 5              (e)
+       7     load_field 1            (message)
+       8     store_var 3             (name)
 
-  45   8     jump +5                 (to 13)
-       9     load_var 1              (input)
-       10    store_var_load_var 4    (u)
+  45   9     jump +6                 (to 15)
+       10    load_var 1              (input)
+       11    store_var 4             (u)
 
-  46   11    load_field 0            (name)
-       12    store_var 3             (name)
+  46   12    load_var 4              (u)
+       13    load_field 0            (name)
+       14    store_var 3             (name)
 
-  50   13    load_var 1              (input)
-       14    is_type 0               
-       15    pop_jump_if_false +2    (to 17)
-       16    jump +7                 (to 23)
-       17    load_var 1              (input)
-       18    store_var_load_var 8    (e)
+  50   15    load_var 1              (input)
+       16    is_type 0               
+       17    pop_jump_if_false +2    (to 19)
+       18    jump +7                 (to 25)
+       19    load_var 1              (input)
+       20    store_var_load_var 8    (e)
 
-  52   19    load_field 0            (code)
-       20    unary_op -              
-       21    store_var 6             (age)
+  52   21    load_field 0            (code)
+       22    unary_op -              
+       23    store_var 6             (age)
 
-  50   22    jump +5                 (to 27)
-       23    load_var 1              (input)
-       24    store_var_load_var 7    (u)
+  50   24    jump +6                 (to 30)
+       25    load_var 1              (input)
+       26    store_var 7             (u)
 
-  51   25    load_field 1            (age)
-       26    store_var 6             (age)
+  51   27    load_var 7              (u)
+       28    load_field 1            (age)
+       29    store_var 6             (age)
 
-  55   27    load_var 1              (input)
-       28    is_type 0               
-       29    pop_jump_if_false +2    (to 31)
-       30    jump +4                 (to 34)
+  55   30    load_var 1              (input)
+       31    is_type 0               
+       32    pop_jump_if_false +2    (to 34)
+       33    jump +4                 (to 37)
 
-  62   31    load_var 2              (threshold)
-       32    store_var 9             (role_mult)
+  62   34    load_var 2              (threshold)
+       35    store_var 9             (role_mult)
 
-  55   33    jump +17                (to 50)
-       34    load_var 1              (input)
-       35    store_var_load_var 10   (u)
+  55   36    jump +17                (to 53)
+       37    load_var 1              (input)
+       38    store_var_load_var 10   (u)
 
-  56   36    load_field 2            (role)
-       37    discriminant            
-       38    jump_table 0            ([to 48, to 45, to 42, to 39], default to 102)
+  56   39    load_field 2            (role)
+       40    discriminant            
+       41    jump_table 0            ([to 51, to 48, to 45, to 42], default to 106)
 
-  60   39    load_var 2              (threshold)
-       40    store_var 9             (role_mult)
-
-  56   41    jump +9                 (to 50)
-
-  59   42    load_var 2              (threshold)
+  60   42    load_var 2              (threshold)
        43    store_var 9             (role_mult)
 
-  56   44    jump +6                 (to 50)
+  56   44    jump +9                 (to 53)
 
-  58   45    load_var 2              (threshold)
+  59   45    load_var 2              (threshold)
        46    store_var 9             (role_mult)
 
-  56   47    jump +3                 (to 50)
+  56   47    jump +6                 (to 53)
 
-  57   48    load_var 2              (threshold)
+  58   48    load_var 2              (threshold)
        49    store_var 9             (role_mult)
 
-  65   50    load_var 6              (age)
-       51    load_const 1            (2)
-       52    mul_int                 
-       53    load_var 9              (role_mult)
-       54    add_int                 
-       55    store_var_load_var 11   (base)
+  56   50    jump +3                 (to 53)
 
-  66   56    load_var 9              (role_mult)
-       57    cmp_int_op >            
-       58    pop_jump_if_false +2    (to 60)
-       59    jump +4                 (to 63)
+  57   51    load_var 2              (threshold)
+       52    store_var 9             (role_mult)
 
-  69   60    load_var 11             (base)
-       61    store_var 12            (capped)
+  65   53    load_var 6              (age)
+       54    load_const 1            (2)
+       55    mul_int                 
+       56    load_var 9              (role_mult)
+       57    add_int                 
+       58    store_var_load_var 11   (base)
 
-  66   62    jump +3                 (to 65)
+  66   59    load_var 9              (role_mult)
+       60    cmp_int_op >            
+       61    pop_jump_if_false +2    (to 63)
+       62    jump +4                 (to 66)
 
-  67   63    load_var 9              (role_mult)
+  69   63    load_var 11             (base)
        64    store_var 12            (capped)
 
-  71   65    load_var2 12 9          
-       66    add_int                 
-       67    store_var_load_var 13   (total)
+  66   65    jump +3                 (to 68)
 
-  73   68    load_var 2              (threshold)
-       69    cmp_int_op >            
-       70    load_const 2            (true)
-       71    cmp_op ==               
-       72    pop_jump_if_false +2    (to 74)
-       73    jump +4                 (to 77)
+  67   66    load_var 9              (role_mult)
+       67    store_var 12            (capped)
 
-  75   74    load_const 3            (" [LOW]")
-       75    store_var 14            (suffix)
+  71   68    load_var2 12 9          
+       69    add_int                 
+       70    store_var_load_var 13   (total)
 
-  73   76    jump +3                 (to 79)
+  73   71    load_var 2              (threshold)
+       72    cmp_int_op >            
+       73    load_const 2            (true)
+       74    cmp_op ==               
+       75    pop_jump_if_false +2    (to 77)
+       76    jump +4                 (to 80)
 
-  74   77    load_const 4            (" [HIGH]")
+  75   77    load_const 3            (" [LOW]")
        78    store_var 14            (suffix)
 
-  77   79    load_var2 3 14          
-       80    bin_op +                
-       81    store_var 15            (label)
+  73   79    jump +3                 (to 82)
 
-  79   82    load_var2 11 12         
-       83    load_var 13             (total)
-       84    alloc_array 3           
-       85    store_var_load_var 16   (scores)
+  74   80    load_const 4            (" [HIGH]")
+       81    store_var 14            (suffix)
 
-  80   86    load_const 5            (0)
-       87    load_var 13             (total)
-       88    store_array_element     
+  77   82    load_var2 3 14          
+       83    bin_op +                
+       84    store_var 15            (label)
 
-  81   89    load_var 16             (scores)
+  79   85    load_var2 11 12         
+       86    load_var 13             (total)
+       87    alloc_array 3           
+       88    store_var 16            (scores)
+
+  80   89    load_var 16             (scores)
        90    load_const 5            (0)
-       91    load_array_element      
-       92    store_var 17            (top)
+       91    load_var 13             (total)
+       92    store_array_element     
 
-  83   93    load_var2 11 9          
-       94    load_const 6            ("base")
-       95    load_const 7            ("role")
-       96    alloc_map 2             
-       97    store_var 18            (breakdown)
+  81   93    load_var 16             (scores)
+       94    load_const 5            (0)
+       95    load_array_element      
+       96    store_var 17            (top)
 
-  86   98    load_var2 17 15         
+  83   97    load_var2 11 9          
+       98    load_const 6            ("base")
+       99    load_const 7            ("role")
+       100   alloc_map 2             
+       101   store_var 18            (breakdown)
 
-  88   99    load_var 18             (breakdown)
-       100   init_instance 0         (user.Report .score, .label, .breakdown)
-       101   return                  
-       102   unreachable             
+  86   102   load_var2 17 15         
+
+  88   103   load_var 18             (breakdown)
+       104   init_instance 0         (user.Report .score, .label, .breakdown)
+       105   return                  
+       106   unreachable             
 }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -2,36 +2,34 @@
 source: crates/baml_tests/tests/bytecode_format/main.rs
 ---
 function assert.contains(haystack: string, needle: string) -> null {
-  32   0    load_var 1             (haystack)
-       1    load_var 2             (needle)
-       2    call 168 ntypeargs=0   (baml.String.includes)
-       3    unary_op !             
-       4    pop_jump_if_false +2   (to 6)
-       5    jump +3                (to 8)
-
-  35   6    load_const 0           (null)
-
-  32   7    jump +3                (to 10)
-
-  33   8    load_const 1           ("assertion failed: string does not contain expected substring")
-       9    call 284 ntypeargs=0   (baml.sys.panic)
-       10   return                 
-}
-
-function assert.equal(actual: unknown, expected: unknown) -> null {
-  23   0   load_var 1             (actual)
-       1   load_var 2             (expected)
-       2   cmp_op !=              
+  32   0   load_var2 1 2          
+       1   call 168 ntypeargs=0   (baml.String.includes)
+       2   unary_op !             
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
-  26   5   load_const 0           (null)
+  35   5   load_const 0           (null)
 
-  23   6   jump +3                (to 9)
+  32   6   jump +3                (to 9)
 
-  24   7   load_const 1           ("assertion failed: expected equal values")
+  33   7   load_const 1           ("assertion failed: string does not contain expected substring")
        8   call 284 ntypeargs=0   (baml.sys.panic)
        9   return                 
+}
+
+function assert.equal(actual: unknown, expected: unknown) -> null {
+  23   0   load_var2 1 2          
+       1   cmp_op !=              
+       2   pop_jump_if_false +2   (to 4)
+       3   jump +3                (to 6)
+
+  26   4   load_const 0           (null)
+
+  23   5   jump +3                (to 8)
+
+  24   6   load_const 1           ("assertion failed: expected equal values")
+       7   call 284 ntypeargs=0   (baml.sys.panic)
+       8   return                 
 }
 
 function assert.is_true(condition: bool) -> null {
@@ -66,10 +64,9 @@ function assert.not_null(value: unknown?) -> null {
 }
 
 function testing.$invoke_collector(collector: (testing.TestCollector) -> void throws unknown, c: testing.TestCollector) -> void {
-  73   0   load_var 2      (c)
-       1   load_var 1      (collector)
-       2   call_indirect   
-       3   return          
+  73   0   load_var2 2 1   
+       1   call_indirect   
+       2   return          
 }
 
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
@@ -199,39 +196,37 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        2    store_var 4            (_3)
        3    load_const 0           (0)
        4    store_var 5            (__for_idx)
-       5    load_var 5             (__for_idx)
-       6    load_var 4             (_3)
-       7    container_len          
-       8    cmp_int_op <           
-       9    pop_jump_if_false +2   (to 11)
-       10   jump +5                (to 15)
+       5    load_var2 5 4          
+       6    container_len          
+       7    cmp_int_op <           
+       8    pop_jump_if_false +2   (to 10)
+       9    jump +5                (to 14)
 
-  66   11   load_const 1           ("TestSet not found: ")
-       12   load_var 2             (name)
-       13   bin_op +               
-       14   throw                  
+  66   10   load_const 1           ("TestSet not found: ")
+       11   load_var 2             (name)
+       12   bin_op +               
+       13   throw                  
 
-  61   15   load_var 4             (_3)
-       16   load_var 5             (__for_idx)
-       17   load_array_element     
-       18   store_var_load_var 6   (ts)
+  61   14   load_var2 4 5          
+       15   load_array_element     
+       16   store_var_load_var 6   (ts)
 
-  62   19   load_field 0           (name)
-       20   load_var 2             (name)
-       21   cmp_op ==              
-       22   pop_jump_if_false +2   (to 24)
-       23   jump +6                (to 29)
+  62   17   load_field 0           (name)
+       18   load_var 2             (name)
+       19   cmp_op ==              
+       20   pop_jump_if_false +2   (to 22)
+       21   jump +6                (to 27)
 
-  61   24   load_var 5             (__for_idx)
-       25   load_const 2           (1)
-       26   add_int                
-       27   store_var 5            (__for_idx)
-       28   jump -23               (to 5)
+  61   22   load_var 5             (__for_idx)
+       23   load_const 2           (1)
+       24   add_int                
+       25   store_var 5            (__for_idx)
+       26   jump -21               (to 5)
 
-  63   29   load_var 6             (ts)
-       30   store_var 3            (_0)
-       31   load_var 3             (_0)
-       32   return                 
+  63   27   load_var 6             (ts)
+       28   store_var 3            (_0)
+       29   load_var 3             (_0)
+       30   return                 
 }
 
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
@@ -303,75 +298,71 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        24   store_var 9             (_13)
        25   load_const 2            (0)
        26   store_var 10            (__for_idx)
-       27   load_var 10             (__for_idx)
-       28   load_var 9              (_13)
-       29   container_len           
-       30   cmp_int_op <            
-       31   pop_jump_if_false +2    (to 33)
-       32   jump +34                (to 66)
+       27   load_var2 10 9          
+       28   container_len           
+       29   cmp_int_op <            
+       30   pop_jump_if_false +2    (to 32)
+       31   jump +32                (to 63)
 
-  45   33   load_var 7              (count)
-       34   load_const 2            (0)
-       35   cmp_int_op >            
-       36   pop_jump_if_false +2    (to 38)
-       37   jump +4                 (to 41)
-       38   load_var 6              (full_name)
-       39   store_var 12            (final_name)
-       40   jump +14                (to 54)
-       41   load_var 6              (full_name)
-       42   load_const 4            ("#")
-       43   bin_op +                
-       44   store_var 13            (_28)
-       45   load_var 7              (count)
-       46   load_const 5            (1)
-       47   add_int                 
-       48   call 383 ntypeargs=0    (baml.unstable.string)
-       49   store_var 14            (_30)
-       50   load_var 13             (_28)
-       51   load_var 14             (_30)
-       52   bin_op +                
-       53   store_var 12            (final_name)
+  45   32   load_var 7              (count)
+       33   load_const 2            (0)
+       34   cmp_int_op >            
+       35   pop_jump_if_false +2    (to 37)
+       36   jump +4                 (to 40)
+       37   load_var 6              (full_name)
+       38   store_var 12            (final_name)
+       39   jump +13                (to 52)
+       40   load_var 6              (full_name)
+       41   load_const 4            ("#")
+       42   bin_op +                
+       43   store_var 13            (_28)
+       44   load_var 7              (count)
+       45   load_const 5            (1)
+       46   add_int                 
+       47   call 383 ntypeargs=0    (baml.unstable.string)
+       48   store_var 14            (_30)
+       49   load_var2 13 14         
+       50   bin_op +                
+       51   store_var 12            (final_name)
 
-  46   54   load_var 1              (self)
-       55   load_field 1            (tests)
-       56   load_var 12             (final_name)
-       57   load_var 3              (body)
-       58   load_var 4              (runner)
-       59   init_instance 0         (testing.TestRegistration .name, .body, .runner)
-       60   call 15 ntypeargs=0     (baml.Array.push)
-       61   pop 1                   
+  46   52   load_var 1              (self)
+       53   load_field 1            (tests)
+       54   load_var2 12 3          
+       55   load_var 4              (runner)
+       56   init_instance 0         (testing.TestRegistration .name, .body, .runner)
+       57   call 15 ntypeargs=0     (baml.Array.push)
+       58   pop 1                   
 
-  38   62   load_const 6            (null)
-       63   store_var 5             (_0)
-       64   load_var 5              (_0)
-       65   return                  
+  38   59   load_const 6            (null)
+       60   store_var 5             (_0)
+       61   load_var 5              (_0)
+       62   return                  
 
-  42   66   load_var 9              (_13)
-       67   load_var 10             (__for_idx)
-       68   load_array_element      
-       69   store_var_load_var 11   (t)
+  42   63   load_var2 9 10          
+       64   load_array_element      
+       65   store_var_load_var 11   (t)
 
-  43   70   load_field 0            (name)
-       71   load_var 6              (full_name)
-       72   cmp_op ==               
-       73   jump_if_false +2        (to 75)
-       74   jump +6                 (to 80)
-       75   pop 1                   
-       76   load_var 11             (t)
-       77   load_field 0            (name)
-       78   load_var 8              (hash_prefix)
-       79   call 141 ntypeargs=0    (baml.String.starts_with)
-       80   pop_jump_if_false +5    (to 85)
-       81   load_var 7              (count)
+  43   66   load_field 0            (name)
+       67   load_var 6              (full_name)
+       68   cmp_op ==               
+       69   jump_if_false +2        (to 71)
+       70   jump +6                 (to 76)
+       71   pop 1                   
+       72   load_var 11             (t)
+       73   load_field 0            (name)
+       74   load_var 8              (hash_prefix)
+       75   call 141 ntypeargs=0    (baml.String.starts_with)
+       76   pop_jump_if_false +5    (to 81)
+       77   load_var 7              (count)
+       78   load_const 5            (1)
+       79   add_int                 
+       80   store_var 7             (count)
+
+  42   81   load_var 10             (__for_idx)
        82   load_const 5            (1)
        83   add_int                 
-       84   store_var 7             (count)
-
-  42   85   load_var 10             (__for_idx)
-       86   load_const 5            (1)
-       87   add_int                 
-       88   store_var 10            (__for_idx)
-       89   jump -62                (to 27)
+       84   store_var 10            (__for_idx)
+       85   jump -58                (to 27)
 }
 
 function testing.TestCollector.register_test_set(self: testing.TestCollector, name: string, collector: (testing.TestCollector) -> void throws unknown, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never)?) -> void {
@@ -405,75 +396,71 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        24   store_var 9             (_13)
        25   load_const 2            (0)
        26   store_var 10            (__for_idx)
-       27   load_var 10             (__for_idx)
-       28   load_var 9              (_13)
-       29   container_len           
-       30   cmp_int_op <            
-       31   pop_jump_if_false +2    (to 33)
-       32   jump +34                (to 66)
+       27   load_var2 10 9          
+       28   container_len           
+       29   cmp_int_op <            
+       30   pop_jump_if_false +2    (to 32)
+       31   jump +32                (to 63)
 
-  56   33   load_var 7              (count)
-       34   load_const 2            (0)
-       35   cmp_int_op >            
-       36   pop_jump_if_false +2    (to 38)
-       37   jump +4                 (to 41)
-       38   load_var 6              (full_name)
-       39   store_var 12            (final_name)
-       40   jump +14                (to 54)
-       41   load_var 6              (full_name)
-       42   load_const 4            ("#")
-       43   bin_op +                
-       44   store_var 13            (_28)
-       45   load_var 7              (count)
-       46   load_const 5            (1)
-       47   add_int                 
-       48   call 383 ntypeargs=0    (baml.unstable.string)
-       49   store_var 14            (_30)
-       50   load_var 13             (_28)
-       51   load_var 14             (_30)
-       52   bin_op +                
-       53   store_var 12            (final_name)
+  56   32   load_var 7              (count)
+       33   load_const 2            (0)
+       34   cmp_int_op >            
+       35   pop_jump_if_false +2    (to 37)
+       36   jump +4                 (to 40)
+       37   load_var 6              (full_name)
+       38   store_var 12            (final_name)
+       39   jump +13                (to 52)
+       40   load_var 6              (full_name)
+       41   load_const 4            ("#")
+       42   bin_op +                
+       43   store_var 13            (_28)
+       44   load_var 7              (count)
+       45   load_const 5            (1)
+       46   add_int                 
+       47   call 383 ntypeargs=0    (baml.unstable.string)
+       48   store_var 14            (_30)
+       49   load_var2 13 14         
+       50   bin_op +                
+       51   store_var 12            (final_name)
 
-  57   54   load_var 1              (self)
-       55   load_field 2            (testsets)
-       56   load_var 12             (final_name)
-       57   load_var 3              (collector)
-       58   load_var 4              (runner)
-       59   init_instance 0         (testing.TestSetRegistration .name, .collector, .runner)
-       60   call 15 ntypeargs=0     (baml.Array.push)
-       61   pop 1                   
+  57   52   load_var 1              (self)
+       53   load_field 2            (testsets)
+       54   load_var2 12 3          
+       55   load_var 4              (runner)
+       56   init_instance 0         (testing.TestSetRegistration .name, .collector, .runner)
+       57   call 15 ntypeargs=0     (baml.Array.push)
+       58   pop 1                   
 
-  49   62   load_const 6            (null)
-       63   store_var 5             (_0)
-       64   load_var 5              (_0)
-       65   return                  
+  49   59   load_const 6            (null)
+       60   store_var 5             (_0)
+       61   load_var 5              (_0)
+       62   return                  
 
-  53   66   load_var 9              (_13)
-       67   load_var 10             (__for_idx)
-       68   load_array_element      
-       69   store_var_load_var 11   (ts)
+  53   63   load_var2 9 10          
+       64   load_array_element      
+       65   store_var_load_var 11   (ts)
 
-  54   70   load_field 0            (name)
-       71   load_var 6              (full_name)
-       72   cmp_op ==               
-       73   jump_if_false +2        (to 75)
-       74   jump +6                 (to 80)
-       75   pop 1                   
-       76   load_var 11             (ts)
-       77   load_field 0            (name)
-       78   load_var 8              (hash_prefix)
-       79   call 141 ntypeargs=0    (baml.String.starts_with)
-       80   pop_jump_if_false +5    (to 85)
-       81   load_var 7              (count)
+  54   66   load_field 0            (name)
+       67   load_var 6              (full_name)
+       68   cmp_op ==               
+       69   jump_if_false +2        (to 71)
+       70   jump +6                 (to 76)
+       71   pop 1                   
+       72   load_var 11             (ts)
+       73   load_field 0            (name)
+       74   load_var 8              (hash_prefix)
+       75   call 141 ntypeargs=0    (baml.String.starts_with)
+       76   pop_jump_if_false +5    (to 81)
+       77   load_var 7              (count)
+       78   load_const 5            (1)
+       79   add_int                 
+       80   store_var 7             (count)
+
+  53   81   load_var 10             (__for_idx)
        82   load_const 5            (1)
        83   add_int                 
-       84   store_var 7             (count)
-
-  53   85   load_var 10             (__for_idx)
-       86   load_const 5            (1)
-       87   add_int                 
-       88   store_var 10            (__for_idx)
-       89   jump -62                (to 27)
+       84   store_var 10            (__for_idx)
+       85   jump -58                (to 27)
 }
 
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {
@@ -539,116 +526,109 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
 
   156   4    load_const 0           (0)
         5    store_var 4            (__for_idx)
-        6    load_var 4             (__for_idx)
-        7    load_var 3             (_3)
-        8    container_len          
-        9    cmp_int_op <           
-        10   pop_jump_if_false +2   (to 12)
-        11   jump +42               (to 53)
+        6    load_var2 4 3          
+        7    container_len          
+        8    cmp_int_op <           
+        9    pop_jump_if_false +2   (to 11)
+        10   jump +38               (to 48)
 
-  173   12   load_var 1             (self)
-        13   load_field 1           (expansions)
-        14   call 17 ntypeargs=0    (baml.Map.keys)
-        15   store_var 10           (_28)
+  173   11   load_var 1             (self)
+        12   load_field 1           (expansions)
+        13   call 17 ntypeargs=0    (baml.Map.keys)
+        14   store_var 10           (_28)
 
-  172   16   load_const 0           (0)
-        17   store_var 11           (__for_idx_1)
-        18   load_var 11            (__for_idx_1)
-        19   load_var 10            (_28)
-        20   container_len          
-        21   cmp_int_op <           
-        22   pop_jump_if_false +2   (to 24)
-        23   jump +5                (to 28)
+  172   15   load_const 0           (0)
+        16   store_var 11           (__for_idx_1)
+        17   load_var2 11 10        
+        18   container_len          
+        19   cmp_int_op <           
+        20   pop_jump_if_false +2   (to 22)
+        21   jump +5                (to 26)
 
-  179   24   load_const 1           ("TestSet not found for expansion: ")
-        25   load_var 2             (name)
-        26   bin_op +               
-        27   throw                  
+  179   22   load_const 1           ("TestSet not found for expansion: ")
+        23   load_var 2             (name)
+        24   bin_op +               
+        25   throw                  
 
-  172   28   load_var 10            (_28)
-        29   load_var 11            (__for_idx_1)
-        30   load_array_element     
-        31   store_var 12           (k)
+  172   26   load_var2 10 11        
+        27   load_array_element     
+        28   store_var 12           (k)
 
-  174   32   load_var 1             (self)
-        33   load_field 1           (expansions)
-        34   load_var 12            (k)
-        35   load_map_element       
-        36   store_var 13           (sub)
+  174   29   load_var 1             (self)
+        30   load_field 1           (expansions)
+        31   load_var 12            (k)
+        32   load_map_element       
+        33   store_var 13           (sub)
 
-  175   37   load_var 2             (name)
-        38   load_var 12            (k)
-        39   load_const 2           ("/")
-        40   bin_op +               
-        41   call 141 ntypeargs=0   (baml.String.starts_with)
-        42   pop_jump_if_false +2   (to 44)
-        43   jump +6                (to 49)
+  175   34   load_var2 2 12         
+        35   load_const 2           ("/")
+        36   bin_op +               
+        37   call 141 ntypeargs=0   (baml.String.starts_with)
+        38   pop_jump_if_false +2   (to 40)
+        39   jump +6                (to 45)
 
-  172   44   load_var 11            (__for_idx_1)
-        45   load_const 3           (1)
-        46   add_int                
-        47   store_var 11           (__for_idx_1)
-        48   jump -30               (to 18)
+  172   40   load_var 11            (__for_idx_1)
+        41   load_const 3           (1)
+        42   add_int                
+        43   store_var 11           (__for_idx_1)
+        44   jump -27               (to 17)
 
-  176   49   load_var 13            (sub)
-        50   load_var 2             (name)
-        51   call 520 ntypeargs=0   (testing.TestRegistry.expand_set)
-        52   jump +43               (to 95)
+  176   45   load_var2 13 2         
+        46   call 520 ntypeargs=0   (testing.TestRegistry.expand_set)
+        47   jump +41               (to 88)
 
-  156   53   load_var 3             (_3)
-        54   load_var 4             (__for_idx)
-        55   load_array_element     
-        56   store_var_load_var 5   (ts)
+  156   48   load_var2 3 4          
+        49   load_array_element     
+        50   store_var_load_var 5   (ts)
 
-  158   57   load_field 0           (name)
-        58   load_var 2             (name)
-        59   cmp_op ==              
-        60   pop_jump_if_false +2   (to 62)
-        61   jump +6                (to 67)
+  158   51   load_field 0           (name)
+        52   load_var 2             (name)
+        53   cmp_op ==              
+        54   pop_jump_if_false +2   (to 56)
+        55   jump +6                (to 61)
 
-  156   62   load_var 4             (__for_idx)
-        63   load_const 3           (1)
-        64   add_int                
-        65   store_var 4            (__for_idx)
-        66   jump -60               (to 6)
+  156   56   load_var 4             (__for_idx)
+        57   load_const 3           (1)
+        58   add_int                
+        59   store_var 4            (__for_idx)
+        60   jump -54               (to 6)
 
-  159   67   call 280 ntypeargs=0   (baml.sys.now_ms)
-        68   store_var 6            (start)
+  159   61   call 280 ntypeargs=0   (baml.sys.now_ms)
+        62   store_var 6            (start)
 
-  160   69   load_var 2             (name)
-        70   alloc_array 0          
-        71   alloc_array 0          
-        72   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
-        73   store_var_load_var 7   (sub_collector)
+  160   63   load_var 2             (name)
+        64   alloc_array 0          
+        65   alloc_array 0          
+        66   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
+        67   store_var_load_var 7   (sub_collector)
 
-  161   74   load_var 5             (ts)
-        75   load_field 1           (collector)
-        76   call_indirect          
-        77   pop 1                  
+  161   68   load_var 5             (ts)
+        69   load_field 1           (collector)
+        70   call_indirect          
+        71   pop 1                  
 
-  162   78   call 280 ntypeargs=0   (baml.sys.now_ms)
-        79   load_var 6             (start)
-        80   sub_int                
-        81   store_var 8            (elapsed)
+  162   72   call 280 ntypeargs=0   (baml.sys.now_ms)
+        73   load_var 6             (start)
+        74   sub_int                
+        75   store_var 8            (elapsed)
 
-  164   82   load_var 7             (sub_collector)
+  164   76   load_var 7             (sub_collector)
 
-  165   83   alloc_map 0            
+  165   77   alloc_map 0            
 
-  166   84   load_var 8             (elapsed)
-        85   init_instance 1        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
-        86   store_var 9            (sub_registry)
+  166   78   load_var 8             (elapsed)
+        79   init_instance 1        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
+        80   store_var 9            (sub_registry)
 
-  168   87   load_var 1             (self)
-        88   load_field 1           (expansions)
-        89   load_var 2             (name)
-        90   load_var 9             (sub_registry)
-        91   call 18 ntypeargs=0    (baml.Map.set)
-        92   pop 1                  
+  168   81   load_var 1             (self)
+        82   load_field 1           (expansions)
+        83   load_var2 2 9          
+        84   call 18 ntypeargs=0    (baml.Map.set)
+        85   pop 1                  
 
-  169   93   load_var 1             (self)
-        94   call 515 ntypeargs=0   (testing.TestRegistry.serialize)
-        95   return                 
+  169   86   load_var 1             (self)
+        87   call 515 ntypeargs=0   (testing.TestRegistry.serialize)
+        88   return                 
 }
 
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
@@ -698,86 +678,80 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
 
   136   4    load_const 0           (0)
         5    store_var 4            (__for_idx)
-        6    load_var 4             (__for_idx)
-        7    load_var 3             (_3)
-        8    container_len          
-        9    cmp_int_op <           
-        10   pop_jump_if_false +2   (to 12)
-        11   jump +42               (to 53)
+        6    load_var2 4 3          
+        7    container_len          
+        8    cmp_int_op <           
+        9    pop_jump_if_false +2   (to 11)
+        10   jump +38               (to 48)
 
-  143   12   load_var 1             (self)
-        13   load_field 1           (expansions)
-        14   call 17 ntypeargs=0    (baml.Map.keys)
-        15   store_var 6            (_13)
+  143   11   load_var 1             (self)
+        12   load_field 1           (expansions)
+        13   call 17 ntypeargs=0    (baml.Map.keys)
+        14   store_var 6            (_13)
 
-  142   16   load_const 0           (0)
-        17   store_var 7            (__for_idx_1)
-        18   load_var 7             (__for_idx_1)
-        19   load_var 6             (_13)
-        20   container_len          
-        21   cmp_int_op <           
-        22   pop_jump_if_false +2   (to 24)
-        23   jump +5                (to 28)
+  142   15   load_const 0           (0)
+        16   store_var 7            (__for_idx_1)
+        17   load_var2 7 6          
+        18   container_len          
+        19   cmp_int_op <           
+        20   pop_jump_if_false +2   (to 22)
+        21   jump +5                (to 26)
 
-  150   24   load_const 1           ("Test not found: ")
-        25   load_var 2             (name)
-        26   bin_op +               
-        27   throw                  
+  150   22   load_const 1           ("Test not found: ")
+        23   load_var 2             (name)
+        24   bin_op +               
+        25   throw                  
 
-  142   28   load_var 6             (_13)
-        29   load_var 7             (__for_idx_1)
-        30   load_array_element     
-        31   store_var 8            (k)
+  142   26   load_var2 6 7          
+        27   load_array_element     
+        28   store_var 8            (k)
 
-  144   32   load_var 1             (self)
-        33   load_field 1           (expansions)
-        34   load_var 8             (k)
-        35   load_map_element       
-        36   store_var 9            (sub)
+  144   29   load_var 1             (self)
+        30   load_field 1           (expansions)
+        31   load_var 8             (k)
+        32   load_map_element       
+        33   store_var 9            (sub)
 
-  146   37   load_var 2             (name)
-        38   load_var 8             (k)
-        39   load_const 2           ("/")
-        40   bin_op +               
-        41   call 141 ntypeargs=0   (baml.String.starts_with)
+  146   34   load_var2 2 8          
+        35   load_const 2           ("/")
+        36   bin_op +               
+        37   call 141 ntypeargs=0   (baml.String.starts_with)
 
-  145   42   pop_jump_if_false +2   (to 44)
-        43   jump +6                (to 49)
+  145   38   pop_jump_if_false +2   (to 40)
+        39   jump +6                (to 45)
 
-  142   44   load_var 7             (__for_idx_1)
-        45   load_const 3           (1)
-        46   add_int                
-        47   store_var 7            (__for_idx_1)
-        48   jump -30               (to 18)
+  142   40   load_var 7             (__for_idx_1)
+        41   load_const 3           (1)
+        42   add_int                
+        43   store_var 7            (__for_idx_1)
+        44   jump -27               (to 17)
 
-  147   49   load_var 9             (sub)
-        50   load_var 2             (name)
-        51   call 519 ntypeargs=0   (testing.TestRegistry.run_test)
-        52   jump +20               (to 72)
+  147   45   load_var2 9 2          
+        46   call 519 ntypeargs=0   (testing.TestRegistry.run_test)
+        47   jump +19               (to 66)
 
-  136   53   load_var 3             (_3)
-        54   load_var 4             (__for_idx)
-        55   load_array_element     
-        56   store_var_load_var 5   (t)
+  136   48   load_var2 3 4          
+        49   load_array_element     
+        50   store_var_load_var 5   (t)
 
-  138   57   load_field 0           (name)
-        58   load_var 2             (name)
-        59   cmp_op ==              
-        60   pop_jump_if_false +2   (to 62)
-        61   jump +6                (to 67)
+  138   51   load_field 0           (name)
+        52   load_var 2             (name)
+        53   cmp_op ==              
+        54   pop_jump_if_false +2   (to 56)
+        55   jump +6                (to 61)
 
-  136   62   load_var 4             (__for_idx)
-        63   load_const 3           (1)
-        64   add_int                
-        65   store_var 4            (__for_idx)
-        66   jump -60               (to 6)
+  136   56   load_var 4             (__for_idx)
+        57   load_const 3           (1)
+        58   add_int                
+        59   store_var 4            (__for_idx)
+        60   jump -54               (to 6)
 
-  139   67   load_var 5             (t)
-        68   load_field 1           (body)
-        69   load_var 5             (t)
-        70   load_field 2           (runner)
-        71   call 526 ntypeargs=0   (testing.run_test)
-        72   return                 
+  139   61   load_var 5             (t)
+        62   load_field 1           (body)
+        63   load_var 5             (t)
+        64   load_field 2           (runner)
+        65   call 526 ntypeargs=0   (testing.run_test)
+        66   return                 
 }
 
 function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.SerializedTest | testing.SerializedTestSet)[] {
@@ -790,102 +764,96 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         5    store_var 4            (_3)
         6    load_const 0           (0)
         7    store_var 5            (__for_idx)
-        8    load_var 5             (__for_idx)
-        9    load_var 4             (_3)
-        10   container_len          
-        11   cmp_int_op <           
-        12   pop_jump_if_false +2   (to 14)
-        13   jump +60               (to 73)
+        8    load_var2 5 4          
+        9    container_len          
+        10   cmp_int_op <           
+        11   pop_jump_if_false +2   (to 13)
+        12   jump +56               (to 68)
 
-  116   14   load_var 1             (self)
-        15   load_field 0           (collector)
-        16   load_field 2           (testsets)
-        17   store_var 7            (_12)
-        18   load_const 0           (0)
-        19   store_var 8            (__for_idx_1)
-        20   load_var 8             (__for_idx_1)
-        21   load_var 7             (_12)
-        22   container_len          
-        23   cmp_int_op <           
-        24   pop_jump_if_false +2   (to 26)
-        25   jump +5                (to 30)
+  116   13   load_var 1             (self)
+        14   load_field 0           (collector)
+        15   load_field 2           (testsets)
+        16   store_var 7            (_12)
+        17   load_const 0           (0)
+        18   store_var 8            (__for_idx_1)
+        19   load_var2 8 7          
+        20   container_len          
+        21   cmp_int_op <           
+        22   pop_jump_if_false +2   (to 24)
+        23   jump +5                (to 28)
 
-  131   26   load_var 3             (items)
-        27   store_var 2            (_0)
-        28   load_var 2             (_0)
-        29   return                 
+  131   24   load_var 3             (items)
+        25   store_var 2            (_0)
+        26   load_var 2             (_0)
+        27   return                 
 
-  116   30   load_var 7             (_12)
-        31   load_var 8             (__for_idx_1)
-        32   load_array_element     
-        33   store_var 9            (ts)
+  116   28   load_var2 7 8          
+        29   load_array_element     
+        30   store_var 9            (ts)
 
-  117   34   load_var 1             (self)
-        35   load_field 1           (expansions)
-        36   load_var 9             (ts)
-        37   load_field 0           (name)
-        38   call 43 ntypeargs=0    (baml.Map.get)
-        39   store_var 10           (expanded)
+  117   31   load_var 1             (self)
+        32   load_field 1           (expansions)
+        33   load_var 9             (ts)
+        34   load_field 0           (name)
+        35   call 43 ntypeargs=0    (baml.Map.get)
+        36   store_var 10           (expanded)
 
-  118   40   load_var 10            (expanded)
-        41   is_type 1              
-        42   pop_jump_if_false +2   (to 44)
-        43   jump +9                (to 52)
+  118   37   load_var 10            (expanded)
+        38   is_type 1              
+        39   pop_jump_if_false +2   (to 41)
+        40   jump +9                (to 49)
 
-  127   44   load_var 3             (items)
-        45   load_const 2           ("lazyTestSet")
-        46   load_var 9             (ts)
-        47   load_field 0           (name)
-        48   init_instance 0        (testing.SerializedTest .type, .name)
-        49   call 15 ntypeargs=0    (baml.Array.push)
-        50   pop 1                  
-        51   jump +17               (to 68)
+  127   41   load_var 3             (items)
+        42   load_const 2           ("lazyTestSet")
+        43   load_var 9             (ts)
+        44   load_field 0           (name)
+        45   init_instance 0        (testing.SerializedTest .type, .name)
+        46   call 15 ntypeargs=0    (baml.Array.push)
+        47   pop 1                  
+        48   jump +15               (to 63)
 
-  118   52   load_var 10            (expanded)
-        53   store_var 11           (sub)
+  118   49   load_var 10            (expanded)
+        50   store_var 11           (sub)
 
-  121   54   load_var 9             (ts)
-        55   load_field 0           (name)
-        56   store_var 12           (_25)
+  121   51   load_var 9             (ts)
+        52   load_field 0           (name)
+        53   store_var 12           (_25)
 
-  122   57   load_var 11            (sub)
-        58   call 515 ntypeargs=0   (testing.TestRegistry.serialize)
-        59   store_var 13           (_26)
+  122   54   load_var 11            (sub)
+        55   call 515 ntypeargs=0   (testing.TestRegistry.serialize)
+        56   store_var 13           (_26)
 
-  120   60   load_var 3             (items)
-        61   load_var 12            (_25)
-        62   load_var 13            (_26)
+  120   57   load_var2 3 12         
+        58   load_var2 13 11        
 
-  123   63   load_var 11            (sub)
-        64   load_field 2           (loading_time_ms)
-        65   init_instance 1        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        66   call 15 ntypeargs=0    (baml.Array.push)
-        67   pop 1                  
+  123   59   load_field 2           (loading_time_ms)
+        60   init_instance 1        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
+        61   call 15 ntypeargs=0    (baml.Array.push)
+        62   pop 1                  
 
-  116   68   load_var 8             (__for_idx_1)
-        69   load_const 3           (1)
-        70   add_int                
-        71   store_var 8            (__for_idx_1)
-        72   jump -52               (to 20)
+  116   63   load_var 8             (__for_idx_1)
+        64   load_const 3           (1)
+        65   add_int                
+        66   store_var 8            (__for_idx_1)
+        67   jump -48               (to 19)
 
-  113   73   load_var 4             (_3)
-        74   load_var 5             (__for_idx)
-        75   load_array_element     
-        76   store_var 6            (t)
+  113   68   load_var2 4 5          
+        69   load_array_element     
+        70   store_var 6            (t)
 
-  114   77   load_var 3             (items)
-        78   load_const 4           ("test")
-        79   load_var 6             (t)
-        80   load_field 0           (name)
-        81   init_instance 2        (testing.SerializedTest .type, .name)
-        82   call 15 ntypeargs=0    (baml.Array.push)
-        83   pop 1                  
+  114   71   load_var 3             (items)
+        72   load_const 4           ("test")
+        73   load_var 6             (t)
+        74   load_field 0           (name)
+        75   init_instance 2        (testing.SerializedTest .type, .name)
+        76   call 15 ntypeargs=0    (baml.Array.push)
+        77   pop 1                  
 
-  113   84   load_var 5             (__for_idx)
-        85   load_const 3           (1)
-        86   add_int                
-        87   store_var 5            (__for_idx)
-        88   jump -80               (to 8)
+  113   78   load_var 5             (__for_idx)
+        79   load_const 3           (1)
+        80   add_int                
+        81   store_var 5            (__for_idx)
+        82   jump -74               (to 8)
 }
 
 function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.json {
@@ -1065,20 +1033,19 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         7    load_const 0           (null)
         8    cmp_op ==              
         9    pop_jump_if_false +2   (to 11)
-        10   jump +8                (to 18)
+        10   jump +7                (to 17)
         11   load_var 2             (runner)
         12   store_var 4            (r)
 
-  203   13   load_var 3             (base_run)
-        14   load_var 4             (r)
-        15   call_indirect          
+  203   13   load_var2 3 4          
+        14   call_indirect          
 
-  204   16   call_indirect          
-        17   jump +3                (to 20)
+  204   15   call_indirect          
+        16   jump +3                (to 19)
 
-  201   18   load_var 3             (base_run)
-        19   call_indirect          
-        20   return                 
+  201   17   load_var 3             (base_run)
+        18   call_indirect          
+        19   return                 
 }
 
 function testing.run_testset(run_children: () -> testing.TestSetReport throws never, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never)?) -> testing.TestSetReport {
@@ -1086,20 +1053,19 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
         1    load_const 0           (null)
         2    cmp_op ==              
         3    pop_jump_if_false +2   (to 5)
-        4    jump +8                (to 12)
+        4    jump +7                (to 11)
         5    load_var 2             (runner)
         6    store_var 3            (r)
 
-  214   7    load_var 1             (run_children)
-        8    load_var 3             (r)
-        9    call_indirect          
+  214   7    load_var2 1 3          
+        8    call_indirect          
 
-  215   10   call_indirect          
-        11   jump +3                (to 14)
+  215   9    call_indirect          
+        10   jump +3                (to 13)
 
-  212   12   load_var 1             (run_children)
-        13   call_indirect          
-        14   return                 
+  212   11   load_var 1             (run_children)
+        12   call_indirect          
+        13   return                 
 }
 
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
@@ -1221,26 +1187,25 @@ function user.User.promote(self: User, bonus: int) -> Report {
        4    bin_op +               
        5    store_field 1          (age)
 
-  10   6    load_var 1             (self)
-       7    load_var 2             (bonus)
-       8    call 3 ntypeargs=0     (user.score)
-       9    store_var 4            (base)
+  10   6    load_var2 1 2          
+       7    call 3 ntypeargs=0     (user.score)
+       8    store_var 4            (base)
 
-  11   10   load_var 4             (base)
-       11   load_field 0           (score)
-       12   load_var 2             (bonus)
-       13   add_int                
-       14   store_var_load_var 5   (new_score)
+  11   9    load_var 4             (base)
+       10   load_field 0           (score)
+       11   load_var 2             (bonus)
+       12   add_int                
+       13   store_var_load_var 5   (new_score)
 
-  14   15   load_var 4             (base)
-       16   load_field 1           (label)
+  14   14   load_var 4             (base)
+       15   load_field 1           (label)
 
-  15   17   load_var 4             (base)
-       18   load_field 2           (breakdown)
-       19   init_instance 0        (user.Report .score, .label, .breakdown)
-       20   store_var 3            (_0)
-       21   load_var 3             (_0)
-       22   return                 
+  15   16   load_var 4             (base)
+       17   load_field 2           (breakdown)
+       18   init_instance 0        (user.Report .score, .label, .breakdown)
+       19   store_var 3            (_0)
+       20   load_var 3             (_0)
+       21   return                 
 }
 
 function user.User.to_json(self: User) -> baml.json.json {
@@ -1265,50 +1230,49 @@ function user.User.to_json(self: User) -> baml.json.json {
 }
 
 function user.http_status(code: int) -> string {
-  95    0    load_const 0   ("HTTP ")
-        1    store_var 2    (prefix)
+  95    0    load_const 0    ("HTTP ")
+        1    store_var 2     (prefix)
 
-  96    2    load_var 1     (code)
-        3    dense_tag 0    
-        4    jump_table 0   ([to 23, to 20, to 17, to 14, to 11, to 8], default to 5)
+  96    2    load_var 1      (code)
+        3    dense_tag 0     
+        4    jump_table 0    ([to 23, to 20, to 17, to 14, to 11, to 8], default to 5)
 
-  103   5    load_const 1   ("Unknown")
-        6    store_var 3    (label)
+  103   5    load_const 1    ("Unknown")
+        6    store_var 3     (label)
 
-  96    7    jump +18       (to 25)
+  96    7    jump +18        (to 25)
 
-  102   8    load_const 2   ("Internal Server Error")
-        9    store_var 3    (label)
+  102   8    load_const 2    ("Internal Server Error")
+        9    store_var 3     (label)
 
-  96    10   jump +15       (to 25)
+  96    10   jump +15        (to 25)
 
-  101   11   load_const 3   ("Not Found")
-        12   store_var 3    (label)
+  101   11   load_const 3    ("Not Found")
+        12   store_var 3     (label)
 
-  96    13   jump +12       (to 25)
+  96    13   jump +12        (to 25)
 
-  100   14   load_const 4   ("Bad Request")
-        15   store_var 3    (label)
+  100   14   load_const 4    ("Bad Request")
+        15   store_var 3     (label)
 
-  96    16   jump +9        (to 25)
+  96    16   jump +9         (to 25)
 
-  99    17   load_const 5   ("No Content")
-        18   store_var 3    (label)
+  99    17   load_const 5    ("No Content")
+        18   store_var 3     (label)
 
-  96    19   jump +6        (to 25)
+  96    19   jump +6         (to 25)
 
-  98    20   load_const 6   ("Created")
-        21   store_var 3    (label)
+  98    20   load_const 6    ("Created")
+        21   store_var 3     (label)
 
-  96    22   jump +3        (to 25)
+  96    22   jump +3         (to 25)
 
-  97    23   load_const 7   ("OK")
-        24   store_var 3    (label)
+  97    23   load_const 7    ("OK")
+        24   store_var 3     (label)
 
-  105   25   load_var 2     (prefix)
-        26   load_var 3     (label)
-        27   bin_op +       
-        28   return         
+  105   25   load_var2 2 3   
+        26   bin_op +        
+        27   return          
 }
 
 function user.score(input: User | ErrorInfo, threshold: int) -> Report {
@@ -1361,7 +1325,7 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
 
   56   36    load_field 2            (role)
        37    discriminant            
-       38    jump_table 0            ([to 48, to 45, to 42, to 39], default to 107)
+       38    jump_table 0            ([to 48, to 45, to 42, to 39], default to 102)
 
   60   39    load_var 2              (threshold)
        40    store_var 9             (role_mult)
@@ -1401,59 +1365,53 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
   67   63    load_var 9              (role_mult)
        64    store_var 12            (capped)
 
-  71   65    load_var 12             (capped)
-       66    load_var 9              (role_mult)
-       67    add_int                 
-       68    store_var_load_var 13   (total)
+  71   65    load_var2 12 9          
+       66    add_int                 
+       67    store_var_load_var 13   (total)
 
-  73   69    load_var 2              (threshold)
-       70    cmp_int_op >            
-       71    load_const 2            (true)
-       72    cmp_op ==               
-       73    pop_jump_if_false +2    (to 75)
-       74    jump +4                 (to 78)
+  73   68    load_var 2              (threshold)
+       69    cmp_int_op >            
+       70    load_const 2            (true)
+       71    cmp_op ==               
+       72    pop_jump_if_false +2    (to 74)
+       73    jump +4                 (to 77)
 
-  75   75    load_const 3            (" [LOW]")
-       76    store_var 14            (suffix)
+  75   74    load_const 3            (" [LOW]")
+       75    store_var 14            (suffix)
 
-  73   77    jump +3                 (to 80)
+  73   76    jump +3                 (to 79)
 
-  74   78    load_const 4            (" [HIGH]")
-       79    store_var 14            (suffix)
+  74   77    load_const 4            (" [HIGH]")
+       78    store_var 14            (suffix)
 
-  77   80    load_var 3              (name)
-       81    load_var 14             (suffix)
-       82    bin_op +                
-       83    store_var 15            (label)
+  77   79    load_var2 3 14          
+       80    bin_op +                
+       81    store_var 15            (label)
 
-  79   84    load_var 11             (base)
-       85    load_var 12             (capped)
-       86    load_var 13             (total)
-       87    alloc_array 3           
-       88    store_var_load_var 16   (scores)
+  79   82    load_var2 11 12         
+       83    load_var 13             (total)
+       84    alloc_array 3           
+       85    store_var_load_var 16   (scores)
 
-  80   89    load_const 5            (0)
-       90    load_var 13             (total)
-       91    store_array_element     
+  80   86    load_const 5            (0)
+       87    load_var 13             (total)
+       88    store_array_element     
 
-  81   92    load_var 16             (scores)
-       93    load_const 5            (0)
-       94    load_array_element      
-       95    store_var 17            (top)
+  81   89    load_var 16             (scores)
+       90    load_const 5            (0)
+       91    load_array_element      
+       92    store_var 17            (top)
 
-  83   96    load_var 11             (base)
-       97    load_var 9              (role_mult)
-       98    load_const 6            ("base")
-       99    load_const 7            ("role")
-       100   alloc_map 2             
-       101   store_var 18            (breakdown)
+  83   93    load_var2 11 9          
+       94    load_const 6            ("base")
+       95    load_const 7            ("role")
+       96    alloc_map 2             
+       97    store_var 18            (breakdown)
 
-  86   102   load_var 17             (top)
+  86   98    load_var2 17 15         
 
-  87   103   load_var 15             (label)
-
-  88   104   load_var 18             (breakdown)
-       105   init_instance 0         (user.Report .score, .label, .breakdown)
-       106   return                  
-       107   unreachable             
+  88   99    load_var 18             (breakdown)
+       100   init_instance 0         (user.Report .score, .label, .breakdown)
+       101   return                  
+       102   unreachable             
 }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -1,10 +1,8 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
-assertion_line: 41
 ---
 function assert.contains(haystack: string, needle: string) -> null {
-    load_var haystack
-    load_var needle
+    load_var2 1 2
     call baml.String.includes
     unary_op !
     pop_jump_if_false L0
@@ -23,8 +21,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
-    load_var actual
-    load_var expected
+    load_var2 1 2
     cmp_op !=
     pop_jump_if_false L0
     jump L1
@@ -79,8 +76,7 @@ function assert.not_null(value: unknown?) -> null {
 }
 
 function testing.$invoke_collector(collector: (testing.TestCollector) -> void throws unknown, c: testing.TestCollector) -> void {
-    load_var c
-    load_var collector
+    load_var2 2 1
     call_indirect
     return
 }
@@ -202,8 +198,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -216,8 +211,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
     throw
 
   L2:
-    load_var _3
-    load_var __for_idx
+    load_var2 3 4
     load_array_element
     store_var_load_var ts
     load_field .name
@@ -308,8 +302,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     store_var __for_idx
 
   L3:
-    load_var __for_idx
-    load_var _13
+    load_var2 9 8
     container_len
     cmp_int_op <
     pop_jump_if_false L4
@@ -337,16 +330,14 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     add_int
     call baml.unstable.string
     store_var _30
-    load_var _28
-    load_var _30
+    load_var2 12 13
     bin_op +
     store_var final_name
 
   L7:
     load_var self
     load_field .tests
-    load_var final_name
-    load_var body
+    load_var2 11 3
     load_var runner
     init_instance testing.TestRegistration .name, .body, .runner
     call baml.Array.push
@@ -355,8 +346,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     return
 
   L8:
-    load_var _13
-    load_var __for_idx
+    load_var2 8 9
     load_array_element
     store_var_load_var t
     load_field .name
@@ -423,8 +413,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     store_var __for_idx
 
   L3:
-    load_var __for_idx
-    load_var _13
+    load_var2 9 8
     container_len
     cmp_int_op <
     pop_jump_if_false L4
@@ -452,16 +441,14 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     add_int
     call baml.unstable.string
     store_var _30
-    load_var _28
-    load_var _30
+    load_var2 12 13
     bin_op +
     store_var final_name
 
   L7:
     load_var self
     load_field .testsets
-    load_var final_name
-    load_var collector
+    load_var2 11 3
     load_var runner
     init_instance testing.TestSetRegistration .name, .collector, .runner
     call baml.Array.push
@@ -470,8 +457,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     return
 
   L8:
-    load_var _13
-    load_var __for_idx
+    load_var2 8 9
     load_array_element
     store_var_load_var ts
     load_field .name
@@ -562,8 +548,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -578,8 +563,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     store_var __for_idx_1
 
   L2:
-    load_var __for_idx_1
-    load_var _28
+    load_var2 10 9
     container_len
     cmp_int_op <
     pop_jump_if_false L3
@@ -592,8 +576,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     throw
 
   L4:
-    load_var _28
-    load_var __for_idx_1
+    load_var2 9 10
     load_array_element
     store_var k
     load_var self
@@ -601,8 +584,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_var k
     load_map_element
     store_var sub
-    load_var name
-    load_var k
+    load_var2 2 11
     load_const "/"
     bin_op +
     call baml.String.starts_with
@@ -617,14 +599,12 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     jump L2
 
   L6:
-    load_var sub
-    load_var name
+    load_var2 12 2
     call testing.TestRegistry.expand_set
     jump L10
 
   L7:
-    load_var _3
-    load_var __for_idx
+    load_var2 3 4
     load_array_element
     store_var_load_var ts
     load_field .name
@@ -656,11 +636,9 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     store_var _19
     load_var self
     load_field .expansions
-    load_var name
-    load_var sub_collector
+    load_var2 2 7
     alloc_map 0
-    load_var _19
-    load_var start
+    load_var2 8 6
     sub_int
     init_instance testing.TestRegistry .collector, .expansions, .loading_time_ms
     call baml.Map.set
@@ -715,8 +693,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -731,8 +708,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     store_var __for_idx_1
 
   L2:
-    load_var __for_idx_1
-    load_var _13
+    load_var2 7 6
     container_len
     cmp_int_op <
     pop_jump_if_false L3
@@ -745,8 +721,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     throw
 
   L4:
-    load_var _13
-    load_var __for_idx_1
+    load_var2 6 7
     load_array_element
     store_var k
     load_var self
@@ -754,8 +729,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var k
     load_map_element
     store_var sub
-    load_var name
-    load_var k
+    load_var2 2 8
     load_const "/"
     bin_op +
     call baml.String.starts_with
@@ -770,14 +744,12 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     jump L2
 
   L6:
-    load_var sub
-    load_var name
+    load_var2 9 2
     call testing.TestRegistry.run_test
     jump L10
 
   L7:
-    load_var _3
-    load_var __for_idx
+    load_var2 3 4
     load_array_element
     store_var_load_var t
     load_field .name
@@ -815,8 +787,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var __for_idx
 
   L0:
-    load_var __for_idx
-    load_var _3
+    load_var2 4 3
     container_len
     cmp_int_op <
     pop_jump_if_false L1
@@ -831,8 +802,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var __for_idx_1
 
   L2:
-    load_var __for_idx_1
-    load_var _12
+    load_var2 6 5
     container_len
     cmp_int_op <
     pop_jump_if_false L3
@@ -843,8 +813,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     return
 
   L4:
-    load_var _12
-    load_var __for_idx_1
+    load_var2 5 6
     load_array_element
     store_var ts
     load_var self
@@ -877,10 +846,8 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     load_var sub
     call testing.TestRegistry.serialize
     store_var _26
-    load_var items
-    load_var _25
-    load_var _26
-    load_var sub
+    load_var2 2 10
+    load_var2 11 9
     load_field .loading_time_ms
     init_instance testing.SerializedTestSet .name, .items, .loadingTimeMs
     call baml.Array.push
@@ -896,8 +863,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
   L8:
     load_var items
     load_const "test"
-    load_var _3
-    load_var __for_idx
+    load_var2 3 4
     load_array_element
     load_field .name
     init_instance testing.SerializedTest .type, .name
@@ -1076,8 +1042,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
     jump L1
 
   L0:
-    load_var base_run
-    load_var runner
+    load_var2 3 2
     call_indirect
     call_indirect
     jump L2
@@ -1098,8 +1063,7 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
     jump L1
 
   L0:
-    load_var run_children
-    load_var runner
+    load_var2 1 2
     call_indirect
     call_indirect
     jump L2
@@ -1220,8 +1184,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
     load_const 1
     bin_op +
     store_field .age
-    load_var self
-    load_var bonus
+    load_var2 1 2
     call user.score
     store_var base
     load_var base
@@ -1394,8 +1357,7 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
     store_var capped
 
   L15:
-    load_var capped
-    load_var role_mult
+    load_var2 7 5
     add_int
     store_var_load_var total
     load_var threshold
@@ -1415,8 +1377,7 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
     store_var suffix
 
   L18:
-    load_var base
-    load_var capped
+    load_var2 6 7
     load_var total
     alloc_array 3
     store_var_load_var scores
@@ -1426,11 +1387,9 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
     load_var scores
     load_const 0
     load_array_element
-    load_var name
-    load_var suffix
+    load_var2 3 9
     bin_op +
-    load_var base
-    load_var role_mult
+    load_var2 6 5
     load_const "base"
     load_const "role"
     alloc_map 2

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -1380,7 +1380,8 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
     load_var2 6 7
     load_var total
     alloc_array 3
-    store_var_load_var scores
+    store_var scores
+    load_var scores
     load_const 0
     load_var total
     store_array_element

--- a/baml_language/crates/bex_vm/Cargo.toml
+++ b/baml_language/crates/bex_vm/Cargo.toml
@@ -50,3 +50,6 @@ tokio = { workspace = true, features = [ "rt", "macros" ] }
 [features]
 default = [  ]
 heap_debug = [ "bex_heap/heap_debug", "bex_vm_types/heap_debug" ]
+# Enables the per-op VM counter for the `kperf` profiler's instructions/op
+# breakdown. Off by default — pure measurement scaffolding on the hot path.
+kperf = [  ]

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -224,6 +224,8 @@ pub(crate) fn display_instruction(
         | Instruction::CmpIntOp(_)
         | Instruction::CmpFloatOp(_)
         | Instruction::CmpBigintOp(_)
+        | Instruction::LoadVar2(..)
+        | Instruction::StoreVar2(..)
         | Instruction::UnaryOp(_)
         | Instruction::AllocArray(_)
         | Instruction::AllocMap(_)
@@ -356,12 +358,14 @@ fn instruction_style(instruction: &Instruction) -> Style {
         Instruction::NotifyBlock(_) => Style::new().yellow().bright(),
         Instruction::LoadConst(_)
         | Instruction::LoadVar(_)
+        | Instruction::LoadVar2(..)
         | Instruction::LoadGlobal(_)
         | Instruction::LoadField(_)
         | Instruction::LoadArrayElement
         | Instruction::LoadMapElement => Style::new().blue(),
         Instruction::StoreVar(_)
         | Instruction::StoreVarLoadVar(_)
+        | Instruction::StoreVar2(..)
         | Instruction::StoreGlobal(_)
         | Instruction::StoreField(_)
         | Instruction::InitField(_)
@@ -719,6 +723,8 @@ fn display_instruction_textual(
         Instruction::LoadVar(idx) => format!("load_var {}", meta_str(idx)),
         Instruction::StoreVar(idx) => format!("store_var {}", meta_str(idx)),
         Instruction::StoreVarLoadVar(idx) => format!("store_var_load_var {}", meta_str(idx)),
+        Instruction::LoadVar2(a, b) => format!("load_var2 {a} {b}"),
+        Instruction::StoreVar2(a, b) => format!("store_var2 {a} {b}"),
 
         // --- Globals ---
         Instruction::LoadGlobal(idx) => format!("load_global {}", meta_str(&idx.raw())),
@@ -1379,6 +1385,13 @@ pub fn display_compact_bytecode(
                     f,
                     "obj={obj_idx}  captures={capture_count}  ntypeargs={ntypeargs}"
                 )?;
+            }
+
+            // Two u32 operands (operand-movement superinstructions)
+            OpCode::LoadVar2 | OpCode::StoreVar2 => {
+                let a = read_u32(code, &mut pc);
+                let b = read_u32(code, &mut pc);
+                writeln!(f, "{a} {b}")?;
             }
         }
     }

--- a/baml_language/crates/bex_vm/src/indexable.rs
+++ b/baml_language/crates/bex_vm/src/indexable.rs
@@ -18,6 +18,13 @@ pub(crate) trait EvalStackTrait {
     fn ensure_pop(&mut self) -> Value;
     fn ensure_stack_top(&self) -> StackIndex;
     fn ensure_slot_from_top(&self, index_from_top: usize) -> StackIndex;
+    /// Read a slot without bounds checking. Same invariant as `ensure_pop`:
+    /// the compiler assigns every local/temp a slot within the live frame's
+    /// region, validated at emit time, so the index is always in bounds.
+    fn get_at(&self, idx: StackIndex) -> Value;
+    /// Write a slot without bounds checking (same invariant). `Value: Copy`,
+    /// so the overwrite needs no drop.
+    fn set_at(&mut self, idx: StackIndex, v: Value);
 }
 
 impl EvalStackTrait for EvalStack {
@@ -51,6 +58,22 @@ impl EvalStackTrait for EvalStack {
         #[allow(unsafe_code)]
         unsafe {
             StackIndex::from_raw(self.0.len().unchecked_sub(index_from_top + 1))
+        }
+    }
+
+    #[allow(clippy::inline_always, unsafe_code)]
+    #[inline(always)]
+    fn get_at(&self, idx: StackIndex) -> Value {
+        // SAFETY: compiler-validated slot (see trait docs).
+        unsafe { *self.0.get_unchecked(idx.raw()) }
+    }
+
+    #[allow(clippy::inline_always, unsafe_code)]
+    #[inline(always)]
+    fn set_at(&mut self, idx: StackIndex, v: Value) {
+        // SAFETY: compiler-validated slot (see trait docs).
+        unsafe {
+            *self.0.get_unchecked_mut(idx.raw()) = v;
         }
     }
 }

--- a/baml_language/crates/bex_vm/src/kperf.rs
+++ b/baml_language/crates/bex_vm/src/kperf.rs
@@ -1,0 +1,192 @@
+//! In-process Apple-Silicon performance-counter probe (cycles + instructions
+//! retired) for the VM dispatch loop, plus a deterministic VM-op counter.
+//!
+//! Enabled only when `BAML_KPERF=1`. Reads the per-thread FIXED PMCs
+//! (cycles, instructions) around each `exec()` call on whatever worker thread
+//! runs it, accumulates the deltas process-globally, and prints a summary at
+//! exit (cyc/op, instr/op, IPC) so we can compare the VM against a reference
+//! interpreter on a stable, frequency-independent basis.
+//!
+//! macOS/aarch64 only; a no-op shim elsewhere. Needs the process to have PMC
+//! access (run under `sudo`), otherwise it disables itself silently.
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[allow(
+    unsafe_code,
+    clippy::print_stderr,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation
+)]
+mod imp {
+    use std::{
+        ffi::{CString, c_char, c_int, c_void},
+        sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+    };
+
+    unsafe extern "C" {
+        fn dlopen(path: *const c_char, mode: c_int) -> *mut c_void;
+        fn dlsym(handle: *mut c_void, sym: *const c_char) -> *mut c_void;
+        fn atexit(cb: extern "C" fn()) -> c_int;
+    }
+
+    const KPC_CLASS_FIXED_MASK: u32 = 1;
+
+    type ForceAll = extern "C" fn(c_int) -> c_int;
+    type SetCounting = extern "C" fn(u32) -> c_int;
+    type CounterCount = extern "C" fn(u32) -> u32;
+    type GetThread = extern "C" fn(u32, u32, *mut u64) -> c_int;
+
+    static INIT: std::sync::Once = std::sync::Once::new();
+    static ENABLED: AtomicBool = AtomicBool::new(false);
+    static N_FIXED: AtomicU32 = AtomicU32::new(0);
+    static GET_THREAD: AtomicU64 = AtomicU64::new(0); // fn ptr as usize
+
+    static ACC_CYCLES: AtomicU64 = AtomicU64::new(0);
+    static ACC_INSTRS: AtomicU64 = AtomicU64::new(0);
+    static ACC_OPS: AtomicU64 = AtomicU64::new(0);
+    static EXEC_CALLS: AtomicU64 = AtomicU64::new(0);
+
+    unsafe fn load_sym<T>(h: *mut c_void, name: &str) -> Option<T> {
+        let c = CString::new(name).ok()?;
+        let p = unsafe { dlsym(h, c.as_ptr()) };
+        if p.is_null() {
+            None
+        } else {
+            Some(unsafe { std::mem::transmute_copy::<*mut c_void, T>(&p) })
+        }
+    }
+
+    /// Idempotent: runs `init()` once, returns whether counters are live.
+    #[inline]
+    pub fn enabled() -> bool {
+        INIT.call_once(|| {
+            init();
+        });
+        ENABLED.load(Ordering::Relaxed)
+    }
+
+    /// One-time setup; returns whether counters are live.
+    fn init() -> bool {
+        if std::env::var("BAML_KPERF").as_deref() != Ok("1") {
+            return false;
+        }
+        unsafe {
+            let path =
+                CString::new("/System/Library/PrivateFrameworks/kperf.framework/kperf").unwrap();
+            let h = dlopen(path.as_ptr(), 2 /* RTLD_NOW */);
+            if h.is_null() {
+                eprintln!("[kperf] dlopen failed; disabled");
+                return false;
+            }
+            let (
+                Some(force_all),
+                Some(set_counting),
+                Some(set_thread),
+                Some(count),
+                Some(get_thread),
+            ) = (
+                load_sym::<ForceAll>(h, "kpc_force_all_ctrs_set"),
+                load_sym::<SetCounting>(h, "kpc_set_counting"),
+                load_sym::<SetCounting>(h, "kpc_set_thread_counting"),
+                load_sym::<CounterCount>(h, "kpc_get_counter_count"),
+                load_sym::<GetThread>(h, "kpc_get_thread_counters"),
+            )
+            else {
+                eprintln!("[kperf] missing symbols; disabled");
+                return false;
+            };
+            if force_all(1) != 0 {
+                eprintln!("[kperf] kpc_force_all_ctrs_set failed (need sudo); disabled");
+                return false;
+            }
+            set_counting(KPC_CLASS_FIXED_MASK);
+            set_thread(KPC_CLASS_FIXED_MASK);
+            let n = count(KPC_CLASS_FIXED_MASK);
+            if n < 2 {
+                eprintln!("[kperf] fixed counter count {n} < 2; disabled");
+                return false;
+            }
+            N_FIXED.store(n, Ordering::Relaxed);
+            GET_THREAD.store(get_thread as usize as u64, Ordering::Relaxed);
+            ENABLED.store(true, Ordering::Relaxed);
+            atexit(report);
+            eprintln!("[kperf] enabled ({n} fixed counters)");
+            true
+        }
+    }
+
+    /// Read (cycles, instructions) for the current thread. Apple fixed PMCs are
+    /// [cycles, instructions, ...].
+    #[inline]
+    fn read() -> (u64, u64) {
+        let f = GET_THREAD.load(Ordering::Relaxed);
+        if f == 0 {
+            return (0, 0);
+        }
+        let get_thread: GetThread = unsafe { std::mem::transmute(f as usize as *const c_void) };
+        let n = N_FIXED.load(Ordering::Relaxed);
+        let mut buf = [0u64; 32];
+        get_thread(0, n, buf.as_mut_ptr());
+        (buf[0], buf[1])
+    }
+
+    /// Snapshot at the start of an `exec()` call.
+    #[inline]
+    pub fn exec_start() -> (u64, u64) {
+        read()
+    }
+
+    /// Accumulate the delta over an `exec()` call plus the ops it dispatched.
+    #[inline]
+    pub fn exec_end(start: (u64, u64), ops: u64) {
+        let (c1, i1) = read();
+        ACC_CYCLES.fetch_add(c1.wrapping_sub(start.0), Ordering::Relaxed);
+        ACC_INSTRS.fetch_add(i1.wrapping_sub(start.1), Ordering::Relaxed);
+        ACC_OPS.fetch_add(ops, Ordering::Relaxed);
+        EXEC_CALLS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    extern "C" fn report() {
+        let c = ACC_CYCLES.load(Ordering::Relaxed);
+        let i = ACC_INSTRS.load(Ordering::Relaxed);
+        let ops = ACC_OPS.load(Ordering::Relaxed);
+        let calls = EXEC_CALLS.load(Ordering::Relaxed);
+        // Total instructions/cycles come straight from the hardware counters and
+        // are the primary metric — always reported. The per-op breakdown needs
+        // the VM op counter, which is only populated under the `kperf` feature.
+        eprintln!(
+            "[kperf] exec calls={calls}  VM ops={ops}\n\
+             [kperf]   cycles={:.3}e9  instructions={:.3}e9  IPC={:.3}",
+            c as f64 / 1e9,
+            i as f64 / 1e9,
+            i as f64 / c.max(1) as f64,
+        );
+        if ops > 0 {
+            eprintln!(
+                "[kperf]   per VM-op: {:.2} cyc/op   {:.2} instr/op",
+                c as f64 / ops as f64,
+                i as f64 / ops as f64,
+            );
+        }
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub use imp::{enabled, exec_end, exec_start};
+
+// ── No-op shim for every other platform ──────────────────────────────────
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+mod shim {
+    #[inline]
+    pub fn enabled() -> bool {
+        false
+    }
+    #[inline]
+    pub fn exec_start() -> (u64, u64) {
+        (0, 0)
+    }
+    #[inline]
+    pub fn exec_end(_start: (u64, u64), _ops: u64) {}
+}
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+pub use shim::{enabled, exec_end, exec_start};

--- a/baml_language/crates/bex_vm/src/kperf.rs
+++ b/baml_language/crates/bex_vm/src/kperf.rs
@@ -99,8 +99,12 @@ mod imp {
                 eprintln!("[kperf] kpc_force_all_ctrs_set failed (need sudo); disabled");
                 return false;
             }
-            set_counting(KPC_CLASS_FIXED_MASK);
-            set_thread(KPC_CLASS_FIXED_MASK);
+            // kpc_* return 0 on success; bail (fail closed) on any error so a
+            // failed setup never feeds zeroed reads into the wrapping deltas.
+            if set_counting(KPC_CLASS_FIXED_MASK) != 0 || set_thread(KPC_CLASS_FIXED_MASK) != 0 {
+                eprintln!("[kperf] failed to enable counting (need sudo?); disabled");
+                return false;
+            }
             let n = count(KPC_CLASS_FIXED_MASK);
             if n < 2 {
                 eprintln!("[kperf] fixed counter count {n} < 2; disabled");
@@ -115,33 +119,41 @@ mod imp {
         }
     }
 
-    /// Read (cycles, instructions) for the current thread. Apple fixed PMCs are
+    /// Read (cycles, instructions) for the current thread, or `None` if the
+    /// counters aren't live or the kernel rejects the read. Apple fixed PMCs are
     /// [cycles, instructions, ...].
     #[inline]
-    fn read() -> (u64, u64) {
+    fn read() -> Option<(u64, u64)> {
         let f = GET_THREAD.load(Ordering::Relaxed);
         if f == 0 {
-            return (0, 0);
+            return None;
         }
         let get_thread: GetThread = unsafe { std::mem::transmute(f as usize as *const c_void) };
         let n = N_FIXED.load(Ordering::Relaxed);
         let mut buf = [0u64; 32];
-        get_thread(0, n, buf.as_mut_ptr());
-        (buf[0], buf[1])
+        // Non-zero return (e.g. EINVAL on too-small a buffer) means the values
+        // are garbage; reject so they don't become huge wrapped deltas.
+        if get_thread(0, n, buf.as_mut_ptr()) != 0 {
+            return None;
+        }
+        Some((buf[0], buf[1]))
     }
 
-    /// Snapshot at the start of an `exec()` call.
+    /// Snapshot at the start of an `exec()` call. `None` if the read failed.
     #[inline]
-    pub fn exec_start() -> (u64, u64) {
+    pub fn exec_start() -> Option<(u64, u64)> {
         read()
     }
 
     /// Accumulate the delta over an `exec()` call plus the ops it dispatched.
+    /// Skips the sample entirely if either the start or end read failed.
     #[inline]
-    pub fn exec_end(start: (u64, u64), ops: u64) {
-        let (c1, i1) = read();
-        ACC_CYCLES.fetch_add(c1.wrapping_sub(start.0), Ordering::Relaxed);
-        ACC_INSTRS.fetch_add(i1.wrapping_sub(start.1), Ordering::Relaxed);
+    pub fn exec_end(start: Option<(u64, u64)>, ops: u64) {
+        let (Some((c0, i0)), Some((c1, i1))) = (start, read()) else {
+            return;
+        };
+        ACC_CYCLES.fetch_add(c1.wrapping_sub(c0), Ordering::Relaxed);
+        ACC_INSTRS.fetch_add(i1.wrapping_sub(i0), Ordering::Relaxed);
         ACC_OPS.fetch_add(ops, Ordering::Relaxed);
         EXEC_CALLS.fetch_add(1, Ordering::Relaxed);
     }
@@ -182,11 +194,11 @@ mod shim {
         false
     }
     #[inline]
-    pub fn exec_start() -> (u64, u64) {
-        (0, 0)
+    pub fn exec_start() -> Option<(u64, u64)> {
+        None
     }
     #[inline]
-    pub fn exec_end(_start: (u64, u64), _ops: u64) {}
+    pub fn exec_end(_start: Option<(u64, u64)>, _ops: u64) {}
 }
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 pub use shim::{enabled, exec_end, exec_start};

--- a/baml_language/crates/bex_vm/src/lib.rs
+++ b/baml_language/crates/bex_vm/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod debug;
 pub mod errors;
 pub mod indexable;
+pub mod kperf;
 pub mod package_baml;
 pub mod types;
 pub mod vm;

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2213,6 +2213,28 @@ impl BexVm {
         Ok(None)
     }
 
+    /// Combine the two `store_local_value` yields from a fused `StoreVar2` when
+    /// at least one watched local notified. `store_local_value` only ever yields
+    /// `Notify(Variables(..))`, so when both locals notify their node lists are
+    /// concatenated into one yield — no watch event is dropped. Cold: reached
+    /// only on the watched-local path, never in normal execution.
+    #[cold]
+    #[inline(never)]
+    fn merge_store_yields(y1: Option<VmExecState>, y2: Option<VmExecState>) -> VmExecState {
+        match (y1, y2) {
+            (
+                Some(VmExecState::Notify(WatchNotification::Variables(mut n1))),
+                Some(VmExecState::Notify(WatchNotification::Variables(n2))),
+            ) => {
+                n1.extend(n2);
+                VmExecState::Notify(WatchNotification::Variables(n1))
+            }
+            // Exactly one notified (or a defensive non-`Variables` variant).
+            (Some(state), _) | (_, Some(state)) => state,
+            (None, None) => unreachable!("merge_store_yields called with both None"),
+        }
+    }
+
     pub fn error_to_exception_value(&mut self, error: VmBamlError) -> Value {
         let (class, fields) = match error {
             VmBamlError::InvalidArgument { message } => (
@@ -3978,10 +4000,14 @@ impl BexVm {
                     self.stack.push(vb);
                 }
                 // StoreVar2(a, b) == `StoreVar(a); StoreVar(b)`: pop TOS into
-                // local[a], then pop into local[b]. Both stores complete before
-                // returning; in the rare case where both are watched locals and
-                // both produce notifications, only the first is surfaced (watch
-                // granularity, not store correctness).
+                // local[a], then pop into local[b]. Both stores always complete
+                // before returning — a single fused op can't yield mid-way and
+                // resume into the second store (the saved PC is already past the
+                // whole instruction), so each `store_local_value` must run. When
+                // both are watched locals and both notify, the two node lists are
+                // merged into one yield rather than dropping the second, so no
+                // watch event is lost (equivalent to two sequential StoreVar
+                // notifications, coalesced into a single batch).
                 OpCode::StoreVar2 => {
                     let a = { read_u32_unchecked(code, pc) as usize };
                     let b = { read_u32_unchecked(code, pc) as usize };
@@ -3997,8 +4023,12 @@ impl BexVm {
                     let vb = self.stack.ensure_pop();
                     let y1 = self.store_local_value(sa, va)?;
                     let y2 = self.store_local_value(sb, vb)?;
-                    if let Some(state) = y1.or(y2) {
-                        return Ok(Some(state));
+                    // Hot path: no watched locals, both stores returned `None` —
+                    // fall through. The merge (only reached when a watched local
+                    // notifies) is outlined into a cold helper so this arm stays
+                    // a single predicted branch.
+                    if unlikely(y1.is_some() || y2.is_some()) {
+                        return Ok(Some(Self::merge_store_yields(y1, y2)));
                     }
                 }
 

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2055,6 +2055,15 @@ impl BexVm {
             .into());
         }
 
+        // Persist the caller's live PC before pushing the interrupt frame.
+        // Once this frame is no longer innermost, unwinding/stack-trace lookups
+        // read its `faulting_pc` (no longer updated per-op under lazy `cur_pc`),
+        // so it must capture the instruction we interrupted. Mirrors
+        // `execute_call_from_locals_offset`.
+        if let Some(Frame::Bytecode(bf)) = self.frames.last_mut() {
+            bf.faulting_pc = self.cur_pc;
+        }
+
         // Index of the frame that starts the interrupt code.
         self.interrupt_frame = Some(self.frames.len());
 
@@ -3333,7 +3342,7 @@ impl BexVm {
         let (kp_start, ops_start) = if kp {
             (crate::kperf::exec_start(), self.op_count)
         } else {
-            ((0, 0), 0)
+            (None, 0)
         };
 
         let result = match self.exec_inner() {

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -231,6 +231,8 @@ mod tests {
         BexVm {
             frames: Vec::new(),
             stack: EvalStack::new(),
+            op_count: 0,
+            cur_pc: 0,
             heap: Arc::clone(&heap),
             early_yield: early_yield_for_test(),
             tlab: Tlab::new(heap),
@@ -578,6 +580,17 @@ pub struct BexVm {
     ///
     /// This stack only stores values.
     pub stack: EvalStack,
+
+    /// Total bytecode ops dispatched (for the `kperf` profiler only; only
+    /// incremented when the `kperf` feature is enabled).
+    pub op_count: u64,
+
+    /// Start-PC of the instruction currently executing in the innermost
+    /// bytecode frame. Updated cheaply once per op (a flat field store) instead
+    /// of writing the frame's `faulting_pc` every op. Outer frames record their
+    /// call-site PC into `faulting_pc` at call time; the innermost frame's live
+    /// PC is read from here. Used for exception-handler lookup and stack traces.
+    pub cur_pc: usize,
 
     /// Reference to the shared heap (long-lived, shared across VMs).
     pub heap: Arc<BexHeap>,
@@ -1039,6 +1052,8 @@ impl BexVm {
         Self {
             frames: Vec::new(),
             stack: EvalStack::new(),
+            op_count: 0,
+            cur_pc: 0,
             heap,
             early_yield,
             tlab,
@@ -2119,7 +2134,28 @@ impl BexVm {
         StackIndex::from_raw(locals_offset.raw() + slot - 1)
     }
 
+    #[allow(clippy::inline_always)]
+    #[inline(always)]
     fn store_local_value(
+        &mut self,
+        local_var_index: StackIndex,
+        value: Value,
+    ) -> Result<Option<VmExecState>, VmError> {
+        // Fast path: no locals are watched, so a local store is just a stack
+        // write. The watch bookkeeping lives in a cold, never-inlined handler
+        // (`store_local_value_watched`) so this hot path stays inlined into
+        // `exec` and costs one predicted branch + one store. `Value` is `Copy`,
+        // so the overwrite needs no `mem::replace`/drop.
+        if unlikely(!self.watched_vars.is_empty()) {
+            return self.store_local_value_watched(local_var_index, value);
+        }
+        self.stack.set_at(local_var_index, value);
+        Ok(None)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn store_local_value_watched(
         &mut self,
         local_var_index: StackIndex,
         value: Value,
@@ -2147,9 +2183,7 @@ impl BexVm {
         // 3. `process_notifications` walks all roots reaching this
         //    node (just itself, since it IS a root) and applies
         //    the watch filter to decide whether to notify.
-        if unlikely(!self.watched_vars.is_empty())
-            && self.watched_vars.contains_key(&local_var_index)
-        {
+        if self.watched_vars.contains_key(&local_var_index) {
             let watched_node = NodeId::LocalVar(local_var_index);
 
             self.update_watched_node(watched_node, watch::Path::Binding, old_value, value);
@@ -2341,16 +2375,28 @@ impl BexVm {
 
     /// Unwinds error values (both thrown and panics).
     fn capture_stack_trace(&self) -> Vec<StackFrame> {
+        // The innermost (topmost) bytecode frame's live PC lives in `cur_pc`;
+        // outer frames recorded their call-site PC in `faulting_pc` at call time.
+        let top_bc = self
+            .frames
+            .iter()
+            .rposition(|f| matches!(f, Frame::Bytecode(_)));
         self.frames
             .iter()
-            .filter_map(|frame| {
+            .enumerate()
+            .filter_map(|(idx, frame)| {
                 let func = self.get_object(frame.function()).as_callable().ok()?;
                 match frame {
                     Frame::Bytecode(frame) => {
-                        let error_line = if let Some(compact) = &func.bytecode.compact {
-                            compact.source_line_for_pc(frame.faulting_pc)
+                        let pc = if Some(idx) == top_bc {
+                            self.cur_pc
                         } else {
-                            func.bytecode.source_line_for_pc(frame.faulting_pc)
+                            frame.faulting_pc
+                        };
+                        let error_line = if let Some(compact) = &func.bytecode.compact {
+                            compact.source_line_for_pc(pc)
+                        } else {
+                            func.bytecode.source_line_for_pc(pc)
                         };
                         Some(StackFrame {
                             function_name: func.name.clone(),
@@ -2378,6 +2424,10 @@ impl BexVm {
     ) -> Result<(), VmError> {
         // Capture the stack trace before unwinding destroys frame information.
         let trace: Vec<StackFrame> = self.capture_stack_trace();
+
+        // The innermost (first) bytecode frame's faulting PC is the live
+        // `cur_pc`; outer frames use the call-site PC they recorded at call time.
+        let mut innermost_bc = true;
 
         // Walk the call stack from the current frame outward looking for an
         // exception table entry that covers the faulting PC.
@@ -2417,9 +2467,14 @@ impl BexVm {
                 unreachable!("non-Native frames already handled above");
             };
 
-            // faulting_pc is kept up-to-date by both exec_inner (legacy) and
-            // exec_compact before dispatching each instruction.
-            let faulting_pc = frame.faulting_pc;
+            // Innermost bytecode frame uses the live `cur_pc`; outer frames use
+            // the call-site PC recorded in `faulting_pc` when they descended.
+            let faulting_pc = if innermost_bc {
+                self.cur_pc
+            } else {
+                frame.faulting_pc
+            };
+            innermost_bc = false;
 
             // Load the function for this frame to access its exception table.
             // SAFETY: See `load_function` doc comment.
@@ -2625,6 +2680,45 @@ impl BexVm {
         frame_idx: &mut usize,
         function: &mut &'static Function,
     ) -> Result<Option<VmExecState>, VmError> {
+        // Record the caller's call-site PC before descending. Once a callee
+        // frame is pushed, this (now-outer) frame is no longer the innermost, so
+        // its live PC must be persisted into `faulting_pc` for correct unwinding
+        // and stack traces. `cur_pc` holds this call instruction's start.
+        let call_site = self.cur_pc;
+        if let Some(Frame::Bytecode(bf)) = self.frames.get_mut(*frame_idx) {
+            bf.faulting_pc = call_site;
+        }
+
+        // Classify the callee with a single heap deref, extracting everything
+        // the slow paths need. A plain `Function` — the overwhelmingly common
+        // case, including all recursion — needs neither closure captures nor
+        // bound-method class args, so it takes the empty fast path. The
+        // `closure_type_args` are a Closure's captured type args; the
+        // `bound_method_class_type_args` are the receiver's class type args (De
+        // Bruijn ordering: class args ++ explicit call-site args, matching
+        // enclosing_generic_params() which puts class params first). Both are
+        // injected into the new BytecodeFrame after it is created.
+        let (is_host, closure_type_args, bound_method_class_type_args): (
+            bool,
+            Box<[baml_type::Ty]>,
+            Box<[baml_type::Ty]>,
+        ) = match self.get_object(callee_ptr) {
+            Object::HostClosure(_) => (true, Box::new([]), Box::new([])),
+            Object::Closure(c) => (false, c.captured_type_args.clone(), Box::new([])),
+            Object::BoundMethod(bm) => {
+                let bm_args: Box<[baml_type::Ty]> = match bm.receiver.as_object_ptr() {
+                    Some(recv_ptr) => match self.get_object(recv_ptr) {
+                        Object::Instance(inst) => inst.class_type_args.clone().into_boxed_slice(),
+                        _ => Box::new([]),
+                    },
+                    None => Box::new([]),
+                };
+                (false, Box::new([]), bm_args)
+            }
+            // Plain Function (fast path) and everything else: no extra args.
+            _ => (false, Box::new([]), Box::new([])),
+        };
+
         // A host closure isn't a Function/Closure/BoundMethod and dispatches via
         // a single-yield sys-op rather than a pushed frame. This path is reached
         // when a host callable is invoked *indirectly* — e.g. handed to a native
@@ -2635,34 +2729,10 @@ impl BexVm {
         // the caller pushed resumes — with the host result on the stack — once
         // the engine completes the op, exactly as for a bytecode callback's
         // return value.
-        if matches!(self.get_object(callee_ptr), Object::HostClosure(_)) {
+        if is_host {
             let user_args: Vec<Value> = self.stack.drain(locals_offset..).collect();
             return Ok(Some(self.host_closure_call_sysop(callee_ptr, user_args)));
         }
-
-        // Extract captured_type_args from a Closure callee before we discard
-        // the concrete Closure type in favour of the inner Function.
-        // These are injected into the new BytecodeFrame after it is created.
-        let closure_type_args: Box<[baml_type::Ty]> = match self.get_object(callee_ptr) {
-            Object::Closure(c) => c.captured_type_args.clone(),
-            _ => Box::new([]),
-        };
-
-        // For BoundMethod callees, extract the receiver's class_type_args so
-        // they can seed frame.type_args before call-site explicit type args are
-        // appended.  This implements the De Bruijn ordering:
-        //   frame.type_args = receiver.class_type_args ++ explicit_call_site_args
-        // matching enclosing_generic_params() which puts class params first.
-        let bound_method_class_type_args: Box<[baml_type::Ty]> = match self.get_object(callee_ptr) {
-            Object::BoundMethod(bm) => match bm.receiver.as_object_ptr() {
-                Some(recv_ptr) => match self.get_object(recv_ptr) {
-                    Object::Instance(inst) => inst.class_type_args.clone().into_boxed_slice(),
-                    _ => Box::new([]),
-                },
-                None => Box::new([]),
-            },
-            _ => Box::new([]),
-        };
 
         // Resolve the callee: either a plain Function, a Closure, or a BoundMethod wrapping one.
         let callee = match self.get_object(callee_ptr) {
@@ -3258,13 +3328,26 @@ impl BexVm {
         // counter to reset at.
         self.early_yield.reset();
 
-        match self.exec_inner() {
+        // BAML_KPERF: read PMCs around this exec() on the current worker thread.
+        let kp = crate::kperf::enabled();
+        let (kp_start, ops_start) = if kp {
+            (crate::kperf::exec_start(), self.op_count)
+        } else {
+            ((0, 0), 0)
+        };
+
+        let result = match self.exec_inner() {
             Err(VmError::InternalError(err)) => {
                 let trace = self.capture_stack_trace();
                 Err(VmError::TracedInternalError { source: err, trace })
             }
             other => other,
+        };
+
+        if kp {
+            crate::kperf::exec_end(kp_start, self.op_count - ops_start);
         }
+        result
     }
 
     #[allow(clippy::inline_always)] // Measured: 20-40% speedup from inlining the dispatch loop
@@ -3766,12 +3849,22 @@ impl BexVm {
         #[allow(unsafe_code)]
         let op_byte = unsafe { *code.get_unchecked(*pc) };
         *pc += 1;
+        // VM-op counter for the `kperf` profiler. Compiled out entirely in
+        // normal builds (it is pure measurement scaffolding and adds a store +
+        // memory dependency on the hottest path); kperf reads cycles and
+        // instructions retired straight from the hardware counters, so the op
+        // count is only needed for the informational per-op breakdown.
+        #[cfg(feature = "kperf")]
+        {
+            self.op_count += 1;
+        }
 
-        // Save faulting PC for error reporting (points to the opcode byte).
-        let Frame::Bytecode(bf) = &mut self.frames[*frame_idx] else {
-            verifier_unreachable!()
-        };
-        bf.faulting_pc = *pc - 1;
+        // Record the innermost frame's current instruction start cheaply (one
+        // flat field store), instead of writing the frame's `faulting_pc` every
+        // op (which needs a bounds-checked index + enum match + store). Outer
+        // frames record their call-site PC at call time; read sites resolve the
+        // innermost frame from `cur_pc`.
+        self.cur_pc = *pc - 1;
 
         // SAFETY: OpCode is #[repr(u8)] and the compact bytecode is produced by our
         // own encoder which only emits valid opcode bytes.
@@ -3833,22 +3926,69 @@ impl BexVm {
                 // ── LoadVar / StoreVar ────────────────────────────────────────
                 OpCode::LoadVar => {
                     let slot = { read_u32_unchecked(code, pc) as usize };
-                    let Frame::Bytecode(bf) = &self.frames[*frame_idx] else {
+                    // SAFETY: dispatch loop always runs with a Bytecode frame on top.
+                    #[allow(unsafe_code)]
+                    let Frame::Bytecode(bf) = (unsafe { self.frames.get_unchecked(*frame_idx) })
+                    else {
                         unreachable!()
                     };
                     let stack_slot = Self::local_slot_stack_index(bf.locals_offset, slot);
-                    let value = self.stack[stack_slot];
+                    let value = self.stack.get_at(stack_slot);
                     self.stack.push(value);
                 }
 
                 OpCode::StoreVar => {
                     let slot = { read_u32_unchecked(code, pc) as usize };
-                    let Frame::Bytecode(bf) = &self.frames[*frame_idx] else {
+                    // SAFETY: dispatch loop always runs with a Bytecode frame on top.
+                    #[allow(unsafe_code)]
+                    let Frame::Bytecode(bf) = (unsafe { self.frames.get_unchecked(*frame_idx) })
+                    else {
                         unreachable!()
                     };
                     let local_var_index = Self::local_slot_stack_index(bf.locals_offset, slot);
                     let value = self.stack.ensure_pop();
                     if let Some(state) = self.store_local_value(local_var_index, value)? {
+                        return Ok(Some(state));
+                    }
+                }
+
+                // ── Operand-movement superinstructions (CPython-style) ────────
+                // LoadVar2(a, b) == `LoadVar(a); LoadVar(b)`: push both locals.
+                OpCode::LoadVar2 => {
+                    let a = { read_u32_unchecked(code, pc) as usize };
+                    let b = { read_u32_unchecked(code, pc) as usize };
+                    #[allow(unsafe_code)]
+                    let Frame::Bytecode(bf) = (unsafe { self.frames.get_unchecked(*frame_idx) })
+                    else {
+                        unreachable!()
+                    };
+                    let off = bf.locals_offset;
+                    let va = self.stack.get_at(Self::local_slot_stack_index(off, a));
+                    let vb = self.stack.get_at(Self::local_slot_stack_index(off, b));
+                    self.stack.push(va);
+                    self.stack.push(vb);
+                }
+                // StoreVar2(a, b) == `StoreVar(a); StoreVar(b)`: pop TOS into
+                // local[a], then pop into local[b]. Both stores complete before
+                // returning; in the rare case where both are watched locals and
+                // both produce notifications, only the first is surfaced (watch
+                // granularity, not store correctness).
+                OpCode::StoreVar2 => {
+                    let a = { read_u32_unchecked(code, pc) as usize };
+                    let b = { read_u32_unchecked(code, pc) as usize };
+                    #[allow(unsafe_code)]
+                    let Frame::Bytecode(bf) = (unsafe { self.frames.get_unchecked(*frame_idx) })
+                    else {
+                        unreachable!()
+                    };
+                    let off = bf.locals_offset;
+                    let sa = Self::local_slot_stack_index(off, a);
+                    let sb = Self::local_slot_stack_index(off, b);
+                    let va = self.stack.ensure_pop();
+                    let vb = self.stack.ensure_pop();
+                    let y1 = self.store_local_value(sa, va)?;
+                    let y2 = self.store_local_value(sb, vb)?;
+                    if let Some(state) = y1.or(y2) {
                         return Ok(Some(state));
                     }
                 }
@@ -5630,8 +5770,12 @@ impl BexVm {
                     let data = self.stack.ensure_pop();
                     let name_value = self.stack.ensure_pop();
                     let event_name = self.as_string(&name_value)?.to_string();
+                    // This is the innermost executing frame, so its live PC is
+                    // `cur_pc` (the frame's `faulting_pc` is no longer updated
+                    // per-op; it only holds outer frames' call-site PCs).
+                    let cur_pc = self.cur_pc;
                     let source_location = if let Frame::Bytecode(bf) = &self.frames[*frame_idx] {
-                        let pc = bf.faulting_pc;
+                        let pc = cur_pc;
                         let func_obj = self.get_object(bf.function).as_callable().ok();
                         func_obj
                             .and_then(|func| {

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -737,6 +737,17 @@ pub enum Instruction {
     /// can emit a `CustomEvent` with full span context. Execution resumes
     /// after the engine processes the event.
     SendEvent,
+
+    // ── Operand-movement superinstructions (CPython-style) ────────────────
+    // Combine two adjacent local-movement ops into one dispatch. Pure
+    // replace-in-place at emit time (like `StoreVarLoadVar`), confined to the
+    // current basic block, so jump targets and block addresses are unaffected.
+    /// Fused `LoadVar(a); LoadVar(b)` — push `local[a]`, then `local[b]`.
+    /// (`CPython` `LOAD_FAST_LOAD_FAST`.)
+    LoadVar2(usize, usize),
+    /// Fused `StoreVar(a); StoreVar(b)` — pop into `local[a]`, then `local[b]`.
+    /// (`CPython` `STORE_FAST_STORE_FAST`.)
+    StoreVar2(usize, usize),
 }
 
 /// Compact bytecode opcodes.
@@ -882,6 +893,10 @@ pub enum OpCode {
     // ── Two operands (9 bytes) ─────────────────────────────────
     JumpTable,   // u32 table_idx + i32 default_offset
     MakeClosure, // u32 object_idx (capture_count is popped from the stack)
+
+    // ── Operand-movement superinstructions: two u32 operands (9 bytes) ──
+    LoadVar2,
+    StoreVar2,
 }
 
 impl OpCode {
@@ -1012,6 +1027,9 @@ impl OpCode {
 
             // 9-byte: opcode + u32 + i32
             Self::JumpTable => 9,
+
+            // 9-byte: opcode + u32 + u32 (operand-movement superinstructions)
+            Self::LoadVar2 | Self::StoreVar2 => 9,
         }
     }
 }
@@ -1135,6 +1153,8 @@ impl TryFrom<u8> for OpCode {
             x if x == Self::JumpIfFalse as u8 => Ok(Self::JumpIfFalse),
             x if x == Self::JumpTable as u8 => Ok(Self::JumpTable),
             x if x == Self::MakeClosure as u8 => Ok(Self::MakeClosure),
+            x if x == Self::LoadVar2 as u8 => Ok(Self::LoadVar2),
+            x if x == Self::StoreVar2 as u8 => Ok(Self::StoreVar2),
             _ => Err(byte),
         }
     }
@@ -1257,6 +1277,8 @@ impl std::fmt::Display for OpCode {
             Self::JumpIfFalse => "JUMP_IF_FALSE",
             Self::JumpTable => "JUMP_TABLE",
             Self::MakeClosure => "MAKE_CLOSURE",
+            Self::LoadVar2 => "LOAD_VAR2",
+            Self::StoreVar2 => "STORE_VAR2",
         };
         f.write_str(name)
     }
@@ -1557,6 +1579,8 @@ impl std::fmt::Display for Instruction {
             Instruction::CaptureRef(idx) => write!(f, "CAPTURE_REF {idx}"),
             Instruction::SendEvent => f.write_str("SEND_EVENT"),
             Instruction::ContainerLen => f.write_str("CONTAINER_LEN"),
+            Instruction::LoadVar2(a, b) => write!(f, "LOAD_VAR2 {a} {b}"),
+            Instruction::StoreVar2(a, b) => write!(f, "STORE_VAR2 {a} {b}"),
         }
     }
 }
@@ -2106,6 +2130,16 @@ impl Bytecode {
                             .to_le_bytes(),
                     );
                 }
+
+                // ── Operand-movement superinstructions: two u32 operands ──
+                Instruction::LoadVar2(a, b) | Instruction::StoreVar2(a, b) => {
+                    code.extend_from_slice(
+                        &u32::try_from(*a).expect("operand fits u32").to_le_bytes(),
+                    );
+                    code.extend_from_slice(
+                        &u32::try_from(*b).expect("operand fits u32").to_le_bytes(),
+                    );
+                }
             }
         }
 
@@ -2213,6 +2247,8 @@ impl Bytecode {
             Instruction::MakeCell => OpCode::MakeCell,
             Instruction::SendEvent => OpCode::SendEvent,
             Instruction::ContainerLen => OpCode::ContainerLen,
+            Instruction::LoadVar2(..) => OpCode::LoadVar2,
+            Instruction::StoreVar2(..) => OpCode::StoreVar2,
 
             // Expanded sub-enum variants
             Instruction::BinOp(op) => match op {


### PR DESCRIPTION
## What

Re-applies the **VM interpreter performance** set on top of the latest `canary`, **without** touching the event-stream / tracing system (it stays exactly as on canary). This is the perf-only slice carved out of the larger `hellovai/trim-events` work so it can land independently.

## Changes

- **`LoadVar2` / `StoreVar2` superinstructions** — fuse two adjacent local-movement ops into one dispatch, mirroring CPython's `LOAD_FAST_LOAD_FAST` / `STORE_FAST_STORE_FAST`. Pure emit-time peephole in `emit_load_var` / `emit_store_var`, confined to the current basic block (`> current_block_start`), so jump targets and block addresses are never affected. New bytecode encodes as two `u32` operands.
- **Unchecked local-slot indexing** on the `LoadVar`/`StoreVar` hot path (`get_at`/`set_at` via `get_unchecked`), and `store_local_value` split into an `#[inline(always)]` fast path + a `#[cold] #[inline(never)]` watched handler so the watch bookkeeping stays out of the inlined hot loop.
- **Lazy faulting PC** — replace the per-op `bf.faulting_pc = pc` write (bounds-checked index + enum match + store, every instruction) with a single flat `self.cur_pc` store. Outer frames persist their call-site PC into `faulting_pc` at call time; the unwind/stack-trace/`SendEvent` read sites resolve the innermost frame from `cur_pc`. Behavior-preserving for exception handler lookup and stack traces.
- **Call-path deref consolidation** — collapse the three separate `get_object(callee)` derefs (host-closure check, closure type args, bound-method class args) into one classifying `match` with a plain-`Function` fast path (the common case, including all recursion).
- **kperf probe** — env-gated (`BAML_KPERF=1`) Apple-Silicon PMC probe (cycles + instructions retired) behind an off-by-default `kperf` cargo feature. The per-op `op_count` increment is compiled out entirely unless the feature is enabled, so it adds nothing to normal builds.

## Not included

The event-stream / tracing system is intentionally left as-is on `canary` — `SendEvent`, `bex_events`, span plumbing, and the engine signatures are all unchanged.

## Testing

- `cargo check` / `cargo clippy` clean on `bex_vm`, `bex_vm_types`, `baml_compiler2_emit` (and with `--features kperf`).
- `bex_vm` unit + integration tests pass.
- `baml_tests` lib (1576 tests, codegen snapshots) and the `baml_src` execution-trace suite pass; snapshots regenerated for the new `LoadVar2`/`StoreVar2` disassembly.
- Exception / stack-trace tests (`catch_stack_trace_on_panic`, etc.) pass, covering the `cur_pc` unwind path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Apple Silicon performance profiling (kperf) for per-op VM measurements.

* **Performance Improvements**
  * Fused local load/store operations to reduce instruction overhead.
  * Faster unchecked stack-slot access paths to lower runtime cost.

* **Improvements**
  * More accurate stack traces and fault-location reporting.
  * Disassembly and textual bytecode output updated to show the new fused instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->