### PR TITLE
Add baml check command

### DIFF
--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use baml_db::baml_compiler_diagnostics::{Severity, render};
+use clap::Args;
+
+use crate::{project_load::load_project_from_reporting, reporter::Reporter};
+
+#[derive(Args, Debug)]
+pub struct CheckArgs {
+    /// Project root to check. Defaults to the current directory.
+    #[arg(long, default_value = ".")]
+    pub from: PathBuf,
+}
+
+impl CheckArgs {
+    pub fn run(&self) -> Result<crate::ExitCode> {
+        let reporter = Reporter::new();
+        let (db, from, baml_files) = load_project_from_reporting(&self.from, &reporter)?;
+        if baml_files.is_empty() {
+            reporter.abandon();
+            crate::reporter::print_error(format_args!(
+                "no .baml files found in {}",
+                from.display()
+            ));
+            return Ok(crate::ExitCode::Other);
+        }
+
+        reporter.spin("Checking", format!("{} file(s)", baml_files.len()));
+        let result = db.check();
+        if !result.diagnostics.is_empty() {
+            let rendered = render::render_diagnostics(
+                &result.diagnostics,
+                &result.sources,
+                &result.file_paths,
+                &render::RenderConfig::cli_auto(),
+            );
+            reporter.suspend(|| {
+                #[allow(clippy::print_stderr)]
+                {
+                    eprintln!("{rendered}");
+                }
+            });
+        }
+
+        let error_count = result
+            .diagnostics
+            .iter()
+            .filter(|diag| diag.severity == Severity::Error)
+            .count();
+        if error_count > 0 {
+            reporter.abandon();
+            return Ok(crate::ExitCode::Other);
+        }
+
+        reporter.spin("Compiling", format!("{} file(s)", baml_files.len()));
+        if let Err(err) = db
+            .get_bytecode()
+            .with_context(|| format!("failed to compile BAML project at {}", from.display()))
+        {
+            reporter.abandon();
+            return Err(err);
+        }
+
+        reporter.finish("Finished", format!("checked {} file(s)", baml_files.len()));
+        Ok(crate::ExitCode::Success)
+    }
+}

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -45,6 +45,8 @@ pub(crate) enum Commands {
 
     // #[command(about = "Checks for errors and warnings in the baml_src directory")]
     // Check(baml_runtime::cli::check::CheckArgs),
+    #[command(about = "Check BAML source files for compiler errors")]
+    Check(crate::check_command::CheckArgs),
 
     // #[command(about = "Starts a server that translates LLM responses to BAML responses")]
     // Serve(baml_runtime::cli::serve::ServeArgs),
@@ -154,6 +156,7 @@ impl RuntimeCli {
         match &self.command {
             Commands::Init(args) => args.run(),
             Commands::New(args) => args.run(),
+            Commands::Check(args) => args.run(),
             Commands::Run(args) => args.run(),
             Commands::Pack(args) => args.run(),
             Commands::Ide(args) => args.run(),
@@ -221,5 +224,25 @@ mod tests {
             "{help}"
         );
         assert!(!help.contains("Usage: baml-cli ide"), "{help}");
+    }
+
+    #[test]
+    fn root_help_lists_check_command() {
+        let help = help_for(&["baml-cli", "--help"]);
+        assert!(help.contains("check"), "{help}");
+        assert!(
+            help.contains("Check BAML source files for compiler errors"),
+            "{help}"
+        );
+    }
+
+    #[test]
+    fn check_help_mentions_default_from_directory() {
+        let help = help_for(&["baml-cli", "check", "--help"]);
+        assert!(help.contains("Usage: baml check [OPTIONS]"), "{help}");
+        assert!(
+            help.contains("Project root to check. Defaults to the current directory"),
+            "{help}"
+        );
     }
 }

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -9,6 +9,7 @@
     clippy::exit
 )]
 
+pub(crate) mod check_command;
 pub(crate) mod commands;
 pub(crate) mod describe_command;
 #[cfg(test)]

--- a/baml_language/crates/baml_cli/tests/common/mod.rs
+++ b/baml_language/crates/baml_cli/tests/common/mod.rs
@@ -4,15 +4,17 @@
 // HACK — replace this with artifact deps once stable.
 // ============================================================================
 //
