### PR TITLE
Set GH repo for release asset publishing

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -380,6 +380,8 @@ jobs:
     needs: [plan, all-builds]
     if: ${{ needs.plan.outputs.dry_run == 'false' && github.ref == 'refs/heads/canary' }}
     runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- set `GH_REPO` for the checkout-free GitHub release publishing job
- keep release asset publishing checkout-free while allowing `gh release` to resolve the target repository

This addresses the failed `Publish GitHub release assets` job where `gh release` tried to infer repository context from `.git` and failed: https://github.com/BoundaryML/baml/actions/runs/26909372225/job/79385930418

## Validation
- `actionlint .github/workflows/release-baml-language.yml`
- `git diff --check`
- `GH_REPO=BoundaryML/baml gh release view baml-language-0.11.0-alpha.4780 --json tagName,url` from `/tmp`, outside a git checkout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for improved deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->