### PR TITLE
chore: use blacksmith instead of github for macos runners

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -158,7 +158,7 @@ jobs:
     # Skip in the merge queue: macos already ran on the PR. The merge_group
     # event is inherited from ci.yaml through the workflow_call boundary.
     if: ${{ github.event_name != 'merge_group' }}
-    runs-on: macos-latest
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
@@ -384,7 +384,7 @@ jobs:
                 "sdk-path": "python_pydantic2",
                 "install-args": "sccache direnv python uv",
                 "os-label": "macos",
-                "runs-on": "macos-latest",
+                "runs-on": "blacksmith-6vcpu-macos-latest",
                 "rust-cache-key": "macos-cargo",
                 "timeout": 40,
               },
@@ -394,7 +394,7 @@ jobs:
                 "sdk-path": "typescript_node",
                 "install-args": "sccache direnv node npm:pnpm",
                 "os-label": "macos",
-                "runs-on": "macos-latest",
+                "runs-on": "blacksmith-6vcpu-macos-latest",
                 "rust-cache-key": "macos-cargo",
                 "timeout": 40,
               },

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -132,7 +132,7 @@ jobs:
 
   size-gate-macos:
     name: "size-gate (macos)"
-    runs-on: macos-latest
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 20
     continue-on-error: true
     steps:


### PR DESCRIPTION
## What

Switches every macOS job reachable transitively from `ci.yaml` to Blacksmith macOS runners (`blacksmith-6vcpu-macos-latest`) instead of GitHub's `macos-latest`.

`ci.yaml` calls five reusable workflows (`cargo-tests`, `size-gate`, `wasm-pack-tests`, `docs`, `webview-tests`). Only two of them have macOS jobs, so those are the only files touched:

- **`cargo-tests.reusable.yaml`**
  - `cargo-test-macos` job (`runs-on`)
  - both `macos` entries in the SDK-test build matrix (`"runs-on"`)
- **`size-gate.reusable.yaml`**
  - `size-gate-macos` job (`runs-on`)

The Linux/Windows legs already run on Blacksmith runners and are unchanged. No other behavior (checkout actions, caching, timeouts) was modified — only the runner labels.

`blacksmith-6vcpu-macos-latest` is Blacksmith's drop-in replacement label for `macos-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI infrastructure configuration for macOS testing jobs to optimize performance and resource allocation across multiple workflow pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->