-// These tests need both `baml-cli` (the CLI that does the packing) and
-// `baml-pack-host` (the host binary whose bytes get embedded into packaged
-// executables). They live in different crates. Cargo's
+// These tests need `baml-cli` (the CLI that does the packing), `baml` (the
+// public wrapper that execs a selected toolchain), and `baml-pack-host` (the
+// host binary whose bytes get embedded into packaged executables). They live
+// in different crates. Cargo's
 // `CARGO_BIN_EXE_<name>` env var only exposes binaries from the test's
 // *own* crate, so we can't get `baml-pack-host`'s path for free.
 //
 // The *right* fix is cargo's artifact dependencies (RFC 3028):
 //
 //     [dev-dependencies]
+//     baml = { workspace = true, artifact = "bin" }
 //     baml_pack_host = { workspace = true, artifact = "bin" }
 //
 // With that, `env!("CARGO_BIN_FILE_baml_pack_host_baml-pack-host")` would
@@ -41,12 +43,13 @@
 
 use std::{path::PathBuf, process::Command, sync::OnceLock};
 
-/// Memoized build: `cargo build -p baml_cli -p baml_pack_host` runs at
+/// Memoized build: `cargo build -p baml -p baml_cli -p baml_pack_host` runs at
 /// most once per test binary regardless of how many tests call in.
 static BUILT: OnceLock<BuiltPaths> = OnceLock::new();
 
 #[derive(Clone, Debug)]
 pub struct BuiltPaths {
+    pub baml: PathBuf,
     pub baml_cli: PathBuf,
     pub baml_pack_host: PathBuf,
 }
@@ -62,20 +65,34 @@ pub fn ensure_built() -> &'static BuiltPaths {
         let profile = profile();
         let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
         let mut build = Command::new(&cargo);
-        build.args(["build", "-p", "baml_cli", "-p", "baml_pack_host"]);
+        build.args([
+            "build",
+            "-p",
+            "baml",
+            "-p",
+            "baml_cli",
+            "-p",
+            "baml_pack_host",
+        ]);
         if profile == "release" {
             build.arg("--release");
         }
         let status = build.status().expect("spawn cargo build");
         assert!(
             status.success(),
-            "cargo build for baml_cli + baml_pack_host failed — see output above",
+            "cargo build for baml + baml_cli + baml_pack_host failed — see output above",
         );
 
         let target = target_dir();
         let bin_dir = target.join(&profile);
+        let baml = bin_dir.join(bin_name("baml"));
         let baml_cli = bin_dir.join(bin_name("baml-cli"));
         let baml_pack_host = bin_dir.join(bin_name("baml-pack-host"));
+        assert!(
+            baml.exists(),
+            "baml not found at {} after build",
+            baml.display()
+        );
         assert!(
             baml_cli.exists(),
             "baml-cli not found at {} after build",
@@ -87,6 +104,7 @@ pub fn ensure_built() -> &'static BuiltPaths {
             baml_pack_host.display()
         );
         BuiltPaths {
+            baml,
             baml_cli,
             baml_pack_host,
         }

--- a/baml_language/crates/baml_cli/tests/common/mod.rs
+++ b/baml_language/crates/baml_cli/tests/common/mod.rs
@@ -4,17 +4,15 @@
 // HACK — replace this with artifact deps once stable.
 // ============================================================================
 //
-// These tests need `baml-cli` (the CLI that does the packing), `baml` (the
-// public wrapper that execs a selected toolchain), and `baml-pack-host` (the
-// host binary whose bytes get embedded into packaged executables). They live
-// in different crates. Cargo's
+// These tests need both `baml-cli` (the CLI that does the packing) and
+// `baml-pack-host` (the host binary whose bytes get embedded into packaged
+// executables). They live in different crates. Cargo's
 // `CARGO_BIN_EXE_<name>` env var only exposes binaries from the test's
 // *own* crate, so we can't get `baml-pack-host`'s path for free.
 //
 // The *right* fix is cargo's artifact dependencies (RFC 3028):
 //
 //     [dev-dependencies]
-//     baml = { workspace = true, artifact = "bin" }
 //     baml_pack_host = { workspace = true, artifact = "bin" }
 //
 // With that, `env!("CARGO_BIN_FILE_baml_pack_host_baml-pack-host")` would
@@ -43,13 +41,12 @@
 
 use std::{path::PathBuf, process::Command, sync::OnceLock};
 
