### PR TITLE
ci(perf): opt-in perf on PRs, run after merge, adaptive bench sampling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -715,7 +715,7 @@ jobs:
     name: "Perf benchmarks (PR notice)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: determine_changes
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,11 +241,12 @@ jobs:
           fi
 
       # Decide whether perf benchmarks (CodSpeed) should run for this event.
-      # Policy: benchmarks run automatically AFTER MERGE (push to main/canary)
-      # and on manual dispatch. On PRs they are OPT-IN — they no longer run on
-      # every code change. A PR opts in by mentioning one of the perf markers in
-      # its title, body, OR any of its commit messages. merge_group is always
-      # skipped (the PR already had its chance to run).
+      # Policy: benchmarks run AFTER MERGE (push to main/canary) only when the
+      # merge actually touched baml_language/, and on manual dispatch. On PRs
+      # they are OPT-IN — they no longer run on every code change. A PR opts in
+      # by mentioning one of the perf markers in its title, body, OR any of its
+      # commit messages. merge_group is always skipped (the PR already had its
+      # chance to run).
       - name: Check perf benchmark opt-in
         id: check_perf
         env:
@@ -253,14 +254,37 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
         run: |
           # Any of these, case-insensitive, in the PR title/body or a commit
           # message opts a PR into a perf run. Keep in sync with the instructions
           # posted by the "Perf benchmarks (PR notice)" job below.
           PATTERN='RUN_CODSPEED=1|run-perf|/perf'
 
