### PR TITLE
Bump BAML language canary to 0.11.2

### DIFF
--- a/baml_language/crates/baml_version/src/lib.rs
+++ b/baml_language/crates/baml_version/src/lib.rs
@@ -1,6 +1,6 @@
 //! Stamped BAML language product version.
 
-pub const CANONICAL_VERSION: &str = "0.11.1";
-pub const PYPI_VERSION: &str = "0.11.1";
+pub const CANONICAL_VERSION: &str = "0.11.2";
+pub const PYPI_VERSION: &str = "0.11.2";
 pub const CHANNEL: &str = "canary";
-pub const STABLE_VERSION: &str = "0.11.1";
+pub const STABLE_VERSION: &str = "0.11.2";

--- a/baml_language/release.toml
+++ b/baml_language/release.toml
@@ -1,2 +1,2 @@
 [release]
-canary_version = "0.11.1"
+canary_version = "0.11.2"

--- a/baml_language/sdks/nodejs/bridge_nodejs/package.json
+++ b/baml_language/sdks/nodejs/bridge_nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaryml/baml-core-node",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/baml_language/sdks/python/pyproject.toml
+++ b/baml_language/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baml_core"
-version = "0.11.1"
+version = "0.11.2"
 description = "BAML python bindings (new system, bex_engine)"
 authors = [{ "name" = "Boundary", "email" = "contact@boundaryml.com" }]
 license = "Apache-2.0"

--- a/baml_language/sdks/python/src/baml_core/__init__.py
+++ b/baml_language/sdks/python/src/baml_core/__init__.py
@@ -36,7 +36,7 @@ from .typemap import (
 # Flush buffered trace events on process exit so nothing is lost.
 atexit.register(flush_events)
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 
 # ---------------------------------------------------------------------------

--- a/typescript2/app-vscode-ext/package.json
+++ b/typescript2/app-vscode-ext/package.json
@@ -2,7 +2,7 @@
   "name": "baml-language",
   "displayName": "BAML",
   "description": "BAML language support — syntax highlighting, hover, completions, diagnostics, go-to-definition",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "publisher": "Boundary",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- bump BAML language canary version from 0.11.1 to 0.11.2
- sync stamped Rust, Python, Node, and VSIX version surfaces via scripts/baml-language-version

## Validation
- scripts/baml-language-version check
- scripts/baml-language-version compute --channel canary
- scripts/baml-wrapper-version check
- git diff --check
- commit hook: cargo fmt, cargo clippy, TOML checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 0.11.2 across all SDKs and tools (Node.js, Python, Rust core, and VS Code extension).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->