### PR TITLE
chore: stop using blacksmith runners for engine/

### DIFF
--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -39,7 +39,7 @@ jobs:
   # This job enables auto-pass when only baml_language/ or typescript/apps/beps/ files are modified
   determine_changes:
     name: "Determine changes"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       # Flag that is raised when runtime-related code is changed
       # If false, we can skip all runtime tests since only baml_language/ or beps/ changed
@@ -141,7 +141,7 @@ jobs:
   # Auto-pass summary when skipping runtime tests
   skip-summary:
     name: "Skip Summary"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.runtime == 'false'
     steps:
@@ -160,7 +160,7 @@ jobs:
 
   # Run all quality checks in parallel (lightweight setup)
   lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.runtime == 'true'
     strategy:
@@ -227,7 +227,7 @@ jobs:
           cd integ-tests/python && uv run ruff check .
 
   typecheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.runtime == 'true'
     steps:
@@ -257,7 +257,7 @@ jobs:
         run: pnpm typecheck --force
 
   build-wasm:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.runtime == 'true'
     steps:
@@ -279,7 +279,7 @@ jobs:
 
   # Test node generator (only needs CLI)
   test-generators:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.runtime == 'true'
     steps:
@@ -336,7 +336,7 @@ jobs:
 
   # Run tests in parallel (rebuild what's needed)
   tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.runtime == 'true'
     strategy:
@@ -459,7 +459,7 @@ jobs:
   # Configure "BAML Runtime / CI Failure Alert" as a required status check.
   ci-failure-alert:
     name: "CI Failure Alert"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - determine_changes
       - lint
@@ -489,7 +489,7 @@ jobs:
 
   # Sync Zed extension to separate repository
   sync-zed-repository:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: determine_changes
     # Only run on pushes to canary branch or manual dispatch, and only if runtime changed
     if: github.ref == 'refs/heads/canary' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.determine_changes.outputs.runtime == 'true'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
- [ ] This PR fixes/closes # (no specific issue)

## Changes
This PR updates the `.github/workflows/primary.yml` workflow file to use GitHub's standard `ubuntu-latest` runners instead of Blacksmith's `blacksmith-4vcpu-ubuntu-2404` runners.

**Affected jobs:**
- `determine_changes`
- `skip-summary`
- `lint`
- `typecheck`
- `build-wasm`
- `test-generators`
- `tests`
- `ci-failure-alert`
- `sync-zed-repository`

All 9 jobs that were previously running on Blacksmith runners now use `ubuntu-latest`.

## Testing
- [x] Manual testing performed - verified YAML syntax and runner configuration
- [x] Confirmed all `runs-on` directives now use `ubuntu-latest` except for the `build-cli` job which correctly uses matrix OS values

## Screenshots
N/A - Configuration change only

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A for this change)
- [x] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings

## Additional Notes
This change switches the CI/CD infrastructure from Blacksmith runners to standard GitHub-hosted runners. The workflow logic and behavior remain unchanged - only the runner platform is different.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1780599021466159?thread_ts=1780599021.466159&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-655eccad-ad35-5236-9c19-32cd3788a336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-655eccad-ad35-5236-9c19-32cd3788a336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure to use standardized runner configurations for improved compatibility and reliability across automated testing and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->