### PR TITLE
Add toolchain status help

### DIFF
--- a/TASK/AMENDMENTS.md
+++ b/TASK/AMENDMENTS.md
@@ -97,7 +97,8 @@ Initial cache policy:
   - `baml toolchain update`: always checks the network and advances the active channel when possible.
   - `baml toolchain install`: always resolves/downloads/verifies the requested selector or version.
   - `baml toolchain use`: checks the network only when the relevant channel cache is missing or expired.
-  - `baml toolchain list`: local-only by default; a remote/latest mode may check the network when the relevant cache is missing or expired.
+  - `baml toolchain status`: always checks remote metadata, but is read-only and never installs or changes selection.
+  - `baml toolchain list`: local-only; it never checks remote versions.
 - All other commands, including `baml generate`, `baml run`, `baml describe`, `baml pack`, and `baml lsp`, use local state only and never hit the network.
 
 Network fetch behavior:

--- a/TASK/COMMANDS.md
+++ b/TASK/COMMANDS.md
@@ -15,7 +15,8 @@ The important split:
 | `baml toolchain install <canary\|nightly\|version>` | Download and verify a toolchain without necessarily making it active. Channel inputs resolve to a concrete version at install time. |
 | `baml toolchain use <canary\|nightly\|version>` | Select the active default toolchain. Installs the resolved toolchain if missing. |
 | `baml toolchain update` | Refresh the active channel and advance to the latest canary/nightly toolchain. Concrete pinned versions do not move. |
-| `baml toolchain list` | Show installed toolchains and the active selector/version. May have a remote/list mode later. |
+| `baml toolchain status` | Check the active selector against the latest remote channel metadata without installing, updating, or changing selection. |
+| `baml toolchain list` | Show installed toolchains and the active selector/version. Local-only; never checks remote versions. |
 | `baml toolchain uninstall <version>` | Remove an installed concrete toolchain. |
 | `baml self-update` | Update only the wrapper for curl-installed wrappers. Refuse for package-manager-managed wrappers with the right package-manager command. |
 

