### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -38,13 +38,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 15.12 MB file.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 15_580_000
+max_file_bytes = 14_523_017
 # Linux x86_64: baseline 20.01 MB file.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 20_620_000
+max_file_bytes = 18_955_914
 # Windows x86_64: baseline 16.32 MB file.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 16_810_000
+max_file_bytes = 15_912_561
 
 [artifacts.packed-program]
 kind = "pack"
@@ -52,13 +52,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 11.50 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 11_850_000
+max_file_bytes = 10_903_006
 # Linux x86_64: baseline 15.12 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 15_570_000
+max_file_bytes = 14_227_737
 # Windows x86_64: baseline 12.24 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 12_610_000
+max_file_bytes = 11_832_879
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -82,4 +82,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 3.87 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 3_990_000
+max_gzip_bytes = 3_613_636

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-02T00:00:00Z"
-git_sha = "465d9d13e"
+recorded_at = "2026-06-07T10:13:16Z"
+git_sha = "804a81718d4d05b66acff771321c571c7513fdc9"
 
 [artifacts.baml-cli]
-file_bytes = 18180634
-stripped_bytes = 18180672
-gzip_bytes = 8715275
+file_bytes = 14100016
+stripped_bytes = 14100064
+gzip_bytes = 6816563
 
 [artifacts.packed-program]
-file_bytes = 11501554
-gzip_bytes = 5522485
+file_bytes = 10585442
+gzip_bytes = 5029582

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-06-02T00:00:00Z"
-git_sha = "465d9d13e"
+recorded_at = "2026-06-07T10:13:16Z"
+git_sha = "804a81718d4d05b66acff771321c571c7513fdc9"
 
 [artifacts.bridge_wasm]
-file_bytes = 13462790
-gzip_bytes = 3869749
+file_bytes = 12445425
+gzip_bytes = 3508384

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-02T00:00:00Z"
-git_sha = "465d9d13e"
+recorded_at = "2026-06-07T10:13:16Z"
+git_sha = "804a81718d4d05b66acff771321c571c7513fdc9"
 
 [artifacts.baml-cli]
-file_bytes = 19611648
-stripped_bytes = 19611648
-gzip_bytes = 8891771
+file_bytes = 15449088
+stripped_bytes = 15449088
+gzip_bytes = 7026885
 
 [artifacts.packed-program]
-file_bytes = 12237959
-gzip_bytes = 5599243
+file_bytes = 11488232
+gzip_bytes = 5157983

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-02T00:00:00Z"
-git_sha = "465d9d13e"
+recorded_at = "2026-06-07T10:13:16Z"
+git_sha = "804a81718d4d05b66acff771321c571c7513fdc9"
 
 [artifacts.baml-cli]
-file_bytes = 24077012
-stripped_bytes = 24077002
-gzip_bytes = 10058180
+file_bytes = 18403800
+stripped_bytes = 18403792
+gzip_bytes = 7840060
 
 [artifacts.packed-program]
-file_bytes = 15115000
-gzip_bytes = 6341353
+file_bytes = 13813336
+gzip_bytes = 5761245


### PR DESCRIPTION
Adopted from CI run [`804a81718d4d05b66acff771321c571c7513fdc9`](https://github.com/BoundaryML/baml/actions/runs/27054080437).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 18.4 MB | 7.8 MB | **file** | 24.1 MB | -5.7 MB (-23.6%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 13.8 MB | 5.8 MB | **file** | 15.1 MB | -1.3 MB (-8.6%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 14.1 MB | 6.8 MB | **file** | 18.2 MB | -4.1 MB (-22.4%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 10.6 MB | 5.0 MB | **file** | 11.5 MB | -916.1 KB (-8.0%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 12.4 MB | 🔒 3.5 MB | **gzip** | 3.9 MB | -361.4 KB (-9.3%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 15.4 MB | 7.0 MB | **file** | 19.6 MB | -4.2 MB (-21.2%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 11.5 MB | 5.2 MB | **file** | 12.2 MB | -749.7 KB (-6.1%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build artifact size thresholds and measurement snapshots across supported platforms (macOS, Linux, Windows, and WebAssembly).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->