### PR TITLE
Install wasm-pack for BAML release VSIX build

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -240,6 +240,16 @@ jobs:
           name: release-plan
       - run: scripts/baml-language-version stamp --plan release-plan.json
       - uses: ./.github/actions/setup-node2
+      - name: Setup Rust for VSIX WASM build
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: wasm32-unknown-unknown
+          workspace: baml_language
+          prefix-key: v5-rust-baml-vsix-wasm
+          cache-on-failure: true
+          enable-wasm: true
+          enable-cross: false
+          skip-protoc: true
       - run: pnpm --dir typescript2 run vscode:package
       - name: Normalize VSIX asset name
         run: |


### PR DESCRIPTION
## Summary

Fixes the VSIX build failure from https://github.com/BoundaryML/baml/actions/runs/26900178631/job/79350143734.

The release VSIX job now sets up Rust WASM tooling via the existing `setup-rust` action before running `pnpm --dir typescript2 run vscode:package`, which calls `pnpm run build:wasm` and requires `wasm-pack`.

## Validation

- `actionlint .github/workflows/release-baml-language.yml`
- `git diff --check`
- commit hooks, including YAML check

## Notes

The failed workflow stopped before publish jobs, so PyPI, GitHub release publishing, Homebrew/AUR, and S3 manifest upload did not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the BAML language VSIX release workflow to include WebAssembly build support in the compilation pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->