### PR TITLE
Bump BAML wrapper to 0.2.0

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "baml_release",

--- a/baml_language/crates/baml/Cargo.toml
+++ b/baml_language/crates/baml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baml"
-version = "0.1.0"
+version = "0.2.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps the BAML wrapper crate from `0.1.0` to `0.2.0`.

This gives the wrapper-owned toolchain UX changes a new wrapper release version, including `baml toolchain status`, improved toolchain help, `baml --version` wrapper/toolchain reporting, and stricter `baml self-update` argument handling.

## Validation

- `cargo check --manifest-path baml_language/Cargo.toml -p baml`
- `scripts/baml-wrapper-version check`
- `git diff --check`
- `cargo run --manifest-path baml_language/Cargo.toml -p baml -- --version`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->