### PR TITLE
Add Int operator metadata to baml describe output

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/int.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/int.baml
@@ -1,4 +1,4 @@
-/// A 64-bit signed integer (i64). Range: -2^63 to 2^63-1.
+/// A 63-bit signed integer. Range: -2^62 to 2^62-1.
 class Int {
   /// Serializes this integer to a JSON number.
   function to_json(self) -> baml.json.json throws never {
@@ -9,7 +9,7 @@ class Int {
   /// Returns the absolute value of `self`.
   ///
   /// Throws `InvalidArgument` for `int.min_value()` because its absolute value
-  /// (`2^63`) does not fit in an `int`.
+  /// (`2^62`) does not fit in an `int`.
   ///
   /// # Examples
   /// ```
@@ -207,7 +207,7 @@ class Int {
   ///
   /// Accepts an optional leading `+` or `-` sign followed by one or more
   /// ASCII digits. No surrounding whitespace, no underscores, no other
-  /// numeric formats. The result must fit in an `int` (`i64`).
+  /// numeric formats. The result must fit in an `int` (`-2^62` to `2^62-1`).
   ///
   /// Throws `ParseError` if `text` is empty, contains a non-digit character,
   /// or represents a value outside the `int` range.

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -571,6 +571,9 @@ pub fn write_description(
     // ── Static methods ───────────────────────────────────────────────────────
     write_method_section(w, db, project_root, "static_methods", &desc.static_methods)?;
 
+    // ── Operators ────────────────────────────────────────────────────────────
+    write_operator_section(w, &desc.operators)?;
+
     // ── Container ────────────────────────────────────────────────────────────
     if let Some(ref c) = desc.container {
         writeln!(w)?;
@@ -620,6 +623,30 @@ pub fn write_description(
     }
 
     let _ = lines_used; // budget tracking removed with new format
+    Ok(())
+}
+
+/// Render a builtin numeric operator section.
+fn write_operator_section(
+    w: &mut impl std::io::Write,
+    operators: &[describe::OperatorRef],
+) -> std::io::Result<()> {
+    if operators.is_empty() {
+        return Ok(());
+    }
+    writeln!(w)?;
+    writeln!(w, "operators:")?;
+    for op in operators {
+        writeln!(
+            w,
+            "  {:<2}  {:<32} precedence: {}",
+            op.symbol, op.signature, op.precedence
+        )?;
+        writeln!(w, "      behavior: {}", op.behavior)?;
+        if let Some(status) = op.status {
+            writeln!(w, "      status: {status}")?;
+        }
+    }
     Ok(())
 }
 

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -104,6 +104,20 @@ class Baz {
 ///
 /// Uses the new `dispatch()` function (based on `ResolvedTarget`) so tests
 /// exercise the same code path as `baml describe <name>`.
+fn described_item_via_dispatch(
+    db: &ProjectDatabase,
+    name: &str,
+) -> baml_lsp2_actions::SymbolDescription {
+    let files = baml_compiler2_hir::compiler2_all_files(db);
+    match dispatch(db, name) {
+        Some(ResolvedTarget::Item(def)) => {
+            baml_lsp2_actions::describe_by_definition(db, &files, def)
+                .unwrap_or_else(|| panic!("no description for {name}"))
+        }
+        other => panic!("expected item target for {name}, got {other:?}"),
+    }
+}
+
 fn describe_via_dispatch(db: &ProjectDatabase, name: &str) -> String {
     let files = baml_compiler2_hir::compiler2_all_files(db);
     match dispatch(db, name) {
@@ -659,6 +673,73 @@ fn dispatch_lowercase_aliases_resolve_to_items() {
             "alias `{alias}` should resolve to a builtin class item"
         );
     }
+}
+
+/// `baml describe int` lists infix/prefix operators outside the body budget.
+#[test]
+fn render_describe_int_lists_operators_even_with_tight_budget() {
+    let db = simple_project();
+    let desc = described_item_via_dispatch(&db, "int");
+    let output = capture_description(&db, &desc, 5);
+
+    assert!(
+        output.contains("operators:"),
+        "missing operators section:\n{output}"
+    );
+    for needle in [
+        "+   (int, int) -> int",
+        "-   (int, int) -> int",
+        "*   (int, int) -> int",
+        "/   (int, int) -> int",
+        "%   (int, int) -> int",
+        "&   (int, int) -> int",
+        "|   (int, int) -> int",
+        "^   (int, int) -> int",
+        "<<  (int, int) -> int",
+        ">>  (int, int) -> int",
+        "~   (int) -> int",
+    ] {
+        assert!(
+            output.contains(needle),
+            "operator `{needle}` missing from describe output:\n{output}"
+        );
+    }
+    assert!(
+        output.contains("63-bit signed integer range [-4611686018427387904, 4611686018427387903]"),
+        "int range note missing:\n{output}"
+    );
+    assert!(
+        output.contains("Known limitation")
+            && output.contains("`~0` currently evaluates as `0` instead of `-1`"),
+        "~ limitation note missing:\n{output}"
+    );
+}
+
+/// JSON describe output carries the same operator metadata for programmatic use.
+#[test]
+fn describe_int_json_includes_operator_metadata() {
+    let db = simple_project();
+    let desc = described_item_via_dispatch(&db, "int");
+    let json = crate::grep_command::description_to_json(&db, &desc, 5, Path::new("/test"));
+    let operators = json["operators"]
+        .as_array()
+        .expect("operators should be a JSON array");
+
+    assert!(
+        operators
+            .iter()
+            .any(|op| op["symbol"] == "%" && op["signature"] == "(int, int) -> int"),
+        "modulo operator missing from JSON: {json:#}"
+    );
+    assert!(
+        operators.iter().any(|op| {
+            op["symbol"] == "~"
+                && op["status"]
+                    .as_str()
+                    .is_some_and(|status| status.contains("Known limitation"))
+        }),
+        "~ limitation missing from JSON: {json:#}"
+    );
 }
 
 /// Comment stripping is CST-token based, so a line that *looks* like a comment

--- a/baml_language/crates/baml_cli/src/grep_command.rs
+++ b/baml_language/crates/baml_cli/src/grep_command.rs
@@ -505,6 +505,15 @@ pub fn description_to_json(
         }).collect::<Vec<_>>(),
         "instance_methods": method_json(db, project_root, &desc.instance_methods),
         "static_methods": method_json(db, project_root, &desc.static_methods),
+        "operators": desc.operators.iter().map(|op| {
+            serde_json::json!({
+                "symbol": op.symbol,
+                "signature": op.signature,
+                "precedence": op.precedence,
+                "behavior": op.behavior,
+                "status": op.status,
+            })
+        }).collect::<Vec<_>>(),
         "container": desc.container.as_ref().map(|c| {
             let c_path = relative_path(&c.file.path(db), project_root);
             serde_json::json!({

--- a/baml_language/crates/baml_lsp2_actions/src/describe.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/describe.rs
@@ -61,6 +61,8 @@ pub struct SymbolDescription {
     pub instance_methods: Vec<MethodRef>,
     /// Static methods (no `self` param) for classes.
     pub static_methods: Vec<MethodRef>,
+    /// Operator forms supported by builtin companion classes.
+    pub operators: Vec<OperatorRef>,
     /// The containing class/enum for members.
     pub container: Option<DepRef>,
     /// Canonical fully-qualified name to print in the header, shown only when
@@ -87,6 +89,16 @@ pub struct MethodRef {
     /// Byte range of the full method definition (1-based line range when rendered).
     #[serde(serialize_with = "serialize_range")]
     pub item_range: TextRange,
+}
+
+/// A builtin operator surfaced by `describe` alongside method-style APIs.
+#[derive(Clone, Serialize)]
+pub struct OperatorRef {
+    pub symbol: &'static str,
+    pub signature: &'static str,
+    pub precedence: &'static str,
+    pub behavior: &'static str,
+    pub status: Option<&'static str>,
 }
 
 /// A symbol referenced in the signature of another symbol.
@@ -284,9 +296,10 @@ fn describe_top_level(
     // ── Reference finding ────────────────────────────────────────────────────
     let references = find_references(db, files, file, sym.name_span, item_range);
 
-    // ── Methods + canonical FQN (classes) ────────────────────────────────────
+    // ── Methods + operators + canonical FQN (classes) ────────────────────────
     let (instance_methods, static_methods, canonical_fqn) =
         class_methods_and_fqn(db, sym, definition);
+    let operators = builtin_operator_docs(db, definition, canonical_fqn.as_deref(), &sym.name);
 
     // Body block, with non-doc comments removed (CST-token based, so `//`
     // inside string/prompt literals is never touched):
@@ -330,6 +343,7 @@ fn describe_top_level(
         references,
         instance_methods,
         static_methods,
+        operators,
         container: None,
         canonical_fqn,
     })
@@ -408,10 +422,255 @@ fn describe_member(
         references,
         instance_methods: Vec::new(),
         static_methods: Vec::new(),
+        operators: Vec::new(),
         container,
         canonical_fqn: None,
     })
 }
+
+fn builtin_operator_docs(
+    db: &dyn Db,
+    def: Option<Definition<'_>>,
+    canonical_fqn: Option<&str>,
+    name: &str,
+) -> Vec<OperatorRef> {
+    let Some(Definition::Class(class_loc)) = def else {
+        return Vec::new();
+    };
+
+    let file = class_loc.file(db);
+    if !file
+        .path(db)
+        .to_string_lossy()
+        .starts_with("<builtin>/baml/")
+    {
+        return Vec::new();
+    }
+
+    let type_name = canonical_fqn.unwrap_or(name);
+    match type_name {
+        "int" | "Int" => INT_OPERATORS.to_vec(),
+        "bigint" | "Bigint" => BIGINT_OPERATORS.to_vec(),
+        "float" | "Float" => FLOAT_OPERATORS.to_vec(),
+        _ => Vec::new(),
+    }
+}
+
+const INT_OPERATORS: &[OperatorRef] = &[
+    OperatorRef {
+        symbol: "+",
+        signature: "(int, int) -> int",
+        precedence: "22 (addition; left-associative)",
+        behavior: "63-bit signed integer range [-4611686018427387904, 4611686018427387903]; current VM fast path wraps the tagged representation on overflow.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "-",
+        signature: "(int, int) -> int",
+        precedence: "22 (addition; left-associative)",
+        behavior: "63-bit signed integer range [-4611686018427387904, 4611686018427387903]; current VM fast path wraps the tagged representation on overflow.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "*",
+        signature: "(int, int) -> int",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "63-bit signed integer range [-4611686018427387904, 4611686018427387903]; result is constructed with Value::int and is not overflow-checked in release builds.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "/",
+        signature: "(int, int) -> int",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "Truncating integer division; division by zero raises baml.panics.DivisionByZero.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "%",
+        signature: "(int, int) -> int",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "Remainder with Rust/i64 sign semantics; modulo by zero raises baml.panics.DivisionByZero.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "&",
+        signature: "(int, int) -> int",
+        precedence: "14 (bitwise AND; left-associative)",
+        behavior: "Bitwise AND on the 63-bit signed integer payload.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "|",
+        signature: "(int, int) -> int",
+        precedence: "10 (bitwise OR; left-associative)",
+        behavior: "Bitwise OR on the 63-bit signed integer payload.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "^",
+        signature: "(int, int) -> int",
+        precedence: "12 (bitwise XOR; left-associative)",
+        behavior: "Bitwise XOR on the 63-bit signed integer payload.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "<<",
+        signature: "(int, int) -> int",
+        precedence: "20 (bitwise shift; left-associative)",
+        behavior: "Left shift on int payload; current runtime does not add a BAML-level guard for negative or oversized counts.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: ">>",
+        signature: "(int, int) -> int",
+        precedence: "20 (bitwise shift; left-associative)",
+        behavior: "Arithmetic right shift on int payload; current runtime does not add a BAML-level guard for negative or oversized counts.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "~",
+        signature: "(int) -> int",
+        precedence: "prefix",
+        behavior: "Intended bitwise NOT.",
+        status: Some(
+            "Known limitation: parsed today, but AST lowering does not map `~`; `~0` currently evaluates as `0` instead of `-1`.",
+        ),
+    },
+    OperatorRef {
+        symbol: "-",
+        signature: "(int) -> int",
+        precedence: "prefix",
+        behavior: "Unary negation on 63-bit signed integers.",
+        status: Some(
+            "Negating int.min_value() is not checked and cannot be represented as an int.",
+        ),
+    },
+];
+
+const BIGINT_OPERATORS: &[OperatorRef] = &[
+    OperatorRef {
+        symbol: "+",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "22 (addition; left-associative)",
+        behavior: "Arbitrary-precision signed addition; int operands are promoted to bigint.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "-",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "22 (addition; left-associative)",
+        behavior: "Arbitrary-precision signed subtraction; int operands are promoted to bigint.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "*",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "Arbitrary-precision multiplication; raises baml.panics.AllocFailure if the estimated result exceeds bigint's workspace cap.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "/",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "Truncating bigint division; division by zero raises baml.panics.DivisionByZero.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "%",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "Bigint remainder; modulo by zero raises baml.panics.DivisionByZero.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "&",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "14 (bitwise AND; left-associative)",
+        behavior: "Two's-complement bitwise AND with infinite sign extension.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "|",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "10 (bitwise OR; left-associative)",
+        behavior: "Two's-complement bitwise OR with infinite sign extension.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "^",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "12 (bitwise XOR; left-associative)",
+        behavior: "Two's-complement bitwise XOR with infinite sign extension.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "<<",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "20 (bitwise shift; left-associative)",
+        behavior: "Left shift; negative counts raise baml.panics.NegativeBitShift and oversized results raise baml.panics.AllocFailure.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: ">>",
+        signature: "(bigint, bigint | int) -> bigint",
+        precedence: "20 (bitwise shift; left-associative)",
+        behavior: "Arithmetic right shift; negative counts raise baml.panics.NegativeBitShift.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "-",
+        signature: "(bigint) -> bigint",
+        precedence: "prefix",
+        behavior: "Unary negation.",
+        status: None,
+    },
+];
+
+const FLOAT_OPERATORS: &[OperatorRef] = &[
+    OperatorRef {
+        symbol: "+",
+        signature: "(float | int, float | int) -> float",
+        precedence: "22 (addition; left-associative)",
+        behavior: "IEEE 754 f64 addition; int operands are promoted when mixed with float.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "-",
+        signature: "(float | int, float | int) -> float",
+        precedence: "22 (addition; left-associative)",
+        behavior: "IEEE 754 f64 subtraction; int operands are promoted when mixed with float.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "*",
+        signature: "(float | int, float | int) -> float",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "IEEE 754 f64 multiplication; int operands are promoted when mixed with float.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "/",
+        signature: "(float | int, float | int) -> float",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "IEEE 754 f64 division; division by zero raises baml.panics.DivisionByZero.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "%",
+        signature: "(float | int, float | int) -> float",
+        precedence: "24 (multiplication; left-associative)",
+        behavior: "IEEE 754 f64 remainder; int operands are promoted when mixed with float.",
+        status: None,
+    },
+    OperatorRef {
+        symbol: "-",
+        signature: "(float) -> float",
+        precedence: "prefix",
+        behavior: "IEEE 754 f64 unary negation.",
+        status: None,
+    },
+];
 
 // ── Local variable lookup ────────────────────────────────────────────────────
 
@@ -485,6 +744,7 @@ fn describe_locals(db: &dyn Db, files: &[SourceFile], name: &str) -> Vec<SymbolD
                     references: param_refs,
                     instance_methods: Vec::new(),
                     static_methods: Vec::new(),
+                    operators: Vec::new(),
                     container: None,
                     canonical_fqn: None,
                 });
@@ -594,6 +854,7 @@ fn describe_locals(db: &dyn Db, files: &[SourceFile], name: &str) -> Vec<SymbolD
                         references: binding_refs,
                         instance_methods: Vec::new(),
                         static_methods: Vec::new(),
+                        operators: Vec::new(),
                         container: None,
                         canonical_fqn: None,
                     });
@@ -1108,6 +1369,7 @@ fn describe_class_method(
         references,
         instance_methods: Vec::new(),
         static_methods: Vec::new(),
+        operators: Vec::new(),
         container,
         canonical_fqn: None,
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

## Issue Reference
- Fixes: Infix/binary operators absent from `baml describe Int` output

## Changes
Adds numeric operator metadata to `baml describe` output for builtin numeric companion classes, including `Int`.

## The error
`baml describe Int` only listed method-style functions such as `.abs()`, `.leading_zeros()`, `.count_ones()`, and `.pow()`, but omitted infix/prefix operators like `%`, `&`, `|`, `^`, `<<`, `>>`, and `~`.

Failing BAML reproduction from the report:

```baml
function test_not() -> int {
    ~0
}
testset "not" {
    test "bitwise not zero" {
        // ~0 should be -1 (all bits set), not 0
        assert.equal(~0, -1);
    }
}
```

Reported output:

```text
FAIL not::bitwise not zero
  => UnhandledThrow { value: Instance { class_name: "baml.panics.UserPanic", fields: {"message": String("assertion failed: expected equal values")} }, trace: [StackFrame { function_name: "testing.TestRegistry.run_test", file_path: "<builtin>/testing/registry.baml", function_span: Span { file_id: FileId(33), range: 4402..5061 }, error_line: 147 }, StackFrame { function_name: "testing.TestRegistry.run_test", file_path: "<builtin>/testing/registry.baml", function_span: Span { file_id: FileId(33), range: 4402..5061 }, error_line: 139 }, StackFrame { function_name: "testing.run_test", file_path: "<builtin>/testing/registry.baml", function_span: Span { file_id: FileId(33), range: 6123..6840 }, error_line: 201 }, StackFrame { function_name: ".<lambda(run_test, 0)>", file_path: "<builtin>/testing/registry.baml", function_span: Span { file_id: FileId(4294967295), range: 0..0 }, error_line: 187 }] }
error: test failures — 0 passed, 1 failed, 1 total
```

Incorrect describe behavior before this change:

```text
baml describe Int --budget 271
# output includes methods, but no operators section and no `%`, `&`, `|`, `^`, `<<`, `>>`, or `~` metadata
```

## Root cause
`baml describe` renders `SymbolDescription` in `baml_language/crates/baml_cli/src/describe_command.rs::write_description`. That description model, defined in `baml_language/crates/baml_lsp2_actions/src/describe.rs::SymbolDescription`, only carried class body, references, dependencies, instance methods, and static methods. Class method discovery came from `class_methods_and_fqn`, so builtin operator syntax implemented by the parser/VM never had a field to populate or render.

For the `~` limitation specifically, `baml_language/crates/baml_compiler_parser/src/parser.rs::parse_prefix` accepts `TokenKind::Tilde`, but `baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs` only maps `!` and unary `-` into `UnaryOp`, leaving `~` without a proper AST lowering path.

`baml_language/crates/baml_builtins2/baml_std/baml/int.baml` also contained stale top-level range prose describing `Int` as 64-bit/i64, even though the runtime tagged integer range and the `max_value()`/`min_value()` docs are 63-bit (`[-2^62, 2^62 - 1]`).

## The fix
- Added `OperatorRef` metadata to `SymbolDescription` in `baml_lsp2_actions/src/describe.rs`.
- Populated operator metadata for builtin `Int`, `Bigint`, and `Float` companion classes via `builtin_operator_docs`.
- Rendered an `operators:` section in `baml_cli/src/describe_command.rs`, outside the body budget path so tight budgets still show operator docs.
- Added `operators` to JSON output in `baml_cli/src/grep_command.rs::description_to_json` for programmatic discovery.
- Added tests covering `baml describe int` operator text and JSON metadata.
- Corrected the builtin `Int` prose in `int.baml` to state the 63-bit signed integer range.

This PR intentionally documents the current `~` runtime limitation instead of changing `~` semantics.

## Verification

Targeted tests for the new behavior:

```text
$ cargo +1.91.1 test -p baml_cli describe_int --lib -- --nocapture
running 2 tests
test describe_command_tests::describe_int_json_includes_operator_metadata ... ok
test describe_command_tests::render_describe_int_lists_operators_even_with_tight_budget ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 163 filtered out; finished in 0.26s
```

Direct CLI verification against a minimal project:

```text
$ rm -rf /tmp/baml-describe-repro && mkdir -p /tmp/baml-describe-repro/baml_src
$ printf '[package]\nname = "describe_repro"\n' > /tmp/baml-describe-repro/baml.toml
$ printf 'function UseInt(x: int) -> int {\n  x %% 2\n}\n' > /tmp/baml-describe-repro/baml_src/main.baml
$ cargo +1.91.1 run -p baml_cli -- describe int --from /tmp/baml-describe-repro --budget 5
class Int  (int)  <builtin>/baml/int.baml:2-270

/// A 63-bit signed integer. Range: -2^62 to 2^62-1.
class Int {}
...
operators:
  +   (int, int) -> int                precedence: 22 (addition; left-associative)
      behavior: 63-bit signed integer range [-4611686018427387904, 4611686018427387903]; current VM fast path wraps the tagged representation on overflow.
  -   (int, int) -> int                precedence: 22 (addition; left-associative)
      behavior: 63-bit signed integer range [-4611686018427387904, 4611686018427387903]; current VM fast path wraps the tagged representation on overflow.
  *   (int, int) -> int                precedence: 24 (multiplication; left-associative)
      behavior: 63-bit signed integer range [-4611686018427387904, 4611686018427387903]; result is constructed with Value::int and is not overflow-checked in release builds.
  /   (int, int) -> int                precedence: 24 (multiplication; left-associative)
      behavior: Truncating integer division; division by zero raises baml.panics.DivisionByZero.
  %   (int, int) -> int                precedence: 24 (multiplication; left-associative)
      behavior: Remainder with Rust/i64 sign semantics; modulo by zero raises baml.panics.DivisionByZero.
  &   (int, int) -> int                precedence: 14 (bitwise AND; left-associative)
      behavior: Bitwise AND on the 63-bit signed integer payload.
  |   (int, int) -> int                precedence: 10 (bitwise OR; left-associative)
      behavior: Bitwise OR on the 63-bit signed integer payload.
  ^   (int, int) -> int                precedence: 12 (bitwise XOR; left-associative)
      behavior: Bitwise XOR on the 63-bit signed integer payload.
  <<  (int, int) -> int                precedence: 20 (bitwise shift; left-associative)
      behavior: Left shift on int payload; current runtime does not add a BAML-level guard for negative or oversized counts.
  >>  (int, int) -> int                precedence: 20 (bitwise shift; left-associative)
      behavior: Arithmetic right shift on int payload; current runtime does not add a BAML-level guard for negative or oversized counts.
  ~   (int) -> int                     precedence: prefix
      behavior: Intended bitwise NOT.
      status: Known limitation: parsed today, but AST lowering does not map `~`; `~0` currently evaluates as `0` instead of `-1`.
```

Affected package tests:

```text
$ cargo +1.91.1 test -p baml_lsp2_actions --lib
running 114 tests
test result: ok. 114 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.68s

$ cargo +1.91.1 test -p baml_cli --lib
running 165 tests
test result: ok. 165 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.22s
```

Required broad command attempted:

```text
$ cargo +1.91.1 test --lib
error: linking with `cc` failed: exit status: 1
= note: rust-lld: error: unable to find library -lpython3.12
error: could not compile `bridge_python` (lib test) due to 1 previous error
error: linking with `cc` failed: exit status: 1
= note: rust-lld: error: undefined symbol: napi_call_threadsafe_function
error: could not compile `bridge_nodejs` (lib test) due to 1 previous error
```

This failure occurs while linking SDK bridge test crates and is unrelated to the describe changes.

## Testing
- [x] Unit tests added/updated
- [x] Manual CLI describe verification performed
- [x] Tested in Linux cloud agent environment

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
The workspace root `rust-toolchain.toml` points to Rust 1.93.0, but that toolchain's cargo component was unusable in this environment. Verification used `cargo +1.91.1`, which satisfies the crates' `rust-version = 1.91.1` requirement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fbfeb9b-6ae2-5c28-87b3-1993c1505978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fbfeb9b-6ae2-5c28-87b3-1993c1505978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

