### PR TITLE
Handle already-normalized VSIX release asset

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -255,9 +255,20 @@ jobs:
         run: |
           set -euo pipefail
           version="${{ needs.plan.outputs.version }}"
-          vsix="$(find typescript2/app-vscode-ext -maxdepth 1 -name '*.vsix' -print -quit)"
-          test -n "$vsix"
-          mv "$vsix" "typescript2/app-vscode-ext/baml-language-$version.vsix"
+          vsix_files=()
+          while IFS= read -r vsix; do
+            vsix_files+=("$vsix")
+          done < <(find typescript2/app-vscode-ext -maxdepth 1 -type f -name '*.vsix' -print)
+          if [[ "${#vsix_files[@]}" -ne 1 ]]; then
+            printf 'expected exactly one VSIX, found %s:\n' "${#vsix_files[@]}" >&2
+            printf '%s\n' "${vsix_files[@]}" >&2
+            exit 1
+          fi
+          vsix="${vsix_files[0]}"
+          dest="typescript2/app-vscode-ext/baml-language-$version.vsix"
+          if [[ "$vsix" != "$dest" ]]; then
+            mv "$vsix" "$dest"
+          fi
       - name: Reject bundled native binaries
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- make VSIX asset normalization skip `mv` when `vsce` already produced the desired release filename
- fail clearly if the VSIX package step leaves zero or multiple `.vsix` files

This addresses the failed release run where normalization tried to move `baml-language-0.11.1-nightly.20260603.a.vsix` onto itself: https://github.com/BoundaryML/baml/actions/runs/26906944560/job/79374326990

## Validation
- `actionlint .github/workflows/release-baml-language.yml`
- `git diff --check`
- local Bash probe for already-normalized VSIX filename
- local Bash probe for needs-rename VSIX filename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process validation to ensure exactly one VSIX artifact is generated during releases. The workflow now verifies artifact uniqueness and reports any discrepancies, improving build reliability and release consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->