### PR TITLE
feat: hide $compiler_intrinsic from sdkgen

### DIFF
--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -193,6 +193,13 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                     continue;
                 }
 
+                if matches!(
+                    method.body.as_ref(),
+                    Some(ast::FunctionBodyDef::Builtin(ast::BuiltinKind::Intrinsic))
+                ) {
+                    continue;
+                }
+
                 let is_instance = method
                     .params
                     .first()
@@ -370,6 +377,13 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
             // primitive clients) are runtime plumbing, not user-callable —
             // skip them so they don't end up as Python factory bindings.
             if matches!(func.origin, FunctionOrigin::Internal) {
+                continue;
+            }
+
+            if matches!(
+                func.body.as_ref(),
+                Some(ast::FunctionBodyDef::Builtin(ast::BuiltinKind::Intrinsic))
+            ) {
                 continue;
             }
 

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_stdlib_entrypoints.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_stdlib_entrypoints.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from baml_sdk.baml.fs import exists
 from baml_sdk.baml.math import trunc
+
+
+def _generated_sdk_file(rel_path: str) -> str | None:
+    # Intrinsic-only modules are not emitted at all, so a missing file is fine;
+    # callers only need to confirm the symbol is absent when the file exists.
+    path = Path.cwd() / "baml_sdk" / rel_path
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
 
 
 # `baml.math.trunc(value: float) -> int` is a `$rust_function` →
@@ -17,3 +28,22 @@ def test_native_trunc_callable_as_entry_point():
 # directory on the test host.
 def test_sysop_fs_exists_callable_as_entry_point():
     assert exists(".") is True
+
+
+def test_compiler_intrinsics_are_not_emitted_as_entry_points():
+    forbidden = [
+        ("vendor/log/__init__.py", '"log.info"'),
+        ("vendor/log/__init__.py", '"log.debug"'),
+        ("vendor/log/__init__.py", '"log.warn"'),
+        ("vendor/log/__init__.py", '"log.error"'),
+        ("vendor/log/__init__.pyi", "def info("),
+        ("vendor/log/__init__.pyi", "def debug("),
+        ("vendor/log/__init__.pyi", "def warn("),
+        ("vendor/log/__init__.pyi", "def error("),
+        ("baml/events/__init__.py", '"baml.events.send"'),
+        ("baml/events/__init__.pyi", "def send("),
+    ]
+
+    for rel_path, snippet in forbidden:
+        contents = _generated_sdk_file(rel_path)
+        assert contents is None or snippet not in contents

--- a/baml_language/sdk_tests/crates/typescript_node/function_calls/customizable/stdlib_entrypoints.test.ts
+++ b/baml_language/sdk_tests/crates/typescript_node/function_calls/customizable/stdlib_entrypoints.test.ts
@@ -2,9 +2,19 @@
 // different `FunctionKind`s are callable as entry points (directly from the
 // host), not only from inside BAML. Each gets its sync + `_async` binding.
 import "./baml_sdk/index.js";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import { trunc, trunc_async } from "./baml_sdk/baml/math/index.js";
 import { exists, exists_async } from "./baml_sdk/baml/fs/index.js";
+
+// Intrinsic-only modules are not emitted at all, so a missing file is fine;
+// callers only need to confirm the symbol is absent when the file exists.
+function generatedSdkFile(relPath: string): string | null {
+  const path = join(process.cwd(), "baml_sdk", relPath);
+  if (!existsSync(path)) return null;
+  return readFileSync(path, "utf8");
+}
 
 describe("function_calls — stdlib entry points", () => {
   // `baml.math.trunc(value: float) -> int` is a native `$rust_function`
@@ -22,5 +32,20 @@ describe("function_calls — stdlib entry points", () => {
   it("sysop baml.fs.exists is callable as an entry point", async () => {
     expect(exists(".")).toBe(true);
     expect(await exists_async(".")).toBe(true);
+  });
+
+  it("compiler intrinsics are not emitted as entry points", () => {
+    const forbidden: Array<[string, string]> = [
+      ["vendor/log/index.ts", "\"log.info\""],
+      ["vendor/log/index.ts", "\"log.debug\""],
+      ["vendor/log/index.ts", "\"log.warn\""],
+      ["vendor/log/index.ts", "\"log.error\""],
+      ["baml/events/index.ts", "\"baml.events.send\""],
+    ];
+
+    for (const [relPath, snippet] of forbidden) {
+      const contents = generatedSdkFile(relPath);
+      if (contents !== null) expect(contents).not.toContain(snippet);
+    }
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where internal compiler intrinsics were being included in generated Python and TypeScript SDKs, resulting in cleaner generated code.

* **Tests**
  * Added tests to verify compiler intrinsics are properly excluded from generated SDK files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->