### PR TITLE
ci: speed up windows tests and snapshot tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,8 +1,11 @@
 self-hosted-runner:
   labels:
     - blacksmith-16vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404
     - blacksmith-8vcpu-ubuntu-2204-arm
+    - blacksmith-6vcpu-macos-latest
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-4vcpu-ubuntu-2204
     - blacksmith-4vcpu-ubuntu-2204-arm
+    - blacksmith-8vcpu-windows-2025
     - blacksmith-4vcpu-windows-2025

--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -55,7 +55,7 @@ runs:
         # Our own prefix (not the upstream default), shared across every
         # baml_language workflow. Bump the trailing number to invalidate
         # every consumer's cache at once.
-        cache_key_prefix: mise-baml1
+        cache_key_prefix: mise-baml2
         install_args: ${{ inputs.install_args }}
         # Keep mise's shims OFF $PATH. mise-action exports the concrete
         # installed-tool bin dirs into PATH directly, so the narrow set we

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -61,7 +61,7 @@ jobs:
 
   cargo-test-linux:
     name: "cargo test (linux)"
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
       - uses: useblacksmith/checkout@v1
@@ -72,10 +72,12 @@ jobs:
         run: rustup show
         working-directory: baml_language
 
-      - name: "Install sccache and direnv"
+      # mise installs sccache/direnv AND cargo-nextest (cargo: backend ->
+      # cargo-binstall prebuilt), replacing taiki-e/install-action.
+      - name: "Install tools (mise)"
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache direnv"
+          install_args: "sccache direnv cargo:cargo-nextest"
 
       - name: "Verify sccache"
         run: sccache --version
@@ -99,11 +101,6 @@ jobs:
       - name: "Fetch cargo dependencies"
         run: cargo fetch
         working-directory: baml_language
-
-      - name: "Install cargo nextest"
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
 
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
@@ -169,10 +166,10 @@ jobs:
         run: rustup show
         working-directory: baml_language
 
-      - name: "Install sccache and direnv"
+      - name: "Install tools (mise)"
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache direnv"
+          install_args: "sccache direnv cargo:cargo-nextest"
 
       - name: "Verify sccache"
         run: sccache --version
@@ -197,19 +194,14 @@ jobs:
         run: cargo fetch
         working-directory: baml_language
 
-      - name: "Install cargo nextest"
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
         working-directory: baml_language
 
-      # Snapshot tests live in `baml_tests` and are covered by the dedicated
-      # `snapshot-tests` job. The `sdk_test_*` crates need uv and run in the
-      # dedicated `sdk-tests` matrix below. Skip both here.
-      - name: "Run tests"
+      # Snapshot tests live in `baml_tests` and are exercised end-to-end by
+      # the dedicated `snapshot-tests` job. The `sdk_test_*` crates need uv
+      # and run in the dedicated `sdk-tests` matrix below. Skip both here.
+      - name: "Run tests with nextest"
         run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/)'
         working-directory: baml_language
 
@@ -246,7 +238,11 @@ jobs:
     # Skip in the merge queue: windows already ran on the PR. The merge_group
     # event is inherited from ci.yaml through the workflow_call boundary.
     if: ${{ github.event_name != 'merge_group' }}
-    runs-on: blacksmith-4vcpu-windows-2025
+    # 8-vCPU + CARGO_BUILD_JOBS=16 (2x cores) was the value sweet spot for the
+    # native Windows Rust builds (build-caching/04 Exp 7/9).
+    runs-on: blacksmith-8vcpu-windows-2025
+    env:
+      CARGO_BUILD_JOBS: "16"
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
     timeout-minutes: 50
@@ -259,10 +255,10 @@ jobs:
         run: rustup show
         working-directory: baml_language
 
-      - name: "Install sccache and direnv"
+      - name: "Install sccache, direnv, and cargo-nextest"
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache direnv"
+          install_args: "sccache direnv cargo:cargo-nextest"
 
       - name: "Verify sccache"
         run: sccache --version
@@ -301,11 +297,6 @@ jobs:
           cargo build -p tools_sccache
           echo "RUSTC_WRAPPER=$(pwd -W)/target/debug/baml-sccache.exe" >> "$GITHUB_ENV"
         working-directory: baml_language