-/// Memoized build: `cargo build -p baml -p baml_cli -p baml_pack_host` runs at
+/// Memoized build: `cargo build -p baml_cli -p baml_pack_host` runs at
 /// most once per test binary regardless of how many tests call in.
 static BUILT: OnceLock<BuiltPaths> = OnceLock::new();
 
 #[derive(Clone, Debug)]
 pub struct BuiltPaths {
-    pub baml: PathBuf,
     pub baml_cli: PathBuf,
     pub baml_pack_host: PathBuf,
 }
@@ -65,34 +62,20 @@ pub fn ensure_built() -> &'static BuiltPaths {
         let profile = profile();
         let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
         let mut build = Command::new(&cargo);
-        build.args([
-            "build",
-            "-p",
-            "baml",
-            "-p",
-            "baml_cli",
-            "-p",
-            "baml_pack_host",
-        ]);
+        build.args(["build", "-p", "baml_cli", "-p", "baml_pack_host"]);
         if profile == "release" {
             build.arg("--release");
         }
         let status = build.status().expect("spawn cargo build");
         assert!(
             status.success(),
-            "cargo build for baml + baml_cli + baml_pack_host failed — see output above",
+            "cargo build for baml_cli + baml_pack_host failed — see output above",
         );
 
         let target = target_dir();
         let bin_dir = target.join(&profile);
-        let baml = bin_dir.join(bin_name("baml"));
         let baml_cli = bin_dir.join(bin_name("baml-cli"));
         let baml_pack_host = bin_dir.join(bin_name("baml-pack-host"));
-        assert!(
-            baml.exists(),
-            "baml not found at {} after build",
-            baml.display()
-        );
         assert!(
             baml_cli.exists(),
             "baml-cli not found at {} after build",
@@ -104,7 +87,6 @@ pub fn ensure_built() -> &'static BuiltPaths {
             baml_pack_host.display()
         );
         BuiltPaths {
-            baml,
             baml_cli,
             baml_pack_host,
         }

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -54,6 +54,84 @@ generator py {
 }
 
 // ============================================================================
+// Tests for `baml check` exit codes
+// ============================================================================
+
+/// A valid project should return exit code 0 from `baml check`.
+#[test]
+fn check_valid_project_returns_zero_exit_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["check", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for valid project, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `baml check` with no `--from` is sugar for `baml check --from .`.
+#[test]
+fn check_defaults_from_to_current_directory() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["check"]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for `baml check` defaulting to cwd, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Compilation errors must result in a non-zero exit code for `baml check`.
+#[test]
+fn check_compilation_error_returns_nonzero_exit_code() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        "function broken() -> MissingType {\n  \"never\"\n}\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["check", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for compilation error in `baml check`",
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "Expected exit code 4 for compilation error",
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("MissingType") || stderr.contains("unresolved"),
+        "Expected error message to mention the unresolved type, got: {stderr}",
+    );
+}
+
+// ============================================================================
 // Tests for `baml generate` exit codes
 // ============================================================================
 

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -8,6 +8,7 @@
 mod common;
 
 use std::{
+    fs,
     path::Path,
     process::{Command, Output},
 };
@@ -51,6 +52,44 @@ generator py {
 "#;
     let full_source = format!("{source}\n{generator_block}");
     create_project(dir, &full_source);
+}
+
+/// Install the built `baml-cli` binary into a temp `BAML_HOME` so the
+/// public `baml` wrapper can resolve and exec it.
+fn install_temp_toolchain(home: &Path, baml_cli: &Path) {
+    let version = "test-version";
+    let toolchain_bin = home.join("toolchains").join(version).join("bin");
+    fs::create_dir_all(&toolchain_bin).unwrap();
+    fs::write(
+        home.join("state.toml"),
+        format!(
+            "[channels.canary]\nactive_version = \"{version}\"\nresolved_at = \"test\"\nmanifest_path = \"test\"\n"
+        ),
+    )
+    .unwrap();
+    fs::write(
+        home.join("toolchains").join(version).join("VERSION"),
+        version,
+    )
+    .unwrap();
+
+    let dest = toolchain_bin.join(bin_name("baml-cli"));
+    fs::copy(baml_cli, &dest).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&dest).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&dest, perms).unwrap();
+    }
+}
+
+fn bin_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
 }
 
 // ============================================================================
