### PR TITLE
Add no-argument String.split whitespace tokenization

### DIFF
--- a/engine/baml-compiler/src/codegen.rs
+++ b/engine/baml-compiler/src/codegen.rs
@@ -1301,12 +1301,6 @@ impl<'g> HirCompiler<'g> {
 
                     Some(TypeIR::Map(_, _, _)) => format!("baml.Map.{method}"),
 
-                    Some(TypeIR::Primitive(TypeValue::String, _))
-                        if method == "split" && args.is_empty() =>
-                    {
-                        baml_vm::native::STRING_SPLIT_WHITESPACE.to_string()
-                    }
-
                     Some(TypeIR::Primitive(TypeValue::String, _)) => {
                         format!("baml.String.{method}")
                     }

--- a/engine/baml-compiler/src/codegen.rs
+++ b/engine/baml-compiler/src/codegen.rs
@@ -1301,6 +1301,12 @@ impl<'g> HirCompiler<'g> {
 
                     Some(TypeIR::Map(_, _, _)) => format!("baml.Map.{method}"),
 
+                    Some(TypeIR::Primitive(TypeValue::String, _))
+                        if method == "split" && args.is_empty() =>
+                    {
+                        baml_vm::native::STRING_SPLIT_WHITESPACE.to_string()
+                    }
+
                     Some(TypeIR::Primitive(TypeValue::String, _)) => {
                         format!("baml.String.{method}")
                     }

--- a/engine/baml-compiler/src/thir/interpret.rs
+++ b/engine/baml-compiler/src/thir/interpret.rs
@@ -2929,16 +2929,22 @@ fn evaluate_method_call(
             let BamlValueWithMeta::String(s, _) = receiver else {
                 bail!("split() method only available on strings at {:?}", meta.0);
             };
-            if args.len() != 1 {
-                bail!("split() method takes exactly 1 argument at {:?}", meta.0);
-            }
-            let BamlValueWithMeta::String(delimiter, _) = &args[0] else {
-                bail!("split() argument must be a string at {:?}", meta.0);
+            let parts: Vec<BamlValueWithMeta<ExprMetadata>> = match args {
+                [] => s
+                    .split_whitespace()
+                    .map(|part| BamlValueWithMeta::String(part.to_string(), meta.clone()))
+                    .collect(),
+                [BamlValueWithMeta::String(delimiter, _)] => s
+                    .split(delimiter.as_str())
+                    .map(|part| BamlValueWithMeta::String(part.to_string(), meta.clone()))
+                    .collect(),
+                [_] => {
+                    bail!("split() argument must be a string at {:?}", meta.0);
+                }
+                _ => {
+                    bail!("split() method takes 0 or 1 arguments at {:?}", meta.0);
+                }
             };
-            let parts: Vec<BamlValueWithMeta<ExprMetadata>> = s
-                .split(delimiter.as_str())
-                .map(|part| BamlValueWithMeta::String(part.to_string(), meta.clone()))
-                .collect();
             Ok(BamlValueWithMeta::List(parts, meta.clone()))
         }
         "substring" => {

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -2271,9 +2271,15 @@ pub fn typecheck_expression(
             } else {
                 args.len() + 1 // self
             };
+            let allow_no_arg_string_split = full_name == "baml.String.split"
+                && args.is_empty()
+                && !is_function_call_on_namespace;
 
             // Check argument count only for known functions
-            if is_known_function && passed_number_of_args != param_types.len() {
+            if is_known_function
+                && passed_number_of_args != param_types.len()
+                && !allow_no_arg_string_split
+            {
                 diagnostics.push_error(DatamodelError::new_validation_error(
                     &format!(
                         "Function {} expects {} arguments, got {}",
@@ -3299,6 +3305,42 @@ mod tests {
         } else {
             panic!("Expected let statement");
         }
+    }
+
+    #[test]
+    fn typecheck_string_split_without_separator() {
+        let source = r##"
+        function test_split(s: string) -> string[] {
+          s.split()
+        }
+        "##;
+
+        let (hir, mut diagnostics) = hir_from_source(source);
+        assert!(!diagnostics.has_errors(), "Should parse without errors");
+
+        let thir = typecheck(&hir, &mut diagnostics);
+        assert!(!diagnostics.has_errors(), "Should typecheck without errors");
+
+        let test_fn = thir
+            .expr_functions
+            .iter()
+            .find(|f| f.name == "test_split")
+            .expect("Should have test_split function");
+
+        let expr = test_fn
+            .body
+            .trailing_expr
+            .as_ref()
+            .expect("test_split should have a trailing expression");
+        assert!(expr
+            .meta()
+            .1
+            .as_ref()
+            .expect("split() should have an inferred return type")
+            .eq_up_to_span(&TypeIR::List(
+                Box::new(TypeIR::string()),
+                Default::default()
+            )));
     }
 
     #[test]

--- a/engine/baml-vm/src/native.rs
+++ b/engine/baml-vm/src/native.rs
@@ -15,6 +15,8 @@ use crate::{
 
 type NativeFunctionResult = Result<Value, VmError>;
 
+pub const STRING_SPLIT_WHITESPACE: &str = "baml.String.split/0";
+
 /// String length.
 pub fn string_len(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
     // Arity is already checked by the VM.
@@ -292,6 +294,18 @@ pub fn string_split(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
 
     let parts: Vec<Value> = string
         .split(&delimiter)
+        .map(|s| vm.alloc_string(s.to_string()))
+        .collect();
+
+    Ok(vm.alloc_array(parts))
+}
+
+/// String split on contiguous whitespace, discarding empty tokens.
+pub fn string_split_whitespace(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
+    let string = vm.objects.as_string(&args[0])?.to_owned();
+
+    let parts: Vec<Value> = string
+        .split_whitespace()
         .map(|s| vm.alloc_string(s.to_string()))
         .collect();
 
@@ -715,6 +729,7 @@ pub fn functions() -> BamlMap<String, (NativeFunction, usize)> {
         ("baml.String.startsWith", (string_starts_with, 2)),
         ("baml.String.endsWith", (string_ends_with, 2)),
         ("baml.String.split", (string_split, 2)),
+        (STRING_SPLIT_WHITESPACE, (string_split_whitespace, 1)),
         ("baml.String.substring", (string_substring, 3)),
         ("baml.String.replace", (string_replace, 3)),
         // Media

--- a/engine/baml-vm/src/native.rs
+++ b/engine/baml-vm/src/native.rs
@@ -15,8 +15,6 @@ use crate::{
 
 type NativeFunctionResult = Result<Value, VmError>;
 
-pub const STRING_SPLIT_WHITESPACE: &str = "baml.String.split/0";
-
 /// String length.
 pub fn string_len(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
     // Arity is already checked by the VM.
@@ -290,24 +288,25 @@ pub fn string_ends_with(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
 /// String split
 pub fn string_split(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
     let string = vm.objects.as_string(&args[0])?.to_owned();
-    let delimiter = vm.objects.as_string(&args[1])?.to_owned();
 
-    let parts: Vec<Value> = string
-        .split(&delimiter)
-        .map(|s| vm.alloc_string(s.to_string()))
-        .collect();
-
-    Ok(vm.alloc_array(parts))
-}
-
-/// String split on contiguous whitespace, discarding empty tokens.
-pub fn string_split_whitespace(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
-    let string = vm.objects.as_string(&args[0])?.to_owned();
-
-    let parts: Vec<Value> = string
-        .split_whitespace()
-        .map(|s| vm.alloc_string(s.to_string()))
-        .collect();
+    let parts: Vec<Value> = match args.len() {
+        1 => string
+            .split_whitespace()
+            .map(|s| vm.alloc_string(s.to_string()))
+            .collect(),
+        2 => {
+            let delimiter = vm.objects.as_string(&args[1])?.to_owned();
+            string
+                .split(&delimiter)
+                .map(|s| vm.alloc_string(s.to_string()))
+                .collect()
+        }
+        _ => {
+            return Err(VmError::RuntimeError(RuntimeError::Other(
+                "split() method takes 0 or 1 arguments".to_string(),
+            )));
+        }
+    };
 
     Ok(vm.alloc_array(parts))
 }
@@ -729,7 +728,6 @@ pub fn functions() -> BamlMap<String, (NativeFunction, usize)> {
         ("baml.String.startsWith", (string_starts_with, 2)),
         ("baml.String.endsWith", (string_ends_with, 2)),
         ("baml.String.split", (string_split, 2)),
-        (STRING_SPLIT_WHITESPACE, (string_split_whitespace, 1)),
         ("baml.String.substring", (string_substring, 3)),
         ("baml.String.replace", (string_replace, 3)),
         // Media

--- a/engine/baml-vm/src/vm.rs
+++ b/engine/baml-vm/src/vm.rs
@@ -1649,7 +1649,9 @@ impl Vm {
 
                     // Compiler should have already checked this so we could
                     // skip it but it's an easy and fast check.
-                    if arg_count != callee.arity {
+                    let allow_no_arg_string_split =
+                        callee.name == "baml.String.split" && arg_count == 1;
+                    if arg_count != callee.arity && !allow_no_arg_string_split {
                         return Err(VmError::from(InternalError::InvalidArgumentCount {
                             expected: callee.arity,
                             got: arg_count,

--- a/engine/baml-vm/tests/strings.rs
+++ b/engine/baml-vm/tests/strings.rs
@@ -229,6 +229,24 @@ fn string_split() -> anyhow::Result<()> {
 }
 
 #[test]
+fn string_split_without_separator_splits_whitespace() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            function main() -> string[] {
+                let s = " \thello  \nworld\r\nBAML ";
+                s.split()
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::Object(Object::Array(vec![
+            Value::string("hello"),
+            Value::string("world"),
+            Value::string("BAML"),
+        ]))),
+    })
+}
+
+#[test]
 fn string_substring() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The error

Calling `String.split()` without a separator currently fails arity validation instead of tokenizing whitespace:

```baml
function ReverseWords(s: string) -> string {
  let tokens = s.split()
  let reversed = tokens | reverse()
  reversed | join(" ")
}
```

Current diagnostic from `engine/baml-compiler/src/thir/typecheck.rs`:

```text
Function baml.String.split expects 2 arguments, got 0
```

The explicit-separator workaround also produces incorrect tokens for mixed whitespace:

```baml
function Tokens() -> string[] {
  let s = " \thello  \nworld\r\nBAML "
  s.split(" ")
}
```

It only splits literal spaces, leaving tab/newline/carriage-return whitespace attached and preserving empty fields from repeated or leading/trailing spaces.

## Root cause

- `engine/baml-compiler/src/thir/typecheck.rs` registered `baml.String.split` as a two-parameter native signature: receiver plus explicit separator, and method-call arity validation rejected receiver-only calls.
- `engine/baml-vm/src/vm.rs` enforced each native function's fixed arity before dispatch, so a receiver-only bytecode call to `baml.String.split` could not reach the native implementation.
- `engine/baml-vm/src/native.rs::string_split` always read `args[1]` as the delimiter and used Rust `str::split`.
- `engine/baml-compiler/src/thir/interpret.rs::evaluate_method_call` also required exactly one delimiter argument.

## The fix

- Allow `s.split()` through THIR typechecking while preserving `s.split(separator)` typechecking.
- Allow the VM to dispatch `baml.String.split` with one VM argument only for the receiver-only no-arg form.
- Update `string_split` to use Rust `split_whitespace()` when called with only the receiver, which collapses contiguous whitespace and omits empty tokens; explicit separators continue to use `str::split`.
- Update the direct THIR interpreter path to support both zero and one split argument.
- Add Rust tests for no-argument whitespace splitting and typechecking.

## Verification

Passing commands:

```text
$ mise exec -- cargo test -p baml-vm string_split --test strings -- --nocapture && mise exec -- cargo test -p baml-compiler typecheck_string_split_without_separator --lib -- --nocapture
...
test result: ok
```

```text
$ mise exec -- cargo test --lib
...
test result: ok
```

```text
$ mise exec -- cargo test --features skip-integ-tests
...
test result: ok
```

The same reproduction now succeeds via the VM test added in `engine/baml-vm/tests/strings.rs`:

```baml
function main() -> string[] {
  let s = " \thello  \nworld\r\nBAML "
  s.split()
}
```

Expected and now-passing output:

```text
["hello", "world", "BAML"]
```

Full language integration runner status:

```text
$ mise exec -- ./run-tests.sh
```

This reached the TypeScript integration phase and then blocked on an interactive Infisical login prompt:

```text
No valid login session found, triggering login flow
? Select your hosting option:
```

Running the TypeScript integration tests directly without Infisical also failed due missing/invalid provider credentials, not this code change:

```text
$ pnpm test -- --silent false --testTimeout 60000
...
LLM client 'GPT35' requires environment variable 'OPENAI_API_KEY' to be set but it is not
LLM client 'Sonnet' requires environment variable 'ANTHROPIC_API_KEY' to be set but it is not
LLM client 'Gemini' requires environment variable 'GOOGLE_API_KEY' to be set but it is not
Request failed with status code: 401 Unauthorized ... invalid_api_key
Test Suites: 34 failed, 8 passed, 42 total
Tests: 155 failed, 81 passed, 236 total
```

## Issue Reference
- [ ] This PR fixes/closes #[issue number]

## Changes
Implemented no-argument `String.split()` for whitespace tokenization while preserving explicit separator behavior.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed through focused VM/typechecker tests
- [x] Tested in Cursor Cloud Linux environment

## Screenshots
Not applicable.

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
The full integration suite requires authenticated provider credentials or a valid Infisical session in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecb9dc03-bd5d-5bf3-b6a2-100c8ca9177b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecb9dc03-bd5d-5bf3-b6a2-100c8ca9177b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