-
-      - name: "Install cargo nextest"
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
 
       - name: "Build tests with --timings"
         run: cargo test --no-run --all-features --timings
@@ -362,7 +353,7 @@ jobs:
                 "sdk-label": "python-pydantic2",
                 "package-name": "sdk_test_python_pydantic2",
                 "sdk-path": "python_pydantic2",
-                "install-args": "sccache direnv python uv",
+                "install-args": "sccache direnv python uv cargo:cargo-nextest",
                 "os-label": "linux",
                 "runs-on": "blacksmith-16vcpu-ubuntu-2404",
                 "rust-cache-key": "linux-cargo",
@@ -372,7 +363,7 @@ jobs:
                 "sdk-label": "typescript-node",
                 "package-name": "sdk_test_typescript_node",
                 "sdk-path": "typescript_node",
-                "install-args": "sccache direnv node npm:pnpm",
+                "install-args": "sccache direnv node npm:pnpm cargo:cargo-nextest",
                 "os-label": "linux",
                 "runs-on": "blacksmith-16vcpu-ubuntu-2404",
                 "rust-cache-key": "linux-cargo",
@@ -382,7 +373,7 @@ jobs:
                 "sdk-label": "python-pydantic2",
                 "package-name": "sdk_test_python_pydantic2",
                 "sdk-path": "python_pydantic2",
-                "install-args": "sccache direnv python uv",
+                "install-args": "sccache direnv python uv cargo:cargo-nextest",
                 "os-label": "macos",
                 "runs-on": "blacksmith-6vcpu-macos-latest",
                 "rust-cache-key": "macos-cargo",
@@ -392,7 +383,7 @@ jobs:
                 "sdk-label": "typescript-node",
                 "package-name": "sdk_test_typescript_node",
                 "sdk-path": "typescript_node",
-                "install-args": "sccache direnv node npm:pnpm",
+                "install-args": "sccache direnv node npm:pnpm cargo:cargo-nextest",
                 "os-label": "macos",
                 "runs-on": "blacksmith-6vcpu-macos-latest",
                 "rust-cache-key": "macos-cargo",
@@ -402,9 +393,9 @@ jobs:
                 "sdk-label": "python-pydantic2",
                 "package-name": "sdk_test_python_pydantic2",
                 "sdk-path": "python_pydantic2",
-                "install-args": "sccache direnv python uv",
+                "install-args": "sccache direnv python uv cargo:cargo-nextest",
                 "os-label": "windows",
-                "runs-on": "blacksmith-4vcpu-windows-2025",
+                "runs-on": "blacksmith-8vcpu-windows-2025",
                 "rust-cache-key": "windows-cargo",
                 "timeout": 60,
               },
@@ -412,9 +403,9 @@ jobs:
                 "sdk-label": "typescript-node",
                 "package-name": "sdk_test_typescript_node",
                 "sdk-path": "typescript_node",
-                "install-args": "sccache direnv node npm:pnpm",
+                "install-args": "sccache direnv node npm:pnpm cargo:cargo-nextest",
                 "os-label": "windows",
-                "runs-on": "blacksmith-4vcpu-windows-2025",
+                "runs-on": "blacksmith-8vcpu-windows-2025",
                 "rust-cache-key": "windows-cargo",
                 "timeout": 60,
               },
@@ -492,12 +483,18 @@ jobs:
           set -euo pipefail
           cargo build -p tools_sccache
           echo "RUSTC_WRAPPER=$(pwd -W)/target/debug/baml-sccache.exe" >> "$GITHUB_ENV"
+          # CARGO_BUILD_JOBS oversubscription only matters for the Windows build.
+          echo "CARGO_BUILD_JOBS=16" >> "$GITHUB_ENV"
         working-directory: baml_language
 
-      - name: "Install cargo nextest"
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
+      # Windows Python only: setup.ps1 builds one baml_core wheel and strips
+      # the editable source block from each fixture so `uv sync` installs that
+      # prebuilt wheel instead of rebuilding baml_core per fixture. The later
+      # test-time `uv run` processes also need this wheelhouse.
+      - name: "Configure Python wheelhouse"
+        if: matrix.os-label == 'windows' && matrix.sdk-label == 'python-pydantic2'
+        run: echo "UV_FIND_LINKS=$(pwd -W)/target/wheels" >> "$GITHUB_ENV"
+        working-directory: baml_language
 
       - name: "Build tests with --timings"
         run: cargo test --no-run -p ${{ matrix.package-name }} --all-features --timings
