### PR TITLE
Show public baml command in CLI help

### DIFF
--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -10,7 +10,14 @@ pub(crate) const fn release_version() -> &'static str {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "baml-cli", author, version = release_version(), about = "A CLI tool for working with BAML. Learn more at https://docs.boundaryml.com.", long_about = None)]
+#[command(
+    name = "baml-cli",
+    bin_name = "baml",
+    author,
+    version = release_version(),
+    about = "A CLI tool for working with BAML. Learn more at https://docs.boundaryml.com.",
+    long_about = None
+)]
 #[command(styles = crate::reporter::CLAP_STYLING)]
 #[command(propagate_version = true)]
 pub(crate) struct RuntimeCli {
@@ -179,5 +186,40 @@ mod tests {
     #[test]
     fn release_version_matches_compile_time_setting() {
         assert_eq!(release_version(), baml_version::CANONICAL_VERSION);
+    }
+
+    fn help_for(args: &[&str]) -> String {
+        let mut command = RuntimeCli::command();
+        command
+            .try_get_matches_from_mut(args)
+            .expect_err("help request should render clap help")
+            .to_string()
+    }
+
+    #[test]
+    fn root_help_presents_public_baml_command() {
+        let help = help_for(&["baml-cli", "--help"]);
+        assert!(help.contains("Usage: baml [OPTIONS] <COMMAND>"), "{help}");
+        assert!(!help.contains("Usage: baml-cli"), "{help}");
+    }
+
+    #[test]
+    fn pack_help_presents_public_baml_command() {
+        let help = help_for(&["baml-cli", "pack", "--help"]);
+        assert!(
+            help.contains("Usage: baml pack [OPTIONS] [TARGET]"),
+            "{help}"
+        );
+        assert!(!help.contains("Usage: baml-cli pack"), "{help}");
+    }
+
+    #[test]
+    fn ide_help_presents_public_baml_command() {
+        let help = help_for(&["baml-cli", "ide", "--help"]);
+        assert!(
+            help.contains("Usage: baml ide [OPTIONS] <COMMAND>"),
+            "{help}"
+        );
+        assert!(!help.contains("Usage: baml-cli ide"), "{help}");
     }
 }

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -1511,19 +1511,25 @@ impl RunArgs {
     }
 
     fn print_run_help() {
+        let _ = Self::run_help_command().print_help();
+    }
+
+    fn run_help_command() -> clap::Command {
         use clap::CommandFactory;
         let cmd = crate::commands::RuntimeCli::command();
-        if let Some(sub) = cmd.find_subcommand("run") {
-            // Clap propagates `styles = …` from the root command to
-            // subcommands at parse time, not when a subcommand
-            // reference is grabbed directly via `find_subcommand`.
-            // Re-apply `CLAP_STYLING` explicitly so `run --help` keeps
-            // the same green/cyan ariadne-adjacent palette as
-            // `baml-cli --help`, instead of falling back to clap's
-            // default bold+underline-no-color treatment.
-            let mut sub = sub.clone().styles(crate::reporter::CLAP_STYLING);
-            let _ = sub.print_help();
-        }
+        let sub = cmd
+            .find_subcommand("run")
+            .expect("RuntimeCli should register a run subcommand");
+        // Clap propagates `styles = …` from the root command to
+        // subcommands at parse time, not when a subcommand reference is
+        // grabbed directly via `find_subcommand`. Re-apply
+        // `CLAP_STYLING` explicitly so `run --help` keeps the same
+        // green/cyan ariadne-adjacent palette as top-level help,
+        // instead of falling back to clap's default
+        // bold+underline-no-color treatment.
+        sub.clone()
+            .bin_name("baml run")
+            .styles(crate::reporter::CLAP_STYLING)
     }
 }
 
@@ -1806,6 +1812,17 @@ mod tests {
     #[test]
     fn test_reserved_verbs_includes_pack() {
         assert!(RESERVED_VERBS.contains(&"pack"));
+    }
+
+    #[test]
+    fn test_run_help_presents_public_baml_command() {
+        let help = RunArgs::run_help_command().render_help().to_string();
+        assert!(
+            help.contains("Usage: baml run [OPTIONS] [TARGET] [-- <TARGET_ARGS>...]"),
+            "{help}"
+        );
+        assert!(!help.contains("Usage: run "), "{help}");
+        assert!(!help.contains("Usage: baml-cli run"), "{help}");
     }
 
     /// BEP-027 Appendix A: the flag is `--output-format`, not `--output`.


### PR DESCRIPTION
## Summary

- Make `baml-cli` generated help present the public command name `baml` in usage lines.
- Update the custom `run --help` path to render `Usage: baml run ...`.
- Add focused tests for root, `pack`, `ide`, and `run` help output.

## Why

The internal toolchain binary is not on user PATH and direct invocation already warns users to use the wrapper. Generated CLI help should therefore teach users and models the public `baml` command, while preserving the internal `baml-cli` binary name and version behavior.

## Validation

- `cargo test -p baml_cli help_presents_public_baml_command`
- Pre-commit hooks during commit: `cargo fmt`, `cargo clippy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI help output now correctly displays "baml" as the binary name in usage instructions (e.g., "Usage: baml pack …") instead of "baml-cli" for root and subcommands.

* **Tests**
  * Added test coverage to verify CLI help text displays correct usage information across all commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->