### PR TITLE
Make baml.toml opt-in for the BAML CLI

### DIFF
--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -8,7 +8,7 @@ use baml_lsp2_actions::{ResolvedTarget, SymbolDescription, describe};
 use baml_project::ProjectDatabase;
 use clap::Args;
 
-use crate::project_load::load_project_from;
+use crate::project_load::load_project_or_default;
 
 #[derive(serde::Deserialize)]
 struct BamlKeywordDoc {
@@ -231,11 +231,12 @@ fn builtin_alias_class_path(name: &str) -> Option<&'static str> {
 
 impl DescribeArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
-        let (db, from, baml_files) = load_project_from(&self.from)?;
-        if baml_files.is_empty() {
-            eprintln!("No .baml files found in {}", from.display());
-            return Ok(crate::ExitCode::Other);
-        }
+        // Introspection never requires a `baml.toml`: with no project, we
+        // fall back to a stdlib-only "default state" so `baml describe
+        // baml.String` works anywhere. An empty user-file set is therefore
+        // expected, not an error — unresolved names still surface through
+        // the per-target "No symbol found" + did-you-mean paths below.
+        let (db, from, _baml_files) = load_project_or_default(&self.from)?;
 
         // ── --symbols deprecation ───────────────────────────────────────────
         if self.symbols {

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -148,6 +148,41 @@ fn describe_via_dispatch(db: &ProjectDatabase, name: &str) -> String {
     }
 }
 
+// ── Default state (no user files) ─────────────────────────────────────────
+//
+// `set_project_root` loads the `baml.*` stdlib regardless of user files, so
+// `baml describe` resolves builtins even with an empty project — the
+// stdlib-only "default state" the CLI falls back to when there's no
+// `baml.toml`. See `project_load::load_project_or_default`.
+
+/// `baml describe baml.String` resolves against the stdlib with zero user
+/// files loaded.
+#[test]
+fn dispatch_resolves_stdlib_class_with_no_user_files() {
+    let db = make_db(&[]);
+    let output = describe_via_dispatch(&db, "baml.String");
+    assert!(
+        output.contains("String"),
+        "expected stdlib `String` description with no user files, got:\n{output}",
+    );
+    assert!(
+        !output.starts_with("NOT FOUND"),
+        "stdlib `String` should resolve in the default state, got:\n{output}",
+    );
+}
+
+/// The lowercase primitive alias `string` also resolves against the stdlib
+/// in the default state (no user files).
+#[test]
+fn dispatch_resolves_primitive_alias_with_no_user_files() {
+    let db = make_db(&[]);
+    let output = describe_via_dispatch(&db, "string");
+    assert!(
+        !output.starts_with("NOT FOUND") && !output.starts_with("NO DESCRIPTION"),
+        "primitive alias `string` should resolve in the default state, got:\n{output}",
+    );
+}
+
 fn multi_ns_project() -> ProjectDatabase {
     make_db(&[
         (

--- a/baml_language/crates/baml_cli/src/format.rs
+++ b/baml_language/crates/baml_cli/src/format.rs
@@ -18,8 +18,9 @@ pub struct FormatArgs {
     pub paths: Vec<PathBuf>,
 
     /// Project root to discover files from when no explicit paths are
-    /// passed. Mirrors `baml run`/`baml pack`'s `--from`; the directory
-    /// must contain a `baml.toml` or a `baml_src/` subdirectory.
+    /// passed. Mirrors `baml run`/`baml pack`'s `--from`. When the
+    /// directory has neither a `baml.toml` nor a `baml_src/` subdirectory,
+    /// there's nothing to format and `baml fmt` is a no-op success.
     #[arg(long, default_value = ".")]
     pub from: PathBuf,
 
@@ -35,14 +36,26 @@ pub struct FormatArgs {
 impl FormatArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
         // Cargo-style default: with no positional paths, discover every
-        // `.baml` file under the project root and format the lot. Same
-        // project-marker rule the rest of the CLI uses, so `baml fmt`
-        // in an unrelated directory fails fast instead of silently
-        // walking the cwd subtree.
+        // `.baml` file under the project root and format the lot. The
+        // project-marker rule keeps `baml fmt` from silently rewriting
+        // every `.baml` under cwd from an unrelated directory; with no
+        // marker there's simply nothing to format (a no-op success).
         let discovered;
         let paths: &[PathBuf] = if self.paths.is_empty() {
-            discovered = discover_project_files(&self.from)?;
-            &discovered
+            match discover_project_files(&self.from)? {
+                Some(files) => {
+                    discovered = files;
+                    &discovered
+                }
+                None => {
+                    // No `baml.toml` / `baml_src/` here — there's nothing to
+                    // format, so don't fail. A no-op success beats a hard
+                    // error for a command agents run reflexively; pass
+                    // explicit file paths to format loose `.baml` files.
+                    Reporter::new().finish("Finished", "no BAML project found; nothing to format");
+                    return Ok(crate::ExitCode::Success);
+                }
+            }
         } else {
             &self.paths
         };
@@ -135,13 +148,18 @@ impl FormatArgs {
     }
 }
 
-/// Walk a project root and return every `.baml` file inside it. Same
-/// rules as `project_load::load_project_from`: require a `baml.toml` or
-/// `baml_src/` marker so `baml fmt` doesn't accidentally rewrite every
-/// `.baml` under cwd from an unrelated directory, and prefer the
-/// `baml_src/` subtree when present so loose top-level fixtures aren't
+/// Walk a project root and return every `.baml` file inside it. Requires a
+/// `baml.toml` or `baml_src/` marker so `baml fmt` doesn't accidentally
+/// rewrite every `.baml` under cwd from an unrelated directory, and prefers
+/// the `baml_src/` subtree when present so loose top-level fixtures aren't
 /// touched.
-fn discover_project_files(from: &Path) -> Result<Vec<PathBuf>> {
+///
+/// Returns `Ok(None)` when neither marker is present — `baml fmt` mutates
+/// files, so unlike the read-only `describe`/`grep` introspection path it
+/// does **not** walk up to adopt a distant ancestor project (that could
+/// silently rewrite files far from the cwd). The caller turns `None` into a
+/// no-op success rather than a hard error.
+fn discover_project_files(from: &Path) -> Result<Option<Vec<PathBuf>>> {
     let canonical = fs::canonicalize(from)
         .with_context(|| format!("Could not resolve path: {}", from.display()))?;
 
@@ -149,14 +167,9 @@ fn discover_project_files(from: &Path) -> Result<Vec<PathBuf>> {
     let baml_src = canonical.join("baml_src");
     let has_baml_src = baml_src.is_dir();
     if !has_baml_toml && !has_baml_src {
-        anyhow::bail!(
-            "`{}` doesn't look like a BAML project.\n\
-             Expected `baml.toml` or a `baml_src/` directory at the project root.\n\
-             Pass `--from <project-dir>` or specific files to format.",
-            canonical.display()
-        );
+        return Ok(None);
     }
 
     let walk_root = if has_baml_src { baml_src } else { canonical };
-    Ok(discover_baml_files(&walk_root))
+    Ok(Some(discover_baml_files(&walk_root)))
 }

--- a/baml_language/crates/baml_cli/src/grep_command.rs
+++ b/baml_language/crates/baml_cli/src/grep_command.rs
@@ -10,7 +10,7 @@ use baml_lsp2_actions::{
 use baml_project::ProjectDatabase;
 use clap::Args;
 
-use crate::project_load::load_project_from;
+use crate::project_load::load_project_or_default;
 
 #[derive(Args, Clone, Debug)]
 pub struct GrepArgs {
@@ -66,11 +66,11 @@ pub struct GrepArgs {
 
 impl GrepArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
-        let (db, from, baml_files) = load_project_from(&self.from)?;
-        if baml_files.is_empty() {
-            eprintln!("No .baml files found in {}", from.display());
-            return Ok(crate::ExitCode::Other);
-        }
+        // Introspection never requires a `baml.toml`. With no project we
+        // get a stdlib-only default state and an empty user-file set;
+        // each grep mode already surfaces "no matches" / "no symbol found"
+        // gracefully below, so there's no need to bail up front.
+        let (db, from, _baml_files) = load_project_or_default(&self.from)?;
 
         let source_files = db.get_source_files();
         let kind_filter = parse_kind_filter(&self.kind)?;

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -63,8 +63,9 @@ pub struct PackArgs {
     pub file: Option<PathBuf>,
 
     /// Output path for the packaged executable. Defaults to the
-    /// `[package].name` from `baml.toml`; for a single target with no
-    /// `[package].name`, falls back to the function name.
+    /// `[package].name` from `baml.toml`; for a manifest-less `baml_src/`
+    /// project, falls back to the project directory name; in `--file` mode,
+    /// to the file stem.
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 
@@ -337,25 +338,24 @@ impl PackArgs {
         Ok((baml_exec::PackMode::Subcommand, resolved))
     }
 
-    /// Pick the default output basename. With `[package].name` mandatory
-    /// in `baml.toml` (validated up front by `project_load`), project-mode
-    /// output naming has exactly one source of truth.
+    /// Pick the default output basename.
     ///
     /// - `--file <PATH>` single-file mode: file stem (e.g. `foo.baml` →
     ///   `foo`). `baml.toml` isn't consulted — single-file packs are
     ///   intentionally hermetic.
-    /// - Project mode: `[package].name` from `<from>/baml.toml`. Guaranteed
-    ///   present (manifest validation happened at load time).
+    /// - Project mode: `[package].name` from `<from>/baml.toml` when a
+    ///   manifest is present, else the project directory name for a
+    ///   manifest-less `baml_src/` project (see
+    ///   [`crate::project_load::resolve_project_name`]).
     fn resolve_output_basename(&self) -> Result<String> {
         if let Some(file) = self.file.as_deref() {
             if let Some(stem) = file.file_stem().and_then(|s| s.to_str()) {
                 return Ok(stem.to_string());
             }
             // Pathologically nameless file (e.g. `.baml`); fall through to
-            // the manifest lookup. In `--file` mode that may still fail
-            // (no project to consult); the user can always pass `-o`.
+            // the project-name lookup. The user can always pass `-o`.
         }
-        crate::project_load::read_package_name(&self.from)
+        crate::project_load::resolve_project_name(&self.from)
     }
 }
 

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -349,11 +349,21 @@ impl PackArgs {
     ///   [`crate::project_load::resolve_project_name`]).
     fn resolve_output_basename(&self) -> Result<String> {
         if let Some(file) = self.file.as_deref() {
-            if let Some(stem) = file.file_stem().and_then(|s| s.to_str()) {
-                return Ok(stem.to_string());
-            }
-            // Pathologically nameless file (e.g. `.baml`); fall through to
-            // the project-name lookup. The user can always pass `-o`.
+            // Keep `--file` hermetic: derive the name from the file path
+            // alone, never from `--from`/project markers. A path with no
+            // usable file-name component (no stem, e.g. `..`, or a non-UTF-8
+            // name) can't be named automatically — bail rather than leak the
+            // cwd's project context into a single-file pack.
+            return file
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "cannot derive an output name from `{}`; pass `-o <PATH>` to name the output.",
+                        file.display()
+                    )
+                });
         }
         crate::project_load::resolve_project_name(&self.from)
     }
@@ -1023,6 +1033,32 @@ mod tests {
         // `--from` defaults to `.`, but file mode short-circuits before
         // touching it. Stem wins.
         assert_eq!(args.resolve_output_basename().unwrap(), "hello");
+    }
+
+    /// A `--file` path with no usable file-name component (here `..`, which
+    /// has no `file_stem`) must error rather than fall back to the project
+    /// name — `--file` stays hermetic. Even with a valid `baml.toml` in
+    /// `--from`, the result is an error, not the package name.
+    #[test]
+    fn test_pack_file_mode_nameless_errors_instead_of_consulting_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("baml.toml"),
+            "[package]\nname = \"should-not-be-used\"\n",
+        )
+        .unwrap();
+
+        let mut args = pack_args();
+        args.from = tmp.path().to_path_buf();
+        args.file = Some(PathBuf::from("..")); // no file_stem
+
+        let err = args.resolve_output_basename().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("-o"), "expected a `-o` hint, got: {msg}");
+        assert!(
+            !msg.contains("should-not-be-used"),
+            "must not consult the project manifest in --file mode, got: {msg}"
+        );
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -8,22 +8,30 @@ use crate::reporter::Reporter;
 
 /// Canonicalize `from` and load all discovered `.baml` files into a fresh
 /// [`ProjectDatabase`]. Returns the database, the canonical project root,
-/// and the list of loaded files.
+/// and the list of loaded files. Used by the build/execute commands
+/// (`run`/`test`/`generate`/`pack`).
 ///
-/// **`baml.toml` is required.** A project root must contain a `baml.toml`
-/// (Cargo-style). Without it, the recursive walk would happily slurp every
-/// `.baml` file under cwd, which in workspace-shaped directories means
-/// hundreds of unrelated/conflicting fixtures. Symptom: `baml run`/`baml
-/// pack` appears to hang for tens of seconds (it's actually salsa churning
-/// through type inference on every fixture). Failing fast with a clear
-/// message is the fix.
+/// **`baml.toml` is opt-in.** A directory is a BAML project if it has
+/// *either* a `baml.toml` *or* a `baml_src/` directory — `baml.toml` is
+/// only needed when you actually use one of its features (dependencies,
+/// version locks, `[scripts]`, multiple packages). The two cases:
+///
+/// - **Manifest present** (`baml.toml`): validated up front (Cargo-style,
+///   `[package].name` is mandatory when you write a manifest). Sources come
+///   from `baml_src/` if present, else the whole project root.
+/// - **Manifest-less** (`baml_src/` only): no validation; sources are
+///   loaded *only* from `baml_src/`. Because discovery is scoped to that
+///   subdirectory, a manifest-less project can never slurp an unmarked
+///   tree — which is exactly the workspace-shaped hang (`baml run`/`pack`
+///   stalling while salsa type-infers hundreds of stray fixtures) the old
+///   "`baml.toml` required" rule guarded against.
+///
+/// A directory with *neither* marker is rejected with a clear message —
+/// that's the only remaining hard failure, and it points at `baml_src/`,
+/// `baml init`, and `--file`.
 ///
 /// Standalone single-file callers (`baml run --file …`, `baml pack --file
-/// …`) skip this path entirely; they don't need a `baml.toml`.
-///
-/// When `baml_src/` exists alongside `baml.toml`, only files under that
-/// directory are loaded (mirroring `run_expression`'s `has_explicit_project`
-/// branch). Without `baml_src/`, the walk falls back to the project root.
+/// …`) skip this path entirely; they don't need a project at all.
 ///
 /// Callers decide how to surface an empty `files` result (e.g. `run` bails,
 /// `test` returns `NoTestsRun`, `generate` returns `Other`).
@@ -36,7 +44,7 @@ pub(crate) fn load_project_from(from: &Path) -> Result<(ProjectDatabase, PathBuf
 /// `   Compiling foo v0.1.0` shape but for source files. Used by
 /// `run`/`pack`/`test`/`generate` so the user sees per-file progress
 /// instead of a single `Loading <project>` line. `grep`/`describe`
-/// stay on the silent [`load_project_from`].
+/// stay on the lenient [`load_project_or_default`].
 pub(crate) fn load_project_from_reporting(
     from: &Path,
     reporter: &Reporter,
@@ -44,6 +52,71 @@ pub(crate) fn load_project_from_reporting(
     load_project_from_inner(from, |path| {
         reporter.spin("Loading", path.display().to_string());
     })
+}
+
+/// Read-only/introspection loader: like [`load_project_from`] but **never
+/// fails on a missing `baml.toml`**. This is for the commands an agent
+/// reaches for first (`describe`, `grep`) — the most expensive thing they
+/// can do is fail fast and burn a turn, so they always have something to
+/// work with.
+///
+/// 1. Walk the ancestors of `from` (Cargo-style, stopping at the
+///    filesystem root) for the nearest directory containing a `baml.toml`.
+///    If one is found, load that project exactly as [`load_project_from`]
+///    would — so running `baml describe` from a subdirectory resolves the
+///    enclosing project. Manifest validation is intentionally skipped:
+///    introspection doesn't need a valid `[package].name`, and a malformed
+///    manifest shouldn't block it.
+/// 2. If no `baml.toml` exists anywhere up the tree, return a **default
+///    state**: a [`ProjectDatabase`] holding only the BAML stdlib
+///    (`baml.*`, loaded by `set_project_root` regardless of user files)
+///    and **zero user files**. This is what makes `baml describe
+///    baml.String` work in any directory, with no project at all. The
+///    empty `files` result is expected, not an error; callers resolve
+///    against the stdlib regardless.
+///
+/// Note the two branches differ in what they load:
+/// - The **default-state** branch (2) loads zero user files, so it can
+///   never trigger the workspace-slurp hang that [`load_project_from`]
+///   guards against.
+/// - The **walk-up** branch (1) loads the ancestor project exactly as
+///   [`load_project_from`] would — including the "no `baml_src/` → walk the
+///   whole root" fallback in [`build_project_db`]. So if an ancestor
+///   `baml.toml` sits at a workspace root with hundreds of loose `.baml`
+///   files and no `baml_src/`, this *can* reintroduce that hang. That's a
+///   deliberate trade-off: a directory with a `baml.toml` is a declared
+///   project, and loading it is the same thing `run`/`test` already do from
+///   that root. The slurp guard exists to reject *unmarked* directories, not
+///   marked ones. In practice projects use `baml_src/`, which scopes the
+///   walk. (See the `walk_up_*` tests.)
+pub(crate) fn load_project_or_default(
+    from: &Path,
+) -> Result<(ProjectDatabase, PathBuf, Vec<PathBuf>)> {
+    let canonical = std::fs::canonicalize(from)
+        .with_context(|| format!("Could not resolve path: {}", from.display()))?;
+
+    match find_project_root(&canonical) {
+        // Walk-up: load the ancestor project. Manifest validation is
+        // intentionally skipped (see the docstring on point 1) — unlike the
+        // strict `load_project_from` path, introspection doesn't need a
+        // valid `[package].name`.
+        Some(root) => build_project_db(root, |_| {}),
+        None => {
+            let mut db = ProjectDatabase::new();
+            db.set_project_root(&canonical);
+            Ok((db, canonical, Vec::new()))
+        }
+    }
+}
+
+/// Walk `start` and its ancestors looking for the nearest directory that
+/// contains a `baml.toml`, stopping at the filesystem root. Returns the
+/// directory (not the manifest path). Cargo-style project discovery.
+fn find_project_root(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|dir| dir.join("baml.toml").is_file())
+        .map(Path::to_path_buf)
 }
 
 fn load_project_from_inner(
@@ -54,21 +127,46 @@ fn load_project_from_inner(
         .with_context(|| format!("Could not resolve path: {}", from.display()))?;
 
     let toml_path = canonical.join("baml.toml");
-    if !toml_path.exists() {
+    let has_baml_toml = toml_path.exists();
+    let has_baml_src = canonical.join("baml_src").is_dir();
+
+    if !has_baml_toml && !has_baml_src {
         anyhow::bail!(
-            "`{}` doesn't look like a BAML project — no `baml.toml` found.\n\
-             Run `baml init` to create one, or pass `--from <project-dir>` to point\n\
-             at an existing project. For one-off scripts, use `--file <PATH>` instead.",
+            "`{}` doesn't look like a BAML project — no `baml.toml` and no \
+             `baml_src/` directory found.\n\
+             Add a `baml_src/` directory with your `.baml` files, run `baml init` \
+             to create a `baml.toml`, or for a one-off script use `--file <PATH>`.",
             canonical.display()
         );
     }
-    // Manifest validation, Cargo-style: `[package].name` is mandatory.
-    // Failing here — before any source discovery or compilation — gives
-    // the user the same fast feedback they get from a malformed
-    // `Cargo.toml`, rather than crashing several seconds in when a
-    // packaging verb tries to use the name.
-    validate_baml_toml(&toml_path)?;
 
+    // Manifest validation, Cargo-style: when a `baml.toml` is present it must
+    // be valid (`[package].name` mandatory). Failing here — before any source
+    // discovery or compilation — gives the same fast feedback as a malformed
+    // `Cargo.toml`, rather than crashing several seconds in when a packaging
+    // verb tries to use the name. A manifest-less `baml_src/` project skips
+    // this: `baml.toml` is opt-in.
+    if has_baml_toml {
+        validate_baml_toml(&toml_path)?;
+    }
+
+    build_project_db(canonical, on_file)
+}
+
+/// Build a [`ProjectDatabase`] rooted at `canonical` (a directory already
+/// known to be a project root). When `baml_src/` exists, only files under
+/// it are loaded; otherwise the walk falls back to the root.
+///
+/// Shared by two callers with **different validation preconditions**: the
+/// strict [`load_project_from`] path validates the manifest *before*
+/// calling this, while the lenient [`load_project_or_default`] walk-up path
+/// intentionally does not. Do **not** add manifest validation in here — it
+/// would silently start rejecting manifests on the lenient path and break
+/// project-less introspection.
+fn build_project_db(
+    canonical: PathBuf,
+    on_file: impl Fn(&Path),
+) -> Result<(ProjectDatabase, PathBuf, Vec<PathBuf>)> {
     let baml_src = canonical.join("baml_src");
     let has_baml_src = baml_src.is_dir();
     let walk_root = if has_baml_src {
@@ -124,12 +222,29 @@ pub(crate) fn validate_baml_toml(toml_path: &Path) -> Result<String> {
     Ok(name.to_string())
 }
 
-/// Convenience: read and return `[package].name` for a known-valid
-/// manifest. The validation pass at load time means this is guaranteed
-/// to succeed for any path we've actually loaded as a project; the
-/// `Result` is purely for the file-IO surface.
-pub(crate) fn read_package_name(root: &Path) -> Result<String> {
-    validate_baml_toml(&root.join("baml.toml"))
+/// Resolve the project's name for output-artifact naming (used by `baml
+/// pack`). Prefers `[package].name` from `<root>/baml.toml` when a manifest
+/// is present (guaranteed valid for any path we've loaded as a project).
+/// For a manifest-less `baml_src/` project, falls back to the project
+/// directory's name — the way `cargo` names a target after its directory
+/// when no explicit name is given.
+pub(crate) fn resolve_project_name(root: &Path) -> Result<String> {
+    let canonical = std::fs::canonicalize(root)
+        .with_context(|| format!("Could not resolve path: {}", root.display()))?;
+    let toml_path = canonical.join("baml.toml");
+    if toml_path.exists() {
+        return validate_baml_toml(&toml_path);
+    }
+    canonical
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Could not derive a project name from `{}`; pass `-o <PATH>` to name the output.",
+                canonical.display()
+            )
+        })
 }
 
 #[cfg(test)]
@@ -168,18 +283,39 @@ mod tests {
         );
     }
 
-    /// `baml_src/` alone (no `baml.toml`) is now rejected — `baml.toml`
-    /// is required, mirroring Cargo's `Cargo.toml` requirement.
+    /// `baml_src/` alone (no `baml.toml`) is a valid manifest-less project:
+    /// `baml.toml` is opt-in. Sources load from `baml_src/` only.
     #[test]
-    fn rejects_baml_src_only_without_baml_toml() {
+    fn accepts_baml_src_only_without_baml_toml() {
         let tmp = TempDir::new().unwrap();
         let src = tmp.path().join("baml_src");
         fs::create_dir(&src).unwrap();
         fs::write(src.join("main.baml"), "function main() -> int { 1 }").unwrap();
 
-        let err = load_project_from(tmp.path()).unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("baml.toml"), "got: {msg}");
+        let (_db, _root, files) = load_project_from(tmp.path()).unwrap();
+        assert_eq!(files.len(), 1, "got files: {files:?}");
+        assert!(files[0].ends_with("main.baml"));
+    }
+
+    /// A manifest-less `baml_src/` project loads *only* `baml_src/` — loose
+    /// `.baml` files at the root are NOT slurped, so the discovery stays
+    /// bounded and can't trigger the workspace hang.
+    #[test]
+    fn baml_src_only_ignores_loose_root_files() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("baml_src");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("main.baml"), "function main() -> int { 1 }").unwrap();
+        // Loose file at the root (no baml.toml) must NOT be discovered.
+        fs::write(
+            tmp.path().join("stray.baml"),
+            "function wrong() -> int { 2 }",
+        )
+        .unwrap();
+
+        let (_db, _root, files) = load_project_from(tmp.path()).unwrap();
+        assert_eq!(files.len(), 1, "got files: {files:?}");
+        assert!(files[0].ends_with("main.baml"));
     }
 
     /// `baml.toml` with no `[package]` table → manifest error at load
@@ -212,16 +348,30 @@ mod tests {
         assert!(format!("{err}").contains("cannot be empty"));
     }
 
-    /// `read_package_name` returns the name for a valid manifest.
+    /// `resolve_project_name` returns `[package].name` when a manifest is
+    /// present.
     #[test]
-    fn read_package_name_returns_field() {
+    fn resolve_project_name_uses_package_name() {
         let tmp = TempDir::new().unwrap();
         fs::write(
             tmp.path().join("baml.toml"),
             "[package]\nname = \"my-app\"\n",
         )
         .unwrap();
-        assert_eq!(read_package_name(tmp.path()).unwrap(), "my-app");
+        assert_eq!(resolve_project_name(tmp.path()).unwrap(), "my-app");
+    }
+
+    /// `resolve_project_name` falls back to the directory name for a
+    /// manifest-less project (cargo-style), so `baml pack` can name the
+    /// artifact without a `baml.toml`.
+    #[test]
+    fn resolve_project_name_falls_back_to_dir_name() {
+        let tmp = TempDir::new().unwrap();
+        let proj = tmp.path().join("my-cool-project");
+        fs::create_dir(&proj).unwrap();
+        fs::create_dir(proj.join("baml_src")).unwrap();
+
+        assert_eq!(resolve_project_name(&proj).unwrap(), "my-cool-project");
     }
 
     fn valid_manifest() -> &'static str {
@@ -238,6 +388,94 @@ mod tests {
         let (_db, _root, files) = load_project_from(tmp.path()).unwrap();
         assert_eq!(files.len(), 1);
         assert!(files[0].ends_with("a.baml"));
+    }
+
+    // ── load_project_or_default (read-only / introspection path) ────────────
+
+    /// A directory with `.baml` files but no `baml.toml` (and no ancestor
+    /// `baml.toml`) yields the "default state": zero user files, but the
+    /// stdlib is loaded so `baml describe baml.*` still resolves. The
+    /// loose `.baml` is deliberately NOT slurped.
+    #[test]
+    fn default_state_loads_no_user_files_but_keeps_stdlib() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("loose.baml"),
+            "function main() -> int { 1 }",
+        )
+        .unwrap();
+
+        let (db, root, files) = load_project_or_default(tmp.path()).unwrap();
+        assert!(
+            files.is_empty(),
+            "default state must not slurp loose files: {files:?}"
+        );
+        assert_eq!(root, std::fs::canonicalize(tmp.path()).unwrap());
+        // The builtin `baml` package is present even with no user files.
+        let pkgs = baml_lsp2_actions::non_user_package_names(&db);
+        assert!(
+            pkgs.contains("baml"),
+            "stdlib `baml` package missing from default state: {pkgs:?}"
+        );
+    }
+
+    /// `load_project_or_default` walks up to find an ancestor `baml.toml`,
+    /// so introspection from a subdirectory resolves the enclosing project.
+    #[test]
+    fn walk_up_finds_ancestor_project() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("baml.toml"), valid_manifest()).unwrap();
+        let src = tmp.path().join("baml_src");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("main.baml"), "function main() -> int { 1 }").unwrap();
+        // A nested directory we invoke from.
+        let nested = src.join("nested");
+        fs::create_dir(&nested).unwrap();
+
+        let (_db, root, files) = load_project_or_default(&nested).unwrap();
+        assert_eq!(root, std::fs::canonicalize(tmp.path()).unwrap());
+        assert_eq!(files.len(), 1, "got files: {files:?}");
+        assert!(files[0].ends_with("main.baml"));
+    }
+
+    /// Walk-up to an ancestor `baml.toml` that has **no `baml_src/`** loads
+    /// the ancestor project by walking its whole root — the documented
+    /// trade-off (a marked directory is a declared project, so loading it is
+    /// intentional; the slurp guard only rejects *unmarked* dirs). This
+    /// pins that behavior so it can't regress silently.
+    #[test]
+    fn walk_up_loads_ancestor_without_baml_src() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("baml.toml"), valid_manifest()).unwrap();
+        // No baml_src/ — loose .baml files live at the root.
+        fs::write(tmp.path().join("a.baml"), "function a() -> int { 1 }").unwrap();
+        fs::write(tmp.path().join("b.baml"), "function b() -> int { 2 }").unwrap();
+        // Invoke from a nested subdir so the walk-up path is exercised.
+        let nested = tmp.path().join("sub").join("deeper");
+        fs::create_dir_all(&nested).unwrap();
+
+        let (_db, root, files) = load_project_or_default(&nested).unwrap();
+        assert_eq!(root, std::fs::canonicalize(tmp.path()).unwrap());
+        assert_eq!(
+            files.len(),
+            2,
+            "ancestor project without baml_src should load its root .baml files: {files:?}"
+        );
+    }
+
+    /// Walk-up tolerates a malformed manifest — introspection doesn't need
+    /// a valid `[package].name`, unlike the strict `load_project_from` path.
+    #[test]
+    fn walk_up_tolerates_invalid_manifest() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("baml.toml"), "# no package table\n").unwrap();
+        fs::write(tmp.path().join("a.baml"), "function main() -> int { 1 }").unwrap();
+
+        // Strict loader rejects it...
+        assert!(load_project_from(tmp.path()).is_err());
+        // ...but the introspection loader still loads the files.
+        let (_db, _root, files) = load_project_or_default(tmp.path()).unwrap();
+        assert_eq!(files.len(), 1, "got files: {files:?}");
     }
 
     /// `baml.toml` + `baml_src/` project layout: only the `baml_src/`

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -876,10 +876,13 @@ impl RunArgs {
 
         let mut db = ProjectDatabase::new();
         // Project marker: matches `project_load::load_project_from_inner`.
-        // `baml.toml` is the marker; `baml_src/` alone no longer qualifies
-        // (would let `baml run -e` pick up project context that every
-        // other verb refuses).
-        let has_explicit_project = from.as_ref().is_some_and(|f| f.join("baml.toml").exists());
+        // A directory is a project if it has *either* a `baml.toml` or a
+        // `baml_src/` — `baml.toml` is opt-in — so `baml run -e` picks up
+        // the surrounding project's definitions in the same cases every
+        // other verb now does.
+        let has_explicit_project = from
+            .as_ref()
+            .is_some_and(|f| f.join("baml.toml").exists() || f.join("baml_src").is_dir());
 
         let project_root = if has_explicit_project {
             let root = from.as_ref().unwrap();

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -230,3 +230,316 @@ fn test_no_tests_returns_specific_exit_code() {
         String::from_utf8_lossy(&output.stderr),
     );
 }
+
+// ============================================================================
+// Tests for project-less introspection (`baml describe` / `baml grep` /
+// `baml fmt` without a `baml.toml`). The most expensive thing an agent can
+// do is fail fast and burn a turn, so these read-only commands fall back to
+// a stdlib-only "default state" instead of erroring.
+// ============================================================================
+
+/// `baml describe baml.String` from a directory with no `baml.toml` must
+/// succeed against the stdlib — the headline use case for the default
+/// state. Regression for the old "doesn't look like a BAML project" bail.
+#[test]
+fn describe_stdlib_without_baml_toml_succeeds() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    let output = run_baml_cli(
+        built,
+        tmp.path(),
+        &["describe", "baml.String", "--from", "."],
+    );
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 describing stdlib with no baml.toml, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("String"),
+        "Expected stdout to describe `String`, got:\n{stdout}",
+    );
+    // The old failure message must not appear.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("doesn't look like a BAML project"),
+        "Default state should not emit the no-project error, got stderr:\n{stderr}",
+    );
+}
+
+/// `baml describe` walks up to an ancestor `baml.toml`, so introspection
+/// from a project subdirectory resolves a user-defined symbol.
+#[test]
+fn describe_walks_up_to_ancestor_project() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    create_project(
+        tmp.path(),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    );
+    let nested = tmp.path().join("baml_src").join("nested");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    // Invoke from the nested subdir (default --from is ".").
+    let output = run_baml_cli(built, &nested, &["describe", "greet"]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 resolving a user symbol from a subdir, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("greet"),
+        "Expected stdout to describe `greet`, got:\n{stdout}",
+    );
+}
+
+/// `baml fmt` in a directory with no project is a no-op success, not an
+/// error — nothing to format is not a failure.
+#[test]
+fn fmt_without_project_is_noop_success() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["fmt", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 for `baml fmt` with no project, got: {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `baml grep` with no `baml.toml` must not hard-fail on the missing
+/// manifest. The user-file set is empty in the default state (grep only
+/// searches user files, not the stdlib), so a "no match" result is correct
+/// — what matters is that the old "doesn't look like a BAML project" bail
+/// is gone and the process doesn't crash.
+#[test]
+fn grep_without_baml_toml_does_not_fail_on_missing_manifest() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["grep", "Foo", "--from", "."]);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("doesn't look like a BAML project"),
+        "grep should not emit the no-project error in the default state, got:\n{stderr}",
+    );
+    // Exited normally (Some(code)) rather than crashing on a signal (None).
+    assert!(
+        output.status.code().is_some(),
+        "grep should exit cleanly in the default state, not crash",
+    );
+}
+
+/// `baml describe` walks up to an ancestor with a **malformed** `baml.toml`
+/// (no `[package].name`) and still succeeds — introspection tolerates a bad
+/// manifest, unlike the strict build/execute path.
+#[test]
+fn describe_walks_up_to_ancestor_with_invalid_manifest() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    // Malformed manifest: no [package] table.
+    std::fs::write(tmp.path().join("baml.toml"), "# no package table\n").unwrap();
+    let nested = tmp.path().join("sub");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let output = run_baml_cli(built, &nested, &["describe", "baml.String"]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 describing stdlib above an invalid manifest, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+// ============================================================================
+// Tests for manifest-less execution: `baml.toml` is opt-in, a `baml_src/`
+// directory alone is a valid project for run/test/generate/pack.
+// ============================================================================
+
+/// `baml run --list` works on a `baml_src/`-only project (no `baml.toml`).
+#[test]
+fn run_list_without_baml_toml_using_baml_src_succeeds() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    // No baml.toml — just a baml_src/ directory with a function.
+    let src = tmp.path().join("baml_src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("main.baml"),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["run", "--list", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 for `baml run --list` on a baml_src-only project, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("greet"),
+        "Expected the function list to include `greet`, got:\n{stdout}",
+    );
+}
+
+/// A directory with neither a `baml.toml` nor a `baml_src/` is still
+/// rejected — but the error points at `baml_src/`, `baml init`, and
+/// `--file`, not just "missing baml.toml".
+#[test]
+fn run_without_any_project_marker_errors_with_hint() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    // A loose .baml at the root, but no baml.toml and no baml_src/.
+    std::fs::write(
+        tmp.path().join("loose.baml"),
+        "function f() -> int {\n  1\n}\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["run", "--list", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit when neither project marker is present",
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The hint names all three escape hatches.
+    for needle in ["baml_src/", "baml init", "--file"] {
+        assert!(
+            stderr.contains(needle),
+            "Expected the error to mention `{needle}`, got:\n{stderr}",
+        );
+    }
+}
+
+/// `baml run <fn>` actually *executes* a function in a manifest-less
+/// `baml_src/` project — the headline of this change, proven end-to-end
+/// (not just `--list`). `answer` is pure (no LLM), so it runs hermetically.
+#[test]
+fn run_execute_function_without_baml_toml_succeeds() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("baml_src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("main.baml"),
+        "function answer() -> int {\n  42\n}\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["run", "answer", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 executing a function on a baml_src-only project, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("42"),
+        "Expected the result `42`, got:\n{stdout}"
+    );
+}
+
+/// `baml run -e <expr>` picks up a manifest-less `baml_src/` project's
+/// definitions (the `has_explicit_project` marker now accepts `baml_src/`).
+#[test]
+fn run_expr_without_baml_toml_picks_up_baml_src_context() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("baml_src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("main.baml"),
+        "function answer() -> int {\n  42\n}\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["run", "-e", "answer()", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 for `run -e` referencing a baml_src-only project fn, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("42"),
+        "Expected the result `42`, got:\n{stdout}"
+    );
+}
+
+/// `baml test` reaches test discovery on a manifest-less `baml_src/`
+/// project — a project with no test blocks returns the `NoTestsRun` code (5),
+/// proving the loader accepted it rather than bailing on the missing manifest.
+#[test]
+fn test_without_baml_toml_using_baml_src_returns_no_tests_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("baml_src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("main.baml"),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["test", "--from", "."]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(5),
+        "Expected NoTestsRun (5) on a manifest-less project, got: {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `baml generate` runs a generator on a manifest-less `baml_src/` project.
+#[test]
+fn generate_without_baml_toml_using_baml_src_succeeds() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("baml_src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("main.baml"),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n\n\
+         generator py {\n  output_type \"python/pydantic\"\n  output_dir \"..\"\n  \
+         naming_convention \"preserve-case\"\n}\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 for `baml generate` on a baml_src-only project, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/baml_language/crates/baml_cli/tests/pack_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/pack_e2e.rs
@@ -207,3 +207,31 @@ fn pack_e2e_sys_exit_propagates_to_shell() {
     let out = run(&bin, &[]);
     assert_eq!(out.status.code(), Some(7));
 }
+
+/// Pack a **manifest-less** `baml_src/`-only project (no `baml.toml`) and
+/// run the resulting binary. Proves the whole pack pipeline works without a
+/// manifest; `-o` overrides the artifact path, so the dir-name fallback in
+/// `resolve_project_name` is covered separately by the unit tests.
+#[test]
+fn pack_e2e_manifest_less_baml_src() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    // No baml.toml — sources live under baml_src/.
+    let src = tmp.path().join("baml_src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("main.baml"),
+        "function main(name: string) -> string { \"hi, \" + name }\n",
+    )
+    .unwrap();
+
+    let bin = pack(built, tmp.path(), &["main"]);
+    let out = run(&bin, &["--name", "Ada"]);
+    assert!(
+        out.status.success(),
+        "manifest-less packed binary exited {:?}; stderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("hi, Ada"));
+}


### PR DESCRIPTION
## Why

The most expensive thing an agent can do is try a command and have it fail fast. Previously every project command bailed with `doesn't look like a BAML project` unless the exact directory contained a `baml.toml` — so `baml describe baml.String` couldn't even read the stdlib without a project, and `baml run`/`test`/`generate`/`pack` refused to run a plain `baml_src/` directory.

This makes **`baml.toml` opt-in**: it's only needed when you actually use one of its features (dependencies, version lock, `[scripts]`, multiple packages). A bare `baml_src/` is a complete project.

## Behavior

| Command | No project at all | `baml_src/` only, no `baml.toml` |
|---|---|---|
| `describe` / `grep` | ✅ stdlib-only default state (walks up for an ancestor `baml.toml`) | ✅ |
| `fmt` | ✅ no-op success | ✅ |
| `run` / `test` / `generate` / `pack` | ❌ error → hints `baml_src/`, `baml init`, `--file` | ✅ |
| `run --file` / `pack --file` | ✅ hermetic (unchanged) | ✅ |

Key points:

- **describe / grep** use a lenient loader: walk ancestors for a `baml.toml`; if none, fall back to a stdlib-only database (the `baml.*` stdlib loads regardless of user files, so `baml describe baml.String` works in any directory with zero user files).
- **fmt** returns a no-op success when there's no project marker, instead of erroring. It deliberately does **not** walk up, since it mutates files.
- **run / test / generate / pack** now treat a directory as a project if it has *either* a `baml.toml` *or* a `baml_src/`. A manifest-less project loads sources **only** from `baml_src/`, so discovery stays scoped and can never slurp an unmarked tree — the workspace-shaped salsa hang the old hard requirement guarded against. `run -e` picks up a `baml_src/`-only project's context too.
- **pack** names the artifact after `[package].name` when a manifest is present, else the project directory name (Cargo-style); `--file` still uses the file stem.
- A present `baml.toml` is still validated (`[package].name` required). The only remaining hard failure is a directory with neither marker.

## Slurp-hang invariant

A whole-root walk only happens for a **declared** project (a `baml.toml` present with no `baml_src/`) — intentional, matching what `run`/`test` already did. Every manifest-less path is scoped to `baml_src/` and provably cannot slurp.

## Testing

`cargo nextest run -p baml_cli --no-default-features --features ring-crypto` → **195 passing**. Added:

- Unit: loader decision table (all four marker cases), walk-up, stdlib default state, `resolve_project_name` dir-name fallback.
- E2E: project-less `describe`/`grep`/`fmt`; manifest-less `run <fn>` (executes), `run -e`, `run --list`, `test` (→ NoTestsRun), `generate`, and `pack` (builds + runs the binary).

fmt + clippy `--all-targets` clean.

## Open question

A `baml.toml` present but **without** `[package].name` (e.g. a manifest added *only* for `[scripts]`/`[dependencies]`) is still rejected — Cargo-consistent, but mildly in tension with "only needed when you use a feature," since `pack` can now fall back to the directory name. Left strict for now; easy to relax if we'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects may be defined by a baml_src/ directory alone (no baml.toml required).
  * CLI read-only commands (describe, grep, fmt) operate in a stdlib-only default when no project is present.

* **Improvements**
  * Formatter is a no-op outside projects and prints a friendly message on success.
  * Packaging: clearer output basename rules and stricter handling of nameless file paths.

* **Tests**
  * New end-to-end and unit tests cover manifest-less and baml_src-only scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->