@@ -804,7 +801,7 @@ jobs:
 
   snapshot-tests:
     name: "snapshot tests"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - uses: useblacksmith/checkout@v1
@@ -815,10 +812,10 @@ jobs:
         run: rustup show
         working-directory: baml_language
 
-      - name: "Install sccache, direnv, python, and uv"
+      - name: "Install tools (mise)"
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache direnv python uv"
+          install_args: "sccache direnv python uv cargo:cargo-insta cargo:cargo-nextest"
 
       - name: "Verify sccache"
         run: sccache --version
@@ -842,11 +839,6 @@ jobs:
       - name: "Fetch cargo dependencies"
         run: cargo fetch
         working-directory: baml_language
-
-      - name: "Install cargo insta and nextest"
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-insta,cargo-nextest
 
       - name: "Build tests with --timings"
         run: cargo test --no-run -p baml_tests -p baml_cli -p baml_lsp2_actions --all-features --timings

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -218,11 +218,13 @@ jobs:
 
   size-gate-windows:
     name: "size-gate (windows)"
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
     timeout-minutes: 45
     continue-on-error: true
+    env:
+      CARGO_BUILD_JOBS: "16"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/baml_language/.config/nextest.toml
+++ b/baml_language/.config/nextest.toml
@@ -22,11 +22,11 @@ filter = 'package(=sdk_test_typescript_node)'
 platform = { host = 'cfg(windows)' }
 setup = 'typescript_node_pnpm_win'
 
-# python tests need each fixture's venv synced with a freshly-rebuilt
-# baml_core `.so`. fire only when a python sdk-test is selected.
-# setup.sh / setup.ps1 are equivalent — `uv sync` per fixture plus one
-# incremental `maturin develop` of the shared extension, in the host
-# shell of each platform.
+# python tests need each fixture's venv synced with freshly-built baml_core.
+# fire only when a python sdk-test is selected. Unix uses `uv sync` per
+# fixture plus one incremental `maturin develop`; Windows builds one wheel
+# first, then fixture `uv sync` installs that wheel to avoid duplicate
+# editable baml_core builds.
 [scripts.setup.python_pydantic2_uv_unix]
 command = './sdk_tests/crates/python_pydantic2/setup.sh'
 

--- a/baml_language/sdk_tests/crates/python_pydantic2/setup.ps1
+++ b/baml_language/sdk_tests/crates/python_pydantic2/setup.ps1
@@ -6,16 +6,11 @@
 # For plain `cargo test` (no nextest), run this manually after
 # `cargo test --no-run` populates each fixture's `generated/pyproject.toml`.
 #
-# See setup.sh for the full rationale. In short: `uv sync` per fixture
-# creates each venv + editable-links baml_core, then a single
-# `maturin develop` against `sdks/python/.venv` rebuilds the shared
-# extension module incrementally (~7s steady state). That venv is
-# populated from `sdks/python/pyproject.toml`'s dev group so the maturin
-# version constraint lives in TOML, not in an error-prone shell argument.
-# The old `uv sync --reinstall-package baml_core` was strictly slower
-# (~70s every run): uv's isolated build used an ephemeral interpreter
-# whose path moved each run, busting pyo3's fingerprint and forcing a
-# full bridge_python rebuild. The steps below are equivalent to setup.sh.
+# See setup.sh for the baseline rationale. The Windows CI path uses the
+# build-caching/04 approach B optimization: build baml_core once as a
+# wheel, then install that wheel into every fixture venv. This avoids the
+# redundant per-fixture editable build that `uv sync` can trigger before
+# the shared extension rebuild.
 
 $ErrorActionPreference = 'Stop'
 Set-Location $PSScriptRoot
@@ -35,33 +30,13 @@ if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
     $UvBin = (mise which uv).Trim()
 }
 
