### PR TITLE
fix: thread inferred generic type args through interface dispatch

### DIFF
--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -320,6 +320,32 @@ fn interface_class_guard_for_args(
     Some(InterfaceClassGuard::Exact(class_args))
 }
 
+/// Choose how to seed the frame of a class-owned method dispatched through an
+/// interface, given the matched arm's class guard and whether the implementor
+/// is generic.
+///
+/// A fully-pinned guard names every class type arg statically (class-param
+/// order), so we seed those directly — keeping the common, hot path
+/// allocation-free and its bytecode unchanged. When the guard is `Any` or only
+/// partially pins the class params (e.g. a generic class behind a *non-generic*
+/// interface, or `Pair<L,R> implements Slot<L>`), the static guard can't name
+/// the args, but the matched runtime instance always carries concrete ones — so
+/// we bind the receiver and let the VM seed from `inst.class_type_args`. A
+/// non-generic implementor needs nothing.
+fn class_owned_frame_seed(guard: &InterfaceClassGuard, impl_is_generic: bool) -> CalleeFrameSeed {
+    match guard {
+        InterfaceClassGuard::Exact(args) if args.iter().all(Option::is_some) => {
+            CalleeFrameSeed::Static(
+                args.iter()
+                    .map(|a| a.clone().expect("all entries are Some"))
+                    .collect(),
+            )
+        }
+        _ if impl_is_generic => CalleeFrameSeed::FromReceiverInstance,
+        _ => CalleeFrameSeed::Static(Vec::new()),
+    }
+}
+
 pub fn convert_tir2_ty(ty: &Tir2Ty, resolved: &ResolvedAliases) -> Ty {
     let attr = ty.attr().clone();
     match ty {
@@ -1175,6 +1201,32 @@ enum InterfaceDispatchGuard {
 struct InterfaceMethodCandidate {
     guard: InterfaceDispatchGuard,
     item_ref: ItemRef,
+    /// How to seed the callee frame's `type_args` so a dispatched method that
+    /// reads its enclosing `T` at runtime resolves it correctly.
+    frame_seed: CalleeFrameSeed,
+}
+
+/// Strategy for seeding a dispatched method's `frame.type_args`.
+#[derive(Clone)]
+enum CalleeFrameSeed {
+    /// Bind the receiver into a `BoundMethod` so the VM seeds `frame.type_args`
+    /// from the runtime instance's `class_type_args` (class-param order), then
+    /// the explicit call-site args. Used for a class-owned method on a generic
+    /// class whose class params are *not* fully pinned by the interface request
+    /// (`Any`/partial guard) — the static guard can't name the args, but the
+    /// matched instance always carries them.
+    FromReceiverInstance,
+    /// Seed statically with these resolved type args, in the De Bruijn order
+    /// the callee body assumes (see `enclosing_generic_params`):
+    ///   • a class-owned method with a fully-pinned guard ⇒ the implementor's
+    ///     resolved class type args (class-param order);
+    ///   • an inherited interface default ⇒ the resolved *interface* args
+    ///     (which can differ from the implementor's class args when the
+    ///     `implements` block renames/reorders params).
+    /// Empty ⇒ no seeding (non-generic, or a path that does not thread args).
+    /// May contain `TypeVar`s referring to the *caller's* enclosing generics;
+    /// `emit_method_candidate_switch` lowers them via `ty_to_template`.
+    Static(Vec<Tir2Ty>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -4735,11 +4787,45 @@ impl LoweringContext<'_> {
                 let Some(&self_local) = self.locals.get(&Name::new("self")) else {
                     return;
                 };
-                let mut all_args = vec![Operand::Copy(Place::Local(self_local))];
+                // Seed the default method's frame with the interface's type
+                // args, expressed over the enclosing class's generic params
+                // (e.g. `implements Cont<T>` → `[T]`). The default body lowers
+                // the interface's `T` to `TypeArgRef` (see
+                // `enclosing_generic_params`), so without this an explicit
+                // `default.<method>()` that reads `T` would resolve it to
+                // `unknown` at runtime. Mirrors the interface-dispatch switch.
+                let iface_type_arg_tys: Vec<Tir2Ty> = if let baml_compiler2_ast::TypeExpr::Path {
+                    generic_args,
+                    ..
+                } = &target_te.expr
+                {
+                    let generic_params = self.enclosing_generic_params();
+                    let mut diags = Vec::new();
+                    generic_args
+                        .iter()
+                        .map(|arg| {
+                            baml_compiler2_tir::lower_type_expr::lower_type_expr_in_ns(
+                                self.db,
+                                arg,
+                                pkg_items,
+                                &current_pkg.namespace_path,
+                                &generic_params,
+                                &mut diags,
+                            )
+                        })
+                        .collect()
+                } else {
+                    vec![]
+                };
+                let frame_type_arg_ops = self.emit_frame_type_arg_ops(&iface_type_arg_tys);
+                let ntypeargs = frame_type_arg_ops.len();
+                let mut all_args = frame_type_arg_ops;
+                all_args.push(Operand::Copy(Place::Local(self_local)));
                 all_args.extend(self.lower_call_arg_operands(expr_id, args));
                 let target = self.builder.create_block();
                 let unwind = self.catch_context.as_ref().map(|c| c.unwind_target);
-                self.builder.call(callee_op, all_args, dest, target, unwind);
+                self.builder
+                    .call_with_type_args(callee_op, all_args, ntypeargs, dest, target, unwind);
                 self.builder.set_current_block(target);
                 return;
             }
@@ -5658,6 +5744,21 @@ impl LoweringContext<'_> {
         {
             return imp.generic_params.clone();
         }
+        // BEP-044: interface default methods are lowered as standalone
+        // functions, but their bodies reference the *interface's* generic
+        // params (e.g. a default `map(self)` building `Map<T, U>`). Mirror the
+        // class-method convention — interface params first, then fn params — so
+        // `TypeVar(T)` lowers to `TypeArgRef(N)` against the frame type args the
+        // interface-dispatch switch seeds (see `emit_method_candidate_switch`).
+        if let Some(iface_data) = item_tree
+            .interfaces
+            .values()
+            .find(|iface_data| iface_data.default_methods.contains(&func_id))
+        {
+            let mut params = iface_data.generic_params.clone();
+            params.extend(item_tree[func_id].generic_params.iter().cloned());
+            return params;
+        }
         let mut params: Vec<baml_base::Name> = item_tree
             .classes
             .values()
@@ -5666,6 +5767,28 @@ impl LoweringContext<'_> {
             .unwrap_or_default();
         params.extend(item_tree[func_id].generic_params.iter().cloned());
         params
+    }
+
+    /// Emit `LoadType` temps for a list of type args resolved at an interface
+    /// dispatch site, returning one `Operand` per arg (in order). Used by
+    /// `emit_method_candidate_switch` to seed the callee frame's `type_args`.
+    /// `TypeVar`s are lowered against the *caller's* `enclosing_generic_params`
+    /// so they substitute against the caller's `frame.type_args` at runtime
+    /// (mirroring the receiver-class-type-args path for direct method calls).
+    fn emit_frame_type_arg_ops(&mut self, tys: &[Tir2Ty]) -> Vec<Operand> {
+        if tys.is_empty() {
+            return Vec::new();
+        }
+        let generic_params = self.enclosing_generic_params();
+        tys.iter()
+            .map(|ty| {
+                let template = self.ty_to_template(ty, &generic_params);
+                let temp = self.builder.temp(Ty::type_type());
+                self.builder
+                    .assign(Place::local(temp), Rvalue::LoadType(template));
+                Operand::Copy(Place::local(temp))
+            })
+            .collect()
     }
 
     /// Emit `LoadType` rvalue assignments for the explicit type arguments of a
@@ -6680,6 +6803,9 @@ impl<'db> LoweringContext<'db> {
                     TyAttr::default(),
                 )),
                 item_ref,
+                // Union-member direct dispatch: frame type args not threaded
+                // here. (Unchanged from prior behavior.)
+                frame_seed: CalleeFrameSeed::Static(Vec::new()),
             }];
         }
         let Some(class_loc) = self.resolve_class_loc_by_type_name(class_tn) else {
@@ -6877,6 +7003,9 @@ impl<'db> LoweringContext<'db> {
             resolved.push(InterfaceMethodCandidate {
                 guard: InterfaceDispatchGuard::Type(implementor.runtime_ty.clone()),
                 item_ref,
+                // Type-implementor (primitive / out-of-body) dispatch: frame
+                // type args not threaded here. (Unchanged from prior behavior.)
+                frame_seed: CalleeFrameSeed::Static(Vec::new()),
             });
         }
         resolved
@@ -6930,18 +7059,59 @@ impl<'db> LoweringContext<'db> {
                 bb_next,
             );
             self.builder.set_current_block(bb_body);
-            let callee_op = Operand::Constant(Constant::Function(candidate.item_ref.clone()));
-            let mut all_args = type_arg_ops.clone();
-            all_args.push(Operand::Copy(Place::Local(recv_local)));
-            all_args.extend(arg_ops.iter().cloned());
-            self.builder.call_with_type_args(
-                callee_op,
-                all_args,
-                ntypeargs,
-                dest.clone(),
-                bb_join,
-                unwind,
-            );
+            // Seed the callee frame's `type_args` so a dispatched method that
+            // reads its enclosing `T` at runtime — e.g. building `Other<T>{}` or
+            // `reflect.type_of<T>()` — resolves it correctly. Without this,
+            // inferred generic instances carry `unknown` class type args and
+            // downstream interface dispatch falls to the wrong implementor.
+            match &candidate.frame_seed {
+                CalleeFrameSeed::FromReceiverInstance => {
+                    // Bind the receiver so the VM seeds `frame.type_args` from
+                    // the instance's `class_type_args` (class-param order) and
+                    // then the explicit call-site args — handling `Any`/partial
+                    // guards that a static seed can't name.
+                    let bm = self.builder.temp(Ty::unknown());
+                    self.builder.assign(
+                        Place::local(bm),
+                        Rvalue::MakeBoundMethod {
+                            item_ref: candidate.item_ref.clone(),
+                            receiver: Operand::Copy(Place::Local(recv_local)),
+                        },
+                    );
+                    // A `BoundMethod` callee inserts the receiver itself, so the
+                    // explicit args carry only the call-site type args + values.
+                    let mut all_args = type_arg_ops.clone();
+                    all_args.extend(arg_ops.iter().cloned());
+                    self.builder.call_with_type_args(
+                        Operand::Copy(Place::local(bm)),
+                        all_args,
+                        ntypeargs,
+                        dest.clone(),
+                        bb_join,
+                        unwind,
+                    );
+                }
+                CalleeFrameSeed::Static(tys) => {
+                    let callee_op =
+                        Operand::Constant(Constant::Function(candidate.item_ref.clone()));
+                    // De Bruijn order: class/iface params first, then explicit
+                    // call-site `<...>` args. Lowered per-arm (args vary).
+                    let frame_type_arg_ops = self.emit_frame_type_arg_ops(tys);
+                    let arm_ntypeargs = frame_type_arg_ops.len() + ntypeargs;
+                    let mut all_args = frame_type_arg_ops;
+                    all_args.extend(type_arg_ops.iter().cloned());
+                    all_args.push(Operand::Copy(Place::Local(recv_local)));
+                    all_args.extend(arg_ops.iter().cloned());
+                    self.builder.call_with_type_args(
+                        callee_op,
+                        all_args,
+                        arm_ntypeargs,
+                        dest.clone(),
+                        bb_join,
+                        unwind,
+                    );
+                }
+            }
             next_check = bb_next;
         }
 