-          # Always run after merge (push to canary/main) and on manual dispatch.
-          if [ "$EVENT_NAME" = "push" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          # After merge (push to canary/main): only run when the merge actually
+          # touched baml_language/. NOTE: we diff the pushed range (before..after)
+          # directly rather than reuse determine_changes' `code` flag — on a push
+          # the merge-base of HEAD and origin/<branch> collapses to HEAD, so that
+          # diff is always empty here. The push payload's before/after are the
+          # real merged range.
+          if [ "$EVENT_NAME" = "push" ]; then
+            if [ -z "$PUSH_BEFORE" ] || [ "$PUSH_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              # Branch creation / unknown previous tip — nothing to diff against,
+              # so run to be safe rather than silently skip.
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if git diff --quiet "$PUSH_BEFORE" "$PUSH_AFTER" -- ':baml_language/**'; then
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          # Manual dispatch always runs.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -543,10 +567,11 @@ jobs:
     name: "benchmarks build (baml)"
     runs-on: blacksmith-8vcpu-ubuntu-2204-arm
     needs: determine_changes
-    # Perf benchmarks run automatically AFTER MERGE (push to main/canary) and on
-    # manual dispatch. On PRs they are OPT-IN: a PR runs them only when its
-    # title/body or a commit message mentions a perf marker (RUN_CODSPEED=1,
-    # run-perf, /perf). See determine_changes' `check_perf` step for the policy
+    # Perf benchmarks run AFTER MERGE (push to main/canary, only when the merge
+    # touched baml_language/) and on manual dispatch. On PRs they are OPT-IN: a
+    # PR runs them only when its title/body or a commit message mentions a perf
+    # marker (RUN_CODSPEED=1, run-perf, /perf). See the `check_perf` step for the
+    # policy
     # and the "Perf benchmarks (PR notice)" job for the comment PRs get when
     # benchmarks are skipped. Skipped in merge_group (already settled on the PR).
     if: needs.determine_changes.outputs.run_perf == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,10 @@ jobs:
       unsafe: ${{ steps.check_unsafe.outputs.changed }}
       # Flag for proto codegen changes - triggers generated file sync check
       proto: ${{ steps.check_proto.outputs.changed }}
+      # Flag that is raised when perf benchmarks (CodSpeed) should run: always
+      # after merge (push to main/canary) and on manual dispatch; on PRs only
+      # when the PR title/body or a commit message opts in.
+      run_perf: ${{ steps.check_perf.outputs.run }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -235,6 +239,50 @@ jobs:
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # Decide whether perf benchmarks (CodSpeed) should run for this event.
+      # Policy: benchmarks run automatically AFTER MERGE (push to main/canary)
+      # and on manual dispatch. On PRs they are OPT-IN — they no longer run on
+      # every code change. A PR opts in by mentioning one of the perf markers in
+      # its title, body, OR any of its commit messages. merge_group is always
+      # skipped (the PR already had its chance to run).
+      - name: Check perf benchmark opt-in
+        id: check_perf
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
+        run: |
+          # Any of these, case-insensitive, in the PR title/body or a commit
+          # message opts a PR into a perf run. Keep in sync with the instructions
+          # posted by the "Perf benchmarks (PR notice)" job below.
+          PATTERN='RUN_CODSPEED=1|run-perf|/perf'
+
+          # Always run after merge (push to canary/main) and on manual dispatch.
+          if [ "$EVENT_NAME" = "push" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Never run in the merge queue — it already ran (or was opted out) on
+          # the PR.
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # On PRs: opt in via the PR title/body or any commit message in the PR.
+          if printf '%s\n%s' "$PR_TITLE" "$PR_BODY" | grep -qiE "$PATTERN"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$MERGE_BASE" ] && git log --format='%B' "${MERGE_BASE}..HEAD" | grep -qiE "$PATTERN"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "run=false" >> "$GITHUB_OUTPUT"
 
   # Lint checks
   prek:
@@ -495,19 +543,13 @@ jobs:
     name: "benchmarks build (baml)"
     runs-on: blacksmith-8vcpu-ubuntu-2204-arm
     needs: determine_changes
-    # Runs automatically on ANY change under baml_language/ (determine_changes'
-    # `code` flag = `git diff ... ':baml_language/**'`), so every PR that could
-    # affect perf is measured. Also runs on push to main/canary, and on manual
-    # opt-in (RUN_CODSPEED=1 in the PR body) for PRs that don't touch
-    # baml_language/. Skipped in merge_group (already ran on the PR).
-    if: |
-      github.event_name != 'merge_group' &&
-      (
-        needs.determine_changes.outputs.code == 'true' ||
-        github.ref == 'refs/heads/main' ||
-        github.ref == 'refs/heads/canary' ||
-        contains(github.event.pull_request.body, 'RUN_CODSPEED=1')
-      )
+    # Perf benchmarks run automatically AFTER MERGE (push to main/canary) and on
+    # manual dispatch. On PRs they are OPT-IN: a PR runs them only when its
+    # title/body or a commit message mentions a perf marker (RUN_CODSPEED=1,
+    # run-perf, /perf). See determine_changes' `check_perf` step for the policy
+    # and the "Perf benchmarks (PR notice)" job for the comment PRs get when
+    # benchmarks are skipped. Skipped in merge_group (already settled on the PR).
+    if: needs.determine_changes.outputs.run_perf == 'true'
     timeout-minutes: 30
     steps:
       - name: "Checkout Branch"
@@ -581,14 +623,8 @@ jobs:
     needs:
       - determine_changes
       - benchmarks-build
-    if: |
-      github.event_name != 'merge_group' &&
-      (
-        needs.determine_changes.outputs.code == 'true' ||
-        github.ref == 'refs/heads/main' ||
-        github.ref == 'refs/heads/canary' ||
-        contains(github.event.pull_request.body, 'RUN_CODSPEED=1')
-      )
+    # Same gate as benchmarks-build — see determine_changes' `check_perf` step.
+    if: needs.determine_changes.outputs.run_perf == 'true'
     timeout-minutes: 30
     steps:
       - name: "Checkout Branch"
@@ -641,6 +677,19 @@ jobs:
           # phase into seconds. Fails fast and loud if the cache ever misses,
           # instead of silently re-cloning for half an hour.
           CARGO_NET_OFFLINE: "true"
+          # Adaptive sampling: cap each bench at ~2s of wall time instead of
+          # CodSpeed walltime's fixed 100 samples/bench. divan then runs as many
+          # samples as fit the budget — ~100 for cheap benches (full statistical
+          # power kept), down to 1 for the heavy O(n²)/1M-iter workloads (whose
+          # run-to-run variance is already tiny, so a single sample suffices).
+          #
+          # WHY: at fixed 100 samples the suite blew past the 30-min timeout. The
+          # long pole was compute::bubble_sort_5k — ~14s/sample on the (≈5×
+          # slower than local) codspeed-macro runner × 100 = ~23min for ONE
+          # bench. With this cap the whole 36-bench suite finishes in ~2 min.
+          # Measured locally: fixed-100 bubble_sort alone >90s; with the budget
+          # the full suite ran in 80s. Tune the budget here, not in code.
+          DIVAN_MAX_TIME: "2"
         with:
           mode: walltime
           # Executes ONLY the prebuilt binaries downloaded above; no compiler runs.
@@ -652,11 +701,68 @@ jobs:
           # region (see bench_vm_main), so only `main()` is timed. Sleep-based
           # workloads are excluded at build time.
           #
-          # The `vm_speedtest` filter selects exactly that suite, which runs in
-          # ~2 min/pass on the macro runner at the default 100 samples — well
-          # within the timeout, no sample-count tuning needed.
+          # The `vm_speedtest` filter selects exactly that suite; DIVAN_MAX_TIME
+          # (above) bounds each bench so the pass stays well under the timeout.
           run: cd baml_language && cargo codspeed run -m walltime 'vm_speedtest'
           token: ${{ secrets.CODSPEED_TOKEN }}
+
+  # Leaves (and keeps up to date) a single sticky comment on each PR explaining
+  # the perf-benchmark policy: either confirming benchmarks were triggered, or —
+  # when they were skipped — telling the author exactly how to opt in. Runs on
+  # every PR event so the same comment is edited in place (no spam) and flips
+  # between the two states as the author edits the PR / pushes commits.
+  perf-pr-notice:
+    name: "Perf benchmarks (PR notice)"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: determine_changes
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: "Comment perf opt-in instructions"
+        uses: actions/github-script@v7
+        env:
+          RUN_PERF: ${{ needs.determine_changes.outputs.run_perf }}
+        with:
+          script: |
+            // Hidden marker so we find & update our own comment instead of
+            // posting a new one on every push.
+            const marker = '<!-- perf-benchmarks-pr-notice -->';
+            const triggered = process.env.RUN_PERF === 'true';
+            const body = triggered
+              ? [
+                  marker,
+                  '### 🏎️ Performance benchmarks are running for this PR',
+                  '',
+                  'CodSpeed perf benchmarks were triggered because this PR opted in. ' +
+                    'Results will appear in the CodSpeed check / dashboard once they finish.',
+                ].join('\n')
+              : [
+                  marker,
+                  '### ⏭️ Performance benchmarks were skipped',
+                  '',
+                  'Perf benchmarks (CodSpeed) are **opt-in** on pull requests — they no ' +
+                    'longer run on every push. They always run automatically after merge ' +
+                    'to `canary`/`main`.',
+                  '',
+                  'To run them on **this** PR, do any of the following, then push a commit ' +
+                    '(or re-run CI):',
+                  '',
+                  '- Add `RUN_CODSPEED=1` to the PR description, **or**',
+                  '- Include `run-perf` or `/perf` in the PR title or any commit message.',
+                ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
 
   # CI Failure Alert - Required status check using "skipped = success" pattern
   # See: https://devopsdirective.com/posts/2025/08/github-actions-required-checks-for-conditional-jobs/

--- a/baml_language/crates/baml_tests/benches/runtime_benchmark.rs
+++ b/baml_language/crates/baml_tests/benches/runtime_benchmark.rs
@@ -25,6 +25,20 @@ fn main() {
         eprintln!("Skipping runtime_benchmark in debug/test profile.");
         return;
     }
+    // Adaptive sampling by default: bound each bench to ~2s of wall time rather
+    // than walltime mode's fixed 100 samples/bench. divan then runs as many
+    // samples as fit the budget — ~100 for cheap benches (full statistical
+    // power), down to 1 for the heavy O(n²)/1M-iter workloads (whose run-to-run
+    // variance is already tiny). Without this the suite blows past CI's 30-min
+    // timeout: compute::bubble_sort_5k alone is ~14s/sample on the codspeed
+    // runner, so 100 samples ≈ 23min for ONE bench. CI overrides the budget via
+    // the DIVAN_MAX_TIME env var (see ci.yaml); we only set a default when the
+    // caller hasn't, so `cargo bench`/`cargo codspeed run` are adaptive too.
+    if std::env::var_os("DIVAN_MAX_TIME").is_none() {
+        // SAFETY: single-threaded here at the very top of main, before divan
+        // reads its args/env. No other thread can observe the environment.
+        unsafe { std::env::set_var("DIVAN_MAX_TIME", "2") };
+    }
     divan::main();
 }
 


### PR DESCRIPTION
## What & why

Two changes to how CodSpeed perf benchmarks run in `ci.yaml`.

### 1. Perf is opt-in on PRs, automatic after merge

Previously benchmarks ran on **every push to any PR** that touched `baml_language/`. Now:

- **After merge** (push to `main`/`canary`) and on `workflow_dispatch` → always run.
- **On PRs** → opt-in only. A PR runs benchmarks when its **title, body, or any commit message** contains `RUN_CODSPEED=1`, `run-perf`, or `/perf`.
- **`merge_group`** → never (already settled on the PR).

A new `perf-pr-notice` job maintains a single sticky comment on each PR (hidden marker, edited in place — no spam) that either confirms benchmarks were triggered or tells the author how to opt in.

Mechanically: a `check_perf` step in `determine_changes` computes a `run_perf` output; both `benchmarks-build` and `benchmarks-run` gate on it.

### 2. Adaptive sampling — fixes the 30-min CI timeout

The perf job was timing out at `timeout-minutes: 30` and getting cancelled mid-run. **Not a deadlock** — benches completed one-by-one until GitHub killed the job.

Root cause: CodSpeed walltime mode runs a **fixed 100 samples/bench** across **36 benches**, several of them heavy. The long pole is `compute::bubble_sort_5k` (O(n²) ≈ 12.5M VM iterations): ~14s/sample on the codspeed-macro runner (which is ~5× slower than local) × 100 samples ≈ **23 min for that one bench**.

Fix: bound each bench to a **~2s adaptive wall-time budget** (`DIVAN_MAX_TIME`). divan then runs as many samples as fit — ~100 for cheap benches (full statistical power kept), down to 1 for the heavy workloads (whose run-to-run variance is already tiny).

Set in CI via the step `env` (tunable from the workflow) **and** defaulted in the bench harness `main()` so local `cargo bench` / `cargo codspeed run` are adaptive too.

## Measured (local, `cargo codspeed run`)

| | fixed 100 | `DIVAN_MAX_TIME=2` |
|---|---|---|
| `bubble_sort_5k` alone | didn't finish in 90s | 1 sample, 2.9s |
| full 36-bench suite | → timeout | **81s** |
| cheap benches (strings, `mixed_ops`, `parallel_sum`) | 100 samples | **still 100** |
| heavy benches (bubble_sort/collatz/fib) | 100 samples | 1–9 |

Verified the in-`main` default applies with **no env var set**: suite ran 81s, `bubble_sort`=1 sample, cheap benches=100. Projected CI: **~2 min**, down from a >30-min timeout.

## Notes
- Benchmarks remain advisory (`continue-on-error`, not a required gate) — this never blocks a merge.
- Remaining long pole is `bubble_sort_5k`'s single ~14s sample on the macro runner (a time budget can't interrupt a sample mid-flight). Shrinking that O(n²) workload is a possible follow-up, but it's shared with the cross-language speedtest corpus, so left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Performance benchmarks are opt-in for pull requests via case-insensitive markers (e.g., RUN_CODSPEED=1, run-perf, /perf); benchmarks still run automatically on direct pushes and manual workflow triggers.
  * CI now uses a single run/skip decision to control all benchmark jobs for clearer gating.
  * PR receives a single sticky status comment that updates with "benchmarks running" or instructions when skipped.
  * Per-benchmark wall time is capped by default (2s) for faster, more predictable feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- triggers the new opt-in perf gate on this PR so the benchmark path runs end-to-end -->
RUN_CODSPEED=1 / run-perf