-# 1. Ensure each fixture venv exists, deps are installed, and baml_core
-#    is editable-linked. Plain `uv sync` (no --reinstall): on a fresh
-#    checkout this builds the editable wheel once; afterward it's a
-#    no-op. The shared extension it points at is (re)built by step 2.
-Get-ChildItem -Directory | ForEach-Object {
-    $generated = Join-Path $_.FullName 'generated'
-    if (Test-Path $generated) {
-        Write-Host "==> uv sync in $($_.Name)/generated"
-        Push-Location $generated
-        try {
-            & $UvBin sync
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-        } finally {
-            Pop-Location
-        }
-    }
-}
-
-# 2. Rebuild the shared baml_core extension incrementally via maturin.
-#    The build venv is `sdks/python/.venv` — uv's default project venv,
-#    at a stable path (see setup.sh for why that matters for the cargo
-#    cache). abi3 wheels are interpreter-version-agnostic, so any
-#    >=3.10 works. `sdks/python/pyproject.toml` owns the maturin
-#    version constraint; the sync below installs dev tools without
-#    installing/building baml_core (`maturin develop` does that).
+# 1. Build the shared baml_core wheel once. `sdks/python/.venv` supplies
+#    maturin at a stable path, keeping pyo3 fingerprints stable.
 $SdkPyVenv = Join-Path $SdkPy '.venv'
 $MaturinExe = Join-Path $SdkPyVenv 'Scripts\maturin.exe'
+$WheelDir = Join-Path $WorkspaceRoot 'target\wheels'
+# Must exist before the first uv command when CI exports UV_FIND_LINKS.
+New-Item -ItemType Directory -Force -Path $WheelDir | Out-Null
 Write-Host "==> uv sync (dev) in $SdkPy"
 Push-Location $SdkPy
 try {
@@ -71,14 +46,49 @@ try {
 } finally {
     Pop-Location
 }
-Write-Host '==> maturin develop (shared baml_core extension)'
+Write-Host '==> maturin build (shared baml_core wheel)'
 Push-Location $SdkPy
 try {
     $env:VIRTUAL_ENV = $SdkPyVenv
-    & $MaturinExe develop
+    & $MaturinExe build --out $WheelDir
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 } finally {
     Pop-Location
+}
+
+# 2. Per fixture: install deps + the prebuilt baml_core wheel. Strip the
+#    editable `[tool.uv.sources] baml_core` block so baml_core resolves
+#    as a normal dependency from UV_FIND_LINKS.
+if (-not $env:UV_FIND_LINKS) { $env:UV_FIND_LINKS = $WheelDir }
+Get-ChildItem -Directory | ForEach-Object {
+    $generated = Join-Path $_.FullName 'generated'
+    if (Test-Path $generated) {
+        $pyproject = Join-Path $generated 'pyproject.toml'
+        $lines = Get-Content $pyproject
+        $out = New-Object System.Collections.Generic.List[string]
+        $skip = $false
+        foreach ($line in $lines) {
+            if ($line -match '^\[tool\.uv\.sources\]$') {
+                $skip = $true
+                continue
+            }
+            if ($skip) {
+                if ($line -match '^\s*$') { $skip = $false }
+                continue
+            }
+            $out.Add($line)
+        }
+        Set-Content -Path $pyproject -Value $out
+
+        Write-Host "==> uv sync in $($_.Name)/generated"
+        Push-Location $generated
+        try {
+            & $UvBin sync
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        } finally {
+            Pop-Location
+        }
+    }
 }
 
 # Per-run breadcrumb for the in-test guard. nextest reads $NEXTEST_ENV

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,8 @@ sccache = "0.10.0"
 "cargo:ripgrep" = "latest"
 "cargo:just" = "latest"
 "cargo:prek" = "0.3.13"
+"cargo:cargo-nextest" = "latest"
+"cargo:cargo-insta" = "latest"
 
 # Go tools
 # locked to match the version in .github/actions/setup-go/action.yml


### PR DESCRIPTION
- windows sdk tests build faster now (less redundant uv sync / pnpm install)
- use 8vcpu windows runners (they schedule faster)
- on 8vcpu windows runners, use -j16 to better saturate cpu (sccache usage means build is i/o bound)
- use mise for tool installation always
- make snapshot tests use an 8vcpu machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated tool installation into a shared setup, added nextest/insta tooling, and updated cache versioning.
  * Adjusted self-hosted runner targets and job-level build parallelism for faster, more consistent CI runs.
* **Tests**
  * Streamlined SDK and snapshot test workflows and improved Windows Python test setup by prebuilding and installing shared wheels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->