### PR TITLE
Fix BAML language release build setup

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -154,8 +154,18 @@ jobs:
             os: ubuntu-24.04-arm
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            before: |
+              sudo apt-get update
+              sudo apt-get install -y musl-tools
+              echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+              echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
+            before: |
+              sudo apt-get update
+              sudo apt-get install -y musl-tools
+              echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+              echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
           - target: x86_64-pc-windows-msvc
             os: windows-latest
           - target: aarch64-pc-windows-msvc
@@ -174,6 +184,18 @@ jobs:
           path: vsix
       - name: Stamp version
         run: scripts/baml-language-version stamp --plan release-plan.json
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.target }}
+          workspace: baml_language
+          prefix-key: v5-rust-baml-language-toolchain-${{ matrix.target }}
+          cache-on-failure: true
+          enable-cross: false
+          skip-protoc: true
+      - name: Build tools setup
+        if: matrix.before
+        run: ${{ matrix.before }}
       - name: Build CLI and pack host
         run: cargo build --manifest-path baml_language/Cargo.toml --release --bin baml-cli --bin baml-pack-host --target "${{ matrix.target }}"
       - name: Archive layout smoke
@@ -217,7 +239,7 @@ jobs:
         with:
           name: release-plan
       - run: scripts/baml-language-version stamp --plan release-plan.json
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node2
       - run: pnpm --dir typescript2 run vscode:package
       - name: Normalize VSIX asset name
         run: |
@@ -255,8 +277,18 @@ jobs:
             os: ubuntu-24.04-arm
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            before: |
+              sudo apt-get update
+              sudo apt-get install -y musl-tools
+              echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+              echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
+            before: |
+              sudo apt-get update
+              sudo apt-get install -y musl-tools
+              echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+              echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
           - target: x86_64-pc-windows-msvc
             os: windows-latest
           - target: aarch64-pc-windows-msvc
@@ -266,6 +298,18 @@ jobs:
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.target }}
+          workspace: baml_language
+          prefix-key: v5-rust-baml-wrapper-${{ matrix.target }}
+          cache-on-failure: true
+          enable-cross: false
+          skip-protoc: true
+      - name: Build tools setup
+        if: matrix.before
+        run: ${{ matrix.before }}
       - name: Build wrapper
         run: cargo build --manifest-path baml_language/Cargo.toml --release --bin baml --target "${{ matrix.target }}"
       - name: Archive wrapper


### PR DESCRIPTION
## Summary

Fixes the post-merge BAML Language Release workflow failures from run https://github.com/BoundaryML/baml/actions/runs/26896670294.

- set up pnpm/Node for the platform-neutral VSIX job using the existing `setup-node2` action
- set up Rust targets/cache before toolchain and wrapper cargo builds
- install musl build tools and target-specific `CC_*` variables for musl wrapper/toolchain targets

## Validation

- `actionlint .github/workflows/release-baml-language.yml`
- `git diff --check`

## Notes

The failed run stopped before publish jobs, so PyPI, GitHub release publishing, Homebrew/AUR, and S3 manifest upload did not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release build infrastructure with a more consistent Rust toolchain setup and safer cross-compilation defaults.
  * Added explicit steps to better support MUSL Linux targets for more reliable platform-specific builds.
  * Streamlined the Node/packaging job to simplify dependency preparation and VSIX packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->