@@ -7170,6 +7340,11 @@ impl<'db> LoweringContext<'db> {
                     class_loc.file(self.db),
                     method_id,
                 );
+                // A class-owned override reads class-level `T` from its frame
+                // type args (class-param order): statically when the guard pins
+                // them, otherwise from the matched runtime instance.
+                let frame_seed =
+                    class_owned_frame_seed(&guard, !class_data.generic_params.is_empty());
                 out.push((
                     requested_idx,
                     InterfaceMethodCandidate {
@@ -7178,6 +7353,7 @@ impl<'db> LoweringContext<'db> {
                             guard,
                         },
                         item_ref: method_item_ref(self.db, class_loc, func_loc),
+                        frame_seed,
                     },
                 ));
             }
@@ -7209,6 +7385,15 @@ impl<'db> LoweringContext<'db> {
                 else {
                     continue;
                 };
+                // An inherited interface default reads the *interface's* type
+                // vars (interface-param order), which can differ from the
+                // implementor's class args when the `implements` block
+                // renames/reorders params. Seed from the matched interface
+                // view's args, not the class guard.
+                let frame_type_args = requested_views
+                    .get(requested_idx)
+                    .map(|(_, args, _)| args.clone())
+                    .unwrap_or_default();
                 out.push((
                     requested_idx,
                     InterfaceMethodCandidate {
@@ -7217,6 +7402,7 @@ impl<'db> LoweringContext<'db> {
                             guard,
                         },
                         item_ref,
+                        frame_seed: CalleeFrameSeed::Static(frame_type_args),
                     },
                 ));
             }
