### PR TITLE
Resolve dot-qualified builtin class methods in baml describe

### DIFF
--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -205,7 +205,58 @@ pub fn dispatch<'db>(db: &'db ProjectDatabase, name: &str) -> Option<ResolvedTar
 
     // User package.
     let user_pkg = baml_compiler2_hir::package::PackageId::new(db, baml_db::Name::new("user"));
-    baml_lsp2_actions::resolve_target(db, user_pkg, name)
+    if let Some(target) = baml_lsp2_actions::resolve_target(db, user_pkg, name) {
+        return Some(target);
+    }
+
+    resolve_builtin_bare_class_member(db, name)
+}
+
+/// Resolve `Class.method` when `Class` is an unqualified builtin class.
+///
+/// Top-level builtin lookups such as `baml describe Array` can fall back to the
+/// substring-based describe path, but `Array.reduce` needs a structural member
+/// target so the class-method renderer can show the method signature directly.
+fn resolve_builtin_bare_class_member<'db>(
+    db: &'db ProjectDatabase,
+    name: &str,
+) -> Option<ResolvedTarget<'db>> {
+    use baml_compiler2_hir::{
+        contributions::{Definition, DefinitionKind},
+        package::{PackageId, package_items},
+    };
+
+    let (class_name, method_name) = name.split_once('.')?;
+    if class_name.is_empty() || method_name.is_empty() || method_name.contains('.') {
+        return None;
+    }
+
+    let class_name = baml_db::Name::new(class_name);
+    let member_name = baml_db::Name::new(method_name);
+    let mut found: Option<Definition<'db>> = None;
+
+    for pkg_name in baml_lsp2_actions::non_user_package_names(db) {
+        let pkg = PackageId::new(db, baml_db::Name::new(&pkg_name));
+        let pkg_items = package_items(db, pkg);
+        for ns_items in pkg_items.namespaces.values() {
+            let Some(def) = ns_items.types.get(&class_name).copied() else {
+                continue;
+            };
+            if def.kind() != DefinitionKind::Class {
+                continue;
+            }
+            if found.replace(def).is_some() {
+                // Keep unqualified lookup deterministic if two builtin
+                // namespaces ever export classes with the same short name.
+                return None;
+            }
+        }
+    }
+
+    found.map(|parent| ResolvedTarget::Member {
+        parent,
+        member_name,
+    })
 }
 
 /// Map a lowercase primitive/keyword alias to the path of its builtin `baml`

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -769,6 +769,48 @@ fn describe_builtin_method_drill_in_via_alias() {
     );
 }
 
+/// Drilling into a builtin method via the natural `Class.method` spelling
+/// resolves the builtin class and shows the method's resolved signature.
+#[test]
+fn describe_builtin_method_drill_in_without_package_prefix() {
+    let db = simple_project();
+    let output = describe_via_dispatch(&db, "Array.reduce");
+    assert!(
+        output.contains(
+            "function reduce<A, E>(self, reducer: (A, T) -> A throws E, initial: A) -> A throws E"
+        ),
+        "expected resolved builtin method signature:\n{output}"
+    );
+    assert!(
+        output.contains("container:") && output.contains("Array"),
+        "owning builtin class should be the container:\n{output}"
+    );
+    assert!(
+        !output.contains("$rust_function"),
+        "native body marker must not appear:\n{output}"
+    );
+    assert!(
+        !output.starts_with("NOT FOUND") && !output.starts_with("NO DESCRIPTION"),
+        "`Array.reduce` should resolve as a builtin class method:\n{output}"
+    );
+}
+
+/// The same unqualified builtin class-member routing works for non-generic
+/// builtin methods too.
+#[test]
+fn describe_string_method_drill_in_without_package_prefix() {
+    let db = simple_project();
+    let output = describe_via_dispatch(&db, "String.split");
+    assert!(
+        output.contains("function split(self, delimiter: string) -> string[]"),
+        "expected resolved builtin method signature:\n{output}"
+    );
+    assert!(
+        !output.starts_with("NOT FOUND") && !output.starts_with("NO DESCRIPTION"),
+        "`String.split` should resolve as a builtin class method:\n{output}"
+    );
+}
+
 // ── definition_line_range tests ──────────────────────────────────────────────
 
 #[test]

--- a/baml_language/crates/baml_lsp2_actions/src/describe.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/describe.rs
@@ -916,16 +916,17 @@ fn collect_class_methods_impl(
 }
 
 /// Render the canonical one-line signature for a method:
