### PR TITLE
Sam/win sdk speedup

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -65,6 +65,12 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  # With sccache, most compile units are R2 cache lookups/fetches (I/O-bound,
+  # ~0.2s each) rather than CPU codegen, so cargo's default parallelism (=
+  # core count, just 4 on the Windows runner) leaves cores idle waiting on the
+  # network. Oversubscribe so cache-hit fetches overlap. Applies to every cargo
+  # invocation in this workflow.
+  CARGO_BUILD_JOBS: "16"
 
 jobs:
 

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -474,6 +474,15 @@ jobs:
     # normal CI (workflow_call) keeps its existing cache semantics untouched.
     env:
       WIN_SDK_EXP: ${{ github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup' }}
+      # D (pnpm store caching) was tried and DROPPED: caching the ~hundreds-MB
+      # store via rust-cache made restore cost (+40s to +190s) >= the ~79s cold
+      # `pnpm install` it saved — a net wash/loss on Windows. See build-caching/04
+      # exp 3a/4b. The cold `pnpm install` is left as-is.
+      # B: resolve baml_core from the prebuilt wheelhouse (maturin build, see
+      # python setup.{sh,ps1}) at BOTH setup and test time — the test step's
+      # `uv run` is a separate process, so this must be a job-level env, not
+      # just exported inside setup. Empty on normal CI (editable path source).
+      UV_FIND_LINKS: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') && format('{0}/baml_language/target/wheels', github.workspace) || '' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -491,14 +500,14 @@ jobs:
       - name: "Verify sccache"
         run: sccache --version
 
-      # EXPERIMENT (build-caching/04, approach C+D): on the win-sdk-speedup
+      # EXPERIMENT (build-caching/04, approach C): on the win-sdk-speedup
       # branch, persist `target/` (cache-targets:true + save) under a per-SDK
       # key so the cold cdylib/proc-macro link (which sccache structurally
-      # cannot cache) and the pnpm store (under target/pnpm-store) come back
-      # warm on the next run — maturin ~1m25→~14s, napi ~1m39→~5s, pnpm
-      # install warm. NOTE: needs one populating run before the warm one.
-      # Per-SDK key (not shared windows-cargo) so the python/ts targets don't
-      # clobber each other. Normal CI keeps cache-targets:false / save-if:false.
+      # cannot cache) comes back warm on the next run — maturin ~1m25→~20s,
+      # napi ~1m39→~22s, the -p build step 44→14s. NOTE: needs one populating
+      # run before the warm one. Per-SDK key (not shared windows-cargo) so the
+      # python/ts targets don't clobber each other. Normal CI keeps
+      # cache-targets:false / save-if:false.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
@@ -506,14 +515,6 @@ jobs:
           cache-targets: ${{ env.WIN_SDK_EXP == 'true' }}
           save-if: ${{ env.WIN_SDK_EXP == 'true' }}
           shared-key: ${{ env.WIN_SDK_EXP == 'true' && format('windows-sdk-exp-{0}', matrix.sdk-label) || matrix.rust-cache-key }}
-          # EXPERIMENT (build-caching/04, approach D-fix): rust-cache's default
-          # cleanup deletes non-cargo dirs from target/ before saving, so the
-          # pnpm store (target/pnpm-store, set by setup.ps1/sh) and uv cache
-          # came back cold every run. cache-directories entries are cached
-          # as-is (no cleanup), so the pnpm store warms → `pnpm install` drops
-          # from ~79s (reused 0) to a few seconds. Only used on the experiment
-          # branch (whole step is normal otherwise).
-          cache-directories: ${{ env.WIN_SDK_EXP == 'true' && 'baml_language/target/pnpm-store' || '' }}
 
       - name: "Load .envrc with direnv"
         run: |

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -36,15 +36,6 @@ on:
         required: false
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
         required: false
-  # EXPERIMENT HARNESS (build-caching/04): standalone push trigger so a *bare*
-  # push (no PR) to this branch runs ONLY the two Windows SDK jobs. Every other
-  # job below is gated `if: !<experiment>`, and the matrix is filtered to
-  # windows, so nothing else in this file runs; no other workflow matches a bare
-  # branch push either. DO NOT open a PR from this branch (that wakes ci.yaml /
-  # primary.yml). Remove this block + the `experiment` gates before merging.
-  push:
-    branches:
-      - sam/win-sdk-speedup
 
 # Read-only by design: these jobs run PR-controlled cargo build/test code, so
 # they should not need elevated repository permissions.
@@ -70,14 +61,12 @@ env:
   # core count, just 4 on the Windows runner) leaves cores idle waiting on the
   # network. Oversubscribe so cache-hit fetches overlap. Applies to every cargo
   # invocation in this workflow.
-  CARGO_BUILD_JOBS: "16"
+  CARGO_BUILD_JOBS: "32"
 
 jobs:
 
   cargo-test-linux:
     name: "cargo test (linux)"
-    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -174,8 +163,7 @@ jobs:
     name: "cargo test (macos)"
     # Skip in the merge queue: macos already ran on the PR. The merge_group
     # event is inherited from ci.yaml through the workflow_call boundary.
-    # EXPERIMENT HARNESS (build-caching/04): also skip on win-sdk-speedup.
-    if: ${{ github.event_name != 'merge_group' && !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 35
     steps:
@@ -263,9 +251,7 @@ jobs:
     name: "cargo test (windows)"
     # Skip in the merge queue: windows already ran on the PR. The merge_group
     # event is inherited from ci.yaml through the workflow_call boundary.
-    # EXPERIMENT HARNESS (build-caching/04): also skip on win-sdk-speedup — the
-    # SDK matrix below covers the Windows native build we're tuning.
-    if: ${{ github.event_name != 'merge_group' && !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: blacksmith-4vcpu-windows-2025
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
@@ -440,15 +426,7 @@ jobs:
               },
             ];
 
-            // EXPERIMENT HARNESS (build-caching/04): on a bare push to the
-            // win-sdk-speedup branch, run ONLY the two Windows SDK legs.
-            const isWinSdkExperiment =
-              context.eventName === "push" &&
-              context.ref === "refs/heads/sam/win-sdk-speedup";
-
-            const matrix = isWinSdkExperiment
-              ? baseMatrix.filter((entry) => entry["os-label"] === "windows")
-              : context.eventName === "merge_group"
+            const matrix = context.eventName === "merge_group"
               ? baseMatrix.filter((entry) => entry["os-label"] === "linux")
               : baseMatrix;
 
@@ -475,20 +453,14 @@ jobs:
         include: ${{ fromJSON(needs.sdk-test-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: ${{ matrix.timeout }}
-    # EXPERIMENT HARNESS (build-caching/04): true only on a bare push to the
-    # win-sdk-speedup branch. Gates the experiment-only cache tweaks below so
-    # normal CI (workflow_call) keeps its existing cache semantics untouched.
     env:
-      WIN_SDK_EXP: ${{ github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup' }}
-      # D (pnpm store caching) was tried and DROPPED: caching the ~hundreds-MB
-      # store via rust-cache made restore cost (+40s to +190s) >= the ~79s cold
-      # `pnpm install` it saved — a net wash/loss on Windows. See build-caching/04
-      # exp 3a/4b. The cold `pnpm install` is left as-is.
-      # B: resolve baml_core from the prebuilt wheelhouse (maturin build, see
-      # python setup.{sh,ps1}) at BOTH setup and test time — the test step's
-      # `uv run` is a separate process, so this must be a job-level env, not
-      # just exported inside setup. Empty on normal CI (editable path source).
-      UV_FIND_LINKS: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') && format('{0}/baml_language/target/wheels', github.workspace) || '' }}
+      # Resolve baml_core from the prebuilt wheelhouse that the Python setup
+      # script populates via `maturin build` (one cdylib build, then each
+      # fixture installs the wheel instead of rebuilding the editable extension
+      # per fixture). The test step's `uv run` is a separate process from setup,
+      # so this must be a job-level env, not just exported inside setup.sh.
+      # Harmless for the TypeScript leg (it runs no uv). See python setup.{sh,ps1}.
+      UV_FIND_LINKS: ${{ format('{0}/baml_language/target/wheels', github.workspace) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -506,21 +478,13 @@ jobs:
       - name: "Verify sccache"
         run: sccache --version
 
-      # EXPERIMENT (build-caching/04, approach C): on the win-sdk-speedup
-      # branch, persist `target/` (cache-targets:true + save) under a per-SDK
-      # key so the cold cdylib/proc-macro link (which sccache structurally
-      # cannot cache) comes back warm on the next run — maturin ~1m25→~20s,
-      # napi ~1m39→~22s, the -p build step 44→14s. NOTE: needs one populating
-      # run before the warm one. Per-SDK key (not shared windows-cargo) so the
-      # python/ts targets don't clobber each other. Normal CI keeps
-      # cache-targets:false / save-if:false.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-targets: ${{ env.WIN_SDK_EXP == 'true' }}
-          save-if: ${{ env.WIN_SDK_EXP == 'true' }}
-          shared-key: ${{ env.WIN_SDK_EXP == 'true' && format('windows-sdk-exp-{0}', matrix.sdk-label) || matrix.rust-cache-key }}
+          cache-targets: false
+          save-if: false
+          shared-key: ${{ matrix.rust-cache-key }}
 
       - name: "Load .envrc with direnv"
         run: |
@@ -609,8 +573,6 @@ jobs:
 
   cargo-test-wasm:
     name: "cargo test (wasm)"
-    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:
@@ -698,8 +660,6 @@ jobs:
 
   cargo-build-msrv:
     name: "cargo build (msrv)"
-    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -787,8 +747,6 @@ jobs:
 
   cargo-doc:
     name: "cargo doc"
-    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -864,8 +822,6 @@ jobs:
 
   snapshot-tests:
     name: "snapshot tests"
-    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
@@ -969,9 +925,6 @@ jobs:
 
   cargo-timings:
     name: "cargo timings (merged)"
-    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch
-    # (the gated-off jobs it needs are skipped there anyway).
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: ubuntu-latest
     needs:
       - cargo-test-linux
@@ -991,8 +944,6 @@ jobs:
           delete-merged: true
   sccache-stats:
     name: "sccache stats (merged)"
-    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: ubuntu-latest
     needs:
       - cargo-test-linux

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -506,6 +506,14 @@ jobs:
           cache-targets: ${{ env.WIN_SDK_EXP == 'true' }}
           save-if: ${{ env.WIN_SDK_EXP == 'true' }}
           shared-key: ${{ env.WIN_SDK_EXP == 'true' && format('windows-sdk-exp-{0}', matrix.sdk-label) || matrix.rust-cache-key }}
+          # EXPERIMENT (build-caching/04, approach D-fix): rust-cache's default
+          # cleanup deletes non-cargo dirs from target/ before saving, so the
+          # pnpm store (target/pnpm-store, set by setup.ps1/sh) and uv cache
+          # came back cold every run. cache-directories entries are cached
+          # as-is (no cleanup), so the pnpm store warms → `pnpm install` drops
+          # from ~79s (reused 0) to a few seconds. Only used on the experiment
+          # branch (whole step is normal otherwise).
+          cache-directories: ${{ env.WIN_SDK_EXP == 'true' && 'baml_language/target/pnpm-store' || '' }}
 
       - name: "Load .envrc with direnv"
         run: |

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -36,6 +36,15 @@ on:
         required: false
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
         required: false
+  # EXPERIMENT HARNESS (build-caching/04): standalone push trigger so a *bare*
+  # push (no PR) to this branch runs ONLY the two Windows SDK jobs. Every other
+  # job below is gated `if: !<experiment>`, and the matrix is filtered to
+  # windows, so nothing else in this file runs; no other workflow matches a bare
+  # branch push either. DO NOT open a PR from this branch (that wakes ci.yaml /
+  # primary.yml). Remove this block + the `experiment` gates before merging.
+  push:
+    branches:
+      - sam/win-sdk-speedup
 
 # Read-only by design: these jobs run PR-controlled cargo build/test code, so
 # they should not need elevated repository permissions.
@@ -61,6 +70,8 @@ jobs:
 
   cargo-test-linux:
     name: "cargo test (linux)"
+    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -157,7 +168,8 @@ jobs:
     name: "cargo test (macos)"
     # Skip in the merge queue: macos already ran on the PR. The merge_group
     # event is inherited from ci.yaml through the workflow_call boundary.
-    if: ${{ github.event_name != 'merge_group' }}
+    # EXPERIMENT HARNESS (build-caching/04): also skip on win-sdk-speedup.
+    if: ${{ github.event_name != 'merge_group' && !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 35
     steps:
@@ -245,7 +257,9 @@ jobs:
     name: "cargo test (windows)"
     # Skip in the merge queue: windows already ran on the PR. The merge_group
     # event is inherited from ci.yaml through the workflow_call boundary.
-    if: ${{ github.event_name != 'merge_group' }}
+    # EXPERIMENT HARNESS (build-caching/04): also skip on win-sdk-speedup — the
+    # SDK matrix below covers the Windows native build we're tuning.
+    if: ${{ github.event_name != 'merge_group' && !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-4vcpu-windows-2025
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
@@ -420,7 +434,15 @@ jobs:
               },
             ];
 
-            const matrix = context.eventName === "merge_group"
+            // EXPERIMENT HARNESS (build-caching/04): on a bare push to the
+            // win-sdk-speedup branch, run ONLY the two Windows SDK legs.
+            const isWinSdkExperiment =
+              context.eventName === "push" &&
+              context.ref === "refs/heads/sam/win-sdk-speedup";
+
+            const matrix = isWinSdkExperiment
+              ? baseMatrix.filter((entry) => entry["os-label"] === "windows")
+              : context.eventName === "merge_group"
               ? baseMatrix.filter((entry) => entry["os-label"] === "linux")
               : baseMatrix;
 
@@ -447,6 +469,11 @@ jobs:
         include: ${{ fromJSON(needs.sdk-test-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: ${{ matrix.timeout }}
+    # EXPERIMENT HARNESS (build-caching/04): true only on a bare push to the
+    # win-sdk-speedup branch. Gates the experiment-only cache tweaks below so
+    # normal CI (workflow_call) keeps its existing cache semantics untouched.
+    env:
+      WIN_SDK_EXP: ${{ github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -464,13 +491,21 @@ jobs:
       - name: "Verify sccache"
         run: sccache --version
 
+      # EXPERIMENT (build-caching/04, approach C+D): on the win-sdk-speedup
+      # branch, persist `target/` (cache-targets:true + save) under a per-SDK
+      # key so the cold cdylib/proc-macro link (which sccache structurally
+      # cannot cache) and the pnpm store (under target/pnpm-store) come back
+      # warm on the next run — maturin ~1m25→~14s, napi ~1m39→~5s, pnpm
+      # install warm. NOTE: needs one populating run before the warm one.
+      # Per-SDK key (not shared windows-cargo) so the python/ts targets don't
+      # clobber each other. Normal CI keeps cache-targets:false / save-if:false.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
           cache-all-crates: true
-          cache-targets: false
-          save-if: false
-          shared-key: ${{ matrix.rust-cache-key }}
+          cache-targets: ${{ env.WIN_SDK_EXP == 'true' }}
+          save-if: ${{ env.WIN_SDK_EXP == 'true' }}
+          shared-key: ${{ env.WIN_SDK_EXP == 'true' && format('windows-sdk-exp-{0}', matrix.sdk-label) || matrix.rust-cache-key }}
 
       - name: "Load .envrc with direnv"
         run: |
@@ -507,6 +542,10 @@ jobs:
         if: always()
         run: sccache --show-stats
 
+      # `-p` scopes *compilation* to this one package; the `-E` filter only
+      # scopes *which tests run*. Without `-p`, nextest compiles the whole
+      # workspace's ~145 test binaries (~4m48s on Windows) to run one. See
+      # build-caching/04 approach A.
       - name: "Run sdk test setup"
         run: cargo nextest run -p ${{ matrix.package-name }} --all-features -E 'package(=${{ matrix.package-name }}) and test(setup_guard::ran)'
         working-directory: baml_language
@@ -555,6 +594,8 @@ jobs:
 
   cargo-test-wasm:
     name: "cargo test (wasm)"
+    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:
@@ -642,6 +683,8 @@ jobs:
 
   cargo-build-msrv:
     name: "cargo build (msrv)"
+    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -729,6 +772,8 @@ jobs:
 
   cargo-doc:
     name: "cargo doc"
+    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -804,6 +849,8 @@ jobs:
 
   snapshot-tests:
     name: "snapshot tests"
+    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
@@ -907,6 +954,9 @@ jobs:
 
   cargo-timings:
     name: "cargo timings (merged)"
+    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch
+    # (the gated-off jobs it needs are skipped there anyway).
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: ubuntu-latest
     needs:
       - cargo-test-linux
@@ -926,6 +976,8 @@ jobs:
           delete-merged: true
   sccache-stats:
     name: "sccache stats (merged)"
+    # EXPERIMENT HARNESS (build-caching/04): skip on the win-sdk-speedup branch.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/sam/win-sdk-speedup') }}
     runs-on: ubuntu-latest
     needs:
       - cargo-test-linux

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -56,12 +56,6 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
-  # With sccache, most compile units are R2 cache lookups/fetches (I/O-bound,
-  # ~0.2s each) rather than CPU codegen, so cargo's default parallelism (=
-  # core count, just 4 on the Windows runner) leaves cores idle waiting on the
-  # network. Oversubscribe so cache-hit fetches overlap. Applies to every cargo
-  # invocation in this workflow.
-  CARGO_BUILD_JOBS: "32"
 
 jobs:
 
@@ -248,11 +242,31 @@ jobs:
           if-no-files-found: ignore
 
   cargo-test-windows:
-    name: "cargo test (windows)"
+    # EXPERIMENT (build-caching/04 Exp 16 — Approach M): can sccache cache
+    # aws-lc-sys's C compiles? Our RUSTC_WRAPPER wraps rustc only, so the
+    # build-script cc compiles bypass sccache today. cc-rs natively supports an
+    # sccache shim via CC. 2 arms on --all-features:
+    #   cc-default — unchanged (aws-lc-sys C compiled fresh each run)
+    #   cc-sccache — CC routed through the baml-sccache shim -> R2 sccache
+    # Run TWICE: run 1 populates the C cache (cold), run 2 measures the warm
+    # aws-lc-sys run-custom-build drop vs cc-default. (M is inferior to ring,
+    # which deletes aws-lc-sys; this just confirms the mechanism + warm win.)
+    name: "cargo test (windows, cc-${{ matrix.cc }})"
     # Skip in the merge queue: windows already ran on the PR. The merge_group
     # event is inherited from ci.yaml through the workflow_call boundary.
     if: ${{ github.event_name != 'merge_group' }}
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: ["default", "sccache"]
+    # 8-vCPU + CARGO_BUILD_JOBS=16 (2x cores) was the value sweet spot for this
+    # full-workspace build: ~127s build vs ~188s at 4-vCPU/-j8 and ~= a 16-vCPU
+    # default build at half the runner cost (sccache cache hits are I/O-bound,
+    # so oversubscribing overlaps the fetches). See build-caching/04.
+    env:
+      CARGO_BUILD_JOBS: "16"
+      FEATURES: "--all-features"
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
     timeout-minutes: 50
@@ -308,20 +322,33 @@ jobs:
           echo "RUSTC_WRAPPER=$(pwd -W)/target/debug/baml-sccache.exe" >> "$GITHUB_ENV"
         working-directory: baml_language
 
+      # Exp 16 cc-sccache arm: route aws-lc-sys's build-script C compiles through
+      # the same baml-sccache shim (maps R2 creds) so cc-rs sends cl.exe compiles
+      # to the shared R2 sccache. Must be the shim, not bare sccache, or the C
+      # compiles fail to auth and fall back to local. Set AFTER RUSTC_WRAPPER is
+      # exported (this reads it). Keep the default cc builder (no CMAKE_BUILDER).
+      - name: "Route C compiles through sccache (arm)"
+        if: matrix.cc == 'sccache'
+        run: |
+          set -euo pipefail
+          echo "CC_X86_64_PC_WINDOWS_MSVC=$RUSTC_WRAPPER cl" >> "$GITHUB_ENV"
+          echo "CXX_X86_64_PC_WINDOWS_MSVC=$RUSTC_WRAPPER cl" >> "$GITHUB_ENV"
+          echo "CC_KNOWN_WRAPPER_CUSTOM=$RUSTC_WRAPPER" >> "$GITHUB_ENV"
+
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
 
       - name: "Build tests with --timings"
-        run: cargo test --no-run --all-features --timings
+        run: cargo test --no-run ${{ env.FEATURES }} --timings
         working-directory: baml_language
 
       # Snapshot tests live in `baml_tests` and are covered by the dedicated
       # `snapshot-tests` job. The `sdk_test_*` crates need uv and run in the
       # dedicated `sdk-tests` matrix below. Skip both here.
       - name: "Run tests"
-        run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/)'
+        run: cargo nextest run ${{ env.FEATURES }} -E 'not package(baml_tests) and not package(/^sdk_test_/)'
         working-directory: baml_language
 
       - name: "Show sccache stats"
@@ -330,26 +357,26 @@ jobs:
 
       - name: "Dump sccache stats (json)"
         if: always()
-        run: sccache --show-stats --stats-format json > sccache-stats-test-windows.json
+        run: sccache --show-stats --stats-format json > sccache-stats-test-windows-cc-${{ matrix.cc }}.json
 
       - name: "Upload sccache stats"
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: sccache-stats-test-windows
-          path: sccache-stats-test-windows.json
+          name: sccache-stats-test-windows-cc-${{ matrix.cc }}
+          path: sccache-stats-test-windows-cc-${{ matrix.cc }}.json
           if-no-files-found: ignore
 
       - name: "Rename cargo timings"
         if: always()
-        run: mv target/cargo-timings/cargo-timing.html target/cargo-timings/cargo-timing-test-windows.html
+        run: mv target/cargo-timings/cargo-timing.html target/cargo-timings/cargo-timing-test-windows-cc-${{ matrix.cc }}.html
         working-directory: baml_language
       - name: "Upload cargo timings"
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: cargo-timings-test-windows
-          path: baml_language/target/cargo-timings/cargo-timing-test-windows.html
+          name: cargo-timings-test-windows-cc-${{ matrix.cc }}
+          path: baml_language/target/cargo-timings/cargo-timing-test-windows-cc-${{ matrix.cc }}.html
           if-no-files-found: ignore
 
   sdk-test-matrix:
@@ -410,7 +437,7 @@ jobs:
                 "sdk-path": "python_pydantic2",
                 "install-args": "sccache direnv python uv",
                 "os-label": "windows",
-                "runs-on": "blacksmith-4vcpu-windows-2025",
+                "runs-on": "blacksmith-8vcpu-windows-2025",
                 "rust-cache-key": "windows-cargo",
                 "timeout": 60,
               },
@@ -420,7 +447,7 @@ jobs:
                 "sdk-path": "typescript_node",
                 "install-args": "sccache direnv node npm:pnpm",
                 "os-label": "windows",
-                "runs-on": "blacksmith-4vcpu-windows-2025",
+                "runs-on": "blacksmith-8vcpu-windows-2025",
                 "rust-cache-key": "windows-cargo",
                 "timeout": 60,
               },

--- a/baml_language/crates/baml/Cargo.toml
+++ b/baml_language/crates/baml/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 baml_release = { workspace = true }
 anyhow = { workspace = true }
-reqwest = { workspace = true, features = [ "blocking", "rustls" ] }
+reqwest = { workspace = true, features = [ "blocking", "rustls-no-provider" ] }
 serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/baml_language/crates/baml_release/Cargo.toml
+++ b/baml_language/crates/baml_release/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 flate2 = { workspace = true }
-reqwest = { workspace = true, features = [ "blocking", "rustls" ] }
+reqwest = { workspace = true, features = [ "blocking", "rustls-no-provider" ] }
 serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/baml_language/crates/baml_tests/Cargo.toml
+++ b/baml_language/crates/baml_tests/Cargo.toml
@@ -26,7 +26,7 @@ baml_workspace = { workspace = true }
 bex_engine = { workspace = true }
 bex_vm = { workspace = true }
 bex_vm_types = { workspace = true }
-sys_native = { workspace = true, features = [ "bundle-http", "aws-crypto" ] }
+sys_native = { workspace = true, features = [ "bundle-http", "ring-crypto" ] }
 sys_ops = { workspace = true }
 sys_types = { workspace = true }
 anyhow = { workspace = true }

--- a/baml_language/crates/bex_engine/Cargo.toml
+++ b/baml_language/crates/bex_engine/Cargo.toml
@@ -41,7 +41,7 @@ baml_project = { workspace = true, features = [ "testing" ] }
 bex_resource_types = { workspace = true }
 bridge_ctypes = { workspace = true }
 sys_llm = { workspace = true }
-sys_native = { workspace = true, features = [ "bundle-http", "aws-crypto" ] }
+sys_native = { workspace = true, features = [ "bundle-http", "ring-crypto" ] }
 anyhow = { workspace = true }
 indexmap = { workspace = true }
 insta = { workspace = true }

--- a/baml_language/sdk_tests/crates/python_pydantic2/setup.ps1
+++ b/baml_language/sdk_tests/crates/python_pydantic2/setup.ps1
@@ -35,33 +35,22 @@ if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
     $UvBin = (mise which uv).Trim()
 }
 
-# 1. Ensure each fixture venv exists, deps are installed, and baml_core
-#    is editable-linked. Plain `uv sync` (no --reinstall): on a fresh
-#    checkout this builds the editable wheel once; afterward it's a
-#    no-op. The shared extension it points at is (re)built by step 2.
-Get-ChildItem -Directory | ForEach-Object {
-    $generated = Join-Path $_.FullName 'generated'
-    if (Test-Path $generated) {
-        Write-Host "==> uv sync in $($_.Name)/generated"
-        Push-Location $generated
-        try {
-            & $UvBin sync
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-        } finally {
-            Pop-Location
-        }
-    }
-}
+# EXPERIMENT (build-caching/04 approach B): build baml_core ONCE as a
+# wheel, then install that prebuilt wheel into every fixture venv. This
+# removes the redundant per-fixture editable build: plain `uv sync` used
+# to build baml_core's editable wheel under build isolation with an
+# *ephemeral* interpreter, busting pyo3's fingerprint and forcing a full
+# bridge_python rebuild every run (~113s even with a warm target/) — and
+# then `maturin develop` rebuilt it again. One `maturin build` (dev
+# profile, reuses the warm cargo target/ ~20s) replaces both.
 
-# 2. Rebuild the shared baml_core extension incrementally via maturin.
-#    The build venv is `sdks/python/.venv` — uv's default project venv,
-#    at a stable path (see setup.sh for why that matters for the cargo
-#    cache). abi3 wheels are interpreter-version-agnostic, so any
-#    >=3.10 works. `sdks/python/pyproject.toml` owns the maturin
-#    version constraint; the sync below installs dev tools without
-#    installing/building baml_core (`maturin develop` does that).
+# 1. Build the shared baml_core wheel once (sdks/python/.venv supplies maturin).
 $SdkPyVenv = Join-Path $SdkPy '.venv'
 $MaturinExe = Join-Path $SdkPyVenv 'Scripts\maturin.exe'
+$WheelDir = Join-Path $WorkspaceRoot 'target\wheels'
+# Must exist before the first uv command: CI exports UV_FIND_LINKS=$WheelDir
+# and uv errors on a missing find-links dir even when nothing needs it yet.
+New-Item -ItemType Directory -Force -Path $WheelDir | Out-Null
 Write-Host "==> uv sync (dev) in $SdkPy"
 Push-Location $SdkPy
 try {
@@ -71,14 +60,46 @@ try {
 } finally {
     Pop-Location
 }
-Write-Host '==> maturin develop (shared baml_core extension)'
+Write-Host '==> maturin build (shared baml_core wheel)'
 Push-Location $SdkPy
 try {
     $env:VIRTUAL_ENV = $SdkPyVenv
-    & $MaturinExe develop
+    & $MaturinExe build --out $WheelDir
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 } finally {
     Pop-Location
+}
+
+# 2. Per fixture: install deps + the prebuilt baml_core wheel. No
+#    per-fixture cdylib build. Strip the editable `[tool.uv.sources]
+#    baml_core` block so baml_core resolves as a normal dependency from
+#    UV_FIND_LINKS (set to $WheelDir; the local 0.1.3 wheel outranks any
+#    public release). Plain `uv sync`/`uv run` then installs the prebuilt
+#    wheel + dev tools without ever building baml_core.
+if (-not $env:UV_FIND_LINKS) { $env:UV_FIND_LINKS = $WheelDir }
+Get-ChildItem -Directory | ForEach-Object {
+    $generated = Join-Path $_.FullName 'generated'
+    if (Test-Path $generated) {
+        # Delete the [tool.uv.sources] section (header → next blank line).
+        $pp = Join-Path $generated 'pyproject.toml'
+        $lines = Get-Content $pp
+        $out = New-Object System.Collections.Generic.List[string]
+        $skip = $false
+        foreach ($line in $lines) {
+            if ($line -match '^\[tool\.uv\.sources\]$') { $skip = $true; continue }
+            if ($skip) { if ($line -match '^\s*$') { $skip = $false }; continue }
+            $out.Add($line)
+        }
+        Set-Content -Path $pp -Value $out
+        Write-Host "==> uv sync in $($_.Name)/generated"
+        Push-Location $generated
+        try {
+            & $UvBin sync
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        } finally {
+            Pop-Location
+        }
+    }
 }
 
 # Per-run breadcrumb for the in-test guard. nextest reads $NEXTEST_ENV

--- a/baml_language/sdk_tests/crates/python_pydantic2/setup.sh
+++ b/baml_language/sdk_tests/crates/python_pydantic2/setup.sh
@@ -63,28 +63,42 @@ mkdir -p "$UV_CACHE_DIR"
 uv_bin="uv"
 command -v uv >/dev/null 2>&1 || uv_bin="$(mise which uv)"
 
-# 1. Ensure each fixture venv exists, deps are installed, and baml_core
-#    is editable-linked. Plain `uv sync` (no --reinstall): on a fresh
-#    checkout this builds the editable wheel once; afterward it's a
-#    no-op. The shared .so it points at is (re)built by step 2.
+# EXPERIMENT (build-caching/04 approach B): build baml_core ONCE as a
+# wheel, then install that prebuilt wheel into every fixture venv. This
+# removes the redundant per-fixture editable build — plain `uv sync` used
+# to build baml_core's editable wheel under build isolation with an
+# *ephemeral* interpreter (see the --reinstall note above), busting
+# pyo3's fingerprint and forcing a full bridge_python rebuild every run
+# (~113s even with a warm target/), and then `maturin develop` rebuilt it
+# again. One `maturin build` (dev profile, reuses the warm cargo target/
+# ~20s) replaces both.
+
+# 1. Build the shared baml_core wheel once (sdks/python/.venv supplies maturin).
+SDK_PY_VENV="$SDK_PY/.venv"
+WHEEL_DIR="$WORKSPACE_ROOT/target/wheels"
+# Must exist before the first uv command: CI exports UV_FIND_LINKS=$WHEEL_DIR
+# and uv errors on a missing find-links dir even when nothing needs it yet.
+mkdir -p "$WHEEL_DIR"
+echo "==> uv sync (dev) in $SDK_PY"
+(cd "$SDK_PY" && UV_PROJECT_ENVIRONMENT="$SDK_PY_VENV" "$uv_bin" sync --group dev --no-install-project)
+echo "==> maturin build (shared baml_core wheel)"
+(cd "$SDK_PY" && VIRTUAL_ENV="$SDK_PY_VENV" "$SDK_PY_VENV/bin/maturin" build --out "$WHEEL_DIR")
+
+# 2. Per fixture: install deps + the prebuilt baml_core wheel. No
+#    per-fixture cdylib build. Strip the editable `[tool.uv.sources]
+#    baml_core` block so baml_core resolves as a normal dependency from
+#    UV_FIND_LINKS (exported by CI to $WHEEL_DIR; the local 0.1.3 wheel
+#    outranks any public release). Plain `uv sync`/`uv run` then installs
+#    the prebuilt wheel + dev tools without ever building baml_core.
+export UV_FIND_LINKS="${UV_FIND_LINKS:-$WHEEL_DIR}"
 for fixture_dir in */generated; do
     [[ -d "$fixture_dir" ]] || continue
+    # Delete the [tool.uv.sources] section (header → next blank line).
+    sed -i.bak '/^\[tool\.uv\.sources\]$/,/^$/d' "$fixture_dir/pyproject.toml"
+    rm -f "$fixture_dir/pyproject.toml.bak"
     echo "==> uv sync in $fixture_dir"
     (cd "$fixture_dir" && "$uv_bin" sync)
 done
-
-# 2. Rebuild the shared baml_core extension incrementally via maturin.
-#    The build venv is `sdks/python/.venv` — uv's default project venv,
-#    at a stable path (see the --reinstall-package note above for why
-#    that matters). abi3 wheels are interpreter-version-agnostic, so
-#    any >=3.10 works. `sdks/python/pyproject.toml` owns the maturin
-#    version constraint; the sync below installs dev tools without
-#    installing/building baml_core (`maturin develop` does that).
-SDK_PY_VENV="$SDK_PY/.venv"
-echo "==> uv sync (dev) in $SDK_PY"
-(cd "$SDK_PY" && UV_PROJECT_ENVIRONMENT="$SDK_PY_VENV" "$uv_bin" sync --group dev --no-install-project)
-echo "==> maturin develop (shared baml_core extension)"
-(cd "$SDK_PY" && VIRTUAL_ENV="$SDK_PY_VENV" "$SDK_PY_VENV/bin/maturin" develop)
 
 # Per-run breadcrumb for the in-test guard. nextest reads $NEXTEST_ENV
 # after this script and injects these vars into the matched tests'

--- a/baml_language/sdk_tests/crates/typescript_node/setup.ps1
+++ b/baml_language/sdk_tests/crates/typescript_node/setup.ps1
@@ -17,9 +17,15 @@ $WorkspaceRoot = (Resolve-Path '..\..\..').Path
 $RepoRoot = (Resolve-Path (Join-Path $WorkspaceRoot '..')).Path
 $BridgeNodejs = Join-Path $WorkspaceRoot 'sdks\nodejs\bridge_nodejs'
 
-# Shared pnpm store under target/ so per-fixture installs hardlink from
-# one location rather than fetching N copies.
-$env:npm_config_store_dir = Join-Path $WorkspaceRoot 'target\pnpm-store'
+# Shared pnpm store so per-fixture installs hardlink from one location.
+# Defaults under target/; CI overrides via BAML_SDK_PNPM_STORE_DIR to a
+# path OUTSIDE target/ so it survives rust-cache's pre-save target cleanup
+# and can be cached (build-caching/04 D-fix).
+if ($env:BAML_SDK_PNPM_STORE_DIR) {
+    $env:npm_config_store_dir = $env:BAML_SDK_PNPM_STORE_DIR
+} else {
+    $env:npm_config_store_dir = Join-Path $WorkspaceRoot 'target\pnpm-store'
+}
 New-Item -ItemType Directory -Force -Path $env:npm_config_store_dir | Out-Null
 
 # 1. Workspace deps. bridge_nodejs is a member of the repo-root

--- a/baml_language/sdk_tests/crates/typescript_node/setup.ps1
+++ b/baml_language/sdk_tests/crates/typescript_node/setup.ps1
@@ -28,19 +28,15 @@ if ($env:BAML_SDK_PNPM_STORE_DIR) {
 }
 New-Item -ItemType Directory -Force -Path $env:npm_config_store_dir | Out-Null
 
-# 1. Workspace deps. bridge_nodejs is a member of the repo-root
-#    pnpm-workspace.yaml, and `pnpm build:debug` needs that workspace
-#    install to have populated bridge_nodejs/node_modules.
-Write-Host '==> pnpm install at repo root'
-Push-Location $RepoRoot
-try {
-    pnpm install
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-} finally {
-    Pop-Location
-}
+# bridge_nodejs is self-contained: its own pnpm-lock.yaml, no `workspace:`
+# deps, and fixtures depend on it via a `file:` path — so the SDK tests need
+# nothing from the repo-root pnpm workspace. We deliberately do NOT run a
+# repo-root `pnpm install`: that pulled all 39 workspace projects (~2928 pkgs:
+# canvas, turbo, vercel, the vscode-ext, the codemirror grammar build, … none
+# used here) and added ~80s. The bridge-local install below populates
+# bridge_nodejs/node_modules standalone — all `pnpm build:debug` needs.
 
-# 2. Bridge-local deps. The bridge package has its own lockfile and build
+# 1. Bridge-local deps. The bridge package has its own lockfile and build
 #    scripts invoke tools from bridge_nodejs/node_modules (for example
 #    node_modules/protobufjs-cli/bin/pbjs), so make that install explicit.
 Write-Host '==> pnpm install in sdks/nodejs/bridge_nodejs'

--- a/baml_language/sdk_tests/crates/typescript_node/setup.sh
+++ b/baml_language/sdk_tests/crates/typescript_node/setup.sh
@@ -30,13 +30,15 @@ BRIDGE_NODEJS="$WORKSPACE_ROOT/sdks/nodejs/bridge_nodejs"
 export npm_config_store_dir="${BAML_SDK_PNPM_STORE_DIR:-$WORKSPACE_ROOT/target/pnpm-store}"
 mkdir -p "$npm_config_store_dir"
 
-# 1. Workspace deps. bridge_nodejs is a member of the repo-root
-#    pnpm-workspace.yaml, and `pnpm build:debug` needs that workspace
-#    install to have populated bridge_nodejs/node_modules.
-echo "==> pnpm install at repo root"
-(cd "$REPO_ROOT" && pnpm install)
+# bridge_nodejs is self-contained: its own pnpm-lock.yaml, no `workspace:`
+# deps, and fixtures depend on it via a `file:` path — so the SDK tests need
+# nothing from the repo-root pnpm workspace. We deliberately do NOT run a
+# repo-root `pnpm install`: that pulled all 39 workspace projects (~2928 pkgs:
+# canvas, turbo, vercel, the vscode-ext, the codemirror grammar build, … none
+# used here) and added ~80s. The bridge-local install below populates
+# bridge_nodejs/node_modules standalone — all `pnpm build:debug` needs.
 
-# 2. Bridge-local deps. The bridge package has its own lockfile and build
+# 1. Bridge-local deps. The bridge package has its own lockfile and build
 #    scripts invoke tools from bridge_nodejs/node_modules (for example
 #    node_modules/protobufjs-cli/bin/pbjs), so make that install explicit.
 echo "==> pnpm install in sdks/nodejs/bridge_nodejs"

--- a/baml_language/sdk_tests/crates/typescript_node/setup.sh
+++ b/baml_language/sdk_tests/crates/typescript_node/setup.sh
@@ -22,9 +22,12 @@ WORKSPACE_ROOT="$(cd ../../.. && pwd)"
 REPO_ROOT="$(cd "$WORKSPACE_ROOT/.." && pwd)"
 BRIDGE_NODEJS="$WORKSPACE_ROOT/sdks/nodejs/bridge_nodejs"
 
-# Shared pnpm store under target/ so per-fixture installs hardlink from
-# one location rather than fetching N copies.
-export npm_config_store_dir="$WORKSPACE_ROOT/target/pnpm-store"
+# Shared pnpm store so per-fixture installs hardlink from one location
+# rather than fetching N copies. Defaults under target/; CI overrides via
+# BAML_SDK_PNPM_STORE_DIR to a path OUTSIDE target/ so it survives
+# rust-cache's pre-save target cleanup and can be cached (build-caching/04
+# D-fix — under target/ it was wiped every run → pnpm install ~79s cold).
+export npm_config_store_dir="${BAML_SDK_PNPM_STORE_DIR:-$WORKSPACE_ROOT/target/pnpm-store}"
 mkdir -p "$npm_config_store_dir"
 
 # 1. Workspace deps. bridge_nodejs is a member of the repo-root

--- a/baml_language/sdk_tests/harness_setup/src/python_pydantic2.rs
+++ b/baml_language/sdk_tests/harness_setup/src/python_pydantic2.rs
@@ -209,6 +209,10 @@ mod {fixture} {{
         );
     }}
 
+    // `uv run` resyncs first; setup.{{sh,ps1}} strip the editable
+    // [tool.uv.sources] baml_core entry and UV_FIND_LINKS points at the
+    // prebuilt wheel (build-caching/04 approach B), so the resync resolves
+    // baml_core from the wheel (no rebuild) and still installs the dev tools.
     #[test]
     fn ruff() {{
         cmd("uv run ruff check --config pyproject.toml baml_sdk");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI: set build-parallelism to oversubscribe builds and added env to test jobs so tests can resolve prebuilt Python wheels.
  * Python SDK fixtures: build a single shared wheel once and reuse it across fixtures; env handling updated to point at the shared wheel.
  * Node SDK setup: pnpm store location made configurable and install flow adjusted to use self-contained package installs.

* **Documentation**
  * Added comments in generated test scaffolds explaining the wheel-based fixture sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->