### PR TITLE
Add assert.approx_equal for epsilon-based float assertions

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/assert/assert.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/assert/assert.baml
@@ -27,6 +27,27 @@ function equal(actual: unknown, expected: unknown) -> null {
   }
 }
 
+/// Asserts that `actual` and `expected` floats differ by no more than `epsilon`.
+/// Panics with the observed delta if `abs(actual - expected) > epsilon`.
+function approx_equal(actual: float, expected: float, epsilon: float) -> null {
+  let delta = (actual - expected).abs();
+  if (!(delta <= epsilon)) {
+    baml.sys.panic(
+      "assertion failed: expected approximately equal floats (actual: " +
+      baml.unstable.string(actual) +
+      ", expected: " +
+      baml.unstable.string(expected) +
+      ", epsilon: " +
+      baml.unstable.string(epsilon) +
+      ", delta: " +
+      baml.unstable.string(delta) +
+      ")"
+    )
+  } else {
+    null
+  }
+}
+
 /// Asserts that `haystack` contains `needle` as a substring. Panics if not.
 function contains(haystack: string, needle: string) -> null {
   if (!haystack.includes(needle)) {

--- a/baml_language/crates/baml_builtins2/baml_std/assert/assert.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/assert/assert.baml
@@ -30,7 +30,8 @@ function equal(actual: unknown, expected: unknown) -> null {
 /// Asserts that `actual` and `expected` floats differ by no more than `epsilon`.
 /// Panics with the observed delta if `abs(actual - expected) > epsilon`.
 function approx_equal(actual: float, expected: float, epsilon: float) -> null {
-  let delta = (actual - expected).abs();
+  let difference = actual - expected;
+  let delta = difference.abs();
   if (!(delta <= epsilon)) {
     baml.sys.panic(
       "assertion failed: expected approximately equal floats (actual: " +

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_assert_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_assert_package_listing.snap
@@ -5,4 +5,5 @@ expression: output
 function         is_true                          <builtin>/assert/assert.baml:4
 function         not_null                         <builtin>/assert/assert.baml:13
 function         equal                            <builtin>/assert/assert.baml:22
-function         contains                         <builtin>/assert/assert.baml:31
+function         approx_equal                     <builtin>/assert/assert.baml:32
+function         contains                         <builtin>/assert/assert.baml:53

--- a/baml_language/crates/baml_tests/baml_src/ns_floats/floats.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_floats/floats.baml
@@ -6,8 +6,7 @@
 // Assertion strategy:
 //   - Boolean predicates (is_nan, is_infinite, is_finite): deep_equals to true/false.
 //   - Exact float values (integer-valued results): deep_equals.
-//   - Approximate float values (transcendental results): inline epsilon check
-//     `assert.is_true(((result) - (expected)).abs() < eps)`.
+//   - Approximate float values: assert.approx_equal(result, expected, eps).
 //   - NaN results: assert.is_true(result.is_nan()).
 //   - Multi-case Rust tests are split into separate BAML tests.
 //
@@ -78,6 +77,16 @@ test "float_is_finite_false_for_infinity" {
 
 test "float_is_finite_false_for_negative_infinity" {
     assert.is_true(baml.deep_equals((-float.inf()).is_finite(), false))
+}
+
+// ─── Approximate assertions ───────────────────────────────────────────────────
+
+test "float_approx_equal_accepts_non_exact_result" {
+    assert.approx_equal(float.parse("0.1") + float.parse("0.2"), float.parse("0.3"), 0.000000000000001)
+}
+
+test "float_approx_equal_accepts_delta_equal_to_epsilon" {
+    assert.approx_equal(1.25, 1.0, 0.25)
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────

--- a/baml_language/crates/baml_tests/snapshots/baml_src/floats.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/floats.snap
@@ -87,1088 +87,1100 @@ function floats.$init_test_ns_floats_floats(registry: testing.TestCollector) -> 
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_pi_value"
+    load_const "float_approx_equal_accepts_non_exact_result"
     make_closure .<lambda($init_test_ns_floats_floats, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_e_value"
+    load_const "float_approx_equal_accepts_delta_equal_to_epsilon"
     make_closure .<lambda($init_test_ns_floats_floats, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_golden_ratio_value"
+    load_const "float_pi_value"
     make_closure .<lambda($init_test_ns_floats_floats, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_nan_is_a_nan"
+    load_const "float_e_value"
     make_closure .<lambda($init_test_ns_floats_floats, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_inf_is_positive_infinity"
+    load_const "float_golden_ratio_value"
     make_closure .<lambda($init_test_ns_floats_floats, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_inf_is_positive_not_negative"
+    load_const "float_nan_is_a_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_negative_inf_via_unary_minus"
+    load_const "float_inf_is_positive_infinity"
     make_closure .<lambda($init_test_ns_floats_floats, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_negative_inf_is_negative"
+    load_const "float_inf_is_positive_not_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_abs_negative"
+    load_const "float_negative_inf_via_unary_minus"
     make_closure .<lambda($init_test_ns_floats_floats, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_abs_positive"
+    load_const "float_negative_inf_is_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_abs_nan_is_nan"
+    load_const "float_abs_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_abs_inf_is_inf"
+    load_const "float_abs_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_abs_inf_becomes_positive"
+    load_const "float_abs_nan_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_min_basic"
+    load_const "float_abs_inf_is_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_min_with_nan_suppresses_nan"
+    load_const "float_abs_inf_becomes_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_min_nan_receiver_suppresses_nan"
+    load_const "float_min_basic"
     make_closure .<lambda($init_test_ns_floats_floats, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_min_both_nan_is_nan"
+    load_const "float_min_with_nan_suppresses_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_max_basic"
+    load_const "float_min_nan_receiver_suppresses_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_max_with_nan_suppresses_nan"
+    load_const "float_min_both_nan_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_max_nan_receiver_suppresses_nan"
+    load_const "float_max_basic"
     make_closure .<lambda($init_test_ns_floats_floats, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_clamp_in_range"
+    load_const "float_max_with_nan_suppresses_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_clamp_below"
+    load_const "float_max_nan_receiver_suppresses_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_clamp_above"
+    load_const "float_clamp_in_range"
     make_closure .<lambda($init_test_ns_floats_floats, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_floor_positive_fraction"
+    load_const "float_clamp_below"
     make_closure .<lambda($init_test_ns_floats_floats, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_floor_negative_fraction"
+    load_const "float_clamp_above"
     make_closure .<lambda($init_test_ns_floats_floats, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_floor_integer_unchanged"
+    load_const "float_floor_positive_fraction"
     make_closure .<lambda($init_test_ns_floats_floats, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_ceil_positive_fraction"
+    load_const "float_floor_negative_fraction"
     make_closure .<lambda($init_test_ns_floats_floats, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_ceil_negative_fraction"
+    load_const "float_floor_integer_unchanged"
     make_closure .<lambda($init_test_ns_floats_floats, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_round_half_up"
+    load_const "float_ceil_positive_fraction"
     make_closure .<lambda($init_test_ns_floats_floats, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_round_negative_half_away_from_zero"
+    load_const "float_ceil_negative_fraction"
     make_closure .<lambda($init_test_ns_floats_floats, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_round_below_half"
+    load_const "float_round_half_up"
     make_closure .<lambda($init_test_ns_floats_floats, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_round_above_half"
+    load_const "float_round_negative_half_away_from_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_round_two_point_five_is_three"
+    load_const "float_round_below_half"
     make_closure .<lambda($init_test_ns_floats_floats, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_round_negative_two_point_five_is_neg_three"
+    load_const "float_round_above_half"
     make_closure .<lambda($init_test_ns_floats_floats, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_trunc_positive"
+    load_const "float_round_two_point_five_is_three"
     make_closure .<lambda($init_test_ns_floats_floats, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_trunc_negative"
+    load_const "float_round_negative_two_point_five_is_neg_three"
     make_closure .<lambda($init_test_ns_floats_floats, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_fract_positive"
+    load_const "float_trunc_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_fract_negative"
+    load_const "float_trunc_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_fract_integer_is_zero"
+    load_const "float_fract_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_floor_nan_propagates"
+    load_const "float_fract_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_ifloor_positive"
+    load_const "float_fract_integer_is_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_ifloor_negative"
+    load_const "float_floor_nan_propagates"
     make_closure .<lambda($init_test_ns_floats_floats, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iceil_positive"
+    load_const "float_ifloor_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iceil_negative"
+    load_const "float_ifloor_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iround_half_up"
+    load_const "float_iceil_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iround_negative_half"
+    load_const "float_iceil_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iround_below_half"
+    load_const "float_iround_half_up"
     make_closure .<lambda($init_test_ns_floats_floats, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_itrunc_positive"
+    load_const "float_iround_negative_half"
     make_closure .<lambda($init_test_ns_floats_floats, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_itrunc_negative"
+    load_const "float_iround_below_half"
     make_closure .<lambda($init_test_ns_floats_floats, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iround_at_i63_min_is_ok"
+    load_const "float_itrunc_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iround_too_large_throws"
+    load_const "float_itrunc_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iround_too_small_throws"
+    load_const "float_iround_at_i63_min_is_ok"
     make_closure .<lambda($init_test_ns_floats_floats, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_itrunc_nan_throws"
+    load_const "float_iround_too_large_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_itrunc_inf_throws"
+    load_const "float_iround_too_small_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iround_nan_throws"
+    load_const "float_itrunc_nan_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iround_inf_throws"
+    load_const "float_itrunc_inf_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_ifloor_nan_throws"
+    load_const "float_iround_nan_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_ifloor_inf_throws"
+    load_const "float_iround_inf_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_ifloor_neg_inf_throws"
+    load_const "float_ifloor_nan_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iceil_nan_throws"
+    load_const "float_ifloor_inf_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_iceil_inf_throws"
+    load_const "float_ifloor_neg_inf_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_sqrt_basic_4"
+    load_const "float_iceil_nan_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_sqrt_basic_2"
+    load_const "float_iceil_inf_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_sqrt_zero"
+    load_const "float_sqrt_basic_4"
     make_closure .<lambda($init_test_ns_floats_floats, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_sqrt_negative_is_nan"
+    load_const "float_sqrt_basic_2"
     make_closure .<lambda($init_test_ns_floats_floats, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_pow_integer"
+    load_const "float_sqrt_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_pow_negative_exp"
+    load_const "float_sqrt_negative_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_pow_fractional_exp"
+    load_const "float_pow_integer"
     make_closure .<lambda($init_test_ns_floats_floats, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_pow_negative_base_fractional_is_nan"
+    load_const "float_pow_negative_exp"
     make_closure .<lambda($init_test_ns_floats_floats, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_pow_one_to_nan_is_one"
+    load_const "float_pow_fractional_exp"
     make_closure .<lambda($init_test_ns_floats_floats, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_pow_nan_to_zero_is_one"
+    load_const "float_pow_negative_base_fractional_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_pow_nan_to_one_is_nan"
+    load_const "float_pow_one_to_nan_is_one"
     make_closure .<lambda($init_test_ns_floats_floats, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_log_base_10"
+    load_const "float_pow_nan_to_zero_is_one"
     make_closure .<lambda($init_test_ns_floats_floats, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_log_base_2"
+    load_const "float_pow_nan_to_one_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_log_negative_self_is_nan"
+    load_const "float_log_base_10"
     make_closure .<lambda($init_test_ns_floats_floats, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_hypot_345"
+    load_const "float_log_base_2"
     make_closure .<lambda($init_test_ns_floats_floats, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_hypot_zero"
+    load_const "float_log_negative_self_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_sin_zero"
+    load_const "float_hypot_345"
     make_closure .<lambda($init_test_ns_floats_floats, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_sin_pi_is_zero"
+    load_const "float_hypot_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_sin_half_pi_is_one"
+    load_const "float_sin_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_cos_zero_is_one"
+    load_const "float_sin_pi_is_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_cos_pi_is_neg_one"
+    load_const "float_sin_half_pi_is_one"
     make_closure .<lambda($init_test_ns_floats_floats, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_tan_zero"
+    load_const "float_cos_zero_is_one"
     make_closure .<lambda($init_test_ns_floats_floats, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_tan_pi_quarter_is_one"
+    load_const "float_cos_pi_is_neg_one"
     make_closure .<lambda($init_test_ns_floats_floats, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_asin_one_is_half_pi"
+    load_const "float_tan_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 98)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_asin_out_of_range_is_nan"
+    load_const "float_tan_pi_quarter_is_one"
     make_closure .<lambda($init_test_ns_floats_floats, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_acos_zero_is_half_pi"
+    load_const "float_asin_one_is_half_pi"
     make_closure .<lambda($init_test_ns_floats_floats, 100)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_acos_out_of_range_is_nan"
+    load_const "float_asin_out_of_range_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_atan_one_is_quarter_pi"
+    load_const "float_acos_zero_is_half_pi"
     make_closure .<lambda($init_test_ns_floats_floats, 102)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_atan2_one_one_is_quarter_pi"
+    load_const "float_acos_out_of_range_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_atan2_one_zero_is_half_pi"
+    load_const "float_atan_one_is_quarter_pi"
     make_closure .<lambda($init_test_ns_floats_floats, 104)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_atan2_zero_neg_one_is_pi"
+    load_const "float_atan2_one_one_is_quarter_pi"
     make_closure .<lambda($init_test_ns_floats_floats, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_sinh_zero"
+    load_const "float_atan2_one_zero_is_half_pi"
     make_closure .<lambda($init_test_ns_floats_floats, 106)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_cosh_zero_is_one"
+    load_const "float_atan2_zero_neg_one_is_pi"
     make_closure .<lambda($init_test_ns_floats_floats, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_tanh_large_input_approaches_one"
+    load_const "float_sinh_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 108)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_asinh_zero"
+    load_const "float_cosh_zero_is_one"
     make_closure .<lambda($init_test_ns_floats_floats, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_acosh_one_is_zero"
+    load_const "float_tanh_large_input_approaches_one"
     make_closure .<lambda($init_test_ns_floats_floats, 110)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_acosh_below_one_is_nan"
+    load_const "float_asinh_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_atanh_zero"
+    load_const "float_acosh_one_is_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 112)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_atanh_out_of_range_is_nan"
+    load_const "float_acosh_below_one_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 113)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_to_radians_180_is_pi"
+    load_const "float_atanh_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 114)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_to_radians_zero"
+    load_const "float_atanh_out_of_range_is_nan"
     make_closure .<lambda($init_test_ns_floats_floats, 115)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_to_degrees_pi_is_180"
+    load_const "float_to_radians_180_is_pi"
     make_closure .<lambda($init_test_ns_floats_floats, 116)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_to_radians_round_trip"
+    load_const "float_to_radians_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 117)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_decimal"
+    load_const "float_to_degrees_pi_is_180"
     make_closure .<lambda($init_test_ns_floats_floats, 118)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_negative"
+    load_const "float_to_radians_round_trip"
     make_closure .<lambda($init_test_ns_floats_floats, 119)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_explicit_plus"
+    load_const "float_parse_decimal"
     make_closure .<lambda($init_test_ns_floats_floats, 120)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_integer"
+    load_const "float_parse_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 121)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_zero"
+    load_const "float_parse_explicit_plus"
     make_closure .<lambda($init_test_ns_floats_floats, 122)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_scientific_lowercase"
+    load_const "float_parse_integer"
     make_closure .<lambda($init_test_ns_floats_floats, 123)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_scientific_uppercase_negative_exp"
+    load_const "float_parse_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 124)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_inf"
+    load_const "float_parse_scientific_lowercase"
     make_closure .<lambda($init_test_ns_floats_floats, 125)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_inf_is_positive"
+    load_const "float_parse_scientific_uppercase_negative_exp"
     make_closure .<lambda($init_test_ns_floats_floats, 126)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_infinity_word"
+    load_const "float_parse_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 127)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_infinity_word_is_positive"
+    load_const "float_parse_inf_is_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 128)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_negative_inf"
+    load_const "float_parse_infinity_word"
     make_closure .<lambda($init_test_ns_floats_floats, 129)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_negative_inf_is_negative"
+    load_const "float_parse_infinity_word_is_positive"
     make_closure .<lambda($init_test_ns_floats_floats, 130)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_nan_lowercase"
+    load_const "float_parse_negative_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 131)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_nan_mixed_case"
+    load_const "float_parse_negative_inf_is_negative"
     make_closure .<lambda($init_test_ns_floats_floats, 132)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_empty_throws"
+    load_const "float_parse_nan_lowercase"
     make_closure .<lambda($init_test_ns_floats_floats, 133)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_alpha_throws"
+    load_const "float_parse_nan_mixed_case"
     make_closure .<lambda($init_test_ns_floats_floats, 134)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_trailing_garbage_throws"
+    load_const "float_parse_empty_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 135)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_whitespace_throws"
+    load_const "float_parse_alpha_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 136)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_just_sign_throws"
+    load_const "float_parse_trailing_garbage_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 137)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_parse_round_trip_in_arithmetic"
+    load_const "float_parse_whitespace_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 138)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_random_returns_a_float"
+    load_const "float_parse_just_sign_throws"
     make_closure .<lambda($init_test_ns_floats_floats, 139)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_random_in_unit_interval_and_covers_both_halves"
+    load_const "float_parse_round_trip_in_arithmetic"
     make_closure .<lambda($init_test_ns_floats_floats, 140)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_random_distinct_values"
+    load_const "float_random_returns_a_float"
     make_closure .<lambda($init_test_ns_floats_floats, 141)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_float_eq_int_literal_fold"
+    load_const "float_random_in_unit_interval_and_covers_both_halves"
     make_closure .<lambda($init_test_ns_floats_floats, 142)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_float_neq_int_distinct_fold"
+    load_const "float_random_distinct_values"
     make_closure .<lambda($init_test_ns_floats_floats, 143)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_fold_ordinary_equal"
+    load_const "float_eq_float_eq_int_literal_fold"
     make_closure .<lambda($init_test_ns_floats_floats, 144)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_fold_ordinary_unequal_false"
+    load_const "float_eq_float_neq_int_distinct_fold"
     make_closure .<lambda($init_test_ns_floats_floats, 145)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_int_eq_float_literal_fold"
+    load_const "float_eq_fold_ordinary_equal"
     make_closure .<lambda($init_test_ns_floats_floats, 146)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_large_integer_valued_fold"
+    load_const "float_eq_fold_ordinary_unequal_false"
     make_closure .<lambda($init_test_ns_floats_floats, 147)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_neg_zero_lit_equals_neg_zero_lit_fold"
+    load_const "float_eq_int_eq_float_literal_fold"
     make_closure .<lambda($init_test_ns_floats_floats, 148)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_positive_zero_equals_negative_zero_fold"
+    load_const "float_eq_large_integer_valued_fold"
     make_closure .<lambda($init_test_ns_floats_floats, 149)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_null_eq_float_symmetric_false"
+    load_const "float_eq_neg_zero_lit_equals_neg_zero_lit_fold"
     make_closure .<lambda($init_test_ns_floats_floats, 150)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_two_pow_53_exact"
+    load_const "float_eq_positive_zero_equals_negative_zero_fold"
     make_closure .<lambda($init_test_ns_floats_floats, 151)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_classic_imprecision_sum"
+    load_const "float_eq_null_eq_float_symmetric_false"
     make_closure .<lambda($init_test_ns_floats_floats, 152)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_div_third_eq_shortest"
+    load_const "float_eq_two_pow_53_exact"
     make_closure .<lambda($init_test_ns_floats_floats, 153)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_div_third_ne_truncated"
+    load_const "float_eq_classic_imprecision_sum"
     make_closure .<lambda($init_test_ns_floats_floats, 154)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_float_eq_null_is_false"
+    load_const "float_eq_div_third_eq_shortest"
     make_closure .<lambda($init_test_ns_floats_floats, 155)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_float_neq_null_is_true"
+    load_const "float_eq_div_third_ne_truncated"
     make_closure .<lambda($init_test_ns_floats_floats, 156)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_half_underflow_to_zero"
+    load_const "float_eq_float_eq_null_is_false"
     make_closure .<lambda($init_test_ns_floats_floats, 157)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_inf_minus_inf_is_nan_ne_self"
+    load_const "float_eq_float_neq_null_is_true"
     make_closure .<lambda($init_test_ns_floats_floats, 158)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_inf_plus_one_equals_inf"
+    load_const "float_eq_half_underflow_to_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 159)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_large_magnitude_precision_loss"
+    load_const "float_eq_inf_minus_inf_is_nan_ne_self"
     make_closure .<lambda($init_test_ns_floats_floats, 160)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_max_finite_ne_inf"
+    load_const "float_eq_inf_plus_one_equals_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 161)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_mul_imprecision_eq_rounded"
+    load_const "float_eq_large_magnitude_precision_loss"
     make_closure .<lambda($init_test_ns_floats_floats, 162)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_mul_imprecision_ne_point3"
+    load_const "float_eq_max_finite_ne_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 163)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_nan_arith_propagates_ne_self"
+    load_const "float_eq_mul_imprecision_eq_rounded"
     make_closure .<lambda($init_test_ns_floats_floats, 164)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_nan_const_not_equal_number"
+    load_const "float_eq_mul_imprecision_ne_point3"
     make_closure .<lambda($init_test_ns_floats_floats, 165)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_nan_eq_null_is_false"
+    load_const "float_eq_nan_arith_propagates_ne_self"
     make_closure .<lambda($init_test_ns_floats_floats, 166)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_nan_ne_number_is_true"
+    load_const "float_eq_nan_const_not_equal_number"
     make_closure .<lambda($init_test_ns_floats_floats, 167)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_nan_ne_self_is_true"
+    load_const "float_eq_nan_eq_null_is_false"
     make_closure .<lambda($init_test_ns_floats_floats, 168)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_nan_not_equal_infinity"
+    load_const "float_eq_nan_ne_number_is_true"
     make_closure .<lambda($init_test_ns_floats_floats, 169)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_nan_not_equal_to_self"
+    load_const "float_eq_nan_ne_self_is_true"
     make_closure .<lambda($init_test_ns_floats_floats, 170)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_neg_inf_equals_neg_inf"
+    load_const "float_eq_nan_not_equal_infinity"
     make_closure .<lambda($init_test_ns_floats_floats, 171)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_neg_zero_from_division"
+    load_const "float_eq_nan_not_equal_to_self"
     make_closure .<lambda($init_test_ns_floats_floats, 172)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_neg_zero_ne_pos_zero_runtime_false"
+    load_const "float_eq_neg_inf_equals_neg_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 173)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_overflow_to_inf"
+    load_const "float_eq_neg_zero_from_division"
     make_closure .<lambda($init_test_ns_floats_floats, 174)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_parse_inf_equals_inf_const"
+    load_const "float_eq_neg_zero_ne_pos_zero_runtime_false"
     make_closure .<lambda($init_test_ns_floats_floats, 175)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_parse_inf_ne_neg_inf"
+    load_const "float_eq_overflow_to_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 176)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_parse_neg_inf_equals_neg_inf_const"
+    load_const "float_eq_parse_inf_equals_inf_const"
     make_closure .<lambda($init_test_ns_floats_floats, 177)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_parse_roundtrip"
+    load_const "float_eq_parse_inf_ne_neg_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 178)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_parse_roundtrip_imprecise_all_runtime"
+    load_const "float_eq_parse_neg_inf_equals_neg_inf_const"
     make_closure .<lambda($init_test_ns_floats_floats, 179)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_pi_eq_pi"
+    load_const "float_eq_parse_roundtrip"
     make_closure .<lambda($init_test_ns_floats_floats, 180)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_pi_ne_truncated"
+    load_const "float_eq_parse_roundtrip_imprecise_all_runtime"
     make_closure .<lambda($init_test_ns_floats_floats, 181)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_pos_inf_equals_pos_inf"
+    load_const "float_eq_pi_eq_pi"
     make_closure .<lambda($init_test_ns_floats_floats, 182)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_pos_inf_ne_neg_inf"
+    load_const "float_eq_pi_ne_truncated"
     make_closure .<lambda($init_test_ns_floats_floats, 183)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_runtime_float_eq_int"
+    load_const "float_eq_pos_inf_equals_pos_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 184)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_runtime_float_neq_int_distinct"
+    load_const "float_eq_pos_inf_ne_neg_inf"
     make_closure .<lambda($init_test_ns_floats_floats, 185)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_runtime_int_eq_float"
+    load_const "float_eq_runtime_float_eq_int"
     make_closure .<lambda($init_test_ns_floats_floats, 186)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_runtime_int_neq_float_distinct"
+    load_const "float_eq_runtime_float_neq_int_distinct"
     make_closure .<lambda($init_test_ns_floats_floats, 187)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_runtime_ordinary_unequal_false"
+    load_const "float_eq_runtime_int_eq_float"
     make_closure .<lambda($init_test_ns_floats_floats, 188)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_runtime_signed_zero"
+    load_const "float_eq_runtime_int_neq_float_distinct"
     make_closure .<lambda($init_test_ns_floats_floats, 189)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_self_equal_nonliteral"
+    load_const "float_eq_runtime_ordinary_unequal_false"
     make_closure .<lambda($init_test_ns_floats_floats, 190)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_sqrt_irrational_ne_two"
+    load_const "float_eq_runtime_signed_zero"
     make_closure .<lambda($init_test_ns_floats_floats, 191)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_sqrt_irrational_property"
+    load_const "float_eq_self_equal_nonliteral"
     make_closure .<lambda($init_test_ns_floats_floats, 192)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_subnormal_nonzero"
+    load_const "float_eq_sqrt_irrational_ne_two"
     make_closure .<lambda($init_test_ns_floats_floats, 193)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "float_eq_sum_equals_exact_rounded"
+    load_const "float_eq_sqrt_irrational_property"
     make_closure .<lambda($init_test_ns_floats_floats, 194)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_subnormal_nonzero"
+    make_closure .<lambda($init_test_ns_floats_floats, 195)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "float_eq_sum_equals_exact_rounded"
+    make_closure .<lambda($init_test_ns_floats_floats, 196)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____03_hir.snap
@@ -6,6 +6,9 @@ source: crates/baml_tests/src/generated_tests.rs
 === HIR2 (package assert) ===
 
 --- <builtin>/assert/assert.baml ---
+function assert.approx_equal(actual: float, expected: float, epsilon: float) -> null  [expr] {
+  { let difference = actual Sub expected; let delta = difference.abs() } if (Not delta Le epsilon) {  } baml.sys.panic("assertion failed:..." Add baml.unstable.string(actual) Add ", expected: " Add baml.unstable.string(expected) Add ", epsilon: " Add baml.unstable.string(epsilon) Add ", delta: " Add baml.unstable.string(delta) Add ")") else {  } null
+}
 function assert.contains(haystack: string, needle: string) -> null  [expr] {
   {  } if (Not haystack.includes(needle)) {  } baml.sys.panic("assertion failed:...") else {  } null
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____04_5_mir.snap
@@ -4,6 +4,82 @@ source: crates/baml_tests/src/generated_tests.rs
 === MIR2 ===
 
 === MIR2 (package assert) ===
+fn assert.approx_equal(actual: float, expected: float, epsilon: float) -> null {
+    // Locals:
+    let _0: null // _0 // return
+    let _1: float // actual // param
+    let _2: float // expected // param
+    let _3: float // epsilon // param
+    let _4: float // difference
+    let _5: float // delta
+    let _6: bool
+    let _7: bool
+    let _8: float
+    let _9: string
+    let _10: string
+    let _11: string
+    let _12: string
+    let _13: string
+    let _14: string
+    let _15: string
+    let _16: string
+    let _17: string
+    let _18: string
+    let _19: string
+    let _20: string
+    let _21: float
+
+    bb0: {
+        _4 = copy _1 - copy _2;
+        _5 = call const fn baml.Float.abs(copy _4) -> [bb1];
+    }
+
+    bb1: {
+        _8 = copy _5;
+        _7 = copy _8 <= copy _3;
+        _6 = !copy _7;
+        branch copy _6 -> [bb3, bb2];
+    }
+
+    bb2: {
+        _0 = const null;
+        goto -> bb8;
+    }
+
+    bb3: {
+        _17 = call const fn baml.unstable.string(copy _1) -> [bb4];
+    }
+
+    bb4: {
+        _16 = const "assertion failed: expected approximately equal floats (actual: " + copy _17;
+        _15 = copy _16 + const ", expected: ";
+        _18 = call const fn baml.unstable.string(copy _2) -> [bb5];
+    }
+
+    bb5: {
+        _14 = copy _15 + copy _18;
+        _13 = copy _14 + const ", epsilon: ";
+        _19 = call const fn baml.unstable.string(copy _3) -> [bb6];
+    }
+
+    bb6: {
+        _12 = copy _13 + copy _19;
+        _11 = copy _12 + const ", delta: ";
+        _21 = copy _5;
+        _20 = call const fn baml.unstable.string(copy _21) -> [bb7];
+    }
+
+    bb7: {
+        _10 = copy _11 + copy _20;
+        _9 = copy _10 + const ")";
+        _0 = call const fn baml.sys.panic(copy _9) -> [bb8];
+    }
+
+    bb8: {
+        return;
+    }
+}
+
 fn assert.contains(haystack: string, needle: string) -> null {
     // Locals:
     let _0: null // _0 // return

--- a/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____04_tir.snap
@@ -42,6 +42,20 @@ function assert.equal(actual: unknown, expected: unknown) -> null throws never {
       }
   }
 }
+function assert.approx_equal(actual: float, expected: float, epsilon: float) -> null throws never {
+  { : null
+    let difference = actual - expected : float
+    let delta = difference.abs() : float
+    if (Not delta <= epsilon : bool) : null
+      { : never
+        baml.sys.panic("assertion failed:..." + baml.unstable.string(actual) + ", expected: " + baml.unstable.string(expected) + ", epsilon: " + baml.unstable.string(epsilon) + ", delta: " + baml.unstable.string(delta) + ")") : never
+      }
+    else
+      { : null
+        null : null
+      }
+  }
+}
 function assert.contains(haystack: string, needle: string) -> null throws never {
   { : null
     if (Not haystack.includes(needle) : bool) : null

--- a/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__assert_std__/baml_tests__compiles____assert_std____06_codegen.snap
@@ -1,6 +1,57 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
 ---
+function assert.approx_equal(actual: float, expected: float, epsilon: float) -> null {
+    load_var2 1 2
+    sub_float
+    call baml.Float.abs
+    store_var delta
+    load_var2 4 3
+    cmp_float_op <=
+    unary_op !
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const null
+    jump L2
+
+  L1:
+    load_var actual
+    call baml.unstable.string
+    store_var _17
+    load_var expected
+    call baml.unstable.string
+    store_var _18
+    load_var epsilon
+    call baml.unstable.string
+    store_var _19
+    load_var delta
+    call baml.unstable.string
+    store_var _20
+    load_const "assertion failed: expected approximately equal floats (actual: "
+    load_var _17
+    bin_op +
+    load_const ", expected: "
+    bin_op +
+    load_var _18
+    bin_op +
+    load_const ", epsilon: "
+    bin_op +
+    load_var _19
+    bin_op +
+    load_const ", delta: "
+    bin_op +
+    load_var _20
+    bin_op +
+    load_const ")"
+    bin_op +
+    call baml.sys.panic
+
+  L2:
+    return
+}
+
 function assert.contains(haystack: string, needle: string) -> null {
     load_var2 1 2
     call baml.String.includes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

## Issue Reference
- [ ] This PR fixes/closes #[issue number]

## Changes
Adds `assert.approx_equal(actual, expected, epsilon)` to the BAML test stdlib for epsilon-based float comparisons.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in Cursor Cloud Linux environment

## Screenshots
Not applicable.

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

### The error
Before this change, the BAML test stdlib did not define `assert.approx_equal`, so this smallest repro failed:

```baml
test "approx_equal_missing" {
    assert.approx_equal(float.parse("0.1") + float.parse("0.2"), float.parse("0.3"), 0.000000000000001)
}
```

Command run against `origin/canary`:

```bash
cargo run -p baml_cli -- test --from /tmp/baml-approx-repro-src
```

Output:

```text
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
     Loading /tmp/baml-approx-repro-src/main.baml
    Checking 1 file(s)
error: unresolved name: approx_equal
   ╭─[ main.baml:1:1 ]
   │
 1 │ test "approx_equal_missing" {
   │ │ 
   │ ╰─ unresolved name: approx_equal
   │ 
   │ Note: Error code: E0003
───╯

error: unresolved name: approx_equal
   ╭─[ main.baml:1:30 ]
   │
 1 │ ╭─▶ test "approx_equal_missing" {
 2 │ ├─▶     assert.approx_equal(float.parse("0.1") + float.parse("0.2"), float.parse("0.3"), 0.000000000000001)
   │ │                                                                                                             
   │ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────── unresolved name: approx_equal
   │     
   │     Note: Error code: E0003
───╯
```

### Root cause
`baml_language/crates/baml_builtins2/baml_std/assert/assert.baml` defined the test stdlib assertions `is_true`, `not_null`, `equal`, and `contains`, but had no epsilon-based float comparison primitive. `assert.equal(actual, expected)` uses exact equality, so float tests for non-exact IEEE 754 results had to inline `(actual - expected).abs() <= epsilon` manually.

### The fix
Added `assert.approx_equal(actual: float, expected: float, epsilon: float) -> null` in `baml_language/crates/baml_builtins2/baml_std/assert/assert.baml`. It computes `difference = actual - expected`, then `delta = difference.abs()`, and panics unless `delta <= epsilon`. The panic message includes `actual`, `expected`, `epsilon`, and the observed `delta`.

I also added BAML float tests for:

- a non-exact runtime float expression: `float.parse("0.1") + float.parse("0.2")` vs `float.parse("0.3")`
- the inclusive boundary where `delta == epsilon`

Snapshots were updated for the assert stdlib compiler phases, the BAML source bytecode, and the CLI package listing.

### Verification
Commands run after the fix:

```bash
PATH="$HOME/.local/bin:$PATH" cargo test -p baml_tests --test baml_src baml_test -- --nocapture
```

Relevant passing output showing the same repro now succeeds in `baml_src/ns_floats/floats.baml`:

```text
PASS ::float_approx_equal_accepts_non_exact_result
PASS ::float_approx_equal_accepts_delta_equal_to_epsilon
Finished 1616 passed, 0 failed, 1616 total in 42s
test baml_test ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 102.63s
```

```bash
PATH="$HOME/.local/bin:$PATH" cargo test -p baml_tests __assert_std__
PATH="$HOME/.local/bin:$PATH" cargo test -p baml_tests --test baml_src bytecode
PATH="$HOME/.local/bin:$PATH" cargo test -p baml_cli render_assert_package_listing
```

Passing output:

```text
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1570 filtered out; finished in 1.14s

test bytecode ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 30.45s

test describe_command_tests::render_assert_package_listing ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 162 filtered out; finished in 0.05s
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23b62b97-c803-5b6b-8f82-aefc7c50fadc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23b62b97-c803-5b6b-8f82-aefc7c50fadc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