@@ -7453,6 +7639,12 @@ impl<'db> LoweringContext<'db> {
                                                 func_loc,
                                             ),
                                         ),
+                                        // Out-of-body override: its frame uses
+                                        // `imp.generic_params` order, which can
+                                        // differ from both the class- and
+                                        // interface-arg orders. Not threaded
+                                        // here. (Unchanged from prior behavior.)
+                                        frame_seed: CalleeFrameSeed::Static(Vec::new()),
                                     },
                                 ));
                                 break 'blanket_search;
@@ -7460,6 +7652,22 @@ impl<'db> LoweringContext<'db> {
                             // No override in blanket impl — check for interface default method
                             for &fn_id in &iface_data.default_methods {
                                 if iface_tree[fn_id].name == *method {
+                                    // Inherited default for an out-of-body
+                                    // implementor: its body reads the owning
+                                    // interface's type vars (interface-param
+                                    // order). Seed from the resolved closure
+                                    // view args, but only when fully concrete —
+                                    // any residual TypeVar there is `imp`-level,
+                                    // not a caller generic, so it must not be
+                                    // emitted as a caller `TypeArgRef`.
+                                    let frame_type_args = if current_iface_args
+                                        .iter()
+                                        .any(baml_compiler2_tir::generics::contains_typevar)
+                                    {
+                                        Vec::new()
+                                    } else {
+                                        current_iface_args
+                                    };
                                     out.push((
                                         requested_idx,
                                         InterfaceMethodCandidate {
@@ -7473,6 +7681,7 @@ impl<'db> LoweringContext<'db> {
                                                 class: iface_data.name.clone(),
                                                 name: method.clone(),
                                             },
+                                            frame_seed: CalleeFrameSeed::Static(frame_type_args),
                                         },
                                     ));
                                     break 'blanket_search;

--- a/baml_language/crates/baml_tests/baml_src/ns_inferred_generic_type_args/inferred_generic_type_args.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_inferred_generic_type_args/inferred_generic_type_args.baml
@@ -1,0 +1,313 @@
+// End-to-end tests for the generic-type-arg dispatch fix.
+//
+// A generic class whose `<T>` is *inferred* (rather than written explicitly)
+// must carry the correct runtime `class_type_args`, and a method dispatched
+// through a multi-implementor interface must receive the resolved
+// class/interface type args in its frame. Without this, a method body that
+// reads its enclosing `T` at runtime — `reflect.type_of<T>()`, or constructing
+// `Other<T>{}` — resolves `T` to `unknown`; the new instance gets empty
+// `class_type_args`; and the runtime `IsType` dispatch guard falls through to
+// the WRONG implementor (a silent wrong answer, or a field-access panic when
+// the sibling has a different field layout).
+//
+// Fixed in `baml_compiler2_mir::lower`: the interface-dispatch switch now seeds
+// the callee frame's `type_args` per candidate — a class-owned method gets the
+// implementor's class args (statically when the guard pins them, otherwise from
+// the matched runtime instance via a `BoundMethod`, which covers `Any`/partial
+// guards); an inherited default gets the interface's args. `default.<method>()`
+// forwarding seeds the same way, and `enclosing_generic_params` includes
+// interface params for default methods.
+//
+// NOTE: test bodies live in top-level helper functions — locals holding class
+// instances misbehave when compared/passed inside `test { ... }` blocks (the
+// same VM local-boxing caveat documented in `ns_class_type_args_at_runtime`).
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Showcase: a lazy cursor protocol — the exact shape `baml.iter` needs.
+//
+// `Cursor<T>` is a generic interface with a default `take_one(self)` that builds
+// a *new* generic adapter (`SingleCursor<T>`) from the interface's element type
+// `T`. The two leaf implementors have different field layouts, so a mis-dispatch
+// doesn't merely return a wrong value — it reads the wrong field and panics.
+//
+// The whole pipeline runs through the `Cursor<int>` interface, and the `<int>`
+// is never written after the first annotation: `ArrayCursor.of([...])` infers
+// it, and the default method must propagate it into the `SingleCursor<int>` it
+// constructs. Correctness depends entirely on the inferred `<int>` reaching
+// each dispatched frame.
+// ═══════════════════════════════════════════════════════════════════════════
+
+interface Cursor<T> {
+  function head(self) -> T throws unknown
+
+  // Default method, inherited by every implementor. It constructs a generic
+  // `SingleCursor<T>` from the interface's own `T`. The resulting instance MUST
+  // carry `class_type_args = [T]`; otherwise the `single.head()` dispatch in
+  // `take_one_then_head` resolves to `ArrayCursor.head` — which indexes an
+  // `arr` field that `SingleCursor` does not have — instead of
+  // `SingleCursor.head`.
+  function take_one(self) -> Cursor<T> throws unknown {
+    return SingleCursor<T> { value: self.head() }
+  }
+}
+
+class ArrayCursor<T> {
+  arr T[]
+  idx int
+
+  // Static constructor: `T` is INFERRED from the argument, never written.
+  function of(items: T[]) -> ArrayCursor<T> {
+    return ArrayCursor<T> { arr: items, idx: 0 }
+  }
+
+  implements Cursor<T> {
+    function head(self) -> T throws unknown { return self.arr[0] }
+  }
+}
+
+class SingleCursor<T> {
+  value T
+
+  implements Cursor<T> {
+    function head(self) -> T throws unknown { return self.value }
+  }
+}
+
+// Build an `ArrayCursor<int>` with an inferred `<int>`, narrow it to a single
+// element via the inherited default method, then read the head back — entirely
+// through the `Cursor<int>` interface. Exercises inferred static-ctor type args
+// AND a default method that builds a generic from the interface's `T`.
+function take_one_then_head() -> int throws unknown {
+  let cursor: Cursor<int> = ArrayCursor.of([10, 20, 30]);
+  let single: Cursor<int> = cursor.take_one();
+  single.head()
+}
+
+test "showcase_lazy_cursor_pipeline" {
+  assert.equal(take_one_then_head(), 10)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Focused regression cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ─── Inferred static constructor + non-generic interface, two implementors ───
+
+interface Animal {
+  function speak(self) -> string
+}
+
+class Dog<T> {
+  value T
+
+  function make(v: T) -> Dog<T> {
+    return Dog<T> { value: v }
+  }
+
+  implements Animal {
+    function speak(self) -> string { return "woof" }
+  }
+}
+
+class Cat {
+  meow_count int
+
+  implements Animal {
+    function speak(self) -> string { return "meow" }
+  }
+}
+
+// `Dog.make(42)` infers `Dog<int>`; dispatched through `Animal` (which `Cat`
+// also implements) it must still pick `Dog`'s method.
+function inferred_static_ctor_speak() -> string {
+  let d: Animal = Dog.make(42);
+  d.speak()
+}
+
+test "inferred_static_ctor_dispatches_to_correct_implementor" {
+  assert.equal(inferred_static_ctor_speak(), "woof")
+}
+
+// ─── Inferred static constructor + generic interface, mismatched shapes ───
+
+interface Bag<T> {
+  function first(self) -> T throws unknown
+}
+
+class ArrBag<T> {
+  arr T[]
+  idx int
+
+  function make(a: T[]) -> ArrBag<T> {
+    return ArrBag<T> { arr: a, idx: 0 }
+  }
+
+  implements Bag<T> {
+    function first(self) -> T throws unknown { return self.arr[0] }
+  }
+}
+
+class OneBag<T> {
+  only T
+
+  implements Bag<T> {
+    function first(self) -> T throws unknown { return self.only }
+  }
+}
+
+// A mis-dispatch would read `only` off an `ArrBag` (or index `arr` on a
+// `OneBag`) — different layouts, so the wrong arm panics rather than silently
+// returning a bad value.
+function inferred_static_ctor_first() -> int throws unknown {
+  let s: Bag<int> = ArrBag.make([5, 6, 7]);
+  s.first()
+}
+
+test "inferred_static_ctor_dispatches_through_generic_interface" {
+  assert.equal(inferred_static_ctor_first(), 5)
+}
+
+// ─── Interface default method can read the interface's type var at runtime ───
+
+interface Named<T> {
+  function first(self) -> T throws unknown
+  function tname(self) -> string {
+    return reflect.type_of<T>().to_string()
+  }
+}
+
+class ArrNamed<T> {
+  arr T[]
+  idx int
+  implements Named<T> {
+    function first(self) -> T throws unknown { return self.arr[0] }
+  }
+}
+
+class OneNamed<T> {
+  only T
+  implements Named<T> {
+    function first(self) -> T throws unknown { return self.only }
+  }
+}
+
+// `tname` is a default method dispatched through `Named<int>`; it must see
+// `T == int`, not `unknown`/`void`.
+function default_method_typevar_name() -> string throws unknown {
+  let s: Named<int> = ArrNamed<int> { arr: [5, 6, 7], idx: 0 };
+  s.tname()
+}
+
+test "interface_default_method_sees_interface_type_var" {
+  assert.equal(default_method_typevar_name(), "int")
+}
+
+// ─── Class-owned (non-default) method that builds a generic from class `T` ───
+
+interface Wrap<T> {
+  function first(self) -> T throws unknown
+}
+
+class SrcWrap<T> {
+  arr T[]
+  idx int
+
+  // A regular class method (not an interface default) that constructs a
+  // generic `Boxed<T>` from the class-level `T`.
+  function boxed(self) -> Wrap<T> throws unknown {
+    return Boxed<T> { val: self.arr[0] }
+  }
+
+  implements Wrap<T> {
+    function first(self) -> T throws unknown { return self.arr[0] }
+  }
+}
+
+class Boxed<T> {
+  val T
+  implements Wrap<T> {
+    function first(self) -> T throws unknown { return self.val }
+  }
+}
+
+function class_method_builds_generic() -> int throws unknown {
+  let s: SrcWrap<int> = SrcWrap<int> { arr: [5, 6, 7], idx: 0 };
+  let w: Wrap<int> = s.boxed();
+  w.first()
+}
+
+test "class_method_builds_generic_via_class_type_var" {
+  assert.equal(class_method_builds_generic(), 5)
+}
+
+// ─── `default.<method>()` forwards into a generic interface default ───
+//
+// Calling the interface's default implementation explicitly (the `super`-like
+// `default.<method>()` form) from inside an override must seed the default
+// body's frame with the interface's type args, so a generic default that reads
+// `T` at runtime resolves it instead of seeing `unknown`.
+
+interface Counter<T> {
+  function element_type(self) -> string {
+    return reflect.type_of<T>().to_string()
+  }
+  function describe(self) -> string
+}
+
+class IntCounter<T> {
+  value T
+  implements Counter<T> {
+    // Override `describe` but delegate to the generic default `element_type`.
+    function describe(self) -> string { return default.element_type() }
+  }
+}
+
+class StrCounter<T> {
+  label T
+  implements Counter<T> {
+    function describe(self) -> string { return "str" }
+  }
+}
+
+function default_forward_reads_type_var() -> string {
+  let c: Counter<int> = IntCounter<int> { value: 7 };
+  c.describe()
+}
+
+test "default_method_forward_reads_interface_type_var" {
+  assert.equal(default_forward_reads_type_var(), "int")
+}
+
+// ─── Generic class behind a NON-generic interface reads its class `T` ───
+//
+// The interface request pins no type args (it has none), so the dispatch guard
+// is `Any` and can't name the implementor's class args statically. The matched
+// runtime instance still carries them, so the dispatched class-owned method
+// must resolve its class `T` (here via `reflect.type_of<T>()`).
+
+interface Describable {
+  function describe(self) -> string
+}
+
+class TypedBox<T> {
+  value T
+  implements Describable {
+    function describe(self) -> string { return reflect.type_of<T>().to_string() }
+  }
+}
+
+class PlainThing {
+  n int
+  implements Describable {
+    function describe(self) -> string { return "plain" }
+  }
+}
+
+function generic_behind_nongeneric_iface() -> string {
+  let d: Describable = TypedBox<int> { value: 42 };
+  d.describe()
+}
+
+test "generic_class_behind_nongeneric_interface_reads_type_var" {
+  assert.equal(generic_behind_nongeneric_iface(), "int")
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -168,6 +168,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/inferred_generic_type_args.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/inferred_generic_type_args.snap
@@ -1,0 +1,500 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function inferred_generic_type_args.$init_test_ns_inferred_generic_type_args_inferred_generic_type_args(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "showcase_lazy_cursor_pipeline"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "inferred_static_ctor_dispatches_to_correct_implementor"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "inferred_static_ctor_dispatches_through_generic_interface"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "interface_default_method_sees_interface_type_var"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "class_method_builds_generic_via_class_type_var"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "default_method_forward_reads_interface_type_var"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 5)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "generic_class_behind_nongeneric_interface_reads_type_var"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 6)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_const null
+    return
+}
+
+function inferred_generic_type_args.ArrBag$stream.Bag<T>.first(self: inferred_generic_type_args.ArrBag$stream) -> void {
+    load_var self
+    load_field .0
+    load_const 0
+    load_array_element
+    return
+}
+
+function inferred_generic_type_args.ArrBag.Bag<T>.first(self: inferred_generic_type_args.ArrBag) -> void {
+    load_var self
+    load_field .0
+    load_const 0
+    load_array_element
+    return
+}
+
+function inferred_generic_type_args.ArrBag.make(a: void[]) -> inferred_generic_type_args.ArrBag<void> {
+    load_var a
+    load_const 0
+    load_type #0
+    init_instance<1> user.inferred_generic_type_args.ArrBag .arr, .idx
+    return
+}
+
+function inferred_generic_type_args.ArrNamed$stream.Named<T>.first(self: inferred_generic_type_args.ArrNamed$stream) -> void {
+    load_var self
+    load_field .0
+    load_const 0
+    load_array_element
+    return
+}
+
+function inferred_generic_type_args.ArrNamed.Named<T>.first(self: inferred_generic_type_args.ArrNamed) -> void {
+    load_var self
+    load_field .0
+    load_const 0
+    load_array_element
+    return
+}
+
+function inferred_generic_type_args.ArrayCursor$stream.Cursor<T>.head(self: inferred_generic_type_args.ArrayCursor$stream) -> void {
+    load_var self
+    load_field .0
+    load_const 0
+    load_array_element
+    return
+}
+
+function inferred_generic_type_args.ArrayCursor.Cursor<T>.head(self: inferred_generic_type_args.ArrayCursor) -> void {
+    load_var self
+    load_field .0
+    load_const 0
+    load_array_element
+    return
+}
+
+function inferred_generic_type_args.ArrayCursor.of(items: void[]) -> inferred_generic_type_args.ArrayCursor<void> {
+    load_var items
+    load_const 0
+    load_type #0
+    init_instance<1> user.inferred_generic_type_args.ArrayCursor .arr, .idx
+    return
+}
+
+function inferred_generic_type_args.Boxed$stream.Wrap<T>.first(self: inferred_generic_type_args.Boxed$stream) -> void {
+    load_var self
+    load_field .0
+    return
+}
+
+function inferred_generic_type_args.Boxed.Wrap<T>.first(self: inferred_generic_type_args.Boxed) -> void {
+    load_var self
+    load_field .0
+    return
+}
+
+function inferred_generic_type_args.Cat$stream.Animal.speak(self: inferred_generic_type_args.Cat$stream) -> string {
+    load_const "meow"
+    return
+}
+
+function inferred_generic_type_args.Cat.Animal.speak(self: inferred_generic_type_args.Cat) -> string {
+    load_const "meow"
+    return
+}
+
+function inferred_generic_type_args.Counter.element_type(self: null) -> string {
+    load_type #0
+    call baml.TypeValue.to_string
+    return
+}
+
+function inferred_generic_type_args.Cursor.take_one(self: null) -> inferred_generic_type_args.Cursor<void> {
+    load_var self
+    is_type SingleCursor<...>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_type #0
+    load_var self
+    call user.inferred_generic_type_args.ArrayCursor.Cursor<T>.head
+    jump L2
+
+  L1:
+    load_type #0
+    load_var self
+    call user.inferred_generic_type_args.SingleCursor.Cursor<T>.head
+
+  L2:
+    load_type #0
+    init_instance<1> user.inferred_generic_type_args.SingleCursor .value
+    return
+}
+
+function inferred_generic_type_args.Dog$stream.Animal.speak(self: inferred_generic_type_args.Dog$stream) -> string {
+    load_const "woof"
+    return
+}
+
+function inferred_generic_type_args.Dog.Animal.speak(self: inferred_generic_type_args.Dog) -> string {
+    load_const "woof"
+    return
+}
+
+function inferred_generic_type_args.Dog.make(v: void) -> inferred_generic_type_args.Dog<void> {
+    load_var v
+    load_type #0
+    init_instance<1> user.inferred_generic_type_args.Dog .value
+    return
+}
+
+function inferred_generic_type_args.IntCounter$stream.Counter<T>.describe(self: inferred_generic_type_args.IntCounter$stream) -> string {
+    load_type #0
+    load_var self
+    call user.inferred_generic_type_args.Counter.element_type
+    return
+}
+
+function inferred_generic_type_args.IntCounter.Counter<T>.describe(self: inferred_generic_type_args.IntCounter) -> string {
+    load_type #0
+    load_var self
+    call user.inferred_generic_type_args.Counter.element_type
+    return
+}
+
+function inferred_generic_type_args.Named.tname(self: null) -> string {
+    load_type #0
+    call baml.TypeValue.to_string
+    return
+}
+
+function inferred_generic_type_args.OneBag$stream.Bag<T>.first(self: inferred_generic_type_args.OneBag$stream) -> void {
+    load_var self
+    load_field .0
+    return
+}
+
+function inferred_generic_type_args.OneBag.Bag<T>.first(self: inferred_generic_type_args.OneBag) -> void {
+    load_var self
+    load_field .0
+    return
+}
+
+function inferred_generic_type_args.OneNamed$stream.Named<T>.first(self: inferred_generic_type_args.OneNamed$stream) -> void {
+    load_var self
+    load_field .0
+    return
+}
+
+function inferred_generic_type_args.OneNamed.Named<T>.first(self: inferred_generic_type_args.OneNamed) -> void {
+    load_var self
+    load_field .0
+    return
+}
+
+function inferred_generic_type_args.PlainThing$stream.Describable.describe(self: inferred_generic_type_args.PlainThing$stream) -> string {
+    load_const "plain"
+    return
+}
+
+function inferred_generic_type_args.PlainThing.Describable.describe(self: inferred_generic_type_args.PlainThing) -> string {
+    load_const "plain"
+    return
+}
+
+function inferred_generic_type_args.SingleCursor$stream.Cursor<T>.head(self: inferred_generic_type_args.SingleCursor$stream) -> void {
+    load_var self
+    load_field .0
+    return
+}
+
+function inferred_generic_type_args.SingleCursor.Cursor<T>.head(self: inferred_generic_type_args.SingleCursor) -> void {
+    load_var self
+    load_field .0
+    return
+}
+
+function inferred_generic_type_args.SrcWrap$stream.Wrap<T>.first(self: inferred_generic_type_args.SrcWrap$stream) -> void {
+    load_var self
+    load_field .0
+    load_const 0
+    load_array_element
+    return
+}
+
+function inferred_generic_type_args.SrcWrap.Wrap<T>.first(self: inferred_generic_type_args.SrcWrap) -> void {
+    load_var self
+    load_field .0
+    load_const 0
+    load_array_element
+    return
+}
+
+function inferred_generic_type_args.SrcWrap.boxed(self: inferred_generic_type_args.SrcWrap) -> inferred_generic_type_args.Wrap<void> {
+    load_var self
+    load_field .arr
+    load_const 0
+    load_array_element
+    load_type #0
+    init_instance<1> user.inferred_generic_type_args.Boxed .val
+    return
+}
+
+function inferred_generic_type_args.StrCounter$stream.Counter<T>.describe(self: inferred_generic_type_args.StrCounter$stream) -> string {
+    load_const "str"
+    return
+}
+
+function inferred_generic_type_args.StrCounter.Counter<T>.describe(self: inferred_generic_type_args.StrCounter) -> string {
+    load_const "str"
+    return
+}
+
+function inferred_generic_type_args.TypedBox$stream.Describable.describe(self: inferred_generic_type_args.TypedBox$stream) -> string {
+    load_type #0
+    call baml.TypeValue.to_string
+    return
+}
+
+function inferred_generic_type_args.TypedBox.Describable.describe(self: inferred_generic_type_args.TypedBox) -> string {
+    load_type #0
+    call baml.TypeValue.to_string
+    return
+}
+
+function inferred_generic_type_args.class_method_builds_generic() -> int {
+    load_type int
+    load_const 5
+    load_const 6
+    load_const 7
+    alloc_array 3
+    load_const 0
+    load_type int
+    init_instance<1> user.inferred_generic_type_args.SrcWrap .arr, .idx
+    call user.inferred_generic_type_args.SrcWrap.boxed
+    store_var w
+    load_var w
+    is_type Boxed<...>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_type int
+    load_var w
+    call user.inferred_generic_type_args.SrcWrap.Wrap<T>.first
+    jump L2
+
+  L1:
+    load_type int
+    load_var w
+    call user.inferred_generic_type_args.Boxed.Wrap<T>.first
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.default_forward_reads_type_var() -> string {
+    load_const 7
+    load_type int
+    init_instance<1> user.inferred_generic_type_args.IntCounter .value
+    store_var_load_var c
+    is_type StrCounter<...>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_type int
+    load_var c
+    call user.inferred_generic_type_args.IntCounter.Counter<T>.describe
+    jump L2
+
+  L1:
+    load_type int
+    load_var c
+    call user.inferred_generic_type_args.StrCounter.Counter<T>.describe
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.default_method_typevar_name() -> string {
+    load_const 5
+    load_const 6
+    load_const 7
+    alloc_array 3
+    load_const 0
+    load_type int
+    init_instance<1> user.inferred_generic_type_args.ArrNamed .arr, .idx
+    store_var_load_var s
+    is_type OneNamed<...>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_type int
+    load_var s
+    call user.inferred_generic_type_args.Named.tname
+    jump L2
+
+  L1:
+    load_type int
+    load_var s
+    call user.inferred_generic_type_args.Named.tname
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.generic_behind_nongeneric_iface() -> string {
+    load_const 42
+    load_type int
+    init_instance<1> user.inferred_generic_type_args.TypedBox .value
+    store_var_load_var d
+    is_type PlainThing
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var d
+    make_bound_method user.inferred_generic_type_args.TypedBox.Describable.describe
+    call_indirect
+    jump L2
+
+  L1:
+    load_var d
+    call user.inferred_generic_type_args.PlainThing.Describable.describe
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.inferred_static_ctor_first() -> int {
+    load_const null
+    load_const 5
+    load_const 6
+    load_const 7
+    alloc_array 3
+    call user.inferred_generic_type_args.ArrBag.make
+    store_var s
+    load_var s
+    is_type OneBag<...>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_type int
+    load_var s
+    call user.inferred_generic_type_args.ArrBag.Bag<T>.first
+    jump L2
+
+  L1:
+    load_type int
+    load_var s
+    call user.inferred_generic_type_args.OneBag.Bag<T>.first
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.inferred_static_ctor_speak() -> string {
+    load_const null
+    load_const 42
+    call user.inferred_generic_type_args.Dog.make
+    store_var d
+    load_var d
+    is_type Dog
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var d
+    call user.inferred_generic_type_args.Cat.Animal.speak
+    jump L2
+
+  L1:
+    load_var d
+    make_bound_method user.inferred_generic_type_args.Dog.Animal.speak
+    call_indirect
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.take_one_then_head() -> int {
+    load_const null
+    load_const 10
+    load_const 20
+    load_const 30
+    alloc_array 3
+    call user.inferred_generic_type_args.ArrayCursor.of
+    store_var cursor
+    load_var cursor
+    is_type SingleCursor<...>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_type int
+    load_var cursor
+    call user.inferred_generic_type_args.Cursor.take_one
+    store_var single
+    jump L2
+
+  L1:
+    load_type int
+    load_var cursor
+    call user.inferred_generic_type_args.Cursor.take_one
+    store_var single
+
+  L2:
+    load_var single
+    is_type SingleCursor<...>
+    pop_jump_if_false L3
+    jump L4
+
+  L3:
+    load_type int
+    load_var single
+    call user.inferred_generic_type_args.ArrayCursor.Cursor<T>.head
+    jump L5
+
+  L4:
+    load_type int
+    load_var single
+    call user.inferred_generic_type_args.SingleCursor.Cursor<T>.head
+
+  L5:
+    return
+}


### PR DESCRIPTION
## Problem

A generic class instance whose `<T>` is **inferred** (not written explicitly) must carry the correct runtime `class_type_args`, and a method dispatched through a multi-implementor interface must receive the resolved class/interface type args in its frame.

The interface-dispatch switch (`emit_method_candidate_switch`) called the matched implementor's method with **only the explicit call-site `<...>` type args** — it never seeded the callee frame. So an interface **default method** (e.g. a lazy iterator's `map` building `Map<T, U>`), or any dispatched method that reads its enclosing `T` at runtime (`reflect.type_of<T>()`, constructing `Other<T>{}`), saw an empty `frame.type_args`. It then built instances with `class_type_args = [unknown]`, and the downstream `IsType` dispatch guard fell through to the **wrong implementor** — a silent wrong answer, or a field-access panic when the sibling class has a different layout.

This was the core compiler blocker for the `baml.iter` lazy-iterator protocol.

### Minimal reproduction (before this fix)

```baml
interface Cursor<T> {
  function head(self) -> T throws unknown
  // default method builds a NEW generic from the interface's T
  function take_one(self) -> Cursor<T> throws unknown {
    return SingleCursor<T> { value: self.head() }
  }
}
class ArrayCursor<T> {
  arr T[]
  idx int
  function of(items: T[]) -> ArrayCursor<T> { return ArrayCursor<T> { arr: items, idx: 0 } }
  implements Cursor<T> { function head(self) -> T throws unknown { return self.arr[0] } }
}
class SingleCursor<T> {
  value T
  implements Cursor<T> { function head(self) -> T throws unknown { return self.value } }
}

function take_one_then_head() -> int throws unknown {
  let cursor: Cursor<int> = ArrayCursor.of([10, 20, 30]);  // <int> inferred
  let single: Cursor<int> = cursor.take_one();             // builds SingleCursor<?>
  single.head()                                            // expected 10
}
```

Before: `take_one()` (a default method) had empty `frame.type_args`, so `SingleCursor<T>` was built with `class_type_args = [unknown]`. `single.head()` then failed the `SingleCursor<int>` guard and dispatched to `ArrayCursor.head`, which indexed a non-existent `arr` field. After: returns `10`.

## Fix (in `baml_compiler2_mir::lower`)

1. **`enclosing_generic_params()`** now includes the **interface's** generic params for interface default methods. They are lowered as standalone functions whose bodies reference the interface's `T`; without this, `TypeVar(T)` lowered to `Concrete(Void)` instead of `TypeArgRef(N)`.

2. **The interface-dispatch switch** seeds each candidate's callee frame (De Bruijn order: class/iface params first, then explicit call-site args):
   - a **class-owned** method gets the implementor's class args — **statically** when the guard fully pins them (common/hot path, allocation-free, unchanged bytecode), otherwise from the **matched runtime instance** via a `BoundMethod` (covers `Any`/partial guards, e.g. a generic class behind a *non-generic* interface);
   - an **inherited interface default** gets the resolved interface view's args (these can differ from the implementor's class args when the `implements` block renames/reorders params).

3. **`default.<method>()`** (the super-like form that forwards into the interface default) seeds the default frame with the interface's type args too.

## Tests

New in-BAML regression namespace `crates/baml_tests/baml_src/ns_inferred_generic_type_args`:

- `showcase_lazy_cursor_pipeline` — the lazy-cursor example above, end-to-end.
- `inferred_static_ctor_dispatches_to_correct_implementor` — inferred static ctor + non-generic interface.
- `inferred_static_ctor_dispatches_through_generic_interface` — inferred static ctor + generic interface, mismatched field shapes.
- `interface_default_method_sees_interface_type_var` — default method reads `T` via `reflect.type_of<T>()` at runtime.
- `class_method_builds_generic_via_class_type_var` — class-owned method builds a generic from its class `T`.
- `default_method_forward_reads_interface_type_var` — `default.<method>()` forwarding into a generic default.
- `generic_class_behind_nongeneric_interface_reads_type_var` — `Any`-guard case, seeded from the runtime instance.

Full `baml_tests` suite green. Existing bytecode snapshots unchanged — only the new namespace's `.snap` changed (no existing namespace exercised this path; the `BoundMethod` path fires only for previously-broken `Any`/partial-guard generic arms).

## Known limitation (separate, pre-existing — not addressed here)

A generic class whose **only** field is `T[]`, built via a static constructor with inferred `T`, gets wrong `class_type_args` from the *producer* side (a TIR inference issue in the struct literal, independent of this dispatch fix). Adding any second field (as every real iterator has, e.g. `idx: int`) avoids it, so it does not affect the `ArrayIterator`-shaped use case. Worth a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generic type-argument propagation for interface dispatch so dispatched calls—including default-method forwards and class-owned implementations—receive correct runtime type arguments.

* **Tests**
  * Added end-to-end tests validating inferred generic type args flow through interface dispatch, default-method forwarding, class-owned vs instance-seeded cases, and regressions for varied implementor layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->