### PR TITLE
minimal contextual const binding support

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -1535,7 +1535,8 @@ impl LoweringContext {
         }
     }
 
-    /// Lower a `BINDING_PATTERN` (`let WORD`). The parser routes `let _` to
+    /// Lower a `BINDING_PATTERN` (`let WORD` / `const WORD`). The parser routes
+    /// `let _` / `const _` to
     /// `WILDCARD_PATTERN` before it ever reaches here, so the WORD's text is
     /// never `_`. The only defensive case is a malformed `let` without a
     /// following WORD (parse error like `let = 1`), which we recover as
@@ -1634,9 +1635,10 @@ impl LoweringContext {
         self.alloc_pattern(Pattern::Type(ty), node.text_range())
     }
 
-    /// Lower a `DESTRUCTURE_PATTERN` (`(let)? PATH ('<' types '>')? '{' field_list '}'`).
+    /// Lower a `DESTRUCTURE_PATTERN` (`(let|const)? PATH ('<' types '>')? '{' field_list '}'`).
     fn lower_destructure_pattern(&mut self, node: &SyntaxNode) -> PatId {
-        // Path tokens live between (the optional) `KW_LET` and either
+        // Path tokens live between the optional binding introducer
+        // (`KW_LET`/`KW_CONST`) and either
         // `GENERIC_ARGS`, `TYPE_ARGS`, or `L_BRACE`.
         // Collect WORD tokens in that range, ignoring DOTs.
         let mut class: Vec<Name> = Vec::new();
@@ -3022,7 +3024,7 @@ impl LoweringContext {
 
     fn lower_let_stmt(&mut self, node: &SyntaxNode, is_watched: bool) -> StmtId {
         // LET_STMT shape (post-pattern-rewrite):
-        //   KW_WATCH? KW_LET? PATTERN EQUALS <init-expr> (KW_ELSE BLOCK_EXPR)? SEMICOLON?
+        //   KW_WATCH? (KW_LET|KW_CONST)? PATTERN EQUALS <init-expr> (KW_ELSE BLOCK_EXPR)? SEMICOLON?
         //
         // The pattern carries its own `: T` narrow as a Chain link, so all we
         // do here is locate the PATTERN child, the initialiser child, and an

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -357,6 +357,23 @@ impl LoweringContext {
         ctx
     }
 
+    fn warn_const_introducer(&mut self, span: TextRange) {
+        self.diags
+            .push(LoweringDiagnostic::ConstBindingIntroducer { span });
+    }
+
+    fn warn_direct_const_introducers(&mut self, node: &SyntaxNode) {
+        let spans: Vec<TextRange> = node
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .filter(|token| token.kind() == SyntaxKind::KW_CONST)
+            .map(|token| token.text_range())
+            .collect();
+        for span in spans {
+            self.warn_const_introducer(span);
+        }
+    }
+
     fn alloc_expr(&mut self, expr: Expr, range: TextRange) -> ExprId {
         let id = self.exprs.alloc(expr);
         self.source_map.expr_spans.alloc(range);
@@ -1182,6 +1199,8 @@ impl LoweringContext {
         // The scrutinee can appear as either a wrapper node (PATH_EXPR,
         // BINARY_EXPR, …) or as a bare token (single identifier / literal), so
         // we mirror `lower_if_expr` and walk children-with-tokens.
+        self.warn_direct_const_introducers(node);
+
         let mut pattern = None;
         let mut exprs: Vec<ExprId> = Vec::new();
         for elem in node.children_with_tokens() {
@@ -1230,6 +1249,8 @@ impl LoweringContext {
         // CST shape: `while let PATTERN = SCRUTINEE BODY_BLOCK`.
         // The first PATTERN node is the pattern; remaining children are
         // [0]=scrutinee, [1]=body (mirrors `lower_if_let_expr` minus else).
+        self.warn_direct_const_introducers(node);
+
         let mut pattern = None;
         let mut exprs: Vec<ExprId> = Vec::new();
         for elem in node.children_with_tokens() {
@@ -1499,6 +1520,8 @@ impl LoweringContext {
     /// `DESTRUCTURE_PATTERN`, `ARRAY_PATTERN`, `TYPE_PATTERN`,
     /// `PAREN_PATTERN`). Returns a fresh `PatId`.
     fn lower_pattern_atom_node(&mut self, node: &SyntaxNode) -> PatId {
+        self.warn_direct_const_introducers(node);
+
         match node.kind() {
             SyntaxKind::UNION_PATTERN => self.lower_union_pattern(node),
             SyntaxKind::BINDING_PATTERN => self.lower_binding_pattern(node),
@@ -1542,11 +1565,21 @@ impl LoweringContext {
     /// following WORD (parse error like `let = 1`), which we recover as
     /// wildcard.
     fn lower_binding_pattern(&mut self, node: &SyntaxNode) -> PatId {
-        let name = node
+        let name_token = node
             .children_with_tokens()
             .filter_map(rowan::NodeOrToken::into_token)
-            .find(|t| t.kind() == SyntaxKind::WORD)
-            .map(|t| Name::new(t.text()));
+            .find(|t| t.kind() == SyntaxKind::WORD);
+
+        if let Some(token) = &name_token
+            && token.text() == "const"
+        {
+            self.diags
+                .push(LoweringDiagnostic::ReservedConstBindingName {
+                    span: token.text_range(),
+                });
+        }
+
+        let name = name_token.map(|t| Name::new(t.text()));
 
         // The parser folds `: <pattern>` into BINDING_PATTERN as a
         // PATTERN child (any pattern).
@@ -3034,6 +3067,7 @@ impl LoweringContext {
         let mut else_branch = None;
         let mut seen_equals = false;
         let mut seen_else = false;
+        self.warn_direct_const_introducers(node);
 
         for elem in node.children_with_tokens() {
             match elem {
@@ -3237,6 +3271,7 @@ impl LoweringContext {
                 },
                 rowan::NodeOrToken::Node(child) => {
                     if !seen_in && binding_id.is_none() && child.kind() == SyntaxKind::LET_STMT {
+                        self.warn_direct_const_introducers(&child);
                         if let Some(pat_node) =
                             child.children().find(|n| n.kind() == SyntaxKind::PATTERN)
                         {

--- a/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
@@ -4,7 +4,7 @@
 //! boundary in `check_file()`.
 
 use baml_base::{FileId, Span};
-use baml_compiler_diagnostics::diagnostic::{Diagnostic, DiagnosticId, DiagnosticPhase};
+use baml_compiler_diagnostics::diagnostic::{Diagnostic, DiagnosticId, DiagnosticPhase, Severity};
 use text_size::TextRange;
 
 /// Diagnostic emitted during CST → AST lowering.
@@ -107,6 +107,13 @@ pub enum LoweringDiagnostic {
         span: TextRange,
     },
 
+    /// `const` currently parses as a non-immutable alias for `let`.
+    ConstBindingIntroducer { span: TextRange },
+
+    /// `const` is reserved as future language surface and cannot be used as a
+    /// binding name.
+    ReservedConstBindingName { span: TextRange },
+
     /// Top-level `implements I for T` where `T` does not match any class in the file.
     UnresolvedImplementsForTarget {
         interface_name: String,
@@ -137,21 +144,24 @@ impl LoweringDiagnostic {
     /// `file_id` is the file this diagnostic was produced in — needed to
     /// construct `Span` values from the stored `TextRange`s.
     pub fn to_diagnostic(&self, file_id: FileId) -> Diagnostic {
-        let (id, message, range, label) = match self {
+        let (id, severity, message, range, label) = match self {
             LoweringDiagnostic::MissingItemName { item_kind, span } => (
                 DiagnosticId::MissingName,
+                Severity::Error,
                 format!("{item_kind} is missing a name"),
                 *span,
                 "expected a name here",
             ),
             LoweringDiagnostic::MissingFieldName { class_name, span } => (
                 DiagnosticId::MissingName,
+                Severity::Error,
                 format!("field in class `{class_name}` is missing a name"),
                 *span,
                 "expected a field name",
             ),
             LoweringDiagnostic::UnparseableType { context, span } => (
                 DiagnosticId::UnparseableType,
+                Severity::Error,
                 format!("could not parse type expression for {context}"),
                 *span,
                 "unparseable type",
@@ -161,12 +171,14 @@ impl LoweringDiagnostic {
                 span,
             } => (
                 DiagnosticId::MissingName,
+                Severity::Error,
                 format!("parameter in function `{function_name}` is missing a name"),
                 *span,
                 "expected a parameter name",
             ),
             LoweringDiagnostic::UnsupportedParameterDefault { context, span } => (
                 DiagnosticId::InvalidSyntax,
+                Severity::Error,
                 format!("parameter defaults are not supported in {context}"),
                 *span,
                 "default value is not allowed here",
@@ -177,6 +189,7 @@ impl LoweringDiagnostic {
                 span,
             } => (
                 DiagnosticId::InvalidSyntax,
+                Severity::Error,
                 format!(
                     "LLM function `{function_name}` cannot declare a parameter named `{param_name}`; `client` is reserved for the compiler-injected LLM client override"
                 ),
@@ -185,12 +198,14 @@ impl LoweringDiagnostic {
             ),
             LoweringDiagnostic::MissingVariantName { enum_name, span } => (
                 DiagnosticId::MissingName,
+                Severity::Error,
                 format!("variant in enum `{enum_name}` is missing a name"),
                 *span,
                 "expected a variant name",
             ),
             LoweringDiagnostic::MalformedAttribute { context, span } => (
                 DiagnosticId::MalformedAttribute,
+                Severity::Error,
                 format!("attribute on {context} is missing a name"),
                 *span,
                 "malformed attribute",
@@ -201,6 +216,7 @@ impl LoweringDiagnostic {
                 span,
             } => (
                 DiagnosticId::MissingConfigKey,
+                Severity::Error,
                 format!("config entry in {block_kind} `{block_name}` is missing a key"),
                 *span,
                 "expected a key",
@@ -211,6 +227,7 @@ impl LoweringDiagnostic {
                 span,
             } => (
                 DiagnosticId::MissingConfigBlock,
+                Severity::Error,
                 format!("{block_kind} `{block_name}` is missing a required config block"),
                 *span,
                 "expected a config block",
@@ -221,6 +238,7 @@ impl LoweringDiagnostic {
                 span,
             } => (
                 DiagnosticId::UnknownProvider,
+                Severity::Error,
                 format!("unknown provider '{provider}'"),
                 *span,
                 "unknown provider",
@@ -231,12 +249,14 @@ impl LoweringDiagnostic {
                 span,
             } => (
                 DiagnosticId::MissingClientOptions,
+                Severity::Error,
                 message.clone(),
                 *span,
                 "missing options",
             ),
             LoweringDiagnostic::FieldAttributeInTypePosition { attr_name, span } => (
                 DiagnosticId::FieldAttributeInTypePosition,
+                Severity::Error,
                 format!(
                     "`@{attr_name}` is only allowed on class fields and enum variants; \
                      remove it here"
@@ -246,27 +266,45 @@ impl LoweringDiagnostic {
             ),
             LoweringDiagnostic::InvalidByteStringEscape { message, span } => (
                 DiagnosticId::InvalidByteStringEscape,
+                Severity::Error,
                 format!("invalid byte string literal: {message}"),
                 *span,
                 "invalid escape",
             ),
             LoweringDiagnostic::InstanceofRemoved { span } => (
                 DiagnosticId::InstanceofRemoved,
+                Severity::Error,
                 "`instanceof` is no longer supported. Use a `match` expression for type checking instead.".to_string(),
                 *span,
                 "use `match` instead",
             ),
             LoweringDiagnostic::VoidInNonReturnPosition { context, span } => (
                 DiagnosticId::VoidInNonReturnPosition,
+                Severity::Error,
                 format!("`void` can only be used as a function return type, not as {context}"),
                 *span,
                 "`void` not allowed here",
             ),
             LoweringDiagnostic::InvalidPatternAscription { reason, span } => (
                 DiagnosticId::TypeMismatch,
+                Severity::Error,
                 format!("invalid pattern type ascription: {reason}"),
                 *span,
                 "type ascription not allowed here",
+            ),
+            LoweringDiagnostic::ConstBindingIntroducer { span } => (
+                DiagnosticId::InvalidSyntax,
+                Severity::Warning,
+                "`const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.".to_string(),
+                *span,
+                "`const` behaves like `let` for now",
+            ),
+            LoweringDiagnostic::ReservedConstBindingName { span } => (
+                DiagnosticId::InvalidSyntax,
+                Severity::Error,
+                "`const` is reserved and cannot be used as a binding name".to_string(),
+                *span,
+                "`const` is reserved here",
             ),
             LoweringDiagnostic::UnresolvedImplementsForTarget {
                 interface_name,
@@ -274,12 +312,14 @@ impl LoweringDiagnostic {
                 span,
             } => (
                 DiagnosticId::UnknownType,
+                Severity::Error,
                 format!("`implements {interface_name} for {target_name}`: type `{target_name}` not found"),
                 *span,
                 "unknown target type",
             ),
             LoweringDiagnostic::InvalidImplementsForFieldsTarget { target_name, span } => (
                 DiagnosticId::TypeMismatch,
+                Severity::Error,
                 format!(
                     "`implements for {target_name}` cannot declare fields; only class targets can add interface fields"
                 ),
@@ -292,6 +332,7 @@ impl LoweringDiagnostic {
                 span,
             } => (
                 DiagnosticId::InterfaceFieldDeclaredInImplementsBlock,
+                Severity::Error,
                 format!(
                     "field `{field_name}` cannot be declared inside `implements {interface_name}`"
                 ),
@@ -300,7 +341,7 @@ impl LoweringDiagnostic {
             ),
         };
 
-        Diagnostic::error(id, message)
+        Diagnostic::new(id, severity, message)
             .with_primary(Span { file_id, range }, label)
             .with_phase(DiagnosticPhase::Hir)
     }

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -339,17 +339,28 @@ impl<'a> Parser<'a> {
         self.current_raw().map(|t| t.kind == kind).unwrap_or(false)
     }
 
-    /// Check if the current token is a `Word` with the given text.
-    /// Used for contextual keywords like `with` that should not be reserved globally.
-    fn at_contextual_kw(&self, kw: &str) -> bool {
-        self.current()
+    fn token_is_contextual_kw(token: Option<&Token>, kw: &str) -> bool {
+        token
             .map(|t| t.kind == TokenKind::Word && t.text == kw)
             .unwrap_or(false)
     }
 
-    /// Consume the current `Word("with")` token, re-labelling it as `KW_WITH`
-    /// in the syntax tree. Handles leading trivia just like [`Self::bump`].
-    fn bump_contextual_with(&mut self) {
+    /// Check if the current token is a `Word` with the given text.
+    /// Used for contextual keywords like `with` and binding-position `const`
+    /// that should not be reserved globally.
+    fn at_contextual_kw(&self, kw: &str) -> bool {
+        Self::token_is_contextual_kw(self.current(), kw)
+    }
+
+    fn peek_is_contextual_kw(&self, n: usize, kw: &str) -> bool {
+        Self::token_is_contextual_kw(self.peek(n), kw)
+    }
+
+    /// Consume the current contextual keyword token, re-labelling it as
+    /// `syntax_kind` in the syntax tree. Handles leading trivia just like
+    /// [`Self::bump`].
+    fn bump_contextual_kw_as(&mut self, kw: &str, syntax_kind: SyntaxKind) {
+        debug_assert!(self.at_contextual_kw(kw));
         // Emit leading trivia (whitespace, newlines, comments) before the keyword,
         // matching the same pattern as `bump_impl`.
         while self.current < self.tokens.len() {
@@ -372,13 +383,68 @@ impl<'a> Parser<'a> {
             }
             break;
         }
-        // Emit the Word("with") token as KW_WITH
+        // Emit the contextual Word token as the requested keyword kind.
         if self.current < self.tokens.len() {
             self.events.push(Event::Token {
-                kind: SyntaxKind::KW_WITH,
+                kind: syntax_kind,
                 text: self.tokens[self.current].text.clone(),
             });
             self.current += 1;
+        }
+    }
+
+    /// Consume the current `Word("with")` token, re-labelling it as `KW_WITH`
+    /// in the syntax tree.
+    fn bump_contextual_with(&mut self) {
+        self.bump_contextual_kw_as("with", SyntaxKind::KW_WITH);
+    }
+
+    fn binding_intro_follower(kind: Option<TokenKind>) -> bool {
+        matches!(kind, Some(TokenKind::Word | TokenKind::LBracket))
+    }
+
+    /// True at either `let` or contextual `const`.
+    fn at_binding_intro(&self) -> bool {
+        self.at(TokenKind::Let) || self.at_contextual_kw("const")
+    }
+
+    /// True for positions that dispatch to a binding statement or
+    /// statement-like binding head. `let` stays a real keyword; contextual
+    /// `const` only claims the position when a pattern-shaped token follows.
+    fn at_binding_intro_stmt(&self) -> bool {
+        self.at(TokenKind::Let)
+            || (self.at_contextual_kw("const")
+                && Self::binding_intro_follower(self.peek(1).map(|t| t.kind)))
+    }
+
+    fn at_binding_intro_pattern(&self) -> bool {
+        self.at(TokenKind::Let)
+            || (self.at_contextual_kw("const")
+                && Self::binding_intro_follower(self.peek(1).map(|t| t.kind)))
+    }
+
+    fn peek_is_binding_intro(&self, n: usize) -> bool {
+        self.peek(n).map(|t| t.kind) == Some(TokenKind::Let)
+            || self.peek_is_contextual_kw(n, "const")
+    }
+
+    fn peek_is_binding_intro_stmt(&self, n: usize) -> bool {
+        self.peek(n).map(|t| t.kind) == Some(TokenKind::Let)
+            || (self.peek_is_binding_intro(n)
+                && Self::binding_intro_follower(self.peek(n + 1).map(|t| t.kind)))
+    }
+
+    fn binding_intro_is_followed_by_array_pattern(&self) -> bool {
+        self.peek(1).map(|t| t.kind) == Some(TokenKind::LBracket)
+    }
+
+    fn bump_binding_intro(&mut self) {
+        if self.at(TokenKind::Let) {
+            self.bump();
+        } else if self.at_contextual_kw("const") {
+            self.bump_contextual_kw_as("const", SyntaxKind::KW_CONST);
+        } else {
+            self.error_unexpected_token("'let' or 'const'".to_string());
         }
     }
 
@@ -1061,11 +1127,11 @@ impl<'a> Parser<'a> {
 
     fn at_statement_recovery_boundary(&self) -> bool {
         self.at_top_level_keyword_except_client()
+            || self.at_binding_intro_stmt()
             || matches!(
                 self.current().map(|t| t.kind),
                 Some(
                     TokenKind::Watch
-                        | TokenKind::Let
                         | TokenKind::Return
                         | TokenKind::While
                         | TokenKind::For
@@ -3387,6 +3453,9 @@ impl<'a> Parser<'a> {
                 TokenKind::RBrace => brace_depth -= 1,
                 TokenKind::Word if brace_depth == 1 => {
                     let text = &token.text;
+                    if text == "const" {
+                        return false;
+                    }
                     if text == "client" || text == "prompt" {
                         return true;
                     }
@@ -3654,7 +3723,7 @@ impl<'a> Parser<'a> {
 
         if self.at(TokenKind::Watch) {
             self.parse_watch_let_stmt();
-        } else if self.at(TokenKind::Let) {
+        } else if self.at_binding_intro_stmt() {
             self.parse_let_stmt();
         } else if self.at(TokenKind::Return) {
             self.parse_return_stmt();
@@ -3707,11 +3776,11 @@ impl<'a> Parser<'a> {
             // itself is permissive (it parses any pattern shape, including
             // ones with no binding), so we enforce the `let` keyword here
             // before delegating. The keyword is consumed inside parse_pattern.
-            if !p.at(TokenKind::Let) {
+            if !p.at_binding_intro_stmt() {
                 p.error_unexpected_token("'let'".to_string());
             }
-            if p.peek(1).map(|t| t.kind) == Some(TokenKind::LBracket) {
-                p.bump(); // statement `let`
+            if p.binding_intro_is_followed_by_array_pattern() {
+                p.bump_binding_intro(); // statement-level binding introducer
                 p.parse_pattern();
             } else {
                 p.parse_pattern();
@@ -3757,11 +3826,11 @@ impl<'a> Parser<'a> {
         self.with_node(SyntaxKind::WATCH_LET, |p| {
             p.expect(TokenKind::Watch);
             // Same invariant as parse_let_stmt: pattern must start with `let`.
-            if !p.at(TokenKind::Let) {
+            if !p.at_binding_intro_stmt() {
                 p.error_unexpected_token("'let'".to_string());
             }
-            if p.peek(1).map(|t| t.kind) == Some(TokenKind::LBracket) {
-                p.bump(); // statement `let`
+            if p.binding_intro_is_followed_by_array_pattern() {
+                p.bump_binding_intro(); // statement-level binding introducer
                 p.parse_pattern();
             } else {
                 p.parse_pattern();
@@ -3840,7 +3909,7 @@ impl<'a> Parser<'a> {
         // Decided here by peeking past `if` for a `let` token — patterns
         // always start with `let` (BAML's binding marker), and no normal
         // expression starts with `let`, so this is unambiguous.
-        if self.peek(1).map(|t| t.kind) == Some(TokenKind::Let) {
+        if self.peek_is_binding_intro_stmt(1) {
             self.parse_if_let_expr();
             return;
         }
@@ -3894,11 +3963,11 @@ impl<'a> Parser<'a> {
             // `let` keyword has to be consumed at the statement level
             // because `parse_let_pattern` only handles binding /
             // destructure shapes after `let`. Mirrors `parse_let_stmt`.
-            if p.peek(1).map(|t| t.kind) == Some(TokenKind::LBracket) {
-                p.bump(); // statement `let`
+            if p.binding_intro_is_followed_by_array_pattern() {
+                p.bump_binding_intro(); // statement-level binding introducer
                 p.parse_pattern();
             } else {
-                // `let` is consumed inside parse_pattern → parse_let_pattern.
+                // The introducer is consumed inside parse_pattern → parse_let_pattern.
                 p.parse_pattern();
             }
 
@@ -4112,7 +4181,7 @@ impl<'a> Parser<'a> {
             return;
         }
 
-        if self.at(TokenKind::Let) {
+        if self.at_binding_intro_pattern() {
             self.parse_let_pattern();
             return;
         }
@@ -4261,7 +4330,7 @@ impl<'a> Parser<'a> {
                     | TokenKind::Less
                     | TokenKind::Let
             )
-        )
+        ) || self.at_contextual_kw("const")
     }
 
     /// Look ahead from the current position (which should be at `WORD`) past
@@ -4360,14 +4429,14 @@ impl<'a> Parser<'a> {
         None
     }
 
-    /// Parse a `let`-prefixed pattern. Either:
-    /// - `let _`           — `WILDCARD_PATTERN`
-    /// - `let WORD`        — simple `BINDING_PATTERN`
-    /// - `let PATH { fields }` — `DESTRUCTURE_PATTERN` with a `let` prefix
+    /// Parse a binding-introducer-prefixed pattern. Either:
+    /// - `let _` / `const _` — `WILDCARD_PATTERN`
+    /// - `let WORD` / `const WORD` — simple `BINDING_PATTERN`
+    /// - `let PATH { fields }` / `const PATH { fields }` — `DESTRUCTURE_PATTERN`
     fn parse_let_pattern(&mut self) {
-        debug_assert!(self.at(TokenKind::Let));
+        debug_assert!(self.at_binding_intro());
         let start = self.events.len();
-        self.bump(); // let
+        self.bump_binding_intro();
 
         if !self.at(TokenKind::Word) {
             self.error_unexpected_token("identifier after 'let'".to_string());
@@ -4719,7 +4788,7 @@ impl<'a> Parser<'a> {
         // always start with `let` (BAML's binding marker), and no normal
         // expression starts with `let`, so this is unambiguous. Mirrors
         // `parse_if_expr`'s `if` vs `if let` decision.
-        if self.peek(1).map(|t| t.kind) == Some(TokenKind::Let) {
+        if self.peek_is_binding_intro_stmt(1) {
             self.parse_while_let_stmt();
             return;
         }
@@ -4755,11 +4824,11 @@ impl<'a> Parser<'a> {
             // the `let` keyword has to be consumed at the statement level
             // because `parse_let_pattern` only handles binding / destructure
             // shapes after `let`. Mirrors `parse_if_let_expr`.
-            if p.peek(1).map(|t| t.kind) == Some(TokenKind::LBracket) {
-                p.bump(); // statement `let`
+            if p.binding_intro_is_followed_by_array_pattern() {
+                p.bump_binding_intro(); // statement-level binding introducer
                 p.parse_pattern();
             } else {
-                // `let` is consumed inside parse_pattern → parse_let_pattern.
+                // The introducer is consumed inside parse_pattern → parse_let_pattern.
                 p.parse_pattern();
             }
 
@@ -4792,12 +4861,12 @@ impl<'a> Parser<'a> {
                 p.bump(); // (
 
                 // Check if this is iterator-style: for (let var in expr) or C-style: for (init; cond; update)
-                if p.at(TokenKind::Let) {
+                if p.at_binding_intro_stmt() {
                     // Peek ahead to check if this is iterator-style (has 'in' keyword)
-                    // For iterator-style: for (let i in expr)
-                    // For C-style: for (let i = 0; ...)
+                    // For iterator-style: for (let i in expr) / for (const i in expr)
+                    // For C-style: for (let i = 0; ...) / for (const i = 0; ...)
                     if p.looks_like_for_in_loop() {
-                        // Iterator-style: for (let var in expr)
+                        // Iterator-style: for (let var in expr) / for (const var in expr)
                         p.parse_for_in_pattern();
                         p.expect(TokenKind::In);
                         p.parse_expr(); // iterator expression
@@ -4851,7 +4920,8 @@ impl<'a> Parser<'a> {
         });
     }
 
-    /// Check if this looks like a for-in loop. We're at `let`. Scan forward
+    /// Check if this looks like a for-in loop. We're at a binding introducer.
+    /// Scan forward
     /// past the (possibly complex) pattern that follows: bindings, paths,
     /// destructures (`{ ... }`), parenthesised groups, type annotations
     /// after `:`. Whichever of `in` / `=` / `;` we hit at the top level
@@ -4861,9 +4931,9 @@ impl<'a> Parser<'a> {
     /// Uses a stack of expected closers so out-of-order delimiters (e.g.
     /// `( [ ) ]`) bail out rather than mis-classify.
     fn looks_like_for_in_loop(&self) -> bool {
-        debug_assert!(self.at(TokenKind::Let));
+        debug_assert!(self.at_binding_intro());
         let mut stack: Vec<TokenKind> = Vec::new();
-        let mut i: usize = 1; // start after `let`
+        let mut i: usize = 1; // start after the binding introducer
         loop {
             let Some(tok) = self.peek(i) else {
                 return false;
@@ -4915,12 +4985,12 @@ impl<'a> Parser<'a> {
     fn parse_for_in_pattern(&mut self) {
         self.with_node(SyntaxKind::LET_STMT, |p| {
             // For-in pattern shares the let-statement shape: must start with
-            // `let`. No initializer.
-            if !p.at(TokenKind::Let) {
+            // `let`/`const`. No initializer.
+            if !p.at_binding_intro_stmt() {
                 p.error_unexpected_token("'let'".to_string());
             }
-            if p.peek(1).map(|t| t.kind) == Some(TokenKind::LBracket) {
-                p.bump(); // statement `let`
+            if p.binding_intro_is_followed_by_array_pattern() {
+                p.bump_binding_intro(); // statement-level binding introducer
                 p.parse_pattern();
             } else {
                 p.parse_pattern();
@@ -7010,7 +7080,7 @@ fn parse_impl(tokens: &[Token], cache: Option<&mut NodeCache>) -> (GreenNode, Ve
             && parser.current().map(|t| t.text == "type").unwrap_or(false)
         {
             parser.parse_type_alias();
-        } else if parser.at(TokenKind::Let) {
+        } else if parser.at_binding_intro_stmt() {
             parser.parse_let_stmt();
         } else if parser.at_header_comment_start() {
             parser.consume_header_comment();
@@ -7130,6 +7200,106 @@ mod tests {
         let source = "function main() -> bigint { 42n }";
         let (_root, errors) = parse_source(source);
         assert_no_errors(&errors);
+    }
+
+    #[test]
+    fn const_bindings_parse_as_existing_binding_shapes() {
+        let source = r#"
+function Demo(user: User, xs: int[], value: int | string, items: int[]) -> int {
+  const x = 1;
+  const y: int = x;
+  const _ = y;
+  const User { name } = user;
+  const [first] = xs;
+  if const narrowed: int = value {
+    narrowed
+  } else {
+    0
+  };
+  while const loop_value: int = value {
+    break;
+  }
+  for (const i = 0; i < 3; i += 1) {
+    x += i;
+  }
+  for (const item in items) {
+    x += item;
+  }
+  for const item in items {
+    x += item;
+  }
+  x
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let const_keywords = root
+            .descendants_with_tokens()
+            .filter(|elem| {
+                matches!(
+                    elem,
+                    rowan::NodeOrToken::Token(token) if token.kind() == SyntaxKind::KW_CONST
+                )
+            })
+            .count();
+        assert_eq!(const_keywords, 10);
+
+        assert!(
+            root.descendants()
+                .any(|node| node.kind() == SyntaxKind::IF_LET_EXPR),
+            "`if const` should keep using IF_LET_EXPR"
+        );
+        assert!(
+            root.descendants()
+                .any(|node| node.kind() == SyntaxKind::WHILE_LET_STMT),
+            "`while const` should keep using WHILE_LET_STMT"
+        );
+        assert!(
+            root.descendants()
+                .any(|node| node.kind() == SyntaxKind::WILDCARD_PATTERN),
+            "`const _` should keep using WILDCARD_PATTERN"
+        );
+        assert!(
+            root.descendants()
+                .any(|node| node.kind() == SyntaxKind::DESTRUCTURE_PATTERN),
+            "`const User {{ ... }}` should keep using DESTRUCTURE_PATTERN"
+        );
+        assert!(
+            root.descendants()
+                .any(|node| node.kind() == SyntaxKind::ARRAY_PATTERN),
+            "`const [x]` should keep using ARRAY_PATTERN"
+        );
+    }
+
+    #[test]
+    fn const_remains_identifier_after_let() {
+        let source = r#"
+function Demo() -> int {
+  let const = 1;
+  const
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        assert!(
+            root.descendants_with_tokens().all(|elem| {
+                !matches!(
+                    elem,
+                    rowan::NodeOrToken::Token(token) if token.kind() == SyntaxKind::KW_CONST
+                )
+            }),
+            "`let const = 1` should not emit contextual KW_CONST"
+        );
+        let has_const_word = root.descendants_with_tokens().any(|elem| {
+            matches!(
+                elem,
+                rowan::NodeOrToken::Token(token)
+                    if token.kind() == SyntaxKind::WORD && token.text() == "const"
+            )
+        });
+        assert!(has_const_word, "`const` should remain a WORD binding name");
     }
 
     #[test]

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -7273,36 +7273,6 @@ function Demo(user: User, xs: int[], value: int | string, items: int[]) -> int {
     }
 
     #[test]
-    fn const_remains_identifier_after_let() {
-        let source = r#"
-function Demo() -> int {
-  let const = 1;
-  const
-}
-"#;
-        let (root, errors) = parse_source(source);
-        assert_no_errors(&errors);
-
-        assert!(
-            root.descendants_with_tokens().all(|elem| {
-                !matches!(
-                    elem,
-                    rowan::NodeOrToken::Token(token) if token.kind() == SyntaxKind::KW_CONST
-                )
-            }),
-            "`let const = 1` should not emit contextual KW_CONST"
-        );
-        let has_const_word = root.descendants_with_tokens().any(|elem| {
-            matches!(
-                elem,
-                rowan::NodeOrToken::Token(token)
-                    if token.kind() == SyntaxKind::WORD && token.text() == "const"
-            )
-        });
-        assert!(has_const_word, "`const` should remain a WORD binding name");
-    }
-
-    #[test]
     fn is_class_in_condition_does_not_eat_then_block() {
         // Regression: `if x is Class { body }` used to be parsed as
         // `if x is Class { body }` where `{ body }` was the destructure

--- a/baml_language/crates/baml_compiler_syntax/src/syntax_kind.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/syntax_kind.rs
@@ -31,6 +31,7 @@ pub enum SyntaxKind {
     KW_FOR,
     KW_WHILE,
     KW_LET,
+    KW_CONST,
     KW_IN,
     KW_BREAK,
     KW_CONTINUE,
@@ -500,6 +501,7 @@ impl SyntaxKind {
                 | Self::KW_FOR
                 | Self::KW_WHILE
                 | Self::KW_LET
+                | Self::KW_CONST
                 | Self::KW_IN
                 | Self::KW_BREAK
                 | Self::KW_CONTINUE

--- a/baml_language/crates/baml_fmt/src/ast/pattern.rs
+++ b/baml_language/crates/baml_fmt/src/ast/pattern.rs
@@ -87,6 +87,15 @@ fn print_trivia_squished_spaced(
     trivia_len
 }
 
+fn print_binding_keyword_with_trailing_trivia(printer: &mut Printer, keyword: &t::BindingKeyword) {
+    printer.print_raw_token(keyword);
+    printer.print_str(" ");
+    let (_, trailing) = printer.trivia.get_for_range_split(keyword.span());
+    if print_trivia_squished_spaced(printer, trailing, false, false) > 0 {
+        printer.print_str(" ");
+    }
+}
+
 /// Top-level pattern AST node — corresponds to a [`SyntaxKind::PATTERN`].
 #[derive(Debug)]
 pub enum MatchPattern {
@@ -215,8 +224,7 @@ impl WildcardPattern {
 impl Printable for WildcardPattern {
     fn print(&self, _shape: Shape, printer: &mut Printer) -> PrintInfo {
         if let Some(let_kw) = &self.let_keyword {
-            printer.print_raw_token(let_kw);
-            printer.print_str(" ");
+            print_binding_keyword_with_trailing_trivia(printer, let_kw);
         }
         printer.print_raw_token(&self.underscore);
         PrintInfo::default_single_line()
@@ -268,8 +276,7 @@ impl BindingPattern {
 
 impl Printable for BindingPattern {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
-        printer.print_raw_token(&self.let_keyword);
-        printer.print_str(" ");
+        print_binding_keyword_with_trailing_trivia(printer, &self.let_keyword);
         printer.print_raw_token(&self.name);
         let mut info = PrintInfo::default_single_line();
         if let Some((colon, pattern)) = &self.subpat {
@@ -405,8 +412,7 @@ impl DestructurePattern {
 
     fn print_path(&self, printer: &mut Printer) {
         if let Some(let_kw) = &self.let_keyword {
-            printer.print_raw_token(let_kw);
-            printer.print_str(" ");
+            print_binding_keyword_with_trailing_trivia(printer, let_kw);
         }
         printer.print_raw_token(&self.first);
         for (dot, word) in &self.rest {

--- a/baml_language/crates/baml_fmt/src/ast/pattern.rs
+++ b/baml_language/crates/baml_fmt/src/ast/pattern.rs
@@ -188,10 +188,10 @@ impl Printable for MatchPattern {
 
 // ─── Atoms ────────────────────────────────────────────────────────────────────
 
-/// `_` or `let _`.
+/// `_`, `let _`, or `const _`.
 #[derive(Debug)]
 pub struct WildcardPattern {
-    pub let_keyword: Option<t::Let>,
+    pub let_keyword: Option<t::BindingKeyword>,
     pub underscore: t::Word,
 }
 
@@ -199,8 +199,8 @@ impl WildcardPattern {
     fn from_node(node: &baml_db::baml_compiler_syntax::SyntaxNode) -> Result<Self, StrongAstError> {
         let mut it = SyntaxNodeIter::new(node);
         let let_keyword = it
-            .next_if_kind(SyntaxKind::KW_LET)
-            .map(t::Let::from_cst)
+            .next_if(|elem| matches!(elem.kind(), SyntaxKind::KW_LET | SyntaxKind::KW_CONST))
+            .map(t::BindingKeyword::from_cst)
             .transpose()?;
         let underscore_elem = it.expect_next("`_`")?;
         let underscore = t::Word::from_cst(underscore_elem)?;
@@ -232,7 +232,7 @@ impl Printable for WildcardPattern {
     }
 }
 
-/// `let WORD` or `let WORD : <pattern>` — name binding with an optional
+/// `let WORD`/`const WORD` or `let WORD : <pattern>`/`const WORD : <pattern>` — name binding with an optional
 /// sub-pattern. The sub-pattern can be a type ascription (`let x: int`),
 /// another binding (`let x: let y`), a structural destructure
 /// (`let x: [a, b]`, `let x: Class { f }`), etc. The parser folds the
@@ -240,7 +240,7 @@ impl Printable for WildcardPattern {
 /// (no `CHAIN_PATTERN` wrapper).
 #[derive(Debug)]
 pub struct BindingPattern {
-    pub let_keyword: t::Let,
+    pub let_keyword: t::BindingKeyword,
     pub name: t::Word,
     pub subpat: Option<(t::Colon, Box<MatchPattern>)>,
 }
@@ -248,7 +248,7 @@ pub struct BindingPattern {
 impl BindingPattern {
     fn from_node(node: &baml_db::baml_compiler_syntax::SyntaxNode) -> Result<Self, StrongAstError> {
         let mut it = SyntaxNodeIter::new(node);
-        let let_keyword = it.expect_parse()?;
+        let let_keyword = t::BindingKeyword::from_cst(it.expect_next("binding introducer")?)?;
         let name = it.expect_parse()?;
         let subpat = if let Some(colon_elem) = it.next_if_kind(SyntaxKind::COLON) {
             let colon = t::Colon::from_cst(colon_elem)?;
@@ -297,10 +297,10 @@ impl Printable for BindingPattern {
     }
 }
 
-/// `(let)? path.Class { field, renamed: <pattern>, ... }`.
+/// `(let|const)? path.Class { field, renamed: <pattern>, ... }`.
 #[derive(Debug)]
 pub struct DestructurePattern {
-    pub let_keyword: Option<t::Let>,
+    pub let_keyword: Option<t::BindingKeyword>,
     pub first: t::Word,
     pub rest: Vec<(t::Dot, t::Word)>,
     pub generic_args: Option<DestructureTypeArgs>,
@@ -356,8 +356,8 @@ impl DestructurePattern {
     fn from_node(node: &baml_db::baml_compiler_syntax::SyntaxNode) -> Result<Self, StrongAstError> {
         let mut it = SyntaxNodeIter::new(node);
         let let_keyword = it
-            .next_if_kind(SyntaxKind::KW_LET)
-            .map(t::Let::from_cst)
+            .next_if(|elem| matches!(elem.kind(), SyntaxKind::KW_LET | SyntaxKind::KW_CONST))
+            .map(t::BindingKeyword::from_cst)
             .transpose()?;
         let first = it.expect_parse()?;
         let mut rest = Vec::new();

--- a/baml_language/crates/baml_fmt/src/ast/statements.rs
+++ b/baml_language/crates/baml_fmt/src/ast/statements.rs
@@ -182,16 +182,16 @@ impl Printable for ExpressionStmt {
 
 /// Corresponds to a [`SyntaxKind::LET_STMT`] node or a [`SyntaxKind::WATCH_LET`] node.
 ///
-/// Post-pattern-rewrite shape: `KW_WATCH? KW_LET? PATTERN EQUALS? <expr>? (KW_ELSE BLOCK_EXPR)? SEMICOLON?`.
-/// Simple bindings carry `let` inside the [`super::MatchPattern`] (e.g.
+/// Post-pattern-rewrite shape: `KW_WATCH? (KW_LET|KW_CONST)? PATTERN EQUALS? <expr>? (KW_ELSE BLOCK_EXPR)? SEMICOLON?`.
+/// Simple bindings carry the introducer inside the [`super::MatchPattern`] (e.g.
 /// `let x: int` parses as a `Chain([Bind, Type])`). Array destructuring uses
-/// the statement-level `let` before an `ARRAY_PATTERN`. The optional
+/// the statement-level introducer before an `ARRAY_PATTERN`. The optional
 /// `else BLOCK_EXPR` tail is the `let … else` form: a refutable binding
 /// whose else branch must diverge.
 #[derive(Debug)]
 pub struct LetStmt {
     pub watch: Option<t::Watch>,
-    pub let_keyword: Option<t::Let>,
+    pub let_keyword: Option<t::BindingKeyword>,
     pub pattern: super::MatchPattern,
     pub initializer: Option<(t::Equals, Expression)>,
     /// `else { … }` tail for `let … else`. None for plain `let`. Boxed
@@ -223,8 +223,8 @@ impl FromCST for LetStmt {
         };
 
         let let_keyword = it
-            .next_if_kind(SyntaxKind::KW_LET)
-            .map(t::Let::from_cst)
+            .next_if(|elem| matches!(elem.kind(), SyntaxKind::KW_LET | SyntaxKind::KW_CONST))
+            .map(t::BindingKeyword::from_cst)
             .transpose()?;
 
         let pattern: super::MatchPattern = it.expect_parse()?;
@@ -271,7 +271,7 @@ impl Printable for LetStmt {
         if let Some(let_keyword) = &self.let_keyword {
             printer.print_raw_token(let_keyword);
             printer.print_str(" ");
-            // Preserve trivia between `let` and the pattern — e.g.
+            // Preserve trivia between the introducer and the pattern — e.g.
             // `let /*keep*/ [x]` would otherwise lose the comment.
             let (_, let_trailing) = printer.trivia.get_for_range_split(let_keyword.span());
             if printer.print_trivia_squished(let_trailing) > 0 {
@@ -427,12 +427,13 @@ impl Printable for WhileStmt {
 #[derive(Debug)]
 pub struct WhileLetStmt {
     pub keyword: t::While,
-    /// Standalone leading `let`, present only for top-level array-pattern heads
-    /// (`while let [x] = xs`), where the parser keeps `let` at the statement
-    /// level instead of inside the pattern. For binding / class / type heads the
-    /// `let` lives inside `pattern` and this is `None`. Mirrors
+    /// Standalone leading binding introducer, present only for top-level
+    /// array-pattern heads (`while let [x] = xs`), where the parser keeps the
+    /// introducer at the statement level instead of inside the pattern. For
+    /// binding / class / type heads the introducer lives inside `pattern` and
+    /// this is `None`. Mirrors
     /// `LetStmt::let_keyword`.
-    pub let_keyword: Option<t::Let>,
+    pub let_keyword: Option<t::BindingKeyword>,
     pub pattern: MatchPattern,
     pub equals: t::Equals,
     pub scrutinee: Box<Expression>,
@@ -449,11 +450,11 @@ impl FromCST for WhileLetStmt {
         // KW_WHILE
         let keyword = it.expect_parse()?;
 
-        // Optional standalone KW_LET for top-level array-pattern heads
+        // Optional standalone KW_LET/KW_CONST for top-level array-pattern heads
         // (`while let [x] = xs`); for other heads `let` is inside the pattern.
         let let_keyword = it
-            .next_if_kind(SyntaxKind::KW_LET)
-            .map(t::Let::from_cst)
+            .next_if(|elem| matches!(elem.kind(), SyntaxKind::KW_LET | SyntaxKind::KW_CONST))
+            .map(t::BindingKeyword::from_cst)
             .transpose()?;
 
         // PATTERN (carries its own leading `let` unless consumed above)

--- a/baml_language/crates/baml_fmt/src/ast/statements.rs
+++ b/baml_language/crates/baml_fmt/src/ast/statements.rs
@@ -499,6 +499,10 @@ impl Printable for WhileLetStmt {
         if let Some(let_keyword) = &self.let_keyword {
             printer.print_raw_token(let_keyword);
             printer.print_str(" ");
+            let (_, trailing) = printer.trivia.get_for_range_split(let_keyword.span());
+            if printer.print_trivia_squished(trailing) > 0 {
+                printer.print_str(" ");
+            }
         }
         printer.print(&self.pattern, shape.clone());
         printer.print_str(" ");

--- a/baml_language/crates/baml_fmt/src/ast/tokens.rs
+++ b/baml_language/crates/baml_fmt/src/ast/tokens.rs
@@ -73,6 +73,7 @@ define_keyword_tokens! {
     "for" => SyntaxKind::KW_FOR => For;
     "while" => SyntaxKind::KW_WHILE => While;
     "let" => SyntaxKind::KW_LET => Let;
+    "const" => SyntaxKind::KW_CONST => Const;
     "in" => SyntaxKind::KW_IN => In;
     "break" => SyntaxKind::KW_BREAK => Break;
     "continue" => SyntaxKind::KW_CONTINUE => Continue;
@@ -84,6 +85,44 @@ define_keyword_tokens! {
     "dynamic" => SyntaxKind::KW_DYNAMIC => Dynamic;
     "with" => SyntaxKind::KW_WITH => With;
     "throws" => SyntaxKind::KW_THROWS => Throws;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BindingKeyword {
+    Let(Let),
+    Const(Const),
+}
+
+impl Token for BindingKeyword {
+    fn span(&self) -> TextRange {
+        match self {
+            Self::Let(token) => token.span(),
+            Self::Const(token) => token.span(),
+        }
+    }
+}
+
+impl FromCST for BindingKeyword {
+    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
+        match elem.kind() {
+            SyntaxKind::KW_LET => Ok(Self::Let(Let::from_cst(elem)?)),
+            SyntaxKind::KW_CONST => Ok(Self::Const(Const::from_cst(elem)?)),
+            found => Err(StrongAstError::UnexpectedKindDesc {
+                expected_desc: "KW_LET or KW_CONST".into(),
+                found,
+                at: elem.text_range(),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for BindingKeyword {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Let(token) => token.fmt(f),
+            Self::Const(token) => token.fmt(f),
+        }
+    }
 }
 
 pub trait PunctuationToken: Token {}

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -580,4 +580,28 @@ mod const_format_tests {
         let source = "function f(items: int[]) -> int {\n    const sum = 0;\n    for (const item in items) {\n        sum += item;\n    }\n    sum\n}\n";
         assert_formats_to(source, source);
     }
+
+    #[test]
+    fn test_const_binding_keyword_trailing_trivia_preserved() {
+        let source = "function f() -> int {\n    const /*keep*/ x = 1;\n    x\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_const_wildcard_keyword_trailing_trivia_preserved() {
+        let source = "function f() -> int {\n    const /*keep*/ _ = 1;\n    0\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_const_destructure_keyword_trailing_trivia_preserved() {
+        let source = "class Foo {\n    a: int,\n}\n\nfunction f(foo: Foo) -> int {\n    const /*keep*/ Foo { a } = foo;\n    a\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_while_const_array_keyword_trailing_trivia_preserved() {
+        let source = "function f(xs: int[]) -> int {\n    while const /*keep*/ [x] = xs {\n        break;\n    }\n    0\n}\n";
+        assert_formats_to(source, source);
+    }
 }

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -523,3 +523,61 @@ mod while_let_format_tests {
         assert_formats_to(source, source);
     }
 }
+
+#[cfg(test)]
+mod const_format_tests {
+    use super::*;
+
+    fn assert_formats_to(source: &str, expected: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed on `const`");
+        assert_eq!(
+            formatted, expected,
+            "formatter output didn't match expected\n--- got ---\n{formatted}\n--- want ---\n{expected}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    #[test]
+    fn test_const_basic_binding() {
+        let source = "function f() -> int {\n    const x = 1;\n    x\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_const_typed_binding() {
+        let source = "function f() -> int {\n    const x: int = 1;\n    x\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_const_array_pattern() {
+        let source = "function f(xs: int[]) -> int {\n    const [x] = xs;\n    x\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_if_const_binding() {
+        let source = "function f(value: int | string) -> int {\n    if const x: int = value {\n        x\n    } else {\n        0\n    }\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_while_const_binding() {
+        let source = "function f(value: int | string) -> int {\n    while const x: int = value {\n        break;\n    }\n    0\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_for_const_c_style() {
+        let source = "function f() -> int {\n    const sum = 0;\n    for (const i = 0; i < 3; i += 1) {\n        sum += i;\n    }\n    sum\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_for_const_iterator() {
+        let source = "function f(items: int[]) -> int {\n    const sum = 0;\n    for (const item in items) {\n        sum += item;\n    }\n    sum\n}\n";
+        assert_formats_to(source, source);
+    }
+}

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/const_binding.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/const_binding.baml
@@ -1,0 +1,22 @@
+function ConstToken() -> int {
+  const x = 1;
+  let const = x;
+  const
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- semantic_tokens
+// const_binding.baml:1:1 (keyword) len=8 "function"
+// const_binding.baml:1:10 (function) len=10 "ConstToken"
+// const_binding.baml:1:26 (type) len=3 "int"
+// const_binding.baml:2:3 (keyword) len=5 "const"
+// const_binding.baml:2:9 (variable) len=1 "x"
+// const_binding.baml:2:11 (operator) len=1 "="
+// const_binding.baml:2:13 (number) len=1 "1"
+// const_binding.baml:3:3 (keyword) len=3 "let"
+// const_binding.baml:3:7 (variable) len=5 "const"
+// const_binding.baml:3:13 (operator) len=1 "="
+// const_binding.baml:3:15 (variable) len=1 "x"

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/const_binding.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/const_binding.baml
@@ -6,7 +6,24 @@ function ConstToken() -> int {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//    ╭─[ const_binding.baml:2:3 ]
+//    │
+//  2 │   const x = 1;
+//    │   ──┬──  
+//    │     ╰──── `const` behaves like `let` for now
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
+// error: `const` is reserved and cannot be used as a binding name
+//    ╭─[ const_binding.baml:3:7 ]
+//    │
+//  3 │   let const = x;
+//    │       ──┬──  
+//    │         ╰──── `const` is reserved here
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
 //
 //- semantic_tokens
 // const_binding.baml:1:1 (keyword) len=8 "function"

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/const_binding.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/const_binding.baml
@@ -1,0 +1,24 @@
+class User {
+  name string
+  age int
+}
+
+function ConstBindings(user: User, value: int | string) -> int {
+  const x = 1;
+  x = 2;
+  const y: int = x;
+  const User { age } = user;
+  const shadowed = if (true) {
+    const x = age;
+    x
+  } else {
+    0
+  };
+  const n: int = value else { return 0; };
+  let const = y;
+  const + shadowed + n
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/const_binding.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/const_binding.baml
@@ -21,4 +21,66 @@ function ConstBindings(user: User, value: int | string) -> int {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//    ╭─[ expr_const_binding.baml:7:3 ]
+//    │
+//  7 │   const x = 1;
+//    │   ──┬──  
+//    │     ╰──── `const` behaves like `let` for now
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//    ╭─[ expr_const_binding.baml:9:3 ]
+//    │
+//  9 │   const y: int = x;
+//    │   ──┬──  
+//    │     ╰──── `const` behaves like `let` for now
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//     ╭─[ expr_const_binding.baml:10:3 ]
+//     │
+//  10 │   const User { age } = user;
+//     │   ──┬──  
+//     │     ╰──── `const` behaves like `let` for now
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//     ╭─[ expr_const_binding.baml:11:3 ]
+//     │
+//  11 │   const shadowed = if (true) {
+//     │   ──┬──  
+//     │     ╰──── `const` behaves like `let` for now
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//     ╭─[ expr_const_binding.baml:12:5 ]
+//     │
+//  12 │     const x = age;
+//     │     ──┬──  
+//     │       ╰──── `const` behaves like `let` for now
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//     ╭─[ expr_const_binding.baml:17:3 ]
+//     │
+//  17 │   const n: int = value else { return 0; };
+//     │   ──┬──  
+//     │     ╰──── `const` behaves like `let` for now
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// error: `const` is reserved and cannot be used as a binding name
+//     ╭─[ expr_const_binding.baml:18:7 ]
+//     │
+//  18 │   let const = y;
+//     │       ──┬──  
+//     │         ╰──── `const` is reserved here
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/const_reserved_binding_names.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/const_reserved_binding_names.baml
@@ -1,0 +1,132 @@
+class Box {
+  value int
+}
+
+class WithConstField {
+  const int
+}
+
+function ConstConst() -> int {
+  const const = 1;
+  const
+}
+
+function DestructureReservedName(box: Box) -> int {
+  let Box { value: let const } = box;
+  0
+}
+
+function MatchReservedName(value: int | string) -> int {
+  match (value) {
+    let const: int => 1,
+    _ => 0
+  }
+}
+
+function ForIteratorReservedName(items: int[]) -> int {
+  let total = 0;
+  for (let const in items) {
+    total += const;
+  }
+  total
+}
+
+function ForCStyleReservedName() -> int {
+  let total = 0;
+  for (let const = 0; const < 1; const += 1) {
+    total += const;
+  }
+  total
+}
+
+function IfWhileConstArrays(items: int[]) -> int {
+  let total = 0;
+  if const [let x] = items {
+    total += x;
+  } else {
+    total += 0;
+  };
+  while const [let y] = items {
+    break;
+  }
+  total
+}
+
+function NonBindingConstField(record: WithConstField) -> int {
+  record.const
+}
+
+//----
+//- diagnostics
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//     ╭─[ expr_const_reserved_binding_names.baml:10:3 ]
+//     │
+//  10 │   const const = 1;
+//     │   ──┬──  
+//     │     ╰──── `const` behaves like `let` for now
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// error: `const` is reserved and cannot be used as a binding name
+//     ╭─[ expr_const_reserved_binding_names.baml:10:9 ]
+//     │
+//  10 │   const const = 1;
+//     │         ──┬──  
+//     │           ╰──── `const` is reserved here
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// error: `const` is reserved and cannot be used as a binding name
+//     ╭─[ expr_const_reserved_binding_names.baml:15:24 ]
+//     │
+//  15 │   let Box { value: let const } = box;
+//     │                        ──┬──  
+//     │                          ╰──── `const` is reserved here
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// error: `const` is reserved and cannot be used as a binding name
+//     ╭─[ expr_const_reserved_binding_names.baml:21:9 ]
+//     │
+//  21 │     let const: int => 1,
+//     │         ──┬──  
+//     │           ╰──── `const` is reserved here
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// error: `const` is reserved and cannot be used as a binding name
+//     ╭─[ expr_const_reserved_binding_names.baml:28:12 ]
+//     │
+//  28 │   for (let const in items) {
+//     │            ──┬──  
+//     │              ╰──── `const` is reserved here
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// error: `const` is reserved and cannot be used as a binding name
+//     ╭─[ expr_const_reserved_binding_names.baml:36:12 ]
+//     │
+//  36 │   for (let const = 0; const < 1; const += 1) {
+//     │            ──┬──  
+//     │              ╰──── `const` is reserved here
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//     ╭─[ expr_const_reserved_binding_names.baml:44:6 ]
+//     │
+//  44 │   if const [let x] = items {
+//     │      ──┬──  
+//     │        ╰──── `const` behaves like `let` for now
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//     ╭─[ expr_const_reserved_binding_names.baml:49:9 ]
+//     │
+//  49 │   while const [let y] = items {
+//     │         ──┬──  
+//     │           ╰──── `const` behaves like `let` for now
+//     │ 
+//     │ Note: Error code: E0010
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/loops/const_for_loops.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/loops/const_for_loops.baml
@@ -11,4 +11,30 @@ function ConstForLoops(items: int[]) -> int {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//    ╭─[ loops_const_for_loops.baml:2:3 ]
+//    │
+//  2 │   const sum = 0;
+//    │   ──┬──  
+//    │     ╰──── `const` behaves like `let` for now
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//    ╭─[ loops_const_for_loops.baml:3:8 ]
+//    │
+//  3 │   for (const i = 0; i < 3; i += 1) {
+//    │        ──┬──  
+//    │          ╰──── `const` behaves like `let` for now
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
+// warning: `const` is currently treated like `let`; BAML does not enforce immutability yet. Use `let` for current BAML semantics.
+//    ╭─[ loops_const_for_loops.baml:6:8 ]
+//    │
+//  6 │   for (const item in items) {
+//    │        ──┬──  
+//    │          ╰──── `const` behaves like `let` for now
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/loops/const_for_loops.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/loops/const_for_loops.baml
@@ -1,0 +1,14 @@
+function ConstForLoops(items: int[]) -> int {
+  const sum = 0;
+  for (const i = 0; i < 3; i += 1) {
+    sum = sum + i;
+  }
+  for (const item in items) {
+    sum = sum + item;
+  }
+  sum
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__loop_stmts.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__loop_stmts.snap
@@ -120,7 +120,7 @@ function LoopStmts(items: int[], flag: bool) -> int {
     /* 1 for keyword leading */
     for ( /* 4 open paren trailing */
         /* 5 init leading */
-        let i = /* 9 equals trailing *//* 10 init value leading */0/* 11 init value trailing */; /* 12 semi1 trailing */
+        let /* 6 let trailing */ i = /* 9 equals trailing *//* 10 init value leading */0/* 11 init value trailing */; /* 12 semi1 trailing */
         /* 13 condition leading */
         i < 10/* 14 condition trailing */; /* 15 semi2 trailing */
         /* 16 update leading */
@@ -150,7 +150,7 @@ function LoopStmts(items: int[], flag: bool) -> int {
     /* 1 for keyword leading */
     for ( /* 4 open paren trailing */
         /* 5 let leading */
-        let item in /* 10 in trailing *//* 11 iterator leading */items /* 12 iterator trailing */
+        let /* 6 let trailing */ item in /* 10 in trailing *//* 11 iterator leading */items /* 12 iterator trailing */
         /* 13 close paren leading */
     ) { /* 16 body open trailing */
         result += item;
@@ -299,7 +299,7 @@ function LoopStmts(items: int[], flag: bool) -> int {
     /* 1 for leading */
     for ( /* 4 open paren trailing */
         /* 5 init leading */
-        let extremely_long_loop_counter_variable = /* 9 equals trailing *//* 10 init value leading */a * a + result * result/* 11 init value trailing */; /* 12 semi1 trailing */
+        let /* 6 let trailing */ extremely_long_loop_counter_variable = /* 9 equals trailing *//* 10 init value leading */a * a + result * result/* 11 init value trailing */; /* 12 semi1 trailing */
         /* 13 condition leading */
         extremely_long_loop_counter_variable < 1000000 && flag && a > 0/* 14 condition trailing */; /* 15 semi2 trailing */
         /* 16 update leading */
@@ -338,7 +338,7 @@ function LoopStmts(items: int[], flag: bool) -> int {
     /* 1 for leading */
     for ( /* 4 open paren trailing */
         /* 5 let leading */
-        let extremely_long_item_variable_name in /* 10 in trailing *//* 11 iterator leading */[
+        let /* 6 let trailing */ extremely_long_item_variable_name in /* 10 in trailing *//* 11 iterator leading */[
             "alpha bravo charlie",
             "delta echo foxtrot",
             "golf hotel india",
@@ -502,7 +502,7 @@ function LoopStmts(items: int[], flag: bool) -> int {
 
     // ===== Trivia on let statement (block comments) =====
     /* 1 let keyword leading */
-    let trivia_var_block /* 4 name trailing */ /* 5 colon leading */: /* 6 colon trailing */ /* 7 type leading */ int = /* 10 equals trailing *//* 11 value leading */42/* 12 value trailing */; /* 13 semicolon trailing */
+    let /* 2 let keyword trailing */ trivia_var_block /* 4 name trailing */ /* 5 colon leading */: /* 6 colon trailing */ /* 7 type leading */ int = /* 10 equals trailing *//* 11 value leading */42/* 12 value trailing */; /* 13 semicolon trailing */
 
     // ===== Trivia on wrapping let with long type (line comments) =====
     // 1 let leading
@@ -512,7 +512,7 @@ function LoopStmts(items: int[], flag: bool) -> int {
 
     // ===== Trivia on wrapping let with long type (block comments) =====
     /* 1 let leading */
-    let very_long_variable_name_for_testing_wrapping /* 4 name trailing */ /* 5 colon leading */: /* 6 colon trailing */ /* 7 type leading */ map<string, int | string | bool | float | null> = /* 10 equals trailing *//* 11 value leading */{ "key": 42 }/* 12 value trailing */; /* 13 semicolon trailing */
+    let /* 2 let trailing */ very_long_variable_name_for_testing_wrapping /* 4 name trailing */ /* 5 colon leading */: /* 6 colon trailing */ /* 7 type leading */ map<string, int | string | bool | float | null> = /* 10 equals trailing *//* 11 value leading */{ "key": 42 }/* 12 value trailing */; /* 13 semicolon trailing */
 
     ///////////////////
 
@@ -532,7 +532,7 @@ function LoopStmts(items: int[], flag: bool) -> int {
 
     // ===== Trivia on wrapping let with long expression (block comments) =====
     /* 1 let leading */
-    let another_extremely_long_variable_name = /* 6 equals trailing *//* 7 value leading */a * a
+    let /* 2 let trailing */ another_extremely_long_variable_name = /* 6 equals trailing *//* 7 value leading */a * a
         + result * result
         + a * result
         + a

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__match_exprs.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__match_exprs.snap
@@ -354,8 +354,8 @@ function MatchExprs(x: int, s: MatchStatus, r: MatchResult, b: bool) -> string {
     // ===== Trivia between Or-pattern alternatives (block comments around `|`) =====
     match (x) {
         /* 1 arm leading */
-        (let x /* 2b name trailing */: /* 2c colon trailing */ int) /* 3 first trailing */
-            |/* 4 pipe trailing *//* 5 second leading */(let x /* 6b name trailing */: /* 6c colon trailing */ int) =>
+        (let /* 2a paren leading */ x /* 2b name trailing */: /* 2c colon trailing */ int) /* 3 first trailing */
+            |/* 4 pipe trailing *//* 5 second leading */(let /* 6a paren leading */ x /* 6b name trailing */: /* 6c colon trailing */ int) =>
         {
             x
         },

--- a/baml_language/crates/baml_tests/tests/const_bindings.rs
+++ b/baml_language/crates/baml_tests/tests/const_bindings.rs
@@ -1,0 +1,35 @@
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+#[tokio::test]
+async fn let_and_const_bindings_execute_the_same() {
+    let source = r#"
+        function WithLet() -> int {
+            let sum = 0;
+            for (let i = 0; i < 4; i += 1) {
+                sum += i;
+            }
+            sum
+        }
+
+        function WithConst() -> int {
+            const sum = 0;
+            for (const i = 0; i < 4; i += 1) {
+                sum += i;
+            }
+            sum
+        }
+    "#;
+
+    let with_let = baml_test! {
+        baml: source,
+        entry: "WithLet",
+    };
+    let with_const = baml_test! {
+        baml: source,
+        entry: "WithConst",
+    };
+
+    assert_eq!(with_let.result, Ok(BexExternalValue::Int(6)));
+    assert_eq!(with_const.result, Ok(BexExternalValue::Int(6)));
+}


### PR DESCRIPTION
## Summary

This PR accepts `const` as a contextual binding introducer in the places where BAML already accepts `let`, so LLM-written BAML like `const x = expr` continues to compile.

Important behavior:

- `const` lowers through the existing `let` binding shapes and keeps current BAML assignment/rebinding semantics.
- Each `const` binding introducer emits a warning that `const` is currently treated like `let` and does not enforce immutability yet.
- `const` is reserved as future language surface for binding names, so cases like `let const = 1`, `const const = 1`, match bindings, destructure renames, and `for` bindings named `const` now diagnose.
- The formatter preserves `const` spelling and trivia/comments between the binding introducer and the pattern.
- Semantic tokens mark contextual `const` introducers as keywords.

## Non-goals

This PR does not add real const/immutability semantics. It does not add `TokenKind::Const`, `Stmt::Const`, `LetKind`, readonly assignment checks, or downstream HIR/TIR/MIR semantic changes.

## Verification

- `cargo fmt --manifest-path baml_language/Cargo.toml --all`
- `cargo clippy --manifest-path baml_language/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p baml_compiler_parser`
- `cargo test -p baml_fmt`
- `cargo test -p baml_lsp2_actions_tests`
- `cargo test -p baml_tests --test const_bindings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support `const` as a binding introducer in let/if/while/for patterns and destructuring; `const` bindings execute like `let`.

* **Diagnostics**
  * New warning when `const` is used (treated like `let`) and an explicit error when `const` is used as a binding name.

* **Formatting**
  * Formatter preserves spacing/trivia around `let`/`const` introducers.

* **Tests**
  * Added extensive parser/formatter/semantic/tests covering `const` bindings and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->