@@ -128,6 +167,34 @@ fn check_compilation_error_returns_nonzero_exit_code() {
     assert!(
         stderr.contains("MissingType") || stderr.contains("unresolved"),
         "Expected error message to mention the unresolved type, got: {stderr}",
+    );
+}
+
+/// The public `baml` wrapper is a passthrough to `baml-cli`, so agents should
+/// discover `check` from `baml --help`, not only from `baml-cli --help`.
+#[test]
+fn public_baml_help_lists_check_command() {
+    let built = common::ensure_built();
+    let home = tempfile::tempdir().unwrap();
+    install_temp_toolchain(home.path(), &built.baml_cli);
+
+    let output = Command::new(&built.baml)
+        .arg("--help")
+        .env("BAML_HOME", home.path())
+        .output()
+        .expect("spawn baml --help");
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for `baml --help`, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("check") && stdout.contains("Check BAML source files for compiler errors"),
+        "Expected `baml --help` to list `check`, got:\n{stdout}",
     );
 }
 

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -8,7 +8,6 @@
 mod common;
 
 use std::{
-    fs,
     path::Path,
     process::{Command, Output},
 };
@@ -52,44 +51,6 @@ generator py {
 "#;
     let full_source = format!("{source}\n{generator_block}");
     create_project(dir, &full_source);
-}
-
-/// Install the built `baml-cli` binary into a temp `BAML_HOME` so the
-/// public `baml` wrapper can resolve and exec it.
-fn install_temp_toolchain(home: &Path, baml_cli: &Path) {
-    let version = "test-version";
-    let toolchain_bin = home.join("toolchains").join(version).join("bin");
-    fs::create_dir_all(&toolchain_bin).unwrap();
-    fs::write(
-        home.join("state.toml"),
-        format!(
-            "[channels.canary]\nactive_version = \"{version}\"\nresolved_at = \"test\"\nmanifest_path = \"test\"\n"
-        ),
-    )
-    .unwrap();
-    fs::write(
-        home.join("toolchains").join(version).join("VERSION"),
-        version,
-    )
-    .unwrap();
-
-    let dest = toolchain_bin.join(bin_name("baml-cli"));
-    fs::copy(baml_cli, &dest).unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&dest).unwrap().permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&dest, perms).unwrap();
-    }
-}
-
-fn bin_name(name: &str) -> String {
-    if cfg!(windows) {
-        format!("{name}.exe")
-    } else {
-        name.to_string()
-    }
 }
 
 // ============================================================================
@@ -167,34 +128,6 @@ fn check_compilation_error_returns_nonzero_exit_code() {
     assert!(
         stderr.contains("MissingType") || stderr.contains("unresolved"),
         "Expected error message to mention the unresolved type, got: {stderr}",
-    );
-}
-
-/// The public `baml` wrapper is a passthrough to `baml-cli`, so agents should
-/// discover `check` from `baml --help`, not only from `baml-cli --help`.
-#[test]
-fn public_baml_help_lists_check_command() {
-    let built = common::ensure_built();
-    let home = tempfile::tempdir().unwrap();
-    install_temp_toolchain(home.path(), &built.baml_cli);
-
-    let output = Command::new(&built.baml)
-        .arg("--help")
-        .env("BAML_HOME", home.path())
-        .output()
-        .expect("spawn baml --help");
-
-    assert!(
-        output.status.success(),
-        "Expected exit code 0 for `baml --help`, got: {:?}\nstdout: {}\nstderr: {}",
-        output.status.code(),
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("check") && stdout.contains("Check BAML source files for compiler errors"),
-        "Expected `baml --help` to list `check`, got:\n{stdout}",
     );
 }
 


### PR DESCRIPTION
## Summary

Adds a minimal `baml check` command to the Rust BAML CLI. The command loads the project from `--from` (defaulting to the current directory), renders compiler diagnostics with the existing CLI diagnostic renderer, exits non-zero on compiler errors, and performs a bytecode compile pass before reporting success.

Also makes the command discoverable in CLI help and covers the default `baml check` sugar for `baml check --from .` in e2e tests.

## Validation

- `cargo check -p baml_cli`
- `cargo test -p baml_cli commands::tests`
- `cargo test -p baml_cli check_ --test exit_code_e2e`
- commit hook: `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `check` command to validate BAML projects, with a `--from` option to set the project root (defaults to current directory).
  * Runs validation, emits formatted diagnostics, and returns appropriate exit codes; proceeds to compile bytecode when checks pass.

* **Tests**
  * Added CLI help tests for the `check` command and end-to-end tests verifying success and failure exit codes and diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->