--- a/TASK/TASK.md
+++ b/TASK/TASK.md
@@ -56,7 +56,7 @@ Note on the two-tier distribution: `pkg.boundaryml.com` is the **directory** (ch
 - Two channels: `canary` + `nightly`. Nightly publishes automatically from every successful `canary` branch CI run. Canary publishes when the human-edited `baml_language/release.toml` `canary_version` advances. There is no `stable` channel in v1. GitHub tags/releases are outputs created by the workflow, not inputs that trigger BAML language releases.
 - The thing distros install is the wrapper, not the CLI. `baml-cli`, `baml-pack-host`, and the VSIX live inside per-toolchain directories under `~/.baml/`.
 - There are two release products: `baml-wrapper` and `baml-toolchain`. Package managers publish only `baml-wrapper`; language releases publish `baml-toolchain` archives and manifests. A toolchain nightly/canary release must never require a Homebrew/AUR package update.
-- The wrapper is a thin pure pass-through. Only toolchain-management commands (`toolchain install`, `toolchain use`, `toolchain uninstall`, `toolchain list`, `toolchain update`, `self-update`) live in the wrapper itself. Everything else (including `ide install`) is owned by the selected toolchain payload and forwarded by the wrapper.
+- The wrapper is a thin pure pass-through. Only toolchain-management commands (`toolchain install`, `toolchain use`, `toolchain uninstall`, `toolchain list`, `toolchain status`, `toolchain update`, `self-update`) live in the wrapper itself. Everything else (including `ide install`) is owned by the selected toolchain payload and forwarded by the wrapper.
 - VSIX is platform-neutral, built once, and bundled into every per-target toolchain archive. Users should not need to install a new VSIX for every toolchain release; compatibility is by explicit LSP/playground protocol ranges and capability flags.
 - Tap rename: `homebrew-baml` -> `homebrew-tap`, one-shot with GitHub redirect + deprecation banner.
 - Hosting: reuse the **existing** `pkg.boundaryml.com` CDK stack (S3 + OIDC release-publish IAM role, already deployed via [tools/pkg_boundaryml_com/lib/pkg-boundaryml-com-stack.ts](tools/pkg_boundaryml_com/lib/pkg-boundaryml-com-stack.ts)). Cloudflare, configured outside this CDK stack, is the HTTPS front door for the domain. Install script and channel manifests live there. No new DNS, no new buckets, no new hosting stack.
@@ -230,7 +230,8 @@ The wrapper crate must not use `version.workspace = true`. V1 may document a man
   - `baml toolchain install <canary|nightly|<version>>` (download/verify/install a concrete toolchain, but do not change the active default selector)
   - `baml toolchain use <canary|nightly|<version>>` (resolve, install if missing, and select as the user default)
   - `baml toolchain uninstall <version>`
-  - `baml toolchain list` (local-only by default; no network)
+  - `baml toolchain list` (local-only; no network)
+  - `baml toolchain status` (remote freshness check; read-only, no install, no active-state mutation)
   - `baml toolchain update` (refresh the active default channel to head; exact-version defaults do not advance; does not update the wrapper)
   - `baml self-update` (replace the wrapper itself; refused for managed installs; does not install toolchains)
 - Self-detect install path. If the wrapper lives under a path owned by Homebrew (`brew --prefix` / `/opt/homebrew/...` / formula marker file), `baml self-update` refuses with a pointer to `brew upgrade baml`.
@@ -366,7 +367,8 @@ Only allowlisted commands make network requests:
 - `baml toolchain install <channel>` always resolves the latest channel pointer and installs that concrete version, but does not change `[default].selector` and does not update that channel's `active_version` in `state.toml`.
 - `baml toolchain install <exact-version>` fetches that immutable version manifest only when needed and does not mutate `config.toml` or `state.toml`.
 - `baml toolchain update` only advances `state.toml` when the active default selector is a channel. It installs the latest concrete version for that channel, then atomically swaps the channel's `active_version`. If the active selector is an exact version, it reports that exact versions do not advance automatically and suggests `baml toolchain use canary` or `baml toolchain use nightly`.
-- `baml toolchain list` is local-only by default. A separate explicit remote mode may be added later, but plain `list` must not hit the network.
+- `baml toolchain list` is local-only and points users to `baml toolchain status` when they want to check remote freshness. Do not add a remote/list mode in v1.
+- `baml toolchain status` always checks remote metadata, may refresh manifest cache, and reports whether the active channel is at the latest remote channel head. It never installs a toolchain, changes `[default].selector`, or mutates active channel state in `state.toml`.
 
 All other commands, including `baml generate`, `baml run`, `baml describe`, `baml pack`, and `baml lsp`, use local state only and never hit the network.
 
@@ -411,7 +413,7 @@ resolved_at = "2026-06-02T12:30:00Z"
 manifest_path = "manifest-cache/prod/version/0.11.1-nightly.20260602.a.json"
 ```
 
-`manifest-cache/` stores remote JSON plus fetch metadata where useful (`fetched_at`, `etag`, etc.). It is not the active-version authority. A remote/list operation may refresh `manifest-cache/canary.json` and discover a newer version, but normal commands continue using `state.toml` until a toolchain-management command successfully installs and activates the newer concrete version.
+`manifest-cache/` stores remote JSON plus fetch metadata where useful (`fetched_at`, `etag`, etc.). It is not the active-version authority. `baml toolchain status` may refresh `manifest-cache/canary.json` or `manifest-cache/nightly.json` and discover a newer version, but normal commands continue using `state.toml` until a mutating toolchain-management command successfully installs and activates the newer concrete version.
 
 `toolchains/<version>/VERSION` contains the exact canonical version and is read as a tamper/sanity check on every wrapper invocation. `toolchains/<version>/install.json` records install metadata such as source manifest URL, archive URL, archive sha256, installed_at, and target triple.
 
@@ -1439,7 +1441,7 @@ Tests/merge criteria for this subsection:
 - Create in-repo implementation/user-flow docs under `TASK/docs/`. There is no established public `baml_language` documentation home yet; public product-docs migration is a later product/docs decision and should not block this release-infra implementation.
 - `TASK/docs/install.md`
   - Audience: users, support, and people testing the new installer.
-  - Required contents: `brew install boundaryml/tap/baml` installs the wrapper only; package-manager installs do not bootstrap toolchains; `curl ... | sh -s` installs the wrapper and default canary toolchain; Docker/CI install example using `--no-modify-path`; PATH behavior and `~/.baml/env`; `baml toolchain use canary`; `baml toolchain use nightly`; `baml toolchain install <version>`; `baml toolchain update`; `baml self-update`; package-manager wrapper upgrade behavior (`brew upgrade baml`, AUR upgrade); IDE setup with `baml ide install --cursor` and `baml ide install --code`.
+  - Required contents: `brew install boundaryml/tap/baml` installs the wrapper only; package-manager installs do not bootstrap toolchains; `curl ... | sh -s` installs the wrapper and default canary toolchain; Docker/CI install example using `--no-modify-path`; PATH behavior and `~/.baml/env`; `baml toolchain use canary`; `baml toolchain use nightly`; `baml toolchain install <version>`; `baml toolchain status`; `baml toolchain list`; `baml toolchain update`; `baml self-update`; package-manager wrapper upgrade behavior (`brew upgrade baml`, AUR upgrade); IDE setup with `baml ide install --cursor` and `baml ide install --code`.
 - `TASK/docs/release-maintainer.md`
   - Audience: maintainers and implementation agents.
   - Required contents: release graph overview; canary vs nightly model; how to bump canary; how nightly suffixes are chosen; release workflow concurrency rule; dry-run release workflow and `BAML_MANIFEST_BASE_URL`; production publish guards; registry publisher identity rule; PyPI trusted-publisher portal pause; Homebrew/AUR wrapper release flow; rerun/idempotency behavior; rollback / mutable pointer repair flow.

--- a/TASK/USER-PATHS.md
+++ b/TASK/USER-PATHS.md
@@ -4,7 +4,7 @@ We are replacing the current alpha-era release flow with a clean, unified releas
 
 The new system keeps Engine releases working as they do today, while giving BAML language users a modern install and update experience:
 
-- `brew install baml` installs the lightweight `baml` wrapper and bootstraps the latest canary BAML toolchain.
+- `brew install baml` installs the lightweight `baml` wrapper; `baml toolchain use canary` explicitly selects and installs the latest canary BAML toolchain.
 - `baml toolchain use nightly` lets users follow every successful `canary` branch release.
 - `baml toolchain update` updates the active language toolchain.
 - `baml self-update` updates only the wrapper.
@@ -32,7 +32,7 @@ Engine remains separate. Existing Engine users keep their current release pipeli
 
 For users:
 
-- New users can install BAML with one package-manager command and get a working canary CLI plus an explicit IDE setup follow-up when relevant.
+- New users can install the BAML wrapper with one package-manager command, then explicitly select a working canary CLI with `baml toolchain use canary`.
 - Nightly users can stay on the latest successful `canary` branch commit.
 - Canary users are not exposed to nightly releases unless they opt in.
 - Project teams can pin a toolchain in `baml.toml`.
@@ -77,16 +77,17 @@ As a new user, I want to run:
 
 ```bash
 brew install baml
+baml toolchain use canary
 ```
 
 and end up with:
 
 - `baml` on my path.
-- the current canary toolchain installed under the wrapper-managed toolchain directory.
+- the current canary toolchain installed under the wrapper-managed toolchain directory after I explicitly select it.
 - no automatic editor extension install as a side effect.
 - a clear follow-up command such as `baml ide install --cursor` when BAML can detect a supported IDE terminal.
 
-The package artifact itself still contains only the wrapper. The canary toolchain is installed through the normal wrapper-owned manifest flow.
+The package artifact itself contains only the wrapper. The canary toolchain is installed only when the user runs the normal wrapper-owned manifest flow.
 
 ### Existing Canary User
 
@@ -242,17 +243,19 @@ Instead, the version script stamps explicit version surfaces from `release-plan.
 
 | Action | Result |
 |---|---|
-| `brew install baml` | Installs wrapper, bootstraps canary toolchain, and may print an explicit `baml ide install` follow-up |
+| `brew install baml` | Installs wrapper only and may print explicit follow-up commands such as `baml toolchain use canary` and `baml ide install` |
 | `curl .../install.sh` | Installs wrapper, bootstraps requested canary/nightly/version |
 | `baml toolchain install canary` | Installs current canary toolchain without necessarily making it active |
 | `baml toolchain install nightly` | Installs current nightly toolchain without necessarily making it active |
 | `baml toolchain use canary` | Selects canary as the active default and installs the resolved toolchain if missing |
 | `baml toolchain use nightly` | Selects nightly as the active default and installs the resolved toolchain if missing |
+| `baml toolchain status` | Checks remote channel freshness without installing or changing selection |
+| `baml toolchain list` | Lists installed toolchains without checking remote metadata |
 | `baml toolchain update` | Updates active language toolchain |
 | `baml self-update` | Updates wrapper only, refused for Homebrew/AUR installs |
 | `baml ide install` | Installs IDE extension from active toolchain |
 
-Wrapper upgrades are idempotent. If a user is already on nightly or has an explicit toolchain, a package-manager wrapper upgrade must not reset them back to canary.
+Package-manager wrapper installs and upgrades must not bootstrap, switch, or reset toolchains. If a user is already on nightly or has an explicit toolchain, a package-manager wrapper upgrade must leave that selection alone; toolchain installs and switches happen through explicit `baml toolchain use` or `baml toolchain update` commands.
 
 ## CI/CD Shape
 

--- a/TASK/docs/install.md
+++ b/TASK/docs/install.md
@@ -73,6 +73,18 @@ Update advances a channel selector only:
 baml toolchain update
 ```
 
+Check remote freshness without installing or changing selection:
+
+```sh
+baml toolchain status
+```
+
+List installed toolchains without checking remote metadata:
+
+```sh
+baml toolchain list
+```
+
 ## IDE
 
 IDE installation is explicit and owned by the selected toolchain:

--- a/TASK/docs/release-maintainer.md
+++ b/TASK/docs/release-maintainer.md
@@ -20,6 +20,7 @@ scripts/baml-language-version check
 scripts/baml-language-version compute --channel nightly
 scripts/baml-language-version compute --channel nightly --pypi
 scripts/baml-language-version plan --channel nightly --out release-plan.json
+baml toolchain status
 ```
 
 PyPI nightly versions use PEP 440 dev releases, for example `0.11.1-nightly.20260602.a` becomes `0.11.1.dev2026060200`.

--- a/TASK/docs/toolchain-system.md
+++ b/TASK/docs/toolchain-system.md
@@ -45,13 +45,13 @@ Precedence:
 
 Normal commands never hit the network and never auto-install. Toolchain commands are the allowlisted network surface.
 
-`toolchain use` installs if missing and selects the default. `toolchain install` downloads without selecting. `toolchain update` advances channel selectors only and is the explicit freshness check. `toolchain list` is local-only.
+`toolchain use` installs if missing and selects the default. `toolchain install` downloads without selecting. `toolchain update` advances channel selectors only. `toolchain status` is the explicit read-only remote freshness check. `toolchain list` is local-only and points users to `toolchain status` when they want remote freshness.
 
 ## Manifests
 
 Toolchain and wrapper manifests use schema `1`, HTTPS artifact URLs, lowercase SHA-256 checksums, and exact target sets. `BAML_MANIFEST_BASE_URL` can point wrapper validation at dry-run or mirror manifests and is not persisted.
 
-Manifest cache entries are namespaced by manifest base URL: production uses `manifest-cache/prod`, while overrides use `manifest-cache/override/<hash>`. Channel `toolchain use` has a 24-hour cache TTL so selecting an already-known channel does not block on the network unnecessarily. `toolchain update` bypasses that TTL and checks the remote channel pointer before mutating state. Normal pass-through commands never read remote metadata; they use `config.toml`, `state.toml`, and installed `VERSION` files only. Channel state records the manifest base URL that produced it, so dry-run or mirror state is not silently reused under production.
+Manifest cache entries are namespaced by manifest base URL: production uses `manifest-cache/prod`, while overrides use `manifest-cache/override/<hash>`. Channel `toolchain use` has a 24-hour cache TTL so selecting an already-known channel does not block on the network unnecessarily. `toolchain update` bypasses that TTL and checks the remote channel pointer before mutating state. `toolchain status` also checks the remote channel pointer, but it is read-only: it may refresh manifest cache, but it never installs a toolchain or mutates active selector/channel state. Normal pass-through commands never read remote metadata; they use `config.toml`, `state.toml`, and installed `VERSION` files only. Channel state records the manifest base URL that produced it, so dry-run or mirror state is not silently reused under production.
 
 ## IDE And Compatibility
 

--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -88,6 +88,38 @@ enum FetchPolicy {
     ForceRemote,
 }
 
+const TOOLCHAIN_HELP: &str = r#"BAML toolchain management
+
+Usage:
+  baml toolchain <command>
+
+Commands:
+  use <canary|nightly|version>       Install if needed and select as default
+  install <canary|nightly|version>   Download without selecting
+  update                             Advance the active channel
+  status                             Check latest remote version without installing
+  list                               Show installed toolchains, local only
+  uninstall <version>                Remove an installed concrete version
+
+Network behavior:
+  list is local-only.
+  status checks remote metadata but does not install or change selection.
+  use, install, and update may download toolchains or change local state.
+
+Wrapper updates:
+  baml self-update                   Update curl-installed wrapper only
+"#;
+
+const SELF_UPDATE_HELP: &str = r#"BAML wrapper self-update
+
+Usage:
+  baml self-update
+
+Updates the wrapper binary only. It never installs or changes the active
+language toolchain. Package-manager-managed wrappers refuse self-update and
+print the package-manager upgrade command instead.
+"#;
+
 fn main() {
     let exit = match run() {
         Ok(code) => code,
@@ -107,7 +139,7 @@ fn run() -> Result<i32> {
         return replace_running_exe(args).map(|()| 0);
     }
     if matches!(args.first().map(String::as_str), Some("--version" | "-V")) {
-        println!("baml {}", env!("CARGO_PKG_VERSION"));
+        print_version();
         return Ok(0);
     }
     if args.first().map(String::as_str) == Some("toolchain") {
@@ -115,9 +147,60 @@ fn run() -> Result<i32> {
         return toolchain(args).map(|()| 0);
     }
     if args.first().map(String::as_str) == Some("self-update") {
+        if args.get(1).is_some_and(|arg| is_help_arg(arg)) {
+            print!("{SELF_UPDATE_HELP}");
+            return Ok(0);
+        }
+        if args.len() > 1 {
+            return Err(anyhow!(
+                "usage: baml self-update\nunexpected arguments: {}",
+                args[1..].join(" ")
+            ));
+        }
         return self_update().map(|()| 0);
     }
     pass_through(args)
+}
+
+fn print_version() {
+    println!("baml wrapper {}", env!("CARGO_PKG_VERSION"));
+    let selector = match active_selector() {
+        Ok(selector) => selector,
+        Err(err) => {
+            println!("baml toolchain not resolved");
+            println!("{err:#}");
+            return;
+        }
+    };
+    let version = match concrete_version_for_selector(&selector) {
+        Ok(version) => version,
+        Err(_) if is_channel(&selector.selector) => {
+            println!("baml toolchain not installed");
+            println!("Run: baml toolchain use {}", selector.selector);
+            return;
+        }
+        Err(err) => {
+            println!("baml toolchain not resolved");
+            println!("{err:#}");
+            return;
+        }
+    };
+    if !toolchain_cli_path(&version).exists() {
+        println!("baml toolchain not installed ({version})");
+        if is_channel(&selector.selector) {
+            println!("Run: baml toolchain use {}", selector.selector);
+        } else {
+            println!("Run: baml toolchain install {version}");
+        }
+        return;
+    }
+    match verify_toolchain_version_file(&version) {
+        Ok(()) => println!("baml toolchain {version}"),
+        Err(_) => {
+            println!("baml toolchain corrupt ({version})");
+            println!("Run: baml toolchain install {version} --force");
+        }
+    }
 }
 
 fn baml_home() -> PathBuf {
@@ -191,6 +274,10 @@ fn write_toml_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
 fn toolchain(args: Vec<String>) -> Result<()> {
     let (args, manifest_base_url) = parse_manifest_base_url(args)?;
     match args.first().map(String::as_str) {
+        Some("--help" | "-h" | "help") | None => {
+            print!("{TOOLCHAIN_HELP}");
+            Ok(())
+        }
         Some("install") => {
             let selector = args
                 .get(1)
@@ -205,6 +292,7 @@ fn toolchain(args: Vec<String>) -> Result<()> {
             use_toolchain(selector, manifest_base_url.as_deref())
         }
         Some("update") => update_toolchain(manifest_base_url.as_deref()),
+        Some("status") => status_toolchain(manifest_base_url.as_deref()),
         Some("list") => {
             list_toolchains();
             Ok(())
@@ -215,10 +303,14 @@ fn toolchain(args: Vec<String>) -> Result<()> {
                 .ok_or_else(|| anyhow!("usage: baml toolchain uninstall <version>"))?;
             uninstall_toolchain(version)
         }
-        _ => Err(anyhow!(
-            "usage: baml toolchain <install|use|update|list|uninstall> ..."
+        Some(other) => Err(anyhow!(
+            "unknown toolchain command {other:?}\n\n{TOOLCHAIN_HELP}"
         )),
     }
+}
+
+fn is_help_arg(arg: &str) -> bool {
+    matches!(arg, "--help" | "-h" | "help")
 }
 
 fn parse_manifest_base_url(mut args: Vec<String>) -> Result<(Vec<String>, Option<String>)> {
@@ -321,10 +413,16 @@ fn project_toolchain_selector() -> Result<Option<(PathBuf, String)>> {
 }
 
 fn concrete_version_for_selector(selector: &ResolvedSelector) -> Result<String> {
+    concrete_version_for_selector_with_base(selector, &baml_release::manifest_base_url())
+}
+
+fn concrete_version_for_selector_with_base(
+    selector: &ResolvedSelector,
+    current_base: &str,
+) -> Result<String> {
     if is_channel(&selector.selector) {
         let state = read_state();
         if let Some(channel) = state.channels.get(&selector.selector) {
-            let current_base = baml_release::manifest_base_url();
             if channel
                 .manifest_base_url
                 .as_deref()
@@ -602,6 +700,67 @@ fn update_toolchain(override_url: Option<&str>) -> Result<()> {
     })
 }
 
+fn status_toolchain(override_url: Option<&str>) -> Result<()> {
+    let selector = active_selector()?;
+    let base = manifest_base_url(override_url);
+    println!("active selector: {}", selector.selector);
+
+    if is_channel(&selector.selector) {
+        match concrete_version_for_selector_with_base(&selector, &base) {
+            Ok(version) => println!("active version: {version}"),
+            Err(_) => println!("active version: (none recorded locally)"),
+        }
+
+        let manifest = fetch_manifest(&selector.selector, override_url, FetchPolicy::ForceRemote)
+            .with_context(|| {
+                format!(
+                    "failed to check latest {} from the remote manifest; local toolchain state was left unchanged",
+                    selector.selector
+                )
+            })?;
+        println!("latest {}: {}", selector.selector, manifest.version);
+
+        match concrete_version_for_selector_with_base(&selector, &base).ok() {
+            Some(active) if active == manifest.version => {
+                println!("status: up to date");
+            }
+            Some(_) => {
+                println!(
+                    "status: a newer {} toolchain is available",
+                    selector.selector
+                );
+                println!("Run: baml toolchain update");
+            }
+            None => {
+                println!(
+                    "status: no active {} toolchain is recorded locally",
+                    selector.selector
+                );
+                println!("Run: baml toolchain use {}", selector.selector);
+            }
+        }
+        return Ok(());
+    }
+
+    if toolchain_cli_path(&selector.selector).exists() {
+        println!("selected version: {}", selector.selector);
+    } else {
+        println!("selected version: {} (not installed)", selector.selector);
+        println!("Run: baml toolchain install {}", selector.selector);
+    }
+
+    let canary = fetch_manifest("canary", override_url, FetchPolicy::ForceRemote)
+        .context("failed to check latest canary from the remote manifest")?;
+    let nightly = fetch_manifest("nightly", override_url, FetchPolicy::ForceRemote)
+        .context("failed to check latest nightly from the remote manifest")?;
+    println!("latest canary: {}", canary.version);
+    println!("latest nightly: {}", nightly.version);
+    println!("status: exact versions do not advance automatically");
+    println!("Run: baml toolchain use canary");
+    println!("Or:  baml toolchain use nightly");
+    Ok(())
+}
+
 fn installed_toolchains() -> Vec<String> {
     let mut versions = fs::read_dir(toolchains_dir())
         .ok()
@@ -636,6 +795,9 @@ fn list_toolchains() {
             println!("  {version}");
         }
     }
+    println!();
+    println!("Remote versions were not checked.");
+    println!("Run: baml toolchain status");
 }
 
 fn uninstall_toolchain(version: &str) -> Result<()> {

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -16,7 +16,8 @@ pub(crate) const fn release_version() -> &'static str {
     author,
     version = release_version(),
     about = "A CLI tool for working with BAML. Learn more at https://docs.boundaryml.com.",
-    long_about = None
+    long_about = None,
+    after_help = "Manage installed BAML toolchains:\n  baml toolchain --help"
 )]
 #[command(styles = crate::reporter::CLAP_STYLING)]
 #[command(propagate_version = true)]


### PR DESCRIPTION
## Summary

- Add `baml toolchain status` as a read-only remote freshness check for the active selector.
- Keep `baml toolchain list` local-only and point users to `status` when they want remote freshness.
- Improve wrapper-owned help for `baml toolchain --help` and `baml self-update --help`.
- Update `baml --version` to show wrapper version plus locally resolved toolchain state without making a network call.
- Add a `baml-cli --help` note pointing users to `baml toolchain --help` for wrapper-owned commands.
- Sync the TASK docs with the new command model.

## Validation

- `cargo fmt --manifest-path baml_language/Cargo.toml --package baml --package baml_cli`
- `cargo check --manifest-path baml_language/Cargo.toml -p baml -p baml_cli`
- `cargo test --manifest-path baml_language/Cargo.toml -p baml`
- `cargo build --manifest-path baml_language/Cargo.toml -p baml -p baml_cli`
- `git diff --check`
- Smoke-tested `baml toolchain --help`, `baml toolchain list`, `baml --version`, `baml-cli --help`, and `baml toolchain status` against a local manifest server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `baml toolchain status` to check remote channel freshness (read-only, no installs/selection changes).
  * Enhanced version and toolchain output to show whether the active toolchain is installed, missing, or corrupt, and to highlight available channel updates.

* **Documentation**
  * Clarified `baml toolchain list` is local-only (no remote checks) and updated install/release/user guides to reflect new commands and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->