### PR TITLE
Generate proto bindings before VSIX package build

### DIFF
--- a/typescript2/README.md
+++ b/typescript2/README.md
@@ -73,19 +73,25 @@ What `pnpm vscode:package` does:
 
    The VSIX is platform-neutral. It does not bundle `baml-cli`; the extension launches `baml lsp` through the configured `baml` wrapper or `baml` on PATH.
 
-3. Builds the packaged React webview:
+3. Generates protobuf TypeScript bindings:
+
+   ```bash
+   pnpm --filter @b/pkg-proto generate
+   ```
+
+4. Builds the packaged React webview:
 
    ```bash
    pnpm --filter app-vscode-webview build
    ```
 
-4. Builds the VS Code extension host bundle:
+5. Builds the VS Code extension host bundle:
 
    ```bash
    pnpm --filter baml-language build
    ```
 
-5. Stages runtime assets into the extension package:
+6. Stages runtime assets into the extension package:
 
    ```bash
    rm -rf app-vscode-ext/dist/playground
@@ -93,7 +99,7 @@ What `pnpm vscode:package` does:
    cp -R app-vscode-webview/dist/. app-vscode-ext/dist/playground/
    ```
 
-6. Packages the VSIX:
+7. Packages the VSIX:
 
    ```bash
    cd app-vscode-ext

--- a/typescript2/package.json
+++ b/typescript2/package.json
@@ -13,7 +13,7 @@
     "build": "turbo run build",
     "vscode:package": "pnpm run vscode:package:clean && pnpm run vscode:package:build && pnpm run vscode:package:stage && pnpm run vscode:package:vsix",
     "vscode:package:clean": "rm -rf app-vscode-webview/dist app-vscode-ext/dist app-vscode-ext/*.vsix",
-    "vscode:package:build": "pnpm run build:wasm && pnpm --filter app-vscode-webview build && pnpm --filter baml-language build",
+    "vscode:package:build": "pnpm run build:wasm && pnpm --filter @b/pkg-proto generate && pnpm --filter app-vscode-webview build && pnpm --filter baml-language build",
     "vscode:package:stage": "rm -rf app-vscode-ext/dist/playground && mkdir -p app-vscode-ext/dist/playground && cp -R app-vscode-webview/dist/. app-vscode-ext/dist/playground/",
     "vscode:package:vsix": "cd app-vscode-ext && pnpm dlx @vscode/vsce package --no-dependencies --allow-missing-repository --skip-license",
     "typecheck": "turbo run typecheck",


### PR DESCRIPTION
## Summary
- generate `@b/pkg-proto` bindings inside `pnpm vscode:package:build` before the webview build
- document the proto generation step in the VSIX packaging README

This addresses the failed VSIX release job where Vite could not resolve `pkg-proto/src/generated/...` from a clean checkout: https://github.com/BoundaryML/baml/actions/runs/26902682253/job/79359045441

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('typescript2/package.json','utf8')); console.log('package.json ok')"`
- `git diff --check`
- `corepack pnpm --dir typescript2 --filter @b/pkg-proto generate`
- `corepack pnpm --dir typescript2 --filter app-vscode-webview build`

Note: full `pnpm vscode:package:build` was not run locally because this shell does not have `wasm-pack` on PATH; the release workflow installs it before this command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include protobuf TypeScript bindings generation in the packaging pipeline.
  * Updated documentation for local build instructions to reflect the new build process step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->