-/// `function <name>(<params>) -> <ret>[ throws <t>]`. Uses resolved types from
-/// the package interface (`exported`) when available, falling back to the
-/// unresolved source `TypeExpr` rendering otherwise. The `self` parameter is
-/// shown bare (no type), as written.
+/// `function <name>[<generics>](<params>) -> <ret>[ throws <t>]`. Uses resolved
+/// types from the package interface (`exported`) when available, falling back
+/// to the unresolved source `TypeExpr` rendering otherwise. The `self`
+/// parameter is shown bare (no type), as written.
 fn render_method_signature(
     db: &dyn Db,
     file: SourceFile,
     m: &baml_compiler2_hir::item_tree::Function,
     exported: Option<&baml_compiler2_tir::package_interface::ExportedFunction>,
 ) -> String {
+    let generics = render_function_generics(&m.generic_params, &m.generic_param_bounds);
     let params: Vec<String> = m
         .params
         .iter()
@@ -981,10 +982,33 @@ fn render_method_signature(
     };
 
     format!(
-        "function {}({}){ret}{throws}",
+        "function {}{generics}({}){ret}{throws}",
         m.name.as_str(),
         params.join(", ")
     )
+}
+
+fn render_function_generics(
+    generic_params: &[baml_base::Name],
+    generic_param_bounds: &[Option<baml_compiler2_ast::TypeExpr>],
+) -> String {
+    if generic_params.is_empty() {
+        return String::new();
+    }
+
+    let params = generic_params
+        .iter()
+        .enumerate()
+        .map(|(idx, param)| {
+            if let Some(bound) = generic_param_bounds.get(idx).and_then(Option::as_ref) {
+                format!("{param} extends {}", crate::utils::display_type_expr(bound))
+            } else {
+                param.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("<{params}>")
 }
 
 /// Build `(instance_methods, static_methods)` for a class's describe output.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

### The error
Given a minimal project:

```baml
function dummy(x: int) -> int { x }
```

Before this change, the natural method lookup failed:

```console
$ baml describe Array.reduce
No symbol found: Array.reduce
```

The command exited with code 4 even though `reduce` is a builtin instance method on `Array`.

### Root cause
`baml_language/crates/baml_cli/src/describe_command.rs::dispatch` handled explicit builtin package paths (`baml.Array.reduce`), lowercase primitive aliases (`string.length`), keywords, `root.*`, and user-package structural paths. For an unqualified builtin class member like `Array.reduce`, user-package resolution returned `None`, then the CLI fell back to substring describe with the whole string `Array.reduce` as an opaque symbol name. That fallback never reaches `describe_item_member`, so it printed `No symbol found`.

Once `Array.reduce` resolved, `baml_language/crates/baml_lsp2_actions/src/describe.rs::render_method_signature` also needed to include method-level generic parameters from `Function::generic_params`; otherwise generic builtin methods documented their callback types without the `<A, E>` surface.

### The fix
- Added a narrowly scoped builtin class-member resolver in `describe_command::dispatch` after user-package resolution fails. It recognizes `Class.method`, searches non-user packages for a unique builtin class with that short name, and returns `ResolvedTarget::Member` so the existing class-method renderer is used.
- Preserved user-project precedence: a user `Class.method` structural target still resolves before builtin fallback.
- Updated method signature rendering to include method generic parameters and generic bounds.
- Added focused CLI dispatch tests for `Array.reduce` and `String.split` without the `baml.` package prefix.

### Verification
Same reproduction after the change:

```console
$ cargo run -p baml_cli -- describe Array.reduce --from /tmp
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
method reduce  <builtin>/baml/containers.baml:224-226

function reduce<A, E>(self, reducer: (A, T) -> A throws E, initial: A) -> A throws E

container:
  class            Array                            <builtin>/baml/containers.baml:2

references (0):
```

Commands run:

```console
$ cargo test -p baml_cli without_package_prefix
running 2 tests
...
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 183 filtered out; finished in 0.26s
```

```console
$ cargo test -p baml_cli --lib && cargo test -p baml_lsp2_actions --lib
# baml_cli
test result: ok. 185 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
# baml_lsp2_actions
test result: ok. 114 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```console
$ LD_LIBRARY_PATH=/home/ubuntu/.local/share/mise/installs/python/3.13.13/lib:${LD_LIBRARY_PATH:-} \
  cargo test --workspace --lib --exclude bridge_nodejs
...
test result: ok
```

I also attempted unexcluded `cargo test --lib`; it is blocked in this environment by `bridge_nodejs` test-linking against Node N-API symbols while the installed mise Node reports `node_shared=false` and provides no `libnode.so`.

## Testing
Please describe how you tested these changes

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in Linux Cursor Cloud environment

## Screenshots
If applicable, add screenshots to help explain your changes

Not applicable.

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where applicable
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The setup required `pnpm install`, `pnpm --filter @boundaryml/baml-core-node build:debug`, and `CI=1 ./setup.sh` under `baml_language/sdk_tests/crates/typescript_node` so the TypeScript SDK harness fixtures had their generated `node_modules` trees.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b067052-c446-5045-a2c9-731a3176e1c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b067052-c446-5045-a2c9-731a3176e1c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

