### PR TITLE
fix: thread inferred generic type args to callee frames at runtime

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -2223,12 +2223,32 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             Terminator::ShortCircuit {
                 operand,
                 is_and,
-                destination: _,
+                destination,
                 eval_rhs,
                 join,
             } => {
                 // Legacy-style short-circuit using JumpIfFalse (peek, no pop).
-                // The destination local is PhiLike — value stays on TOS, no store/load.
+                //
+                // The short-circuit (taken) path leaves the operand value on TOS
+                // and jumps to the join. The `eval_rhs` block computes and stores
+                // the result via its own trailing `destination = <rhs>` statement.
+                // Both paths must agree on where the result lives at the join:
+                //
+                //  * When `destination` is stack-carried (PhiLike etc.), the join
+                //    consumes the value straight off TOS, and the `eval_rhs` store
+                //    is also elided (EvalNoStore) — so the taken path correctly
+                //    leaves the value on TOS and we emit no store here.
+                //  * Otherwise `destination` is a real slot: the `eval_rhs` store
+                //    writes the slot (StoreSlot) and pops, so the join reads via
+                //    `LoadVar`. The taken path must therefore also store its TOS
+                //    value into the slot — otherwise the slot is never written on
+                //    the short-circuit path and the join reads uninitialized
+                //    state. We emit that store on the taken path before the join.
+                let store_on_taken_path = !matches!(destination, Place::Local(l)
+                if matches!(
+                    pull_semantics::local_store_behavior(self.analysis.classifications[l]),
+                    pull_semantics::LocalStoreBehavior::KeepOnStack
+                ));
                 self.emit_operand_pull(operand);
 
                 if *is_and {
@@ -2236,14 +2256,37 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                     //     true → pop, evaluate rhs.
                     let sc_jump = self.emit(Instruction::JumpIfFalse(0));
                     let resolved_join = self.resolve_pending_target(*join);
-                    self.pending_jumps.push((sc_jump, resolved_join));
-                    self.emit(Instruction::Pop(1));
-                    self.emit_jump_unless_fallthrough(*eval_rhs);
+                    if store_on_taken_path {
+                        // The taken (false) path keeps its value on TOS and must
+                        // store it into the destination slot before the join.
+                        // JumpIfFalse jumps directly to the join, so route it to a
+                        // short trampoline (emitted after the true-path code below)
+                        // that performs the slot store, then jumps to join. Because
+                        // the trampoline sits between the true path and `eval_rhs`,
+                        // the true path needs an explicit (non-fall-through) jump.
+                        self.emit(Instruction::Pop(1));
+                        self.emit_jump_always(*eval_rhs);
+                        // Trampoline for the short-circuit (taken) path.
+                        let taken_pc = self.bytecode.instructions.len();
+                        self.patch_jump_to(sc_jump, taken_pc);
+                        self.emit_store_place(destination);
+                        let join_jump = self.emit(Instruction::Jump(0));
+                        self.pending_jumps.push((join_jump, resolved_join));
+                    } else {
+                        self.pending_jumps.push((sc_jump, resolved_join));
+                        self.emit(Instruction::Pop(1));
+                        self.emit_jump_unless_fallthrough(*eval_rhs);
+                    }
                 } else {
                     // ||: false → pop, evaluate rhs.
                     //     true → value stays on TOS, jump to join.
                     let false_jump = self.emit(Instruction::JumpIfFalse(0));
                     let resolved_join = self.resolve_pending_target(*join);
+                    if store_on_taken_path {
+                        // Taken (true) path: store TOS into the destination slot,
+                        // then jump to the join so it matches the `eval_rhs` store.
+                        self.emit_store_place(destination);
+                    }
                     let true_jump = self.emit(Instruction::Jump(0));
                     self.pending_jumps.push((true_jump, resolved_join));
                     // False landing: patch JumpIfFalse to here, pop, fall to eval_rhs.

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -864,6 +864,44 @@ fn resolution_to_item_ref(
     }
 }
 
+/// The generic-param frame layout a callee's body assumes, split into the
+/// owner part (class / interface / out-of-body `implements` params) and the
+/// function's own params. Mirrors `LoweringContext::enclosing_generic_params`
+/// — which builds this same layout on the CALLEE side when lowering its body —
+/// minus the lambda extension, which cannot apply to a top-level callee.
+/// A call site that seeds `frame.type_args` must follow this exact order.
+fn callee_frame_generic_params(
+    db: &dyn crate::Db,
+    func_loc: FunctionLoc<'_>,
+) -> (Vec<Name>, Vec<Name>) {
+    let item_tree = file_item_tree(db, func_loc.file(db));
+    let func_id = func_loc.id(db);
+    if let Some(imp) = item_tree
+        .implements_for
+        .iter()
+        .find(|imp| imp.methods.contains(&func_id))
+    {
+        // Out-of-body impl methods use the impl block's params as the whole
+        // frame (see `enclosing_generic_params`) — no fn-param extension.
+        return (imp.generic_params.clone(), Vec::new());
+    }
+    let fn_params = item_tree[func_id].generic_params.clone();
+    if let Some(iface_data) = item_tree
+        .interfaces
+        .values()
+        .find(|iface_data| iface_data.default_methods.contains(&func_id))
+    {
+        return (iface_data.generic_params.clone(), fn_params);
+    }
+    let owner = item_tree
+        .classes
+        .values()
+        .find(|class_data| class_data.methods.contains(&func_id))
+        .map(|class_data| class_data.generic_params.clone())
+        .unwrap_or_default();
+    (owner, fn_params)
+}
+
 // ─── LoweringContext ─────────────────────────────────────────────────────────
 
 // Re-use ExprId from baml_compiler2_ast (already imported above via ExprId)
@@ -1296,6 +1334,11 @@ struct LoweringContext<'db> {
         FxHashMap<ExprMetadataKey, Vec<baml_compiler2_tir::inference::MemberResolution<'db>>>,
     // Full-arity argument binding plans from TIR.
     call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan>,
+    // Inferred generic type-arg bindings (sorted by param name) for call
+    // expressions whose type args were NOT written explicitly. Used to seed
+    // the callee frame's runtime `type_args`; values may contain the caller's
+    // own TypeVars (lowered via `ty_to_template`).
+    call_inferred_type_args: FxHashMap<ExprMetadataKey, Vec<(Name, Tir2Ty)>>,
     // Function-value adapters from TIR checked coercions.
     function_coercions: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::FunctionCoercion>,
     // Function generic bounds, lowered in TIR space. MIR uses these to keep
@@ -1818,97 +1861,107 @@ impl<'db> LoweringContext<'db> {
         > = FxHashMap::default();
         let mut call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan> =
             FxHashMap::default();
+        let mut call_inferred_type_args: FxHashMap<ExprMetadataKey, Vec<(Name, Tir2Ty)>> =
+            FxHashMap::default();
         let mut function_coercions: FxHashMap<
             ExprMetadataKey,
             baml_compiler2_tir::inference::FunctionCoercion,
         > = FxHashMap::default();
 
-        let merge_scope = |fsi: FileScopeId,
-                           expr_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           pat_types: &mut FxHashMap<PatMetadataKey, Tir2Ty>,
-                           resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
-        >,
-                           exhaustive_matches: &mut rustc_hash::FxHashSet<ExprMetadataKey>,
-                           path_root_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           path_segment_types: &mut FxHashMap<
-            (MetadataScope, AstExprId, usize),
-            Tir2Ty,
-        >,
-                           path_member_resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        >,
-                           call_plans: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::CallPlan,
-        >,
-                           function_coercions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        >| {
-            let scope_id = index.scope_ids[fsi.index() as usize];
-            let inference = infer_scope_types(db, scope_id);
-            let body_scope = MetadataScope::Body(fsi);
-            for (&expr_id, ty) in inference.iter_expressions() {
-                expr_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_bindings() {
-                pat_types.insert((body_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_resolutions() {
-                resolutions.insert((body_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_exhaustive_matches() {
-                exhaustive_matches.insert((body_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_path_root_types() {
-                path_root_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_path_segment_types() {
-                path_segment_types.insert((body_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_path_member_resolutions() {
-                path_member_resolutions.insert((body_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_call_plans() {
-                call_plans.insert((body_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_function_coercions() {
-                function_coercions.insert((body_scope, expr_id), coercion.clone());
-            }
+        let merge_scope =
+            |fsi: FileScopeId,
+             expr_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
+             pat_types: &mut FxHashMap<PatMetadataKey, Tir2Ty>,
+             resolutions: &mut FxHashMap<
+                ExprMetadataKey,
+                baml_compiler2_tir::inference::MemberResolution<'db>,
+            >,
+             exhaustive_matches: &mut rustc_hash::FxHashSet<ExprMetadataKey>,
+             path_root_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
+             path_segment_types: &mut FxHashMap<(MetadataScope, AstExprId, usize), Tir2Ty>,
+             path_member_resolutions: &mut FxHashMap<
+                ExprMetadataKey,
+                Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
+            >,
+             call_plans: &mut FxHashMap<
+                ExprMetadataKey,
+                baml_compiler2_tir::inference::CallPlan,
+            >,
+             call_inferred_type_args: &mut FxHashMap<ExprMetadataKey, Vec<(Name, Tir2Ty)>>,
+             function_coercions: &mut FxHashMap<
+                ExprMetadataKey,
+                baml_compiler2_tir::inference::FunctionCoercion,
+            >| {
+                let scope_id = index.scope_ids[fsi.index() as usize];
+                let inference = infer_scope_types(db, scope_id);
+                let body_scope = MetadataScope::Body(fsi);
+                for (&expr_id, ty) in inference.iter_expressions() {
+                    expr_types.insert((body_scope, expr_id), ty.clone());
+                }
+                for (&pat_id, ty) in inference.iter_bindings() {
+                    pat_types.insert((body_scope, pat_id), ty.clone());
+                }
+                for (&expr_id, res) in inference.iter_resolutions() {
+                    resolutions.insert((body_scope, expr_id), res.clone());
+                }
+                for &expr_id in inference.iter_exhaustive_matches() {
+                    exhaustive_matches.insert((body_scope, expr_id));
+                }
+                for (&expr_id, ty) in inference.iter_path_root_types() {
+                    path_root_types.insert((body_scope, expr_id), ty.clone());
+                }
+                for (&(expr_id, seg_idx), ty) in inference.iter_path_segment_types() {
+                    path_segment_types.insert((body_scope, expr_id, seg_idx), ty.clone());
+                }
+                for (&expr_id, member_resolutions) in inference.iter_path_member_resolutions() {
+                    path_member_resolutions
+                        .insert((body_scope, expr_id), member_resolutions.clone());
+                }
+                for (&expr_id, plan) in inference.iter_call_plans() {
+                    call_plans.insert((body_scope, expr_id), plan.clone());
+                }
+                for (&expr_id, args) in inference.iter_call_inferred_type_args() {
+                    call_inferred_type_args.insert((body_scope, expr_id), args.clone());
+                }
+                for (&expr_id, coercion) in inference.iter_function_coercions() {
+                    function_coercions.insert((body_scope, expr_id), coercion.clone());
+                }
 
-            let default_scope = MetadataScope::ParameterDefault(fsi);
-            for (&expr_id, ty) in inference.iter_default_expressions() {
-                expr_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_default_bindings() {
-                pat_types.insert((default_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_default_resolutions() {
-                resolutions.insert((default_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_default_exhaustive_matches() {
-                exhaustive_matches.insert((default_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_default_path_root_types() {
-                path_root_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_default_path_segment_types() {
-                path_segment_types.insert((default_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_default_path_member_resolutions() {
-                path_member_resolutions
-                    .insert((default_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_default_call_plans() {
-                call_plans.insert((default_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_default_function_coercions() {
-                function_coercions.insert((default_scope, expr_id), coercion.clone());
-            }
-        };
+                let default_scope = MetadataScope::ParameterDefault(fsi);
+                for (&expr_id, ty) in inference.iter_default_expressions() {
+                    expr_types.insert((default_scope, expr_id), ty.clone());
+                }
+                for (&pat_id, ty) in inference.iter_default_bindings() {
+                    pat_types.insert((default_scope, pat_id), ty.clone());
+                }
+                for (&expr_id, res) in inference.iter_default_resolutions() {
+                    resolutions.insert((default_scope, expr_id), res.clone());
+                }
+                for &expr_id in inference.iter_default_exhaustive_matches() {
+                    exhaustive_matches.insert((default_scope, expr_id));
+                }
+                for (&expr_id, ty) in inference.iter_default_path_root_types() {
+                    path_root_types.insert((default_scope, expr_id), ty.clone());
+                }
+                for (&(expr_id, seg_idx), ty) in inference.iter_default_path_segment_types() {
+                    path_segment_types.insert((default_scope, expr_id, seg_idx), ty.clone());
+                }
+                for (&expr_id, member_resolutions) in
+                    inference.iter_default_path_member_resolutions()
+                {
+                    path_member_resolutions
+                        .insert((default_scope, expr_id), member_resolutions.clone());
+                }
+                for (&expr_id, plan) in inference.iter_default_call_plans() {
+                    call_plans.insert((default_scope, expr_id), plan.clone());
+                }
+                for (&expr_id, args) in inference.iter_default_call_inferred_type_args() {
+                    call_inferred_type_args.insert((default_scope, expr_id), args.clone());
+                }
+                for (&expr_id, coercion) in inference.iter_default_function_coercions() {
+                    function_coercions.insert((default_scope, expr_id), coercion.clone());
+                }
+            };
 
         // Include the function scope itself
         merge_scope(
@@ -1921,6 +1974,7 @@ impl<'db> LoweringContext<'db> {
             &mut path_segment_types,
             &mut path_member_resolutions,
             &mut call_plans,
+            &mut call_inferred_type_args,
             &mut function_coercions,
         );
 
@@ -1939,6 +1993,7 @@ impl<'db> LoweringContext<'db> {
                 &mut path_segment_types,
                 &mut path_member_resolutions,
                 &mut call_plans,
+                &mut call_inferred_type_args,
                 &mut function_coercions,
             );
         }
@@ -2074,6 +2129,7 @@ impl<'db> LoweringContext<'db> {
             path_segment_types,
             path_member_resolutions,
             call_plans,
+            call_inferred_type_args,
             function_coercions,
             generic_param_bounds,
             current_scope: func_scope_id,
@@ -2141,97 +2197,107 @@ impl<'db> LoweringContext<'db> {
         > = FxHashMap::default();
         let mut call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan> =
             FxHashMap::default();
+        let mut call_inferred_type_args: FxHashMap<ExprMetadataKey, Vec<(Name, Tir2Ty)>> =
+            FxHashMap::default();
         let mut function_coercions: FxHashMap<
             ExprMetadataKey,
             baml_compiler2_tir::inference::FunctionCoercion,
         > = FxHashMap::default();
 
-        let merge_scope = |fsi: FileScopeId,
-                           expr_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           pat_types: &mut FxHashMap<PatMetadataKey, Tir2Ty>,
-                           resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
-        >,
-                           exhaustive_matches: &mut rustc_hash::FxHashSet<ExprMetadataKey>,
-                           path_root_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           path_segment_types: &mut FxHashMap<
-            (MetadataScope, AstExprId, usize),
-            Tir2Ty,
-        >,
-                           path_member_resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        >,
-                           call_plans: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::CallPlan,
-        >,
-                           function_coercions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        >| {
-            let scope_id = index.scope_ids[fsi.index() as usize];
-            let inference = infer_scope_types(db, scope_id);
-            let body_scope = MetadataScope::Body(fsi);
-            for (&expr_id, ty) in inference.iter_expressions() {
-                expr_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_bindings() {
-                pat_types.insert((body_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_resolutions() {
-                resolutions.insert((body_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_exhaustive_matches() {
-                exhaustive_matches.insert((body_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_path_root_types() {
-                path_root_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_path_segment_types() {
-                path_segment_types.insert((body_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_path_member_resolutions() {
-                path_member_resolutions.insert((body_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_call_plans() {
-                call_plans.insert((body_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_function_coercions() {
-                function_coercions.insert((body_scope, expr_id), coercion.clone());
-            }
+        let merge_scope =
+            |fsi: FileScopeId,
+             expr_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
+             pat_types: &mut FxHashMap<PatMetadataKey, Tir2Ty>,
+             resolutions: &mut FxHashMap<
+                ExprMetadataKey,
+                baml_compiler2_tir::inference::MemberResolution<'db>,
+            >,
+             exhaustive_matches: &mut rustc_hash::FxHashSet<ExprMetadataKey>,
+             path_root_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
+             path_segment_types: &mut FxHashMap<(MetadataScope, AstExprId, usize), Tir2Ty>,
+             path_member_resolutions: &mut FxHashMap<
+                ExprMetadataKey,
+                Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
+            >,
+             call_plans: &mut FxHashMap<
+                ExprMetadataKey,
+                baml_compiler2_tir::inference::CallPlan,
+            >,
+             call_inferred_type_args: &mut FxHashMap<ExprMetadataKey, Vec<(Name, Tir2Ty)>>,
+             function_coercions: &mut FxHashMap<
+                ExprMetadataKey,
+                baml_compiler2_tir::inference::FunctionCoercion,
+            >| {
+                let scope_id = index.scope_ids[fsi.index() as usize];
+                let inference = infer_scope_types(db, scope_id);
+                let body_scope = MetadataScope::Body(fsi);
+                for (&expr_id, ty) in inference.iter_expressions() {
+                    expr_types.insert((body_scope, expr_id), ty.clone());
+                }
+                for (&pat_id, ty) in inference.iter_bindings() {
+                    pat_types.insert((body_scope, pat_id), ty.clone());
+                }
+                for (&expr_id, res) in inference.iter_resolutions() {
+                    resolutions.insert((body_scope, expr_id), res.clone());
+                }
+                for &expr_id in inference.iter_exhaustive_matches() {
+                    exhaustive_matches.insert((body_scope, expr_id));
+                }
+                for (&expr_id, ty) in inference.iter_path_root_types() {
+                    path_root_types.insert((body_scope, expr_id), ty.clone());
+                }
+                for (&(expr_id, seg_idx), ty) in inference.iter_path_segment_types() {
+                    path_segment_types.insert((body_scope, expr_id, seg_idx), ty.clone());
+                }
+                for (&expr_id, member_resolutions) in inference.iter_path_member_resolutions() {
+                    path_member_resolutions
+                        .insert((body_scope, expr_id), member_resolutions.clone());
+                }
+                for (&expr_id, plan) in inference.iter_call_plans() {
+                    call_plans.insert((body_scope, expr_id), plan.clone());
+                }
+                for (&expr_id, args) in inference.iter_call_inferred_type_args() {
+                    call_inferred_type_args.insert((body_scope, expr_id), args.clone());
+                }
+                for (&expr_id, coercion) in inference.iter_function_coercions() {
+                    function_coercions.insert((body_scope, expr_id), coercion.clone());
+                }
 
-            let default_scope = MetadataScope::ParameterDefault(fsi);
-            for (&expr_id, ty) in inference.iter_default_expressions() {
-                expr_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_default_bindings() {
-                pat_types.insert((default_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_default_resolutions() {
-                resolutions.insert((default_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_default_exhaustive_matches() {
-                exhaustive_matches.insert((default_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_default_path_root_types() {
-                path_root_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_default_path_segment_types() {
-                path_segment_types.insert((default_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_default_path_member_resolutions() {
-                path_member_resolutions
-                    .insert((default_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_default_call_plans() {
-                call_plans.insert((default_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_default_function_coercions() {
-                function_coercions.insert((default_scope, expr_id), coercion.clone());
-            }
-        };
+                let default_scope = MetadataScope::ParameterDefault(fsi);
+                for (&expr_id, ty) in inference.iter_default_expressions() {
+                    expr_types.insert((default_scope, expr_id), ty.clone());
+                }
+                for (&pat_id, ty) in inference.iter_default_bindings() {
+                    pat_types.insert((default_scope, pat_id), ty.clone());
+                }
+                for (&expr_id, res) in inference.iter_default_resolutions() {
+                    resolutions.insert((default_scope, expr_id), res.clone());
+                }
+                for &expr_id in inference.iter_default_exhaustive_matches() {
+                    exhaustive_matches.insert((default_scope, expr_id));
+                }
+                for (&expr_id, ty) in inference.iter_default_path_root_types() {
+                    path_root_types.insert((default_scope, expr_id), ty.clone());
+                }
+                for (&(expr_id, seg_idx), ty) in inference.iter_default_path_segment_types() {
+                    path_segment_types.insert((default_scope, expr_id, seg_idx), ty.clone());
+                }
+                for (&expr_id, member_resolutions) in
+                    inference.iter_default_path_member_resolutions()
+                {
+                    path_member_resolutions
+                        .insert((default_scope, expr_id), member_resolutions.clone());
+                }
+                for (&expr_id, plan) in inference.iter_default_call_plans() {
+                    call_plans.insert((default_scope, expr_id), plan.clone());
+                }
+                for (&expr_id, args) in inference.iter_default_call_inferred_type_args() {
+                    call_inferred_type_args.insert((default_scope, expr_id), args.clone());
+                }
+                for (&expr_id, coercion) in inference.iter_default_function_coercions() {
+                    function_coercions.insert((default_scope, expr_id), coercion.clone());
+                }
+            };
 
         // Include the let scope itself
         merge_scope(
@@ -2244,6 +2310,7 @@ impl<'db> LoweringContext<'db> {
             &mut path_segment_types,
             &mut path_member_resolutions,
             &mut call_plans,
+            &mut call_inferred_type_args,
             &mut function_coercions,
         );
 
@@ -2262,6 +2329,7 @@ impl<'db> LoweringContext<'db> {
                 &mut path_segment_types,
                 &mut path_member_resolutions,
                 &mut call_plans,
+                &mut call_inferred_type_args,
                 &mut function_coercions,
             );
         }
@@ -2293,6 +2361,7 @@ impl<'db> LoweringContext<'db> {
             path_segment_types,
             path_member_resolutions,
             call_plans,
+            call_inferred_type_args,
             function_coercions,
             generic_param_bounds: FxHashMap::default(),
             current_scope: let_scope_id,
@@ -5101,9 +5170,131 @@ impl LoweringContext<'_> {
         // If the base is a real value (not a package namespace), prepend it as self.
         let mut receiver_base_for_class_type_args: Option<AstExprId> = None;
         let mut receiver_path_tir_ty: Option<Tir2Ty> = None;
-        let (callee_operand, arg_operands) =
-            if let AstExpr::MemberAccess { base, .. } = &callee_expr {
-                if self
+        let (callee_operand, arg_operands) = if let AstExpr::MemberAccess { base, .. } =
+            &callee_expr
+        {
+            if self
+                .resolutions
+                .get(&self.expr_metadata_key(callee))
+                .is_some_and(|r| {
+                    use baml_compiler2_tir::inference::MemberResolution;
+                    matches!(
+                        r,
+                        MemberResolution::BoundMethod { .. }
+                            | MemberResolution::UnboundMethod { .. }
+                            | MemberResolution::Free { .. }
+                            | MemberResolution::InterfaceDefaultMethod { .. }
+                    )
+                })
+            {
+                // Check if base is a value receiver or a bare type/package path.
+                // Type-name bases like `Label<int>.method` can have concrete
+                // TIR types (`Interface`, `Class`) but are not runtime values.
+                let base_is_value = match &self.body.exprs[*base] {
+                    AstExpr::Path(segments) if !segments.is_empty() => {
+                        self.locals.contains_key(&segments[0])
+                            || self
+                                .capture_index_for_name_at(*base, &segments[0])
+                                .is_some()
+                    }
+                    _ => self
+                        .expr_types
+                        .get(&self.expr_metadata_key(*base))
+                        .map(|ty| !matches!(ty, Tir2Ty::Unknown { .. }))
+                        .unwrap_or(false),
+                };
+                // Check if the resolved method expects a `self` receiver.
+                // Static methods (e.g. StreamCache.new) have no `self` param
+                // and must not get the class reference prepended as an argument.
+                let method_takes_self = {
+                    use baml_compiler2_tir::inference::MemberResolution;
+                    self.resolutions
+                        .get(&self.expr_metadata_key(callee))
+                        .is_some_and(|r| match r {
+                            MemberResolution::BoundMethod { func_loc, .. }
+                            | MemberResolution::UnboundMethod { func_loc, .. }
+                            | MemberResolution::Free { func_loc }
+                            | MemberResolution::InterfaceDefaultMethod { func_loc, .. } => {
+                                let sig =
+                                    baml_compiler2_ppir::function_signature(self.db, *func_loc);
+                                sig.params
+                                    .first()
+                                    .is_some_and(|param| param.name.as_str() == "self")
+                            }
+                            _ => false,
+                        })
+                };
+                if base_is_value && method_takes_self {
+                    // Instance method call: arr.length() — prepend receiver as self.
+                    // For immediate calls, emit the callee as a plain function constant
+                    // (not MakeBoundMethod) since the receiver is passed explicitly as self.
+                    let receiver_op = self.lower_to_operand(*base);
+                    receiver_base_for_class_type_args = Some(*base);
+                    let callee_op = {
+                        let resolution = self
+                            .resolutions
+                            .get(&self.expr_metadata_key(callee))
+                            .cloned();
+                        match resolution
+                            .as_ref()
+                            .and_then(|r| resolution_to_item_ref(self.db, r))
+                        {
+                            Some(item) => Operand::Constant(Constant::Function(item)),
+                            None => self.lower_to_operand(callee),
+                        }
+                    };
+                    let mut all_args = vec![receiver_op];
+                    all_args.extend(self.lower_call_arg_operands(expr_id, args));
+                    (callee_op, all_args)
+                } else {
+                    // Non-self method or package function reference:
+                    // e.g. Factory<int>.create(42), baml.Array.length(array).
+                    // Resolve the callee as a plain function constant using
+                    // resolution_to_item_ref to avoid lower_member_access emitting
+                    // MakeBoundMethod (which would try to load the base type as a
+                    // runtime value).
+                    let callee_op = {
+                        let resolution = self
+                            .resolutions
+                            .get(&self.expr_metadata_key(callee))
+                            .cloned();
+                        match resolution
+                            .as_ref()
+                            .and_then(|r| resolution_to_item_ref(self.db, r))
+                        {
+                            Some(item) => Operand::Constant(Constant::Function(item)),
+                            None => self.lower_to_operand(callee),
+                        }
+                    };
+                    (callee_op, self.lower_call_arg_operands(expr_id, args))
+                }
+            } else {
+                let callee_op = self.lower_to_operand(callee);
+                (callee_op, self.lower_call_arg_operands(expr_id, args))
+            }
+        } else if let AstExpr::Path(segments) = &callee_expr {
+            // Check path_member_resolutions first (local-rooted paths like `self.method()`
+            // or `obj.field.method()`). The last resolution determines if the final segment
+            // is a method call (e.g. for `user.profile.items.slice`, resolutions are
+            // [Field{profile}, Field{items}, Method{slice}] — last() is Method).
+            let is_local_method = segments.len() >= 2
+                && self
+                    .path_member_resolutions
+                    .get(&self.expr_metadata_key(callee))
+                    .and_then(|resolutions| resolutions.last())
+                    .is_some_and(|r| {
+                        use baml_compiler2_tir::inference::MemberResolution;
+                        matches!(
+                            r,
+                            MemberResolution::BoundMethod { .. }
+                                | MemberResolution::UnboundMethod { .. }
+                                | MemberResolution::InterfaceDefaultMethod { .. }
+                        )
+                    });
+            // Also check flat resolutions (package-path method call, kept for compatibility).
+            let is_pkg_method = !is_local_method
+                && segments.len() >= 2
+                && self
                     .resolutions
                     .get(&self.expr_metadata_key(callee))
                     .is_some_and(|r| {
@@ -5112,151 +5303,54 @@ impl LoweringContext<'_> {
                             r,
                             MemberResolution::BoundMethod { .. }
                                 | MemberResolution::UnboundMethod { .. }
-                                | MemberResolution::Free { .. }
                                 | MemberResolution::InterfaceDefaultMethod { .. }
                         )
-                    })
-                {
-                    // Check if base is a value receiver or a bare type/package path.
-                    // Type-name bases like `Label<int>.method` can have concrete
-                    // TIR types (`Interface`, `Class`) but are not runtime values.
-                    let base_is_value = match &self.body.exprs[*base] {
-                        AstExpr::Path(segments) if !segments.is_empty() => {
-                            self.locals.contains_key(&segments[0])
-                                || self
-                                    .capture_index_for_name_at(*base, &segments[0])
-                                    .is_some()
-                        }
-                        _ => self
-                            .expr_types
-                            .get(&self.expr_metadata_key(*base))
-                            .map(|ty| !matches!(ty, Tir2Ty::Unknown { .. }))
-                            .unwrap_or(false),
-                    };
-                    // Check if the resolved method expects a `self` receiver.
-                    // Static methods (e.g. StreamCache.new) have no `self` param
-                    // and must not get the class reference prepended as an argument.
-                    let method_takes_self = {
-                        use baml_compiler2_tir::inference::MemberResolution;
-                        self.resolutions
-                            .get(&self.expr_metadata_key(callee))
-                            .is_some_and(|r| match r {
-                                MemberResolution::BoundMethod { func_loc, .. }
-                                | MemberResolution::UnboundMethod { func_loc, .. }
-                                | MemberResolution::Free { func_loc }
-                                | MemberResolution::InterfaceDefaultMethod { func_loc, .. } => {
-                                    let sig =
-                                        baml_compiler2_ppir::function_signature(self.db, *func_loc);
-                                    sig.params
-                                        .first()
-                                        .is_some_and(|param| param.name.as_str() == "self")
-                                }
-                                _ => false,
-                            })
-                    };
-                    if base_is_value && method_takes_self {
-                        // Instance method call: arr.length() — prepend receiver as self.
-                        // For immediate calls, emit the callee as a plain function constant
-                        // (not MakeBoundMethod) since the receiver is passed explicitly as self.
-                        let receiver_op = self.lower_to_operand(*base);
-                        receiver_base_for_class_type_args = Some(*base);
-                        let callee_op = {
-                            let resolution = self
-                                .resolutions
-                                .get(&self.expr_metadata_key(callee))
-                                .cloned();
-                            match resolution
-                                .as_ref()
-                                .and_then(|r| resolution_to_item_ref(self.db, r))
-                            {
-                                Some(item) => Operand::Constant(Constant::Function(item)),
-                                None => self.lower_to_operand(callee),
-                            }
-                        };
-                        let mut all_args = vec![receiver_op];
-                        all_args.extend(self.lower_call_arg_operands(expr_id, args));
-                        (callee_op, all_args)
-                    } else {
-                        // Non-self method or package function reference:
-                        // e.g. Factory<int>.create(42), baml.Array.length(array).
-                        // Resolve the callee as a plain function constant using
-                        // resolution_to_item_ref to avoid lower_member_access emitting
-                        // MakeBoundMethod (which would try to load the base type as a
-                        // runtime value).
-                        let callee_op = {
-                            let resolution = self
-                                .resolutions
-                                .get(&self.expr_metadata_key(callee))
-                                .cloned();
-                            match resolution
-                                .as_ref()
-                                .and_then(|r| resolution_to_item_ref(self.db, r))
-                            {
-                                Some(item) => Operand::Constant(Constant::Function(item)),
-                                None => self.lower_to_operand(callee),
-                            }
-                        };
-                        (callee_op, self.lower_call_arg_operands(expr_id, args))
-                    }
-                } else {
-                    let callee_op = self.lower_to_operand(callee);
-                    (callee_op, self.lower_call_arg_operands(expr_id, args))
-                }
-            } else if let AstExpr::Path(segments) = &callee_expr {
-                // Check path_member_resolutions first (local-rooted paths like `self.method()`
-                // or `obj.field.method()`). The last resolution determines if the final segment
-                // is a method call (e.g. for `user.profile.items.slice`, resolutions are
-                // [Field{profile}, Field{items}, Method{slice}] — last() is Method).
-                let is_local_method = segments.len() >= 2
-                    && self
-                        .path_member_resolutions
-                        .get(&self.expr_metadata_key(callee))
-                        .and_then(|resolutions| resolutions.last())
-                        .is_some_and(|r| {
-                            use baml_compiler2_tir::inference::MemberResolution;
-                            matches!(
-                                r,
-                                MemberResolution::BoundMethod { .. }
-                                    | MemberResolution::UnboundMethod { .. }
-                                    | MemberResolution::InterfaceDefaultMethod { .. }
-                            )
-                        });
-                // Also check flat resolutions (package-path method call, kept for compatibility).
-                let is_pkg_method = !is_local_method
-                    && segments.len() >= 2
-                    && self
-                        .resolutions
-                        .get(&self.expr_metadata_key(callee))
-                        .is_some_and(|r| {
-                            use baml_compiler2_tir::inference::MemberResolution;
-                            matches!(
-                                r,
-                                MemberResolution::BoundMethod { .. }
-                                    | MemberResolution::UnboundMethod { .. }
-                                    | MemberResolution::InterfaceDefaultMethod { .. }
-                            )
-                        });
+                    });
 
-                if is_local_method {
-                    // Multi-segment path callee with a local-rooted Method resolution.
-                    // The last segment is the method; segments[0..n-1] form the receiver.
-                    // e.g. `self.method()` → receiver=self, `user.profile.items.slice()` → receiver=user.profile.items.
-                    //
-                    // For immediate calls we emit the callee as a plain function constant
-                    // (not MakeBoundMethod) since the receiver is passed explicitly as self.
-                    let receiver_segments = &segments[..segments.len() - 1];
-                    let method_resolution = self
-                        .path_member_resolutions
-                        .get(&self.expr_metadata_key(callee))
-                        .and_then(|resolutions| resolutions.last())
-                        .cloned();
-                    let callee_op = match method_resolution
-                        .as_ref()
-                        .and_then(|r| resolution_to_item_ref(self.db, r))
-                    {
-                        Some(item) => Operand::Constant(Constant::Function(item)),
-                        None => self.lower_to_operand(callee),
-                    };
+            if is_local_method {
+                // Multi-segment path callee with a local-rooted Method resolution.
+                // The last segment is the method; segments[0..n-1] form the receiver.
+                // e.g. `self.method()` → receiver=self, `user.profile.items.slice()` → receiver=user.profile.items.
+                //
+                // For immediate calls we emit the callee as a plain function constant
+                // (not MakeBoundMethod) since the receiver is passed explicitly as self.
+                let receiver_segments = &segments[..segments.len() - 1];
+                let method_resolution = self
+                    .path_member_resolutions
+                    .get(&self.expr_metadata_key(callee))
+                    .and_then(|resolutions| resolutions.last())
+                    .cloned();
+                let callee_op = match method_resolution
+                    .as_ref()
+                    .and_then(|r| resolution_to_item_ref(self.db, r))
+                {
+                    Some(item) => Operand::Constant(Constant::Function(item)),
+                    None => self.lower_to_operand(callee),
+                };
+                // Static methods reached through a type-name root (e.g.
+                // `ArrA.of(...)`) resolve here as UnboundMethod but take no
+                // `self` — do NOT prepend a receiver (the old fallback
+                // pushed a stray `null` the VM had to ignore, which breaks
+                // the leading type-arg window once the call seeds inferred
+                // type args). Mirrors the MemberAccess branch's
+                // `method_takes_self` gate.
+                let method_takes_self = method_resolution.as_ref().is_some_and(|r| {
+                    use baml_compiler2_tir::inference::MemberResolution;
+                    match r {
+                        MemberResolution::BoundMethod { func_loc, .. }
+                        | MemberResolution::UnboundMethod { func_loc, .. }
+                        | MemberResolution::InterfaceDefaultMethod { func_loc, .. } => {
+                            let sig = baml_compiler2_ppir::function_signature(self.db, *func_loc);
+                            sig.params
+                                .first()
+                                .is_some_and(|param| param.name.as_str() == "self")
+                        }
+                        _ => false,
+                    }
+                });
+                if !method_takes_self {
+                    (callee_op, self.lower_call_arg_operands(expr_id, args))
+                } else {
                     let receiver_op = if receiver_segments.len() == 1 {
                         // Simple local variable receiver (e.g. `self`).
                         if let Some(&recv_local) = self.locals.get(&receiver_segments[0]) {
@@ -5287,48 +5381,49 @@ impl LoweringContext<'_> {
                     let mut all_args = vec![receiver_op];
                     all_args.extend(self.lower_call_arg_operands(expr_id, args));
                     (callee_op, all_args)
-                } else if is_pkg_method {
-                    // Package-path method call (via flat resolutions): same treatment.
-                    // For immediate calls, emit the callee as a plain function constant
-                    // (not MakeBoundMethod) since the receiver is passed explicitly as self.
-                    let flat_resolution = self
-                        .resolutions
-                        .get(&self.expr_metadata_key(callee))
-                        .cloned();
-                    let callee_op = match flat_resolution
-                        .as_ref()
-                        .and_then(|r| resolution_to_item_ref(self.db, r))
-                    {
-                        Some(item) => Operand::Constant(Constant::Function(item)),
-                        None => self.lower_to_operand(callee),
-                    };
-                    let first_seg = &segments[0];
-                    let receiver_op = if let Some(&receiver_local) = self.locals.get(first_seg) {
-                        Some(Operand::Copy(Place::Local(receiver_local)))
-                    } else {
-                        self.capture_index_for_name_at(callee, first_seg)
-                            .map(|cap_idx| Operand::Copy(Place::Capture(cap_idx)))
-                    };
-                    if let Some(receiver_op) = receiver_op {
-                        let prefix_idx = segments.len() - 2;
-                        receiver_path_tir_ty = self
-                            .path_segment_types
-                            .get(&(self.current_metadata_scope, callee, prefix_idx))
-                            .cloned();
-                        let mut all_args = vec![receiver_op];
-                        all_args.extend(self.lower_call_arg_operands(expr_id, args));
-                        (callee_op, all_args)
-                    } else {
-                        (callee_op, self.lower_call_arg_operands(expr_id, args))
-                    }
+                }
+            } else if is_pkg_method {
+                // Package-path method call (via flat resolutions): same treatment.
+                // For immediate calls, emit the callee as a plain function constant
+                // (not MakeBoundMethod) since the receiver is passed explicitly as self.
+                let flat_resolution = self
+                    .resolutions
+                    .get(&self.expr_metadata_key(callee))
+                    .cloned();
+                let callee_op = match flat_resolution
+                    .as_ref()
+                    .and_then(|r| resolution_to_item_ref(self.db, r))
+                {
+                    Some(item) => Operand::Constant(Constant::Function(item)),
+                    None => self.lower_to_operand(callee),
+                };
+                let first_seg = &segments[0];
+                let receiver_op = if let Some(&receiver_local) = self.locals.get(first_seg) {
+                    Some(Operand::Copy(Place::Local(receiver_local)))
                 } else {
-                    let callee_op = self.lower_to_operand(callee);
+                    self.capture_index_for_name_at(callee, first_seg)
+                        .map(|cap_idx| Operand::Copy(Place::Capture(cap_idx)))
+                };
+                if let Some(receiver_op) = receiver_op {
+                    let prefix_idx = segments.len() - 2;
+                    receiver_path_tir_ty = self
+                        .path_segment_types
+                        .get(&(self.current_metadata_scope, callee, prefix_idx))
+                        .cloned();
+                    let mut all_args = vec![receiver_op];
+                    all_args.extend(self.lower_call_arg_operands(expr_id, args));
+                    (callee_op, all_args)
+                } else {
                     (callee_op, self.lower_call_arg_operands(expr_id, args))
                 }
             } else {
                 let callee_op = self.lower_to_operand(callee);
                 (callee_op, self.lower_call_arg_operands(expr_id, args))
-            };
+            }
+        } else {
+            let callee_op = self.lower_to_operand(callee);
+            (callee_op, self.lower_call_arg_operands(expr_id, args))
+        };
 
         let target = self.builder.create_block();
         let unwind = self.catch_context.as_ref().map(|c| c.unwind_target);
@@ -5437,13 +5532,39 @@ impl LoweringContext<'_> {
             _ => vec![],
         };
 
-        let type_arg_operands: Vec<Operand> = if !receiver_class_type_arg_operands.is_empty() {
-            let mut combined = receiver_class_type_arg_operands;
-            combined.extend(explicit_type_arg_operands);
-            combined
+        // Check if callee resolves to a builtin IO function (sys-op).
+        // Hoisted above the inferred-type-arg emission: sys-ops read their
+        // type args positionally in Rust glue (appended AFTER value args, one
+        // per declared type param), so they must receive exactly the
+        // receiver/explicit args — never the inferred extension below.
+        let is_sys_op = self.check_sys_op(callee);
+
+        // ── Append INFERRED type args (recorded by TIR) ──────────────────────
+        // Explicit `<...>` args are lowered from the AST above, but a call
+        // like `ArrA.of([1, 2, 3])` carries its instantiation only in TIR's
+        // `call_inferred_type_args`. Seed the remaining frame positions
+        // (after any receiver-provided class args) in the callee's De Bruijn
+        // order so the callee body can resolve its `T` at runtime. Without
+        // this the callee runs with `T = unknown`: instances it builds get
+        // `class_type_args = [unknown]`, runtime `IsType` tests against them
+        // fail, and interface dispatch falls through to the wrong
+        // implementor. Explicit args and inference are mutually exclusive
+        // (TIR skips inference when `<...>` is written), so at most one of
+        // `explicit_type_arg_operands` / `inferred_type_arg_operands` is
+        // non-empty.
+        let inferred_type_arg_operands: Vec<Operand> = if !is_sys_op && ast_type_args.is_empty() {
+            self.emit_inferred_call_type_arg_ops(
+                expr_id,
+                callee,
+                receiver_class_type_arg_operands.len(),
+            )
         } else {
-            explicit_type_arg_operands
+            Vec::new()
         };
+
+        let mut type_arg_operands: Vec<Operand> = receiver_class_type_arg_operands;
+        type_arg_operands.extend(explicit_type_arg_operands);
+        type_arg_operands.extend(inferred_type_arg_operands);
         let ntypeargs = type_arg_operands.len();
 
         // Prepend type-arg operands before the value-arg operands.
@@ -5456,9 +5577,6 @@ impl LoweringContext<'_> {
         } else {
             arg_operands.clone()
         };
-
-        // Check if callee resolves to a builtin IO function (sys-op)
-        let is_sys_op = self.check_sys_op(callee);
 
         if is_sys_op {
             // BEP-034 phase D′: sys-ops now lower to a single
@@ -5934,6 +6052,107 @@ impl LoweringContext<'_> {
                 Operand::Copy(Place::local(temp))
             })
             .collect()
+    }
+
+    /// Emit `LoadType` operands for a call's TIR-inferred generic type args
+    /// (calls like `ArrA.of([1, 2, 3])` whose `<T>` was inferred, not written).
+    ///
+    /// `already_seeded` is the number of leading frame positions the call site
+    /// has already provided (the receiver's class-level args); only positions
+    /// after that prefix are emitted, in the callee's De Bruijn order
+    /// (owner params, then fn params — matching `enclosing_generic_params` on
+    /// the callee side). Positions inference did not bind get `unknown`, which
+    /// is what an unseeded frame slot reads as today.
+    ///
+    /// Returns empty (no seeding — the status quo) when:
+    ///   - the call has no recorded inference,
+    ///   - the callee can't be resolved to a function declaration
+    ///     (e.g. a function *value* in a local),
+    ///   - the receiver-provided prefix doesn't line up with the callee's
+    ///     owner params (mis-aligned positions would be worse than an
+    ///     unseeded frame), or
+    ///   - every remaining position would be `unknown` anyway.
+    fn emit_inferred_call_type_arg_ops(
+        &mut self,
+        expr_id: AstExprId,
+        callee: AstExprId,
+        already_seeded: usize,
+    ) -> Vec<Operand> {
+        use baml_compiler2_tir::inference::MemberResolution;
+
+        let Some(bindings) = self
+            .call_inferred_type_args
+            .get(&self.expr_metadata_key(expr_id))
+            .cloned()
+        else {
+            return Vec::new();
+        };
+        // Resolve the callee declaration: member-access callees record a flat
+        // resolution; multi-segment path callees record per-segment ones (the
+        // last entry is the method).
+        let resolution = self
+            .resolutions
+            .get(&self.expr_metadata_key(callee))
+            .cloned()
+            .or_else(|| {
+                self.path_member_resolutions
+                    .get(&self.expr_metadata_key(callee))
+                    .and_then(|rs| rs.last().cloned())
+            });
+        let func_loc = match &resolution {
+            Some(
+                MemberResolution::Free { func_loc }
+                | MemberResolution::BoundMethod { func_loc, .. }
+                | MemberResolution::UnboundMethod { func_loc, .. }
+                | MemberResolution::InterfaceDefaultMethod { func_loc, .. },
+            ) => *func_loc,
+            Some(MemberResolution::Field { .. } | MemberResolution::Variant { .. }) | None => {
+                return Vec::new();
+            }
+        };
+        let (owner_params, fn_params) = callee_frame_generic_params(self.db, func_loc);
+        let layout_len = owner_params.len() + fn_params.len();
+        if layout_len == 0 || already_seeded >= layout_len {
+            return Vec::new();
+        }
+        // A receiver-provided prefix must be exactly the callee's owner params
+        // for the remaining positions to line up.
+        if already_seeded > 0 && already_seeded != owner_params.len() {
+            return Vec::new();
+        }
+        // A binding value may reference the caller's own generic params — those
+        // lower to `TypeArgRef` templates and resolve at runtime. Any OTHER
+        // TypeVar (notably a rigid `Self` pinned by a Self-pinned interface
+        // call, which is never in `enclosing_generic_params`) would silently
+        // template to `Concrete(Void)` — seeding e.g. `Self[]` as `void[]`
+        // where the status quo was an unseeded `unknown`. Demote such bindings
+        // to `unknown` so the slot reads exactly as it did before seeding.
+        let caller_generic_params = self.enclosing_generic_params();
+        let resolvable = |ty: &Tir2Ty| {
+            !baml_compiler2_tir::generics::contains_typevar_where(ty, &|name| {
+                !caller_generic_params.iter().any(|p| p == name)
+            })
+        };
+        let tys: Vec<Tir2Ty> = owner_params
+            .iter()
+            .chain(fn_params.iter())
+            .skip(already_seeded)
+            .map(|name| {
+                bindings
+                    .iter()
+                    .find(|(n, _)| n == name)
+                    .map(|(_, ty)| ty.clone())
+                    .filter(|ty| resolvable(ty))
+                    .unwrap_or(Tir2Ty::Unknown {
+                        attr: baml_compiler2_tir::ty::TyAttr::default(),
+                    })
+            })
+            .collect();
+        // All-unknown seeds are a runtime no-op; skip the bytecode noise.
+        if tys.iter().all(|ty| matches!(ty, Tir2Ty::Unknown { .. })) {
+            return Vec::new();
+        }
+        self.emit_frame_type_arg_ops(&tys)
     }
 
     /// Emit `LoadType` rvalue assignments for the explicit type arguments of a

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -596,6 +596,16 @@ pub struct TypeInferenceBuilder<'db> {
     pub param_types: Vec<(Name, Ty)>,
     /// Full parameter binding plans for checked call expressions.
     pub call_plans: FxHashMap<ExprId, crate::inference::CallPlan>,
+    /// Inferred generic type-arg bindings for checked call expressions whose
+    /// type args were NOT written explicitly (e.g. `ArrA.of([1,2,3])` infers
+    /// `T := int`). Sorted by param name; keyed by the call's `ExprId`. MIR
+    /// uses this to seed the callee frame's runtime `type_args` — explicit
+    /// `<...>` args are lowered straight from the AST, but inferred ones exist
+    /// only here. Values may contain the caller's own `TypeVar`s (resolved to
+    /// frame indices during MIR lowering); values containing any OTHER
+    /// `TypeVar` (e.g. a nested rigid `Self`) are demoted to `unknown` by the
+    /// MIR seeding.
+    pub call_inferred_type_args: FxHashMap<ExprId, Vec<(Name, Ty)>>,
     /// Function adapters required by checked optional-parameter coercions.
     pub function_coercions: FxHashMap<ExprId, crate::inference::FunctionCoercion>,
     /// Metadata produced while checking parameter defaults. Kept separate from
@@ -812,6 +822,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self_pinned_rigid_var: FxHashMap::default(),
             param_types: Vec::new(),
             call_plans: FxHashMap::default(),
+            call_inferred_type_args: FxHashMap::default(),
             function_coercions: FxHashMap::default(),
             default_parameter_inference: crate::inference::DefaultParameterInference::empty(),
             nested_lambda_types: FxHashMap::default(),
@@ -879,6 +890,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         FxHashMap<ExprId, Vec<crate::inference::MemberResolution<'db>>>,
         Vec<(Name, Ty)>,
         FxHashMap<ExprId, crate::inference::CallPlan>,
+        FxHashMap<ExprId, Vec<(Name, Ty)>>,
         FxHashMap<ExprId, crate::inference::FunctionCoercion>,
         FxHashMap<FileScopeId, Ty>,
         crate::inference::DefaultParameterInference<'db>,
@@ -896,6 +908,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.path_member_resolutions,
             self.param_types,
             self.call_plans,
+            self.call_inferred_type_args,
             self.function_coercions,
             self.nested_lambda_types,
             self.default_parameter_inference,
@@ -1974,6 +1987,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             std::mem::take(&mut self.interface_method_generic_params);
         let saved_self_pinned_rigid_var = std::mem::take(&mut self.self_pinned_rigid_var);
         let saved_call_plans = std::mem::take(&mut self.call_plans);
+        let saved_call_inferred_type_args = std::mem::take(&mut self.call_inferred_type_args);
         let saved_function_coercions = std::mem::take(&mut self.function_coercions);
         let saved_lambda_effective_throws = std::mem::take(&mut self.lambda_effective_throws);
         let defaults = &parameter_defaults.defaults;
@@ -2053,6 +2067,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             path_segment_types: std::mem::take(&mut self.path_segment_types),
             path_member_resolutions: std::mem::take(&mut self.path_member_resolutions),
             call_plans: std::mem::take(&mut self.call_plans),
+            call_inferred_type_args: std::mem::take(&mut self.call_inferred_type_args),
             function_coercions: std::mem::take(&mut self.function_coercions),
         };
 
@@ -2067,6 +2082,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.interface_method_generic_params = saved_interface_method_generic_params;
         self.self_pinned_rigid_var = saved_self_pinned_rigid_var;
         self.call_plans = saved_call_plans;
+        self.call_inferred_type_args = saved_call_inferred_type_args;
         self.function_coercions = saved_function_coercions;
         self.lambda_effective_throws = saved_lambda_effective_throws;
         self.body_source_map = saved_body_source_map;
@@ -2898,6 +2914,22 @@ impl<'db> TypeInferenceBuilder<'db> {
                     crate::generics::erase_unresolved_typevars(&substituted_ret, &mut erase_diags);
                 for d in erase_diags {
                     self.context.report_simple(d, expr_id);
+                }
+
+                // Persist the inferred instantiation so MIR can seed the callee
+                // frame's runtime `type_args`. Explicit `<...>` args are lowered
+                // straight from the AST at the call site, but INFERRED bindings
+                // exist only here — without recording them the callee runs with
+                // `T = unknown` (instances built inside get `class_type_args =
+                // [unknown]`, runtime `IsType` tests fail, interface dispatch
+                // falls to the wrong implementor).
+                if !explicit_args_used && !bindings.is_empty() {
+                    let mut inferred: Vec<(Name, Ty)> = bindings
+                        .iter()
+                        .map(|(name, ty)| (name.clone(), ty.clone()))
+                        .collect();
+                    inferred.sort_by(|(a, _), (b, _)| a.cmp(b));
+                    self.call_inferred_type_args.insert(expr_id, inferred);
                 }
 
                 CheckedCallInner {
@@ -14019,6 +14051,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let saved_self_pinned_rigid_var = std::mem::take(&mut self.self_pinned_rigid_var);
         let saved_lambda_effective_throws = std::mem::take(&mut self.lambda_effective_throws);
         let saved_call_plans = std::mem::take(&mut self.call_plans);
+        let saved_call_inferred_type_args = std::mem::take(&mut self.call_inferred_type_args);
         let saved_function_coercions = std::mem::take(&mut self.function_coercions);
         let saved_body_source_map = self.body_source_map.clone();
         self.body_source_map = Some(lambda_source_map.clone());
@@ -14123,6 +14156,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.self_pinned_rigid_var = saved_self_pinned_rigid_var;
         self.lambda_effective_throws = saved_lambda_effective_throws;
         self.call_plans = saved_call_plans;
+        self.call_inferred_type_args = saved_call_inferred_type_args;
         self.function_coercions = saved_function_coercions;
         self.locals = saved_locals;
         self.scoped_local_declarations = saved_scoped_local_declarations;

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -596,6 +596,11 @@ pub struct ScopeInference<'db> {
     param_types: Vec<(Name, Ty)>,
     /// Full parameter binding plan for checked calls.
     call_plans: FxHashMap<ExprId, CallPlan>,
+    /// Inferred generic type-arg bindings (sorted by param name) for call
+    /// expressions whose type args were NOT written explicitly. MIR uses this
+    /// to seed the callee frame's runtime `type_args`; values may contain the
+    /// caller's own `TypeVar`s.
+    call_inferred_type_args: FxHashMap<ExprId, Vec<(Name, Ty)>>,
     /// Function value adapters required after structural function subtyping.
     ///
     /// Optional parameters are matched by name in TIR types, but runtime calls
@@ -624,6 +629,7 @@ pub struct DefaultParameterInference<'db> {
     pub(crate) path_segment_types: FxHashMap<(ExprId, usize), Ty>,
     pub(crate) path_member_resolutions: FxHashMap<ExprId, Vec<MemberResolution<'db>>>,
     pub(crate) call_plans: FxHashMap<ExprId, CallPlan>,
+    pub(crate) call_inferred_type_args: FxHashMap<ExprId, Vec<(Name, Ty)>>,
     pub(crate) function_coercions: FxHashMap<ExprId, FunctionCoercion>,
 }
 
@@ -639,6 +645,7 @@ impl DefaultParameterInference<'_> {
             path_segment_types: FxHashMap::default(),
             path_member_resolutions: FxHashMap::default(),
             call_plans: FxHashMap::default(),
+            call_inferred_type_args: FxHashMap::default(),
             function_coercions: FxHashMap::default(),
         }
     }
@@ -774,6 +781,14 @@ impl<'db> ScopeInference<'db> {
         self.call_plans.iter()
     }
 
+    /// Iterate over all inferred call-site generic type-arg bindings in this
+    /// scope (calls whose type args were inferred rather than written).
+    pub fn iter_call_inferred_type_args(
+        &self,
+    ) -> impl Iterator<Item = (&ExprId, &Vec<(Name, Ty)>)> {
+        self.call_inferred_type_args.iter()
+    }
+
     /// Iterate over all function adapters required by checked coercions.
     pub fn iter_function_coercions(&self) -> impl Iterator<Item = (&ExprId, &FunctionCoercion)> {
         self.function_coercions.iter()
@@ -821,6 +836,13 @@ impl<'db> ScopeInference<'db> {
     /// Iterate over all default-parameter call binding plans.
     pub fn iter_default_call_plans(&self) -> impl Iterator<Item = (&ExprId, &CallPlan)> {
         self.parameter_defaults.call_plans.iter()
+    }
+
+    /// Iterate over all default-parameter inferred call-site type-arg bindings.
+    pub fn iter_default_call_inferred_type_args(
+        &self,
+    ) -> impl Iterator<Item = (&ExprId, &Vec<(Name, Ty)>)> {
+        self.parameter_defaults.call_inferred_type_args.iter()
     }
 
     /// Iterate over all default-parameter function adapters.
@@ -991,6 +1013,7 @@ fn infer_scope_types_cycle_initial<'db>(
         nested_lambda_types: FxHashMap::default(),
         param_types: Vec::new(),
         call_plans: FxHashMap::default(),
+        call_inferred_type_args: FxHashMap::default(),
         function_coercions: FxHashMap::default(),
         parameter_defaults: DefaultParameterInference::empty(),
         extra: None,
@@ -2014,6 +2037,7 @@ pub fn infer_scope_types<'db>(
         path_member_resolutions,
         param_types,
         call_plans,
+        call_inferred_type_args,
         function_coercions,
         nested_lambda_types,
         parameter_defaults,
@@ -2037,6 +2061,7 @@ pub fn infer_scope_types<'db>(
         nested_lambda_types,
         param_types,
         call_plans,
+        call_inferred_type_args,
         function_coercions,
         parameter_defaults,
         extra,

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -379,6 +379,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
                 _path_member_resolutions,
                 _param_types,
                 _call_plans,
+                _call_inferred_type_args,
                 _function_coercions,
                 _call_throws,
                 _default_parameter_inference,

--- a/baml_language/crates/baml_tests/baml_src/ns_inferred_generic_type_args/inferred_generic_type_args.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_inferred_generic_type_args/inferred_generic_type_args.baml
@@ -311,3 +311,150 @@ function generic_behind_nongeneric_iface() -> string {
 test "generic_class_behind_nongeneric_interface_reads_type_var" {
   assert.equal(generic_behind_nongeneric_iface(), "int")
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Inferred call-site type args reach the callee frame at runtime.
+//
+// The cases above dispatch correctly, but dispatch alone can pass "by luck"
+// of arm order even when the instantiation is lost (the unguarded last arm of
+// the candidate switch happens to be the right implementor). The cases below
+// pin the instantiation itself, so they cannot pass by dispatch luck:
+//   • a free generic function must see its inferred `T` via reflect;
+//   • an instance built by an inferred static ctor must carry
+//     `class_type_args = [int]` — observable through a user-level
+//     `match`/IsType test, which consults the args directly.
+// Both were broken before TIR began persisting inferred call bindings
+// (`call_inferred_type_args`) for MIR to seed the callee frame.
+// ═══════════════════════════════════════════════════════════════════════════
+
+function free_fn_tname<T>(a: T[]) -> string {
+  return reflect.type_of<T>().to_string()
+}
+
+function free_fn_inferred_t() -> string {
+  return free_fn_tname([1, 2, 3])
+}
+
+test "free_function_sees_inferred_type_arg" {
+  assert.equal(free_fn_inferred_t(), "int")
+}
+
+// The inferred-ctor instance must pass a runtime `IsType ArrBag<int>` test —
+// NOT fall through to the wildcard arm.
+function inferred_ctor_instance_is_typed() -> int throws unknown {
+  let s: Bag<int> = ArrBag.make([5, 6, 7]);
+  match (s) {
+    let a: ArrBag<int> => 1,
+    let o: OneBag<int> => 2,
+    _ => 9,
+  }
+}
+
+test "inferred_static_ctor_instance_carries_class_type_args" {
+  assert.equal(inferred_ctor_instance_is_typed(), 1)
+}
+
+// Lazy-iterator shape end-to-end: inferred static ctor, consumption through
+// an inherited default method that drives `self.next()` in a loop, with a
+// second implementor present. Returns the COLLECTED COUNT, so a mis-dispatch
+// (e.g. `next` resolving to `Lone.next` against an `ArrIter` receiver)
+// yields 0 or 1 instead of 3.
+interface NextIter<T, E> {
+  function next2(self) -> T | IterDone throws E
+
+  function collect2(self) -> T[] throws E {
+    let out: T[] = [];
+    while (true) {
+      match (self.next2()) {
+        IterDone => { break; },
+        let x: T => { out.push(x); }
+      }
+    }
+    out
+  }
+}
+
+class IterDone {}
+
+class ArrIter<T> {
+  arr T[]
+  idx int
+
+  function of(a: T[]) -> ArrIter<T> throws never {
+    return ArrIter<T> { arr: a, idx: 0 }
+  }
+
+  implements NextIter<T, never> {
+    function next2(self) -> T | IterDone throws never {
+      match (self.arr.at(self.idx)) {
+        null => IterDone {},
+        let x: T => { self.idx += 1; x }
+      }
+    }
+  }
+}
+
+class LoneIter<T> {
+  v T
+  used bool
+
+  implements NextIter<T, never> {
+    function next2(self) -> T | IterDone throws never {
+      if (self.used) { IterDone {} } else { self.used = true; self.v }
+    }
+  }
+}
+
+function inferred_ctor_collect_count() -> int throws unknown {
+  let it: NextIter<int, never> = ArrIter.of([1, 2, 3]);
+  it.collect2().length()
+}
+
+test "inferred_ctor_default_method_collects_all" {
+  assert.equal(inferred_ctor_collect_count(), 3)
+}
+
+// ─── Inferred binding nesting a rigid `Self` must NOT seed `void` ───
+//
+// Inside an interface default method, `self` has the rigid pinned type `Self`,
+// which is never among the caller frame's generic params. An inferred generic
+// call whose binding NESTS it (here `T := Self[]` via `echo_type([self])`)
+// cannot be resolved to a frame index — the seeding must demote that binding
+// to `unknown` (the unseeded status quo), not lower `Self` to `void`.
+
+function echo_type<T>(a: T) -> string {
+  return reflect.type_of<T>().to_string()
+}
+
+interface SelfEcho {
+  function tag(self) -> string
+  function nested_self_type(self) -> string {
+    return echo_type([self])
+  }
+}
+
+class EchoA {
+  n int
+  implements SelfEcho {
+    function tag(self) -> string { return "a" }
+  }
+}
+
+class EchoB {
+  s string
+  implements SelfEcho {
+    function tag(self) -> string { return "b" }
+  }
+}
+
+function nested_self_inferred_binding() -> string throws unknown {
+  let e: SelfEcho = EchoA { n: 1 };
+  e.nested_self_type()
+}
+
+// `unknown` (the whole binding demoted) is the pre-existing status quo for an
+// unresolvable binding — the regression this guards against is `void[]`, which
+// a naive lowering of the nested rigid `Self` produces.
+test "nested_self_inferred_binding_not_voided" {
+  assert.equal(nested_self_inferred_binding(), "unknown")
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/builtins.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/builtins.snap
@@ -31,6 +31,7 @@ function builtins.$init_test_ns_builtins_builtins(registry: testing.TestCollecto
 }
 
 function builtins.builtins_any_value_to_string() -> string {
+    load_type builtins.BuiltinsPerson
     load_const "Alice"
     load_const 25
     load_const 10
@@ -59,19 +60,24 @@ function builtins.builtins_bind_method_call() -> int {
 }
 
 function builtins.builtins_float_to_string_concat() -> string {
+    load_type 1.0
     load_const 1.0
     call baml.unstable.string
     store_var a
+    load_type 0.0
     load_const 0.0
     call baml.unstable.string
     store_var b
+    load_type -1.0
     load_const 1.0
     unary_op -
     call baml.unstable.string
     store_var c
+    load_type 3.14
     load_const 3.14
     call baml.unstable.string
     store_var d
+    load_type 2
     load_const 2
     call baml.unstable.string
     store_var e

--- a/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
@@ -187,6 +187,9 @@ function closures.closures_apply(f: (int, int) -> int throws never, a: int, b: i
 }
 
 function closures.closures_bound_formatter_mapper() -> string[] {
+    load_type void
+    load_type string
+    load_type void
     load_const "a"
     load_const "b"
     alloc_array 2
@@ -245,6 +248,9 @@ function closures.closures_bound_throwing_method_reference_catches_error() -> in
 }
 
 function closures.closures_bound_validator_mapped() -> bool[] {
+    load_type void
+    load_type bool
+    load_type void
     load_const 5
     load_const 15
     load_const 25
@@ -329,6 +335,9 @@ function closures.closures_strategy_swap() -> int[] {
 }
 
 function closures.closures_unbound_in_map() -> string[] {
+    load_type void
+    load_type string
+    load_type void
     load_const "Alice"
     load_const "Smith"
     init_instance user.closures.ClsEmployee .first, .last

--- a/baml_language/crates/baml_tests/snapshots/baml_src/deep_copy.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/deep_copy.snap
@@ -114,6 +114,7 @@ function deep_copy.deep_copy_circular_helper() -> int {
     init_instance user.deep_copy.Node .value, .children
     alloc_array 1
     store_field .children
+    load_type deep_copy.Node
     load_var a
     call baml.deep_copy
     load_var a
@@ -140,7 +141,9 @@ function deep_copy.deep_copy_complex_helper() -> int {
     load_const "second"
     alloc_map 2
     init_instance user.deep_copy.DeepOuter .middle, .data
-    store_var_load_var original
+    store_var original
+    load_type deep_copy.DeepOuter
+    load_var original
     call baml.deep_copy
     store_var copy
     load_var original
@@ -191,7 +194,9 @@ function deep_copy.deep_copy_independence_helper() -> int {
     init_instance user.deep_copy.Node .value, .children
     alloc_array 2
     init_instance user.deep_copy.Node .value, .children
-    store_var_load_var original
+    store_var original
+    load_type deep_copy.Node
+    load_var original
     call baml.deep_copy
     load_var original
     load_field .children
@@ -213,7 +218,9 @@ function deep_copy.deep_copy_map_helper() -> int {
     load_const "b"
     alloc_map 2
     init_instance user.deep_copy.Container .values
-    store_var_load_var original
+    store_var original
+    load_type deep_copy.Container
+    load_var original
     call baml.deep_copy
     load_var original
     load_field .values
@@ -235,7 +242,9 @@ function deep_copy.deep_copy_nested_arrays_helper() -> int {
     alloc_array 2
     alloc_array 2
     init_instance user.deep_copy.Matrix .data
-    store_var_load_var original
+    store_var original
+    load_type deep_copy.Matrix
+    load_var original
     call baml.deep_copy
     load_var original
     load_field .data
@@ -253,6 +262,7 @@ function deep_copy.deep_copy_nested_arrays_helper() -> int {
 }
 
 function deep_copy.deep_copy_object_helper() -> deep_copy.Tree {
+    load_type deep_copy.Tree
     load_const "1"
     load_const "2"
     alloc_array 0
@@ -289,12 +299,14 @@ function deep_copy.deep_equals_circular_helper() -> bool {
     init_instance user.deep_copy.Node .value, .children
     alloc_array 1
     store_field .children
+    load_type deep_copy.Node
     load_var2 1 2
     call baml.deep_equals
     return
 }
 
 function deep_copy.deep_equals_different_primitives_helper() -> bool {
+    load_type int
     load_const 42
     load_const 43
     call baml.deep_equals
@@ -302,6 +314,7 @@ function deep_copy.deep_equals_different_primitives_helper() -> bool {
 }
 
 function deep_copy.deep_equals_primitives_helper() -> bool {
+    load_type int
     load_const 42
     load_const 42
     call baml.deep_equals
@@ -312,8 +325,9 @@ function deep_copy.deep_equals_same_reference_helper() -> bool {
     load_const 1
     alloc_array 0
     init_instance user.deep_copy.Node .value, .children
-    store_var_load_var n
-    load_var n
+    store_var n
+    load_type deep_copy.Node
+    load_var2 1 1
     call baml.deep_equals
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
@@ -285,6 +285,7 @@ function fs.fs_file_read_bytes_n_fn() -> bool {
     load_const "/tmp/baml_fs_read_bytes_n.bin"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 3
     load_var data
     container_len
     load_const 3
@@ -417,6 +418,7 @@ function fs.fs_file_rw_write_bytes_fn() -> bool {
     load_const "/tmp/baml_fs_file_write_bytes_dst.bin"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 2
     load_var n
     load_const 2
     call baml.deep_equals
@@ -474,6 +476,7 @@ function fs.fs_open_and_read_bytes_fn() -> bool {
     load_const "/tmp/baml_fs_open_and_read_bytes.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 16
     load_var data
     container_len
     load_const 16
@@ -515,11 +518,13 @@ function fs.fs_open_append_creates_and_appends_fn() -> bool {
     load_const "/tmp/baml_fs_append.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 5
     load_var n
     load_const 5
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type string | "start!more!"
     load_var readback
     load_const "start!more!"
     call baml.deep_equals
@@ -547,11 +552,13 @@ function fs.fs_open_append_creates_missing_file_fn() -> bool {
     load_const "/tmp/baml_fs_append_new.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 2
     load_var n
     load_const 2
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type string | "hi"
     load_var readback
     load_const "hi"
     call baml.deep_equals
@@ -601,11 +608,13 @@ function fs.fs_open_w_creates_missing_file_fn() -> bool {
     load_const "/tmp/baml_fs_open_w_new.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 2
     load_var n
     load_const 2
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type string | "hi"
     load_var readback
     load_const "hi"
     call baml.deep_equals
@@ -627,11 +636,13 @@ function fs.fs_open_w_creates_parent_dirs_fn() -> bool {
     load_const "/tmp/baml_fs_open_w_parent/nested/dir/new.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 6
     load_var n
     load_const 6
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type string | "nested"
     load_var readback
     load_const "nested"
     call baml.deep_equals
@@ -685,11 +696,13 @@ function fs.fs_open_w_truncates_existing_fn() -> bool {
     load_const "/tmp/baml_fs_open_w_truncate.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 3
     load_var n
     load_const 3
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type string | "new"
     load_var readback
     load_const "new"
     call baml.deep_equals
@@ -706,6 +719,9 @@ function fs.fs_read_dir_empty_dir_fn() -> bool {
     pop 1
     load_const "/tmp/baml_fs_read_dir_empty_abc"
     sys_op baml.fs.read_dir
+    store_var entries
+    load_type int | 0
+    load_var entries
     container_len
     load_const 0
     call baml.deep_equals
@@ -750,6 +766,7 @@ function fs.fs_read_dir_returns_entries_fn() -> bool {
     bin_op +
     sys_op baml.fs.remove
     pop 1
+    load_type int | 3
     load_var entries
     container_len
     load_const 3
@@ -855,6 +872,9 @@ function fs.fs_remove_deletes_file_fn() -> bool {
     pop 1
     load_const "/tmp/baml_fs_remove_deletes.txt"
     sys_op baml.fs.exists
+    store_var _6
+    load_type bool | false
+    load_var _6
     load_const false
     call baml.deep_equals
     return
@@ -917,11 +937,13 @@ function fs.fs_write_bytes_fn() -> bool {
     load_const "/tmp/baml_fs_write_bytes_dst.bin"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 11
     load_var n
     load_const 11
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type int | 11
     load_var readback
     container_len
     load_const 11
@@ -942,11 +964,13 @@ function fs.fs_write_creates_parent_dirs_fn() -> bool {
     load_const "/tmp/baml_fs_write_parent/nested/dir/file.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 14
     load_var n
     load_const 14
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type string | "nested content"
     load_var readback
     load_const "nested content"
     call baml.deep_equals
@@ -970,11 +994,13 @@ function fs.fs_write_overwrites_existing_fn() -> bool {
     load_const "/tmp/baml_fs_write_overwrite.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 11
     load_var n
     load_const 11
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type string | "new content"
     load_var readback
     load_const "new content"
     call baml.deep_equals
@@ -994,11 +1020,13 @@ function fs.fs_write_string_fn() -> bool {
     load_const "/tmp/baml_fs_write_string.txt"
     sys_op baml.fs.remove
     pop 1
+    load_type int | 13
     load_var n
     load_const 13
     call baml.deep_equals
     jump_if_false L0
     pop 1
+    load_type string | "Hello, world!"
     load_var readback
     load_const "Hello, world!"
     call baml.deep_equals

--- a/baml_language/crates/baml_tests/snapshots/baml_src/inferred_generic_type_args.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/inferred_generic_type_args.snap
@@ -44,6 +44,30 @@ function inferred_generic_type_args.$init_test_ns_inferred_generic_type_args_inf
     load_const null
     call testing.TestCollector.register_test
     pop 1
+    load_var registry
+    load_const "free_function_sees_inferred_type_arg"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 7)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "inferred_static_ctor_instance_carries_class_type_args"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 8)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "inferred_ctor_default_method_collects_all"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 9)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "nested_self_inferred_binding_not_voided"
+    make_closure .<lambda($init_test_ns_inferred_generic_type_args_inferred_generic_type_args, 10)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
     load_const null
     return
 }
@@ -69,6 +93,74 @@ function inferred_generic_type_args.ArrBag.make(a: void[]) -> inferred_generic_t
     load_const 0
     load_type #0
     init_instance<1> user.inferred_generic_type_args.ArrBag .arr, .idx
+    return
+}
+
+function inferred_generic_type_args.ArrIter$stream.NextIter<T, never>.next2(self: inferred_generic_type_args.ArrIter$stream) -> void | inferred_generic_type_args.IterDone {
+    load_var self
+    load_field .0
+    load_var self
+    load_field .1
+    call baml.Array.at
+    store_var _2
+    load_var _2
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var self
+    copy 0
+    load_field .1
+    load_const 1
+    bin_op +
+    store_field .1
+    load_var _2
+    jump L2
+
+  L1:
+    alloc_instance user.inferred_generic_type_args.IterDone
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.ArrIter.NextIter<T, never>.next2(self: inferred_generic_type_args.ArrIter) -> void | inferred_generic_type_args.IterDone {
+    load_var self
+    load_field .0
+    load_var self
+    load_field .1
+    call baml.Array.at
+    store_var _2
+    load_var _2
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var self
+    copy 0
+    load_field .1
+    load_const 1
+    bin_op +
+    store_field .1
+    load_var _2
+    jump L2
+
+  L1:
+    alloc_instance user.inferred_generic_type_args.IterDone
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.ArrIter.of(a: void[]) -> inferred_generic_type_args.ArrIter<void> {
+    load_var a
+    load_const 0
+    load_type #0
+    init_instance<1> user.inferred_generic_type_args.ArrIter .arr, .idx
     return
 }
 
@@ -180,6 +272,26 @@ function inferred_generic_type_args.Dog.make(v: void) -> inferred_generic_type_a
     return
 }
 
+function inferred_generic_type_args.EchoA$stream.SelfEcho.tag(self: inferred_generic_type_args.EchoA$stream) -> string {
+    load_const "a"
+    return
+}
+
+function inferred_generic_type_args.EchoA.SelfEcho.tag(self: inferred_generic_type_args.EchoA) -> string {
+    load_const "a"
+    return
+}
+
+function inferred_generic_type_args.EchoB$stream.SelfEcho.tag(self: inferred_generic_type_args.EchoB$stream) -> string {
+    load_const "b"
+    return
+}
+
+function inferred_generic_type_args.EchoB.SelfEcho.tag(self: inferred_generic_type_args.EchoB) -> string {
+    load_const "b"
+    return
+}
+
 function inferred_generic_type_args.IntCounter$stream.Counter<T>.describe(self: inferred_generic_type_args.IntCounter$stream) -> string {
     load_type #0
     load_var self
@@ -194,9 +306,93 @@ function inferred_generic_type_args.IntCounter.Counter<T>.describe(self: inferre
     return
 }
 
+function inferred_generic_type_args.LoneIter$stream.NextIter<T, never>.next2(self: inferred_generic_type_args.LoneIter$stream) -> void | inferred_generic_type_args.IterDone {
+    load_var self
+    load_field .1
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var self
+    load_const true
+    store_field .1
+    load_var self
+    load_field .0
+    jump L2
+
+  L1:
+    alloc_instance user.inferred_generic_type_args.IterDone
+
+  L2:
+    return
+}
+
+function inferred_generic_type_args.LoneIter.NextIter<T, never>.next2(self: inferred_generic_type_args.LoneIter) -> void | inferred_generic_type_args.IterDone {
+    load_var self
+    load_field .1
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var self
+    load_const true
+    store_field .1
+    load_var self
+    load_field .0
+    jump L2
+
+  L1:
+    alloc_instance user.inferred_generic_type_args.IterDone
+
+  L2:
+    return
+}
+
 function inferred_generic_type_args.Named.tname(self: null) -> string {
     load_type #0
     call baml.TypeValue.to_string
+    return
+}
+
+function inferred_generic_type_args.NextIter.collect2(self: null) -> void[] {
+    alloc_array 0
+    store_var out
+
+  L0:
+    load_const true
+    pop_jump_if_false L5
+    load_var self
+    is_type LoneIter<...>
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_type #0
+    load_var self
+    call user.inferred_generic_type_args.ArrIter.NextIter<T, never>.next2
+    store_var _3
+    jump L3
+
+  L2:
+    load_type #0
+    load_var self
+    call user.inferred_generic_type_args.LoneIter.NextIter<T, never>.next2
+    store_var _3
+
+  L3:
+    load_var _3
+    is_type inferred_generic_type_args.IterDone
+    pop_jump_if_false L4
+    jump L5
+
+  L4:
+    load_var2 2 3
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L5:
+    load_var out
     return
 }
 
@@ -231,6 +427,13 @@ function inferred_generic_type_args.PlainThing$stream.Describable.describe(self:
 
 function inferred_generic_type_args.PlainThing.Describable.describe(self: inferred_generic_type_args.PlainThing) -> string {
     load_const "plain"
+    return
+}
+
+function inferred_generic_type_args.SelfEcho.nested_self_type(self: null) -> string {
+    load_var self
+    alloc_array 1
+    call user.inferred_generic_type_args.echo_type
     return
 }
 
@@ -377,6 +580,28 @@ function inferred_generic_type_args.default_method_typevar_name() -> string {
     return
 }
 
+function inferred_generic_type_args.echo_type(a: void) -> string {
+    load_type #0
+    call baml.TypeValue.to_string
+    return
+}
+
+function inferred_generic_type_args.free_fn_inferred_t() -> string {
+    load_type int
+    load_const 1
+    load_const 2
+    load_const 3
+    alloc_array 3
+    call user.inferred_generic_type_args.free_fn_tname
+    return
+}
+
+function inferred_generic_type_args.free_fn_tname(a: void[]) -> string {
+    load_type #0
+    call baml.TypeValue.to_string
+    return
+}
+
 function inferred_generic_type_args.generic_behind_nongeneric_iface() -> string {
     load_const 42
     load_type int
@@ -400,8 +625,73 @@ function inferred_generic_type_args.generic_behind_nongeneric_iface() -> string 
     return
 }
 
+function inferred_generic_type_args.inferred_ctor_collect_count() -> int {
+    load_type int
+    load_const 1
+    load_const 2
+    load_const 3
+    alloc_array 3
+    call user.inferred_generic_type_args.ArrIter.of
+    store_var it
+    load_var it
+    is_type LoneIter<...>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_type int
+    load_type void
+    load_var it
+    call user.inferred_generic_type_args.NextIter.collect2
+    jump L2
+
+  L1:
+    load_type int
+    load_type void
+    load_var it
+    call user.inferred_generic_type_args.NextIter.collect2
+
+  L2:
+    container_len
+    return
+}
+
+function inferred_generic_type_args.inferred_ctor_instance_is_typed() -> int {
+    load_type int
+    load_const 5
+    load_const 6
+    load_const 7
+    alloc_array 3
+    call user.inferred_generic_type_args.ArrBag.make
+    store_var s
+    load_var s
+    is_type inferred_generic_type_args.ArrBag<...>
+    pop_jump_if_false L0
+    jump L3
+
+  L0:
+    load_var s
+    is_type inferred_generic_type_args.OneBag<...>
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_const 9
+    jump L4
+
+  L2:
+    load_const 2
+    jump L4
+
+  L3:
+    load_const 1
+
+  L4:
+    return
+}
+
 function inferred_generic_type_args.inferred_static_ctor_first() -> int {
-    load_const null
+    load_type int
     load_const 5
     load_const 6
     load_const 7
@@ -429,7 +719,7 @@ function inferred_generic_type_args.inferred_static_ctor_first() -> int {
 }
 
 function inferred_generic_type_args.inferred_static_ctor_speak() -> string {
-    load_const null
+    load_type 42
     load_const 42
     call user.inferred_generic_type_args.Dog.make
     store_var d
@@ -452,8 +742,29 @@ function inferred_generic_type_args.inferred_static_ctor_speak() -> string {
     return
 }
 
+function inferred_generic_type_args.nested_self_inferred_binding() -> string {
+    load_const 1
+    init_instance user.inferred_generic_type_args.EchoA .n
+    store_var_load_var e
+    is_type EchoA
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    call user.inferred_generic_type_args.SelfEcho.nested_self_type
+    jump L2
+
+  L1:
+    load_var e
+    call user.inferred_generic_type_args.SelfEcho.nested_self_type
+
+  L2:
+    return
+}
+
 function inferred_generic_type_args.take_one_then_head() -> int {
-    load_const null
+    load_type int
     load_const 10
     load_const 20
     load_const 30

--- a/baml_language/crates/baml_tests/snapshots/baml_src/instantiation_expr.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/instantiation_expr.snap
@@ -222,9 +222,11 @@ function instantiation_expr.identity(x: void) -> void {
 }
 
 function instantiation_expr.identity_deep_copy_equal() -> bool {
+    load_type (int) -> int throws never
     load_const user.instantiation_expr.identity<...>
     call baml.deep_copy
     store_var _3
+    load_type (int) -> int throws never
     load_const user.instantiation_expr.identity<...>
     load_var _3
     call baml.deep_equals
@@ -239,6 +241,7 @@ function instantiation_expr.identity_int_value_fn() -> int {
 }
 
 function instantiation_expr.identity_same_specialization() -> bool {
+    load_type (int) -> int throws never
     load_const user.instantiation_expr.identity<...>
     load_const user.instantiation_expr.identity<...>
     call baml.deep_equals

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_auto_derive.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_auto_derive.snap
@@ -325,6 +325,9 @@ function json_auto_derive.BZeroFrom.from_json(j: baml.json.json) -> json_auto_de
 }
 
 function json_auto_derive.G.f(self: json_auto_derive.G) -> baml.json.json[] {
+    load_type void
+    load_type baml.json.json
+    load_type baml.json.JsonSerializationError | baml.json.JsonParseError
     load_var self
     load_field .items
     load_type #0
@@ -368,9 +371,6 @@ function json_auto_derive.SecretReset.from_json(j: baml.json.json) -> json_auto_
 function json_auto_derive.alias_chain_dispatch_from_json_val() -> int {
     load_const "{\"y\":7}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.BAliasFrom.from_json
     load_field .y
     return
@@ -422,9 +422,6 @@ function json_auto_derive.array_of_int_to_json_str() -> string {
 function json_auto_derive.array_of_primitive_from_json_sum() -> int {
     load_const "{\"xs\":[1,2,3]}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.C4.from_json
     store_var c
     load_var c
@@ -470,9 +467,6 @@ function json_auto_derive.float_to_json_result() -> baml.json.json {
 function json_auto_derive.from_json_wrapper_body_fallback_val() -> int {
     load_const "{\"value\":42}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.Holder.from_json
     load_field .value
     store_var_load_var _4
@@ -587,9 +581,6 @@ function json_auto_derive.independent_synthesis_only_from_json_result() -> strin
     call user.json_auto_derive.AOnlyFrom.to_json
     call baml.json.stringify
     call baml.json.parse
-    store_var _6
-    load_const null
-    load_var _6
     call user.json_auto_derive.AOnlyFrom.from_json
     load_field .b
     load_field .y
@@ -612,9 +603,6 @@ function json_auto_derive.independent_synthesis_only_from_json_result() -> strin
 function json_auto_derive.independent_synthesis_only_to_json_val() -> int {
     load_const "{\"b\":{\"y\":7}}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.AOnlyTo.from_json
     load_field .b
     load_field .y
@@ -641,9 +629,6 @@ function json_auto_derive.map_of_int_to_json_str() -> string {
 function json_auto_derive.map_of_primitive_from_json_sum() -> int {
     load_const "{\"lookup\":{\"a\":1,\"b\":2,\"c\":3}}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.C6.from_json
     store_var c
     load_var c
@@ -666,9 +651,6 @@ function json_auto_derive.map_of_primitive_from_json_sum() -> int {
 function json_auto_derive.nested_class_override_array_from_json_sum() -> int {
     load_const "{\"items\":[{\"y\":1},{\"y\":2}]}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.AItemsFrom.from_json
     store_var a
     load_var a
@@ -688,9 +670,6 @@ function json_auto_derive.nested_class_override_array_from_json_sum() -> int {
 function json_auto_derive.nested_class_override_direct_from_json_val() -> int {
     load_const "{\"b\":{\"y\":7}}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.AOverride.from_json
     load_field .b
     load_field .y
@@ -735,9 +714,6 @@ function json_auto_derive.nested_class_override_in_map_str() -> string {
 function json_auto_derive.nested_class_override_map_from_json_sum() -> int {
     load_const "{\"lookup\":{\"k1\":{\"v\":7},\"k2\":{\"v\":9}}}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.ALookupFrom.from_json
     store_var a
     load_var a
@@ -763,9 +739,6 @@ function json_auto_derive.null_to_json_result() -> baml.json.json {
 function json_auto_derive.optional_class_override_non_null_val() -> int {
     load_const "{\"b\":{\"y\":7}}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.AOptFrom.from_json
     load_field .b
     store_var_load_var _4
@@ -790,9 +763,6 @@ function json_auto_derive.optional_class_override_non_null_val() -> int {
 function json_auto_derive.optional_class_override_null_val() -> int {
     load_const "{\"b\":null}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.AOptFrom.from_json
     load_field .b
     store_var_load_var _4
@@ -817,16 +787,10 @@ function json_auto_derive.optional_class_override_null_val() -> int {
 function json_auto_derive.optional_primitive_field_from_json_sum() -> int {
     load_const "{\"x\":42}"
     call baml.json.parse
-    store_var j1
-    load_const null
-    load_var j1
     call user.json_auto_derive.C5.from_json
     store_var c1
     load_const "{\"x\":null}"
     call baml.json.parse
-    store_var j2
-    load_const null
-    load_var j2
     call user.json_auto_derive.C5.from_json
     store_var c2
     load_var c1
@@ -867,7 +831,7 @@ function json_auto_derive.optional_primitive_field_from_json_sum() -> int {
     store_var v2
 
   L5:
-    load_var2 5 7
+    load_var2 3 5
     add_int
     return
 }
@@ -875,9 +839,6 @@ function json_auto_derive.optional_primitive_field_from_json_sum() -> int {
 function json_auto_derive.primitive_field_from_json_val() -> int {
     load_const "{\"x\":42}"
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.C3.from_json
     load_field .x
     return
@@ -901,9 +862,6 @@ function json_auto_derive.recursive_class_from_json_sum() -> int {
     call user.json_auto_derive.Tree.to_json
     call baml.json.stringify
     call baml.json.parse
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.Tree.from_json
     store_var parsed
     load_var parsed
@@ -935,9 +893,6 @@ function json_auto_derive.round_trip_with_overrides_both_directions_val() -> str
     call user.json_auto_derive.SecretBoth.to_json
     call baml.json.stringify
     call baml.json.parse
-    store_var parsed_json
-    load_const null
-    load_var parsed_json
     call user.json_auto_derive.SecretBoth.from_json
     load_field .data
     return
@@ -948,9 +903,6 @@ function json_auto_derive.simple_class_to_json_roundtrip_name() -> string {
     load_const 30
     init_instance user.json_auto_derive.User .name, .age
     call user.json_auto_derive.User.to_json
-    store_var j
-    load_const null
-    load_var j
     call user.json_auto_derive.User.from_json
     load_field .name
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -268,6 +268,9 @@ function lambdas.lambdas_closure_in_map_with_captured_offset() -> int[] {
     store_var ?1
     load_const 10
     store_deref ?1
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
@@ -615,9 +618,12 @@ function lambdas.lambdas_multiple_closures_share_cell_deep_copy() -> int {
     store_deref ?1
     load_var x
     make_closure .<lambda(lambdas_multiple_closures_share_cell_deep_copy, 0)>, 1
-    store_var_load_var inc
+    store_var inc
+    load_type () -> int throws never
+    load_var inc
     call baml.deep_copy
     store_var inc2
+    load_type () -> int throws never
     load_var x
     make_closure .<lambda(lambdas_multiple_closures_share_cell_deep_copy, 1)>, 1
     call baml.deep_copy

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
@@ -726,7 +726,6 @@ function type_error_repro.bytecode_set_item(c: type_error_repro.BytecodeContaine
 }
 
 function type_error_repro.class_method_1d_array_write_through_self_body() -> string {
-    load_const null
     call user.type_error_repro.ContainerSelf.new
     store_var c
     load_var c
@@ -741,7 +740,6 @@ function type_error_repro.class_method_1d_array_write_through_self_body() -> str
 }
 
 function type_error_repro.class_method_2d_array_write_minimal_body() -> null {
-    load_const null
     call user.type_error_repro.BoardMinimal.new
     load_const "x"
     load_const 1
@@ -753,7 +751,6 @@ function type_error_repro.class_method_2d_array_write_minimal_body() -> null {
 }
 
 function type_error_repro.class_method_2d_array_write_through_self_literals_body() -> string {
-    load_const null
     call user.type_error_repro.GridSelf.new
     store_var g
     load_var g
@@ -770,7 +767,6 @@ function type_error_repro.class_method_2d_array_write_through_self_literals_body
 }
 
 function type_error_repro.class_method_3d_array_write_through_self_body() -> int {
-    load_const null
     call user.type_error_repro.Cube.new
     store_var c
     load_var c
@@ -789,7 +785,6 @@ function type_error_repro.class_method_3d_array_write_through_self_body() -> int
 }
 
 function type_error_repro.class_method_array_push_through_self_body() -> int {
-    load_const null
     call user.type_error_repro.Stack.new
     store_var s
     load_var s
@@ -802,7 +797,6 @@ function type_error_repro.class_method_array_push_through_self_body() -> int {
 }
 
 function type_error_repro.class_method_array_read_works_body() -> string {
-    load_const null
     call user.type_error_repro.BoardRead.new
     load_const 1
     load_const 2
@@ -811,7 +805,6 @@ function type_error_repro.class_method_array_read_works_body() -> string {
 }
 
 function type_error_repro.class_method_array_write_type_error_body() -> string {
-    load_const null
     call user.type_error_repro.BoardWrite.new
     store_var board
     load_var board
@@ -828,7 +821,6 @@ function type_error_repro.class_method_array_write_type_error_body() -> string {
 }
 
 function type_error_repro.class_method_map_then_array_write_through_self_body() -> int {
-    load_const null
     call user.type_error_repro.Registry.new
     store_var r
     load_var r
@@ -845,7 +837,6 @@ function type_error_repro.class_method_map_then_array_write_through_self_body() 
 }
 
 function type_error_repro.class_method_map_write_through_self_body() -> int {
-    load_const null
     call user.type_error_repro.ScoresSelf.new
     store_var s
     load_var s
@@ -860,7 +851,6 @@ function type_error_repro.class_method_map_write_through_self_body() -> int {
 }
 
 function type_error_repro.class_method_nested_field_array_write_body() -> string {
-    load_const null
     call user.type_error_repro.OuterItems.new
     store_var o
     load_var o

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_reflection.snap
@@ -100,6 +100,8 @@ function type_reflection.GetBar$parse(json: string, client: baml.llm.Client) -> 
     store_var client
 
   L0:
+    load_type void
+    load_type type_reflection.Bar
     load_const "GetBar"
     load_var json
     call baml.llm.parse
@@ -115,6 +117,8 @@ function type_reflection.GetBar$parse_stream(sse: baml.http.SseStream, client: b
     store_var client
 
   L0:
+    load_type null | type_reflection.Bar$stream
+    load_type type_reflection.Bar
     load_var2 2 1
     load_const "GetBar"
     call baml.llm.Client.__make_stream
@@ -146,6 +150,8 @@ function type_reflection.GetBar$stream(client: baml.llm.Client) -> baml.llm.Stre
     store_var client
 
   L0:
+    load_type null | type_reflection.Bar$stream
+    load_type type_reflection.Bar
     load_var client
     load_const "GetBar"
     alloc_map 0
@@ -211,6 +217,8 @@ function type_reflection.GetFoo$parse(json: string, client: baml.llm.Client) -> 
     store_var client
 
   L0:
+    load_type void
+    load_type type_reflection.Foo
     load_const "GetFoo"
     load_var json
     call baml.llm.parse
@@ -226,6 +234,8 @@ function type_reflection.GetFoo$parse_stream(sse: baml.http.SseStream, client: b
     store_var client
 
   L0:
+    load_type null | type_reflection.Foo$stream
+    load_type type_reflection.Foo
     load_var2 2 1
     load_const "GetFoo"
     call baml.llm.Client.__make_stream
@@ -257,6 +267,8 @@ function type_reflection.GetFoo$stream(client: baml.llm.Client) -> baml.llm.Stre
     store_var client
 
   L0:
+    load_type null | type_reflection.Foo$stream
+    load_type type_reflection.Foo
     load_var client
     load_const "GetFoo"
     alloc_map 0
@@ -294,6 +306,7 @@ function type_reflection.deep_equals_type_values_different_fn() -> bool {
     load_const "GetBar"
     sys_op baml.llm.get_return_type
     store_var b
+    load_type type
     load_var2 1 2
     call baml.deep_equals
     return
@@ -306,6 +319,7 @@ function type_reflection.deep_equals_type_values_same_fn() -> bool {
     load_const "GetFoo"
     sys_op baml.llm.get_return_type
     store_var b
+    load_type type
     load_var2 1 2
     call baml.deep_equals
     return

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -2797,7 +2797,7 @@ fn baml.llm.parse(function_name: string, json: string) -> void {
     bb2: {
         _6 = copy _3;
         _7 = copy _4;
-        _5 = sys_op const fn baml.llm.StreamCache.new(const null, copy _6, copy _7) -> bb3;
+        _5 = sys_op const fn baml.llm.StreamCache.new(copy _6, copy _7) -> bb3;
     }
 
     bb3: {
@@ -3096,7 +3096,7 @@ fn baml.llm.Client.__make_stream(self: baml.llm.Client, sse: baml.http.SseStream
     bb4: {
         _9 = copy _5;
         _10 = copy _6;
-        _8 = sys_op const fn baml.llm.StreamCache.new(const null, copy _9, copy _10) -> bb5;
+        _8 = sys_op const fn baml.llm.StreamCache.new(copy _9, copy _10) -> bb5;
     }
 
     bb5: {
@@ -7869,7 +7869,7 @@ fn baml.time.Instant.elapsed(self: baml.time.Instant) -> baml.time.Duration {
     let _5: bigint
 
     bb0: {
-        _4 = sys_op const fn baml.time.Instant.now(const null) -> bb1;
+        _4 = sys_op const fn baml.time.Instant.now() -> bb1;
     }
 
     bb1: {
@@ -7925,7 +7925,7 @@ fn baml.time.Instant.from_json(j: baml.json.json) -> baml.time.Instant {
     }
 
     bb2: {
-        _0 = call const fn baml.time.Instant.parse(const null, copy _1) -> [bb3, unwind: bb4];
+        _0 = call const fn baml.time.Instant.parse(copy _1) -> [bb3, unwind: bb4];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -2221,7 +2221,6 @@ function baml.llm.Client.__make_stream(self: baml.llm.Client, sse: baml.http.Sse
     load_var primitive
     sys_op baml.llm.PrimitiveClient.new_stream_accumulator
     store_var acc
-    load_const null
     load_var2 5 6
     sys_op baml.llm.StreamCache.new
     store_var cache
@@ -3936,7 +3935,6 @@ function baml.llm.parse(function_name: string, json: string) -> unknown {
     load_var function_name
     sys_op baml.llm.get_stream_return_type
     store_var stream_return_type
-    load_const null
     load_var2 3 4
     sys_op baml.llm.StreamCache.new
     store_var cache
@@ -4852,7 +4850,6 @@ function baml.time.Instant.abs_diff(self: baml.time.Instant, other: baml.time.In
 }
 
 function baml.time.Instant.elapsed(self: baml.time.Instant) -> baml.time.Duration {
-    load_const null
     sys_op baml.time.Instant.now
     store_var _4
     load_var _4
@@ -4883,7 +4880,6 @@ function baml.time.Instant.from_json(j: baml.json.json) -> baml.time.Instant {
     throw
 
   L1:
-    load_const null
     load_var j
     call baml.time.Instant.parse
     jump L4

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
@@ -595,10 +595,11 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
     let _30: string
     let _31: int
     let _32: int
-    let _33: int
-    let _34: (testing.TestRegistration[], testing.TestRegistration) -> int throws never
-    let _35: testing.TestRegistration
-    let _36: string
+    let _33: type
+    let _34: int
+    let _35: (testing.TestRegistration[], testing.TestRegistration) -> int throws never
+    let _36: testing.TestRegistration
+    let _37: string
 
     bb0: {
         _7 = copy _1.0;
@@ -649,7 +650,8 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
         _28 = copy _29 + const "#";
         _32 = copy _10;
         _31 = copy _32 + const 1_i64;
-        _30 = call const fn baml.unstable.string(copy _31) -> [bb8];
+        _33 = load_type(int);
+        _30 = call const fn baml.unstable.string<copy _33>(copy _31) -> [bb8];
     }
 
     bb8: {
@@ -658,10 +660,10 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
     }
 
     bb9: {
-        _34 = copy _1.1;
-        _36 = copy _25;
-        _35 = testing.TestRegistration { copy _36, copy _3, copy _4 };
-        _33 = call const fn baml.Array.push(copy _34, copy _35) -> [bb10];
+        _35 = copy _1.1;
+        _37 = copy _25;
+        _36 = testing.TestRegistration { copy _37, copy _3, copy _4 };
+        _34 = call const fn baml.Array.push(copy _35, copy _36) -> [bb10];
     }
 
     bb10: {
@@ -739,10 +741,11 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
     let _30: string
     let _31: int
     let _32: int
-    let _33: int
-    let _34: (testing.TestSetRegistration[], testing.TestSetRegistration) -> int throws never
-    let _35: testing.TestSetRegistration
-    let _36: string
+    let _33: type
+    let _34: int
+    let _35: (testing.TestSetRegistration[], testing.TestSetRegistration) -> int throws never
+    let _36: testing.TestSetRegistration
+    let _37: string
 
     bb0: {
         _7 = copy _1.0;
@@ -793,7 +796,8 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
         _28 = copy _29 + const "#";
         _32 = copy _10;
         _31 = copy _32 + const 1_i64;
-        _30 = call const fn baml.unstable.string(copy _31) -> [bb8];
+        _33 = load_type(int);
+        _30 = call const fn baml.unstable.string<copy _33>(copy _31) -> [bb8];
     }
 
     bb8: {
@@ -802,10 +806,10 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
     }
 
     bb9: {
-        _34 = copy _1.2;
-        _36 = copy _25;
-        _35 = testing.TestSetRegistration { copy _36, copy _3, copy _4 };
-        _33 = call const fn baml.Array.push(copy _34, copy _35) -> [bb10];
+        _35 = copy _1.2;
+        _37 = copy _25;
+        _36 = testing.TestSetRegistration { copy _37, copy _3, copy _4 };
+        _34 = call const fn baml.Array.push(copy _35, copy _36) -> [bb10];
     }
 
     bb10: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
@@ -251,6 +251,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     load_const "#"
     bin_op +
     store_var _28
+    load_type int
     load_var count
     load_const 1
     add_int
@@ -362,6 +363,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     load_const "#"
     bin_op +
     store_var _28
+    load_type int
     load_var count
     load_const 1
     add_int

--- a/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__04_5_mir.snap
@@ -23,9 +23,15 @@ fn user.apply_to_each(items: Employee[], f: (Employee) -> string throws never) -
     let _0: string[] // _0 // return
     let _1: Employee[] // items // param
     let _2: (Employee) -> string throws never // f // param
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(string);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
@@ -474,13 +480,19 @@ fn user.test_bound_mapper() -> string[] {
     let _2: (string) -> string throws never // transform
     let _3: string[]
     let _4: (string) -> string throws never
+    let _5: type
+    let _6: type
+    let _7: type
 
     bb0: {
         _1 = user.Formatter { const ">> " };
         _2 = make_bound_method user.Formatter.format(copy _1);
         _3 = [const "hello", const "world"];
         _4 = copy _2;
-        _0 = call const fn baml.Array.map(copy _3, copy _4) -> [bb1];
+        _5 = load_type(void);
+        _6 = load_type(string);
+        _7 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _5, copy _6, copy _7>(copy _3, copy _4) -> [bb1];
     }
 
     bb1: {
@@ -495,13 +507,19 @@ fn user.test_bound_validator() -> bool[] {
     let _2: (int) -> bool throws never // check
     let _3: int[]
     let _4: (int) -> bool throws never
+    let _5: type
+    let _6: type
+    let _7: type
 
     bb0: {
         _1 = user.RangeCheck { const 10_i64, const 50_i64 };
         _2 = make_bound_method user.RangeCheck.is_valid(copy _1);
         _3 = [const 5_i64, const 15_i64, const 25_i64, const 75_i64];
         _4 = copy _2;
-        _0 = call const fn baml.Array.map(copy _3, copy _4) -> [bb1];
+        _5 = load_type(void);
+        _6 = load_type(bool);
+        _7 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _5, copy _6, copy _7>(copy _3, copy _4) -> [bb1];
     }
 
     bb1: {
@@ -662,12 +680,18 @@ fn user.test_unbound_in_map() -> string[] {
     let _1: Employee[] // employees
     let _2: Employee
     let _3: Employee
+    let _4: type
+    let _5: type
+    let _6: type
 
     bb0: {
         _2 = user.Employee { const "Alice", const "Smith" };
         _3 = user.Employee { const "Bob", const "Jones" };
         _1 = [copy _2, copy _3];
-        _0 = call const fn baml.Array.map(copy _1, const fn user.Employee.full_name) -> [bb1];
+        _4 = load_type(void);
+        _5 = load_type(string);
+        _6 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _4, copy _5, copy _6>(copy _1, const fn user.Employee.full_name) -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__06_codegen.snap
@@ -294,6 +294,9 @@ function user.apply(f: (int, int) -> int throws never, a: int, b: int) -> int {
 }
 
 function user.apply_to_each(items: Employee[], f: (Employee) -> string throws never) -> string[] {
+    load_type void
+    load_type string
+    load_type void
     load_var2 1 2
     call baml.Array.map
     return
@@ -318,6 +321,9 @@ function user.test_bound_in_lambda() -> string {
 }
 
 function user.test_bound_mapper() -> string[] {
+    load_type void
+    load_type string
+    load_type void
     load_const "hello"
     load_const "world"
     alloc_array 2
@@ -329,6 +335,9 @@ function user.test_bound_mapper() -> string[] {
 }
 
 function user.test_bound_validator() -> bool[] {
+    load_type void
+    load_type bool
+    load_type void
     load_const 5
     load_const 15
     load_const 25
@@ -421,6 +430,9 @@ function user.test_unbound_higher_order() -> string[] {
 }
 
 function user.test_unbound_in_map() -> string[] {
+    load_type void
+    load_type string
+    load_type void
     load_const "Alice"
     load_const "Smith"
     init_instance user.Employee .first, .last

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__04_5_mir.snap
@@ -91,6 +91,8 @@ fn user.CommentAfterArrow$parse(json: string, client: baml.llm.Client) -> string
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -103,7 +105,9 @@ fn user.CommentAfterArrow$parse(json: string, client: baml.llm.Client) -> string
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "CommentAfterArrow", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(string);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "CommentAfterArrow", copy _1) -> [bb3];
     }
 
     bb3: {
@@ -233,6 +237,8 @@ fn user.FunctionWithComments$parse(json: string, client: baml.llm.Client) -> str
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -245,7 +251,9 @@ fn user.FunctionWithComments$parse(json: string, client: baml.llm.Client) -> str
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "FunctionWithComments", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(string);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "FunctionWithComments", copy _1) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__06_codegen.snap
@@ -66,6 +66,8 @@ function user.CommentAfterArrow$parse(json: string, client: baml.llm.Client) -> 
     store_var client
 
   L0:
+    load_type void
+    load_type string
     load_const "CommentAfterArrow"
     load_var json
     call baml.llm.parse
@@ -81,6 +83,8 @@ function user.CommentAfterArrow$parse_stream(sse: baml.http.SseStream, client: b
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var2 2 1
     load_const "CommentAfterArrow"
     call baml.llm.Client.__make_stream
@@ -112,6 +116,8 @@ function user.CommentAfterArrow$stream(client: baml.llm.Client) -> baml.llm.Stre
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var client
     load_const "CommentAfterArrow"
     alloc_map 0
@@ -186,6 +192,8 @@ function user.FunctionWithComments$parse(json: string, client: baml.llm.Client) 
     store_var client
 
   L0:
+    load_type void
+    load_type string
     load_const "FunctionWithComments"
     load_var json
     call baml.llm.parse
@@ -201,6 +209,8 @@ function user.FunctionWithComments$parse_stream(sse: baml.http.SseStream, client
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var2 2 1
     load_const "FunctionWithComments"
     call baml.llm.Client.__make_stream
@@ -235,6 +245,8 @@ function user.FunctionWithComments$stream(a: string, b: int, client: baml.llm.Cl
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var client
     load_const "FunctionWithComments"
     load_var2 1 2

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__04_5_mir.snap
@@ -91,6 +91,8 @@ fn user.ExtractAny$parse(json: string, client: baml.llm.Client) -> baml.json.jso
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -103,7 +105,9 @@ fn user.ExtractAny$parse(json: string, client: baml.llm.Client) -> baml.json.jso
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "ExtractAny", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(baml.json.json);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "ExtractAny", copy _1) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__06_codegen.snap
@@ -66,6 +66,8 @@ function user.ExtractAny$parse(json: string, client: baml.llm.Client) -> baml.js
     store_var client
 
   L0:
+    load_type void
+    load_type baml.json.json
     load_const "ExtractAny"
     load_var json
     call baml.llm.parse
@@ -81,6 +83,8 @@ function user.ExtractAny$parse_stream(sse: baml.http.SseStream, client: baml.llm
     store_var client
 
   L0:
+    load_type null | baml.json.json$stream
+    load_type baml.json.json
     load_var2 2 1
     load_const "ExtractAny"
     call baml.llm.Client.__make_stream
@@ -112,6 +116,8 @@ function user.ExtractAny$stream(client: baml.llm.Client) -> baml.llm.Stream<null
     store_var client
 
   L0:
+    load_type null | baml.json.json$stream
+    load_type baml.json.json
     load_var client
     load_const "ExtractAny"
     alloc_map 0

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__04_5_mir.snap
@@ -66,12 +66,18 @@ fn user.test_capture_in_map_inferred() -> int[] {
     let _1: int[] // items
     let _2: int // factor [captured]
     let _3: (int) -> int throws never
+    let _4: type
+    let _5: type
+    let _6: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = const 10_i64;
         _3 = make_closure lambda[0](copy _2);
-        _0 = call const fn baml.Array.map(copy _1, copy _3) -> [bb1];
+        _4 = load_type(void);
+        _5 = load_type(int);
+        _6 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _4, copy _5, copy _6>(copy _1, copy _3) -> [bb1];
     }
 
     bb1: {
@@ -156,17 +162,29 @@ fn user.test_chained_map() -> int[] {
     let _1: int[] // items
     let _2: int[] // step1
     let _3: (int) -> int throws never
-    let _4: (int) -> int throws never
+    let _4: type
+    let _5: type
+    let _6: type
+    let _7: (int) -> int throws never
+    let _8: type
+    let _9: type
+    let _10: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _3 = make_closure lambda[0]();
-        _2 = call const fn baml.Array.map(copy _1, copy _3) -> [bb1];
+        _4 = load_type(void);
+        _5 = load_type(int);
+        _6 = load_type(void);
+        _2 = call const fn baml.Array.map<copy _4, copy _5, copy _6>(copy _1, copy _3) -> [bb1];
     }
 
     bb1: {
-        _4 = make_closure lambda[1]();
-        _0 = call const fn baml.Array.map(copy _2, copy _4) -> [bb2];
+        _7 = make_closure lambda[1]();
+        _8 = load_type(void);
+        _9 = load_type(int);
+        _10 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _8, copy _9, copy _10>(copy _2, copy _7) -> [bb2];
     }
 
     bb2: {
@@ -212,17 +230,29 @@ fn user.test_compose_inferred() -> int[] {
     let _1: int[] // items
     let _2: int[] // step1
     let _3: (int) -> int throws never
-    let _4: (int) -> int throws never
+    let _4: type
+    let _5: type
+    let _6: type
+    let _7: (int) -> int throws never
+    let _8: type
+    let _9: type
+    let _10: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _3 = make_closure lambda[0]();
-        _2 = call const fn baml.Array.map(copy _1, copy _3) -> [bb1];
+        _4 = load_type(void);
+        _5 = load_type(int);
+        _6 = load_type(void);
+        _2 = call const fn baml.Array.map<copy _4, copy _5, copy _6>(copy _1, copy _3) -> [bb1];
     }
 
     bb1: {
-        _4 = make_closure lambda[1]();
-        _0 = call const fn baml.Array.map(copy _2, copy _4) -> [bb2];
+        _7 = make_closure lambda[1]();
+        _8 = load_type(void);
+        _9 = load_type(int);
+        _10 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _8, copy _9, copy _10>(copy _2, copy _7) -> [bb2];
     }
 
     bb2: {
@@ -387,11 +417,17 @@ fn user.test_fully_inferred_map() -> int[] {
     let _0: int[] // _0 // return
     let _1: int[] // items
     let _2: (int) -> int throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(int);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
@@ -857,12 +893,18 @@ fn user.test_lambda_variable_then_pass() -> int[] {
     let _1: int[] // items
     let _2: (int) -> int throws never // halve
     let _3: (int) -> int throws never
+    let _4: type
+    let _5: type
+    let _6: type
 
     bb0: {
         _1 = [const 10_i64, const 20_i64, const 30_i64];
         _2 = make_closure lambda[0]();
         _3 = copy _2;
-        _0 = call const fn baml.Array.map(copy _1, copy _3) -> [bb1];
+        _4 = load_type(void);
+        _5 = load_type(int);
+        _6 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _4, copy _5, copy _6>(copy _1, copy _3) -> [bb1];
     }
 
     bb1: {
@@ -993,11 +1035,17 @@ fn user.test_literal_return_inference() -> int[] {
     let _0: int[] // _0 // return
     let _1: int[] // items
     let _2: (int) -> int throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(int);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
@@ -1026,11 +1074,17 @@ fn user.test_map_multi_statement() -> int[] {
     let _0: int[] // _0 // return
     let _1: int[] // items
     let _2: (int) -> int throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(int);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
@@ -1067,11 +1121,17 @@ fn user.test_map_optional_inferred() -> int[] {
     let _0: int[] // _0 // return
     let _1: int?[] // items
     let _2: (int?) -> int throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _1 = [const 1_i64, const null, const 3_i64];
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(int);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
@@ -1111,11 +1171,17 @@ fn user.test_map_string_to_int() -> int[] {
     let _0: int[] // _0 // return
     let _1: string[] // words
     let _2: (string) -> int throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _1 = [const "hello", const "world"];
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(int);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
@@ -1143,11 +1209,17 @@ fn user.test_map_type_change_inferred() -> string[] {
     let _0: string[] // _0 // return
     let _1: int[] // nums
     let _2: (int) -> string throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(string);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
@@ -1191,12 +1263,18 @@ fn user.test_map_with_capture() -> int[] {
     let _1: int[] // items
     let _2: int // factor [captured]
     let _3: (int) -> int throws never
+    let _4: type
+    let _5: type
+    let _6: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = const 10_i64;
         _3 = make_closure lambda[0](copy _2);
-        _0 = call const fn baml.Array.map(copy _1, copy _3) -> [bb1];
+        _4 = load_type(void);
+        _5 = load_type(int);
+        _6 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _4, copy _5, copy _6>(copy _1, copy _3) -> [bb1];
     }
 
     bb1: {
@@ -1229,13 +1307,19 @@ fn user.test_nested_map() -> int[][] {
     let _2: int[]
     let _3: int[]
     let _4: (int[]) -> int[] throws never
+    let _5: type
+    let _6: type
+    let _7: type
 
     bb0: {
         _2 = [const 1_i64, const 2_i64];
         _3 = [const 3_i64, const 4_i64];
         _1 = [copy _2, copy _3];
         _4 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _4) -> [bb1];
+        _5 = load_type(void);
+        _6 = load_type(int[]);
+        _7 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _5, copy _6, copy _7>(copy _1, copy _4) -> [bb1];
     }
 
     bb1: {
@@ -1249,10 +1333,16 @@ fn .<lambda(test_nested_map, 0)>(row: int[]) -> null {
     let _0: null // _0 // return
     let _1: int[] // row // param
     let _2: (int) -> int throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(int);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
@@ -1327,34 +1417,40 @@ fn user.test_shadowing() -> string {
     let _2: int[] // items
     let _3: int[] // mapped
     let _4: (int) -> int throws never
-    let _5: int[]
-    let _6: int // __for_idx
-    let _7: int
-    let _8: bool
-    let _9: int
-    let _10: int // y
-    let _11: int // i
-    let _12: bool
-    let _13: int
-    let _14: int
+    let _5: type
+    let _6: type
+    let _7: type
+    let _8: int[]
+    let _9: int // __for_idx
+    let _10: int
+    let _11: bool
+    let _12: int
+    let _13: int // y
+    let _14: int // i
+    let _15: bool
+    let _16: int
+    let _17: int
 
     bb0: {
         _1 = const "999";
         _2 = [const 1_i64, const 2_i64, const 3_i64];
         _4 = make_closure lambda[0]();
-        _3 = call const fn baml.Array.map(copy _2, copy _4) -> [bb1];
+        _5 = load_type(void);
+        _6 = load_type(int);
+        _7 = load_type(void);
+        _3 = call const fn baml.Array.map<copy _5, copy _6, copy _7>(copy _2, copy _4) -> [bb1];
     }
 
     bb1: {
-        _5 = copy _3;
-        _6 = const 0_i64;
+        _8 = copy _3;
+        _9 = const 0_i64;
         goto -> bb2;
     }
 
     bb2: {
-        _7 = len(_5);
-        _8 = copy _6 < copy _7;
-        branch copy _8 -> [bb5, bb3];
+        _10 = len(_8);
+        _11 = copy _9 < copy _10;
+        branch copy _11 -> [bb5, bb3];
     }
 
     bb3: {
@@ -1367,28 +1463,28 @@ fn user.test_shadowing() -> string {
     }
 
     bb5: {
-        _9 = copy _5[_6];
-        fresh_cell(_10);
-        _10 = copy _9;
-        _11 = const 0_i64;
+        _12 = copy _8[_9];
+        fresh_cell(_13);
+        _13 = copy _12;
+        _14 = const 0_i64;
         goto -> bb6;
     }
 
     bb6: {
-        _13 = copy _11;
-        _14 = copy _10;
-        _12 = copy _13 < copy _14;
-        branch copy _12 -> [bb8, bb7];
+        _16 = copy _14;
+        _17 = copy _13;
+        _15 = copy _16 < copy _17;
+        branch copy _15 -> [bb8, bb7];
     }
 
     bb7: {
-        _6 = copy _6 + const 1_i64;
+        _9 = copy _9 + const 1_i64;
         goto -> bb2;
     }
 
     bb8: {
         _1 = copy _1 + const "1";
-        _11 = copy _11 + const 1_i64;
+        _14 = copy _14 + const 1_i64;
         goto -> bb6;
     }
 }
@@ -1414,11 +1510,17 @@ fn user.test_shadowing_inferred() -> int[] {
     let _0: int[] // _0 // return
     let _1: int[] // items
     let _2: (int) -> int throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(int);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
@@ -15,6 +15,9 @@ function user.test_capture_in_map_inferred() -> int[] {
     store_var ?1
     load_const 10
     store_deref ?1
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
@@ -39,24 +42,40 @@ function user.test_capture_lambda_inferred() -> int {
 }
 
 function user.test_chained_map() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
     make_closure .<lambda(test_chained_map, 0)>, 0
     call baml.Array.map
+    store_var step1
+    load_type void
+    load_type int
+    load_type void
+    load_var step1
     make_closure .<lambda(test_chained_map, 1)>, 0
     call baml.Array.map
     return
 }
 
 function user.test_compose_inferred() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
     make_closure .<lambda(test_compose_inferred, 0)>, 0
     call baml.Array.map
+    store_var step1
+    load_type void
+    load_type int
+    load_type void
+    load_var step1
     make_closure .<lambda(test_compose_inferred, 1)>, 0
     call baml.Array.map
     return
@@ -89,6 +108,9 @@ function user.test_deep_capture_inferred() -> int {
 }
 
 function user.test_fully_inferred_map() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
@@ -201,6 +223,9 @@ function user.test_lambda_in_match_inferred() -> int {
 }
 
 function user.test_lambda_variable_then_pass() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 10
     load_const 20
     load_const 30
@@ -225,6 +250,9 @@ function user.test_lambda_with_match() -> string {
 }
 
 function user.test_literal_return_inference() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
@@ -235,6 +263,9 @@ function user.test_literal_return_inference() -> int[] {
 }
 
 function user.test_map_multi_statement() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
@@ -245,6 +276,9 @@ function user.test_map_multi_statement() -> int[] {
 }
 
 function user.test_map_optional_inferred() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const null
     load_const 3
@@ -255,6 +289,9 @@ function user.test_map_optional_inferred() -> int[] {
 }
 
 function user.test_map_string_to_int() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const "hello"
     load_const "world"
     alloc_array 2
@@ -264,6 +301,9 @@ function user.test_map_string_to_int() -> int[] {
 }
 
 function user.test_map_type_change_inferred() -> string[] {
+    load_type void
+    load_type string
+    load_type void
     load_const 1
     load_const 2
     load_const 3
@@ -279,6 +319,9 @@ function user.test_map_with_capture() -> int[] {
     store_var ?1
     load_const 10
     store_deref ?1
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
@@ -290,6 +333,9 @@ function user.test_map_with_capture() -> int[] {
 }
 
 function user.test_nested_map() -> int[][] {
+    load_type void
+    load_type int[]
+    load_type void
     load_const 1
     load_const 2
     alloc_array 2
@@ -312,13 +358,16 @@ function user.test_optional_return() -> int? {
 function user.test_shadowing() -> string {
     load_const "999"
     store_var x
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
     make_closure .<lambda(test_shadowing, 0)>, 0
     call baml.Array.map
-    store_var _5
+    store_var _8
     load_const 0
     store_var __for_idx
 
@@ -366,6 +415,9 @@ function user.test_shadowing() -> string {
 }
 
 function user.test_shadowing_inferred() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__04_5_mir.snap
@@ -143,11 +143,17 @@ fn user.test_map_inferred() -> int[] {
     let _0: int[] // _0 // return
     let _1: int[] // items
     let _2: (int) -> int throws never
+    let _3: type
+    let _4: type
+    let _5: type
 
     bb0: {
         _1 = [const 1_i64, const 2_i64, const 3_i64];
         _2 = make_closure lambda[0]();
-        _0 = call const fn baml.Array.map(copy _1, copy _2) -> [bb1];
+        _3 = load_type(void);
+        _4 = load_type(int);
+        _5 = load_type(void);
+        _0 = call const fn baml.Array.map<copy _3, copy _4, copy _5>(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__06_codegen.snap
@@ -36,6 +36,9 @@ function user.test_inferred_return() -> int {
 }
 
 function user.test_map_inferred() -> int[] {
+    load_type void
+    load_type int
+    load_type void
     load_const 1
     load_const 2
     load_const 3

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__04_5_mir.snap
@@ -94,6 +94,8 @@ fn user.GenerateImage$parse(json: string, client: baml.llm.Client) -> image {
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -106,7 +108,9 @@ fn user.GenerateImage$parse(json: string, client: baml.llm.Client) -> image {
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "GenerateImage", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(image);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "GenerateImage", copy _1) -> [bb3];
     }
 
     bb3: {
@@ -234,6 +238,8 @@ fn user.GenerateImageSet$parse(json: string, client: baml.llm.Client) -> image[]
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -246,7 +252,9 @@ fn user.GenerateImageSet$parse(json: string, client: baml.llm.Client) -> image[]
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "GenerateImageSet", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(image[]);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "GenerateImageSet", copy _1) -> [bb3];
     }
 
     bb3: {
@@ -374,6 +382,8 @@ fn user.GenerateMixedImageNarrative$parse(json: string, client: baml.llm.Client)
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -386,7 +396,9 @@ fn user.GenerateMixedImageNarrative$parse(json: string, client: baml.llm.Client)
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "GenerateMixedImageNarrative", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(image | string[]);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "GenerateMixedImageNarrative", copy _1) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__06_codegen.snap
@@ -72,6 +72,8 @@ function user.GenerateImage$parse(json: string, client: baml.llm.Client) -> imag
     store_var client
 
   L0:
+    load_type void
+    load_type image
     load_const "GenerateImage"
     load_var json
     call baml.llm.parse
@@ -87,6 +89,8 @@ function user.GenerateImage$parse_stream(sse: baml.http.SseStream, client: baml.
     store_var client
 
   L0:
+    load_type image
+    load_type image
     load_var2 2 1
     load_const "GenerateImage"
     call baml.llm.Client.__make_stream
@@ -120,6 +124,8 @@ function user.GenerateImage$stream(prompt: string, client: baml.llm.Client) -> b
     store_var client
 
   L0:
+    load_type image
+    load_type image
     load_var client
     load_const "GenerateImage"
     load_var prompt
@@ -193,6 +199,8 @@ function user.GenerateImageSet$parse(json: string, client: baml.llm.Client) -> i
     store_var client
 
   L0:
+    load_type void
+    load_type image[]
     load_const "GenerateImageSet"
     load_var json
     call baml.llm.parse
@@ -208,6 +216,8 @@ function user.GenerateImageSet$parse_stream(sse: baml.http.SseStream, client: ba
     store_var client
 
   L0:
+    load_type image[]
+    load_type image[]
     load_var2 2 1
     load_const "GenerateImageSet"
     call baml.llm.Client.__make_stream
@@ -241,6 +251,8 @@ function user.GenerateImageSet$stream(prompt: string, client: baml.llm.Client) -
     store_var client
 
   L0:
+    load_type image[]
+    load_type image[]
     load_var client
     load_const "GenerateImageSet"
     load_var prompt
@@ -314,6 +326,8 @@ function user.GenerateMixedImageNarrative$parse(json: string, client: baml.llm.C
     store_var client
 
   L0:
+    load_type void
+    load_type image | string[]
     load_const "GenerateMixedImageNarrative"
     load_var json
     call baml.llm.parse
@@ -329,6 +343,8 @@ function user.GenerateMixedImageNarrative$parse_stream(sse: baml.http.SseStream,
     store_var client
 
   L0:
+    load_type image | string[]
+    load_type image | string[]
     load_var2 2 1
     load_const "GenerateMixedImageNarrative"
     call baml.llm.Client.__make_stream
@@ -362,6 +378,8 @@ function user.GenerateMixedImageNarrative$stream(prompt: string, client: baml.ll
     store_var client
 
   L0:
+    load_type image | string[]
+    load_type image | string[]
     load_var client
     load_const "GenerateMixedImageNarrative"
     load_var prompt

--- a/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__04_5_mir.snap
@@ -163,6 +163,8 @@ fn user.AskDocs$parse(json: string, client: baml.llm.Client) -> string {
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -175,7 +177,9 @@ fn user.AskDocs$parse(json: string, client: baml.llm.Client) -> string {
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "AskDocs", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(string);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "AskDocs", copy _1) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__06_codegen.snap
@@ -129,6 +129,8 @@ function user.AskDocs$parse(json: string, client: baml.llm.Client) -> string {
     store_var client
 
   L0:
+    load_type void
+    load_type string
     load_const "AskDocs"
     load_var json
     call baml.llm.parse
@@ -144,6 +146,8 @@ function user.AskDocs$parse_stream(sse: baml.http.SseStream, client: baml.llm.Cl
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var2 2 1
     load_const "AskDocs"
     call baml.llm.Client.__make_stream
@@ -212,6 +216,8 @@ function user.AskDocs$stream(query: string, max_results: int, filter: string, cl
     store_var client
 
   L2:
+    load_type null | string
+    load_type string
     load_var client
     load_const "AskDocs"
     load_var2 1 2

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__04_5_mir.snap
@@ -116,6 +116,8 @@ fn user.TestFunc$parse(json: string, client: baml.llm.Client) -> string {
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -128,7 +130,9 @@ fn user.TestFunc$parse(json: string, client: baml.llm.Client) -> string {
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "TestFunc", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(string);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "TestFunc", copy _1) -> [bb3];
     }
 
     bb3: {
@@ -168,10 +172,14 @@ fn user.call_stream_inferred() -> baml.llm.Stream<null | string, string> {
     // Locals:
     let _0: baml.llm.Stream<null | string, string> // _0 // return
     let _1: map<string, unknown>
+    let _2: type
+    let _3: type
 
     bb0: {
         _1 = { const "input": const "world" };
-        _0 = call const fn baml.llm.stream_llm_function(const fn user.TestClient, const "TestFunc", copy _1) -> [bb1];
+        _2 = load_type(null | string);
+        _3 = load_type(string);
+        _0 = call const fn baml.llm.stream_llm_function<copy _2, copy _3>(const fn user.TestClient, const "TestFunc", copy _1) -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__06_codegen.snap
@@ -95,6 +95,8 @@ function user.TestFunc$parse(json: string, client: baml.llm.Client) -> string {
     store_var client
 
   L0:
+    load_type void
+    load_type string
     load_const "TestFunc"
     load_var json
     call baml.llm.parse
@@ -110,6 +112,8 @@ function user.TestFunc$parse_stream(sse: baml.http.SseStream, client: baml.llm.C
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var2 2 1
     load_const "TestFunc"
     call baml.llm.Client.__make_stream
@@ -143,6 +147,8 @@ function user.TestFunc$stream(input: string, client: baml.llm.Client) -> baml.ll
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var client
     load_const "TestFunc"
     load_var input
@@ -153,6 +159,8 @@ function user.TestFunc$stream(input: string, client: baml.llm.Client) -> baml.ll
 }
 
 function user.call_stream_inferred() -> baml.llm.Stream<null | string, string> {
+    load_type null | string
+    load_type string
     load_global user.TestClient
     load_const "TestFunc"
     load_const "world"

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
@@ -413,6 +413,8 @@ fn user.ClassifySentiment$parse(json: string, client: baml.llm.Client) -> Sentim
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -425,7 +427,9 @@ fn user.ClassifySentiment$parse(json: string, client: baml.llm.Client) -> Sentim
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "ClassifySentiment", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(Sentiment);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "ClassifySentiment", copy _1) -> [bb3];
     }
 
     bb3: {
@@ -553,6 +557,8 @@ fn user.ClassifySentiment2$parse(json: string, client: baml.llm.Client) -> strin
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -565,7 +571,9 @@ fn user.ClassifySentiment2$parse(json: string, client: baml.llm.Client) -> strin
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "ClassifySentiment2", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(string);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "ClassifySentiment2", copy _1) -> [bb3];
     }
 
     bb3: {
@@ -769,6 +777,8 @@ fn user.GenerateTests$parse(json: string, client: baml.llm.Client) -> string[] {
     let _1: string // json // param
     let _2: baml.llm.Client // client // param
     let _3: bool
+    let _4: type
+    let _5: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -781,7 +791,9 @@ fn user.GenerateTests$parse(json: string, client: baml.llm.Client) -> string[] {
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "GenerateTests", copy _1) -> [bb3];
+        _4 = load_type(void);
+        _5 = load_type(string[]);
+        _0 = call const fn baml.llm.parse<copy _4, copy _5>(const "GenerateTests", copy _1) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
@@ -91,6 +91,8 @@ function user.ClassifySentiment$parse(json: string, client: baml.llm.Client) -> 
     store_var client
 
   L0:
+    load_type void
+    load_type Sentiment
     load_const "ClassifySentiment"
     load_var json
     call baml.llm.parse
@@ -106,6 +108,8 @@ function user.ClassifySentiment$parse_stream(sse: baml.http.SseStream, client: b
     store_var client
 
   L0:
+    load_type null | Sentiment$stream
+    load_type Sentiment
     load_var2 2 1
     load_const "ClassifySentiment"
     call baml.llm.Client.__make_stream
@@ -139,6 +143,8 @@ function user.ClassifySentiment$stream(text: string, client: baml.llm.Client) ->
     store_var client
 
   L0:
+    load_type null | Sentiment$stream
+    load_type Sentiment
     load_var client
     load_const "ClassifySentiment"
     load_var text
@@ -212,6 +218,8 @@ function user.ClassifySentiment2$parse(json: string, client: baml.llm.Client) ->
     store_var client
 
   L0:
+    load_type void
+    load_type string
     load_const "ClassifySentiment2"
     load_var json
     call baml.llm.parse
@@ -227,6 +235,8 @@ function user.ClassifySentiment2$parse_stream(sse: baml.http.SseStream, client: 
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var2 2 1
     load_const "ClassifySentiment2"
     call baml.llm.Client.__make_stream
@@ -260,6 +270,8 @@ function user.ClassifySentiment2$stream(text: string, client: baml.llm.Client) -
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var client
     load_const "ClassifySentiment2"
     load_var text
@@ -391,6 +403,8 @@ function user.GenerateTests$parse(json: string, client: baml.llm.Client) -> stri
     store_var client
 
   L0:
+    load_type void
+    load_type string[]
     load_const "GenerateTests"
     load_var json
     call baml.llm.parse
@@ -406,6 +420,8 @@ function user.GenerateTests$parse_stream(sse: baml.http.SseStream, client: baml.
     store_var client
 
   L0:
+    load_type string[]
+    load_type string[]
     load_var2 2 1
     load_const "GenerateTests"
     call baml.llm.Client.__make_stream
@@ -440,6 +456,8 @@ function user.GenerateTests$stream(count: int, topic: string, client: baml.llm.C
     store_var client
 
   L0:
+    load_type string[]
+    load_type string[]
     load_var client
     load_const "GenerateTests"
     load_var2 1 2

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__04_5_mir.snap
@@ -101,6 +101,8 @@ fn user.TypeBuilderFn$parse(json: string, client: baml.llm.Client) -> Resume {
     let _2: baml.llm.Client // client // param
     let _3: bool
     let _4: baml.llm.Client[]
+    let _5: type
+    let _6: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -114,7 +116,9 @@ fn user.TypeBuilderFn$parse(json: string, client: baml.llm.Client) -> Resume {
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "TypeBuilderFn", copy _1) -> [bb3];
+        _5 = load_type(void);
+        _6 = load_type(Resume);
+        _0 = call const fn baml.llm.parse<copy _5, copy _6>(const "TypeBuilderFn", copy _1) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_errors/baml_tests__compiles__type_builder_errors__06_codegen.snap
@@ -110,6 +110,8 @@ function user.TypeBuilderFn$parse(json: string, client: baml.llm.Client) -> Resu
     store_var client
 
   L0:
+    load_type void
+    load_type Resume
     load_const "TypeBuilderFn"
     load_var json
     call baml.llm.parse
@@ -131,6 +133,8 @@ function user.TypeBuilderFn$parse_stream(sse: baml.http.SseStream, client: baml.
     store_var client
 
   L0:
+    load_type null | Resume$stream
+    load_type Resume
     load_var2 2 1
     load_const "TypeBuilderFn"
     call baml.llm.Client.__make_stream
@@ -176,6 +180,8 @@ function user.TypeBuilderFn$stream(from_text: string, client: baml.llm.Client) -
     store_var client
 
   L0:
+    load_type null | Resume$stream
+    load_type Resume
     load_var client
     load_const "TypeBuilderFn"
     load_var from_text

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__04_5_mir.snap
@@ -98,6 +98,8 @@ fn user.Fn$parse(json: string, client: baml.llm.Client) -> string {
     let _2: baml.llm.Client // client // param
     let _3: bool
     let _4: baml.llm.Client[]
+    let _5: type
+    let _6: type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -111,7 +113,9 @@ fn user.Fn$parse(json: string, client: baml.llm.Client) -> string {
     }
 
     bb2: {
-        _0 = call const fn baml.llm.parse(const "Fn", copy _1) -> [bb3];
+        _5 = load_type(void);
+        _6 = load_type(string);
+        _0 = call const fn baml.llm.parse<copy _5, copy _6>(const "Fn", copy _1) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_builder_test/baml_tests__compiles__type_builder_test__06_codegen.snap
@@ -83,6 +83,8 @@ function user.Fn$parse(json: string, client: baml.llm.Client) -> string {
     store_var client
 
   L0:
+    load_type void
+    load_type string
     load_const "Fn"
     load_var json
     call baml.llm.parse
@@ -104,6 +106,8 @@ function user.Fn$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client)
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var2 2 1
     load_const "Fn"
     call baml.llm.Client.__make_stream
@@ -147,6 +151,8 @@ function user.Fn$stream(client: baml.llm.Client) -> baml.llm.Stream<null | strin
     store_var client
 
   L0:
+    load_type null | string
+    load_type string
     load_var client
     load_const "Fn"
     alloc_map 0

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -284,7 +284,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        28   container_len           
        29   cmp_int_op <            
        30   pop_jump_if_false +2    (to 32)
-       31   jump +30                (to 61)
+       31   jump +31                (to 62)
 
   45   32   load_var 6              (count)
        33   load_const 2            (0)
@@ -293,56 +293,57 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        36   jump +4                 (to 40)
        37   load_var 5              (full_name)
        38   store_var 11            (final_name)
-       39   jump +13                (to 52)
+       39   jump +14                (to 53)
        40   load_var 5              (full_name)
        41   load_const 4            ("#")
        42   bin_op +                
        43   store_var 12            (_28)
-       44   load_var 6              (count)
-       45   load_const 5            (1)
-       46   add_int                 
-       47   call 383 ntypeargs=0    (baml.unstable.string)
-       48   store_var 13            (_30)
-       49   load_var2 12 13         
-       50   bin_op +                
-       51   store_var 11            (final_name)
+       44   load_type 5             
+       45   load_var 6              (count)
+       46   load_const 6            (1)
+       47   add_int                 
+       48   call 383 ntypeargs=1    (baml.unstable.string)
+       49   store_var 13            (_30)
+       50   load_var2 12 13         
+       51   bin_op +                
+       52   store_var 11            (final_name)
 
-  46   52   load_var 1              (self)
-       53   load_field 1            (tests)
-       54   load_var2 11 3          
-       55   load_var 4              (runner)
-       56   init_instance 0         (testing.TestRegistration .name, .body, .runner)
-       57   call 15 ntypeargs=0     (baml.Array.push)
-       58   pop 1                   
+  46   53   load_var 1              (self)
+       54   load_field 1            (tests)
+       55   load_var2 11 3          
+       56   load_var 4              (runner)
+       57   init_instance 0         (testing.TestRegistration .name, .body, .runner)
+       58   call 15 ntypeargs=0     (baml.Array.push)
+       59   pop 1                   
 
-  38   59   load_const 6            (null)
-       60   return                  
+  38   60   load_const 7            (null)
+       61   return                  
 
-  42   61   load_var2 8 9           
-       62   load_array_element      
-       63   store_var_load_var 10   (t)
+  42   62   load_var2 8 9           
+       63   load_array_element      
+       64   store_var_load_var 10   (t)
 
-  43   64   load_field 0            (name)
-       65   load_var 5              (full_name)
-       66   cmp_op ==               
-       67   jump_if_false +2        (to 69)
-       68   jump +6                 (to 74)
-       69   pop 1                   
-       70   load_var 10             (t)
-       71   load_field 0            (name)
-       72   load_var 7              (hash_prefix)
-       73   call 141 ntypeargs=0    (baml.String.starts_with)
-       74   pop_jump_if_false +5    (to 79)
-       75   load_var 6              (count)
-       76   load_const 5            (1)
-       77   add_int                 
-       78   store_var 6             (count)
+  43   65   load_field 0            (name)
+       66   load_var 5              (full_name)
+       67   cmp_op ==               
+       68   jump_if_false +2        (to 70)
+       69   jump +6                 (to 75)
+       70   pop 1                   
+       71   load_var 10             (t)
+       72   load_field 0            (name)
+       73   load_var 7              (hash_prefix)
+       74   call 141 ntypeargs=0    (baml.String.starts_with)
+       75   pop_jump_if_false +5    (to 80)
+       76   load_var 6              (count)
+       77   load_const 6            (1)
+       78   add_int                 
+       79   store_var 6             (count)
 
-  42   79   load_var 9              (__for_idx)
-       80   load_const 5            (1)
-       81   add_int                 
-       82   store_var 9             (__for_idx)
-       83   jump -56                (to 27)
+  42   80   load_var 9              (__for_idx)
+       81   load_const 6            (1)
+       82   add_int                 
+       83   store_var 9             (__for_idx)
+       84   jump -57                (to 27)
 }
 
 function testing.TestCollector.register_test_set(self: testing.TestCollector, name: string, collector: (testing.TestCollector) -> void throws unknown, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never)?) -> void {
@@ -380,7 +381,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        28   container_len           
        29   cmp_int_op <            
        30   pop_jump_if_false +2    (to 32)
-       31   jump +30                (to 61)
+       31   jump +31                (to 62)
 
   56   32   load_var 6              (count)
        33   load_const 2            (0)
@@ -389,56 +390,57 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        36   jump +4                 (to 40)
        37   load_var 5              (full_name)
        38   store_var 11            (final_name)
-       39   jump +13                (to 52)
+       39   jump +14                (to 53)
        40   load_var 5              (full_name)
        41   load_const 4            ("#")
        42   bin_op +                
        43   store_var 12            (_28)
-       44   load_var 6              (count)
-       45   load_const 5            (1)
-       46   add_int                 
-       47   call 383 ntypeargs=0    (baml.unstable.string)
-       48   store_var 13            (_30)
-       49   load_var2 12 13         
-       50   bin_op +                
-       51   store_var 11            (final_name)
+       44   load_type 5             
+       45   load_var 6              (count)
+       46   load_const 6            (1)
+       47   add_int                 
+       48   call 383 ntypeargs=1    (baml.unstable.string)
+       49   store_var 13            (_30)
+       50   load_var2 12 13         
+       51   bin_op +                
+       52   store_var 11            (final_name)
 
-  57   52   load_var 1              (self)
-       53   load_field 2            (testsets)
-       54   load_var2 11 3          
-       55   load_var 4              (runner)
-       56   init_instance 0         (testing.TestSetRegistration .name, .collector, .runner)
-       57   call 15 ntypeargs=0     (baml.Array.push)
-       58   pop 1                   
+  57   53   load_var 1              (self)
+       54   load_field 2            (testsets)
+       55   load_var2 11 3          
+       56   load_var 4              (runner)
+       57   init_instance 0         (testing.TestSetRegistration .name, .collector, .runner)
+       58   call 15 ntypeargs=0     (baml.Array.push)
+       59   pop 1                   
 
-  49   59   load_const 6            (null)
-       60   return                  
+  49   60   load_const 7            (null)
+       61   return                  
 
-  53   61   load_var2 8 9           
-       62   load_array_element      
-       63   store_var_load_var 10   (ts)
+  53   62   load_var2 8 9           
+       63   load_array_element      
+       64   store_var_load_var 10   (ts)
 
-  54   64   load_field 0            (name)
-       65   load_var 5              (full_name)
-       66   cmp_op ==               
-       67   jump_if_false +2        (to 69)
-       68   jump +6                 (to 74)
-       69   pop 1                   
-       70   load_var 10             (ts)
-       71   load_field 0            (name)
-       72   load_var 7              (hash_prefix)
-       73   call 141 ntypeargs=0    (baml.String.starts_with)
-       74   pop_jump_if_false +5    (to 79)
-       75   load_var 6              (count)
-       76   load_const 5            (1)
-       77   add_int                 
-       78   store_var 6             (count)
+  54   65   load_field 0            (name)
+       66   load_var 5              (full_name)
+       67   cmp_op ==               
+       68   jump_if_false +2        (to 70)
+       69   jump +6                 (to 75)
+       70   pop 1                   
+       71   load_var 10             (ts)
+       72   load_field 0            (name)
+       73   load_var 7              (hash_prefix)
+       74   call 141 ntypeargs=0    (baml.String.starts_with)
+       75   pop_jump_if_false +5    (to 80)
+       76   load_var 6              (count)
+       77   load_const 6            (1)
+       78   add_int                 
+       79   store_var 6             (count)
 
-  53   79   load_var 9              (__for_idx)
-       80   load_const 5            (1)
-       81   add_int                 
-       82   store_var 9             (__for_idx)
-       83   jump -56                (to 27)
+  53   80   load_var 9              (__for_idx)
+       81   load_const 6            (1)
+       82   add_int                 
+       83   store_var 9             (__for_idx)
+       84   jump -57                (to 27)
 }
 
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -302,7 +302,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        28   container_len           
        29   cmp_int_op <            
        30   pop_jump_if_false +2    (to 32)
-       31   jump +32                (to 63)
+       31   jump +33                (to 64)
 
   45   32   load_var 7              (count)
        33   load_const 2            (0)
@@ -311,58 +311,59 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        36   jump +4                 (to 40)
        37   load_var 6              (full_name)
        38   store_var 12            (final_name)
-       39   jump +13                (to 52)
+       39   jump +14                (to 53)
        40   load_var 6              (full_name)
        41   load_const 4            ("#")
        42   bin_op +                
        43   store_var 13            (_28)
-       44   load_var 7              (count)
-       45   load_const 5            (1)
-       46   add_int                 
-       47   call 383 ntypeargs=0    (baml.unstable.string)
-       48   store_var 14            (_30)
-       49   load_var2 13 14         
-       50   bin_op +                
-       51   store_var 12            (final_name)
+       44   load_type 5             
+       45   load_var 7              (count)
+       46   load_const 6            (1)
+       47   add_int                 
+       48   call 383 ntypeargs=1    (baml.unstable.string)
+       49   store_var 14            (_30)
+       50   load_var2 13 14         
+       51   bin_op +                
+       52   store_var 12            (final_name)
 
-  46   52   load_var 1              (self)
-       53   load_field 1            (tests)
-       54   load_var2 12 3          
-       55   load_var 4              (runner)
-       56   init_instance 0         (testing.TestRegistration .name, .body, .runner)
-       57   call 15 ntypeargs=0     (baml.Array.push)
-       58   pop 1                   
+  46   53   load_var 1              (self)
+       54   load_field 1            (tests)
+       55   load_var2 12 3          
+       56   load_var 4              (runner)
+       57   init_instance 0         (testing.TestRegistration .name, .body, .runner)
+       58   call 15 ntypeargs=0     (baml.Array.push)
+       59   pop 1                   
 
-  38   59   load_const 6            (null)
-       60   store_var 5             (_0)
-       61   load_var 5              (_0)
-       62   return                  
+  38   60   load_const 7            (null)
+       61   store_var 5             (_0)
+       62   load_var 5              (_0)
+       63   return                  
 
-  42   63   load_var2 9 10          
-       64   load_array_element      
-       65   store_var_load_var 11   (t)
+  42   64   load_var2 9 10          
+       65   load_array_element      
+       66   store_var_load_var 11   (t)
 
-  43   66   load_field 0            (name)
-       67   load_var 6              (full_name)
-       68   cmp_op ==               
-       69   jump_if_false +2        (to 71)
-       70   jump +6                 (to 76)
-       71   pop 1                   
-       72   load_var 11             (t)
-       73   load_field 0            (name)
-       74   load_var 8              (hash_prefix)
-       75   call 141 ntypeargs=0    (baml.String.starts_with)
-       76   pop_jump_if_false +5    (to 81)
-       77   load_var 7              (count)
-       78   load_const 5            (1)
-       79   add_int                 
-       80   store_var 7             (count)
+  43   67   load_field 0            (name)
+       68   load_var 6              (full_name)
+       69   cmp_op ==               
+       70   jump_if_false +2        (to 72)
+       71   jump +6                 (to 77)
+       72   pop 1                   
+       73   load_var 11             (t)
+       74   load_field 0            (name)
+       75   load_var 8              (hash_prefix)
+       76   call 141 ntypeargs=0    (baml.String.starts_with)
+       77   pop_jump_if_false +5    (to 82)
+       78   load_var 7              (count)
+       79   load_const 6            (1)
+       80   add_int                 
+       81   store_var 7             (count)
 
-  42   81   load_var 10             (__for_idx)
-       82   load_const 5            (1)
-       83   add_int                 
-       84   store_var 10            (__for_idx)
-       85   jump -58                (to 27)
+  42   82   load_var 10             (__for_idx)
+       83   load_const 6            (1)
+       84   add_int                 
+       85   store_var 10            (__for_idx)
+       86   jump -59                (to 27)
 }
 
 function testing.TestCollector.register_test_set(self: testing.TestCollector, name: string, collector: (testing.TestCollector) -> void throws unknown, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never)?) -> void {
@@ -400,7 +401,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        28   container_len           
        29   cmp_int_op <            
        30   pop_jump_if_false +2    (to 32)
-       31   jump +32                (to 63)
+       31   jump +33                (to 64)
 
   56   32   load_var 7              (count)
        33   load_const 2            (0)
@@ -409,58 +410,59 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        36   jump +4                 (to 40)
        37   load_var 6              (full_name)
        38   store_var 12            (final_name)
-       39   jump +13                (to 52)
+       39   jump +14                (to 53)
        40   load_var 6              (full_name)
        41   load_const 4            ("#")
        42   bin_op +                
        43   store_var 13            (_28)
-       44   load_var 7              (count)
-       45   load_const 5            (1)
-       46   add_int                 
-       47   call 383 ntypeargs=0    (baml.unstable.string)
-       48   store_var 14            (_30)
-       49   load_var2 13 14         
-       50   bin_op +                
-       51   store_var 12            (final_name)
+       44   load_type 5             
+       45   load_var 7              (count)
+       46   load_const 6            (1)
+       47   add_int                 
+       48   call 383 ntypeargs=1    (baml.unstable.string)
+       49   store_var 14            (_30)
+       50   load_var2 13 14         
+       51   bin_op +                
+       52   store_var 12            (final_name)
 
-  57   52   load_var 1              (self)
-       53   load_field 2            (testsets)
-       54   load_var2 12 3          
-       55   load_var 4              (runner)
-       56   init_instance 0         (testing.TestSetRegistration .name, .collector, .runner)
-       57   call 15 ntypeargs=0     (baml.Array.push)
-       58   pop 1                   
+  57   53   load_var 1              (self)
+       54   load_field 2            (testsets)
+       55   load_var2 12 3          
+       56   load_var 4              (runner)
+       57   init_instance 0         (testing.TestSetRegistration .name, .collector, .runner)
+       58   call 15 ntypeargs=0     (baml.Array.push)
+       59   pop 1                   
 
-  49   59   load_const 6            (null)
-       60   store_var 5             (_0)
-       61   load_var 5              (_0)
-       62   return                  
+  49   60   load_const 7            (null)
+       61   store_var 5             (_0)
+       62   load_var 5              (_0)
+       63   return                  
 
-  53   63   load_var2 9 10          
-       64   load_array_element      
-       65   store_var_load_var 11   (ts)
+  53   64   load_var2 9 10          
+       65   load_array_element      
+       66   store_var_load_var 11   (ts)
 
-  54   66   load_field 0            (name)
-       67   load_var 6              (full_name)
-       68   cmp_op ==               
-       69   jump_if_false +2        (to 71)
-       70   jump +6                 (to 76)
-       71   pop 1                   
-       72   load_var 11             (ts)
-       73   load_field 0            (name)
-       74   load_var 8              (hash_prefix)
-       75   call 141 ntypeargs=0    (baml.String.starts_with)
-       76   pop_jump_if_false +5    (to 81)
-       77   load_var 7              (count)
-       78   load_const 5            (1)
-       79   add_int                 
-       80   store_var 7             (count)
+  54   67   load_field 0            (name)
+       68   load_var 6              (full_name)
+       69   cmp_op ==               
+       70   jump_if_false +2        (to 72)
+       71   jump +6                 (to 77)
+       72   pop 1                   
+       73   load_var 11             (ts)
+       74   load_field 0            (name)
+       75   load_var 8              (hash_prefix)
+       76   call 141 ntypeargs=0    (baml.String.starts_with)
+       77   pop_jump_if_false +5    (to 82)
+       78   load_var 7              (count)
+       79   load_const 6            (1)
+       80   add_int                 
+       81   store_var 7             (count)
 
-  53   81   load_var 10             (__for_idx)
-       82   load_const 5            (1)
-       83   add_int                 
-       84   store_var 10            (__for_idx)
-       85   jump -58                (to 27)
+  53   82   load_var 10             (__for_idx)
+       83   load_const 6            (1)
+       84   add_int                 
+       85   store_var 10            (__for_idx)
+       86   jump -59                (to 27)
 }
 
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -325,6 +325,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     load_const "#"
     bin_op +
     store_var _28
+    load_type int
     load_var count
     load_const 1
     add_int
@@ -436,6 +437,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     load_const "#"
     bin_op +
     store_var _28
+    load_type int
     load_var count
     load_const 1
     add_int

--- a/baml_language/tools/speedtest/workloads/compute/generic-apply-inferred-1m.md
+++ b/baml_language/tools/speedtest/workloads/compute/generic-apply-inferred-1m.md
@@ -1,0 +1,34 @@
+# compute::generic apply with inferred type args 1m
+
+Exercises the inferred-generic-call frame seeding (a `LoadType` + wider
+`Call` per iteration): `gapply<T>`'s `T` is inferred at every call site,
+so the caller seeds `frame.type_args = [int]` each time. Guards the cost
+of `call_inferred_type_args` threading against regressions — the rest of
+the compute suite is monomorphic and cannot see it.
+
+## BAML
+```baml
+function gapply<T>(f: (T) -> T, x: T) -> T { f(x) }
+function main() -> int {
+  let double = (x: int) -> int { x * 2 };
+  let s = 0;
+  for (let i = 0; i < 1000000; i += 1) { s += gapply(double, i); };
+  return s;
+}
+```
+
+## Python
+```python
+def gapply(f, x): return f(x)
+double = lambda x: x * 2
+s = 0
+for i in range(1000000): s += gapply(double, i)
+print(s)
+```
+
+## Typescript
+```ts
+function gapply(f,x){return f(x)}
+const double=x=>x*2;let s=0;
+for(let i=0;i<1000000;i++)s+=gapply(double,i);console.log(s)
+```


### PR DESCRIPTION
## What was wrong

A generic call whose type args are **inferred** rather than written ran its callee with `T = unknown`. TIR inferred the bindings, used them to compute the result type, then threw them away; MIR seeded `frame.type_args` from receiver class args ++ **explicit `<...>` args only**. On current canary (`d968182`, verified pre-merge):

| Program | Wrong (canary) | Right (this PR) |
|---|---|---|
| `function tn<T>(a: T[]) -> string { reflect.type_of<T>().to_string() }` — `tn([1,2,3])` | `"unknown"` | `"int"` |
| Same, class static: `Holder.tn([1,2,3])` | `"unknown"` | `"int"` |
| `let it: IterA<int, never> = ArrA.of([1,2,3]); it.collect().length()` (2 implementors) | **0** — wrong implementor runs | **3** |
| `match (ArrBag.make([5,6,7])) { let a: ArrBag<int> => ... }` | falls to `_` arm — instance carries `class_type_args=[unknown]` | matches `ArrBag<int>` |
| `fwd<int>(true \|\| false)` where `fwd<T>(x: bool) -> bool { x }` | **`null`** (pre-existing emitter miscompile, surfaced by this work) | `true` |

The dispatch fallout is the nasty part: instances built by inferred static ctors are born with `class_type_args = [unknown]`, every pinned `is_type C<int>` dispatch guard fails, and the interface-dispatch switch's **last candidate arm is an unguarded else** — so whichever implementor is last in hash order silently runs. That made the bug look "fragile" (renames, extra declarations in the file, or method names flip the arm order and mask it), and it is why #3667's regression suite stayed green: those tests pass by luck of arm order — their instances carry the same broken `[unknown]` args (now pinned by a direct `IsType` regression test that fails without this fix).

## What the fix does

**1. TIR** (`baml_compiler2_tir`): `check_call_inner` records the post-inference bindings per call expr in `call_inferred_type_args` (sorted `Vec<(Name, Ty)>`), plumbed through `ScopeInference` / `DefaultParameterInference` with the same save/restore discipline as `call_plans` (parameter defaults + inline lambda inference).

**2. MIR** (`baml_compiler2_mir`): at the call-lowering merge point, `emit_inferred_call_type_arg_ops` emits those bindings as leading `LoadType` frame args in the callee's De Bruijn order (`callee_frame_generic_params` = owner params ++ fn params, mirroring `enclosing_generic_params`). Conservative gates preserve the status quo when seeding can't be done soundly: explicit `<...>` args, sys-ops (positional Rust glue), function values (no resolution), misaligned receiver prefixes, all-unknown seeds. Bindings nesting a TypeVar **outside** the caller's generic params — a rigid `Self` from a Self-pinned call — are demoted to `unknown`: naive templating lowers them to `void`, which would seed `Self[]` as `void[]` (caught by adversarial review; guarded by `nested_self_inferred_binding_not_voided`).

Also: the path-callee branch no longer prepends a stray `Constant::Null` receiver to **self-less static** methods (`ArrA.of(...)`). The VM's arity-based pop silently tolerated the orphan, but it corrupts the leading type-arg window once calls carry seeds.

**3. EMIT** (`baml_compiler2_emit`): pre-existing `ShortCircuit` miscompile, reproducible on canary without this PR. The emitter assumed the destination local was always stack-carried; when the stack-carry pass rejects the carry (e.g. a `LoadType` operand pushes before the use), the taken path never stored the slot while `eval_rhs` did — a half-applied phi, so `a || b` fed into such a call reads an unwritten local. The taken path now stores whenever the destination is not stack-carried (`&&` via a small trampoline). Bonus: the previously-failing `if_else_assigned_then_passed_to_call` shape now passes.

## Verification

- Clean A/B on the same canary base: all five wrong behaviors above reproduce on `origin/canary` and flip with this PR.
- In-BAML suite **1646/1646**; MIR/codegen/bytecode/format snapshot targets green; workspace Rust tests green; clippy/fmt clean.
- Snapshot churn is exactly the expected categories: `+load_type` seeds at inferred generic call sites, `-const null` stray receivers, store/load pairs where short-circuit carries are now correctly rejected.
- 4 new regression tests in `ns_inferred_generic_type_args` (free-fn reflect, instance `IsType` after inferred ctor, the lazy-iterator collect shape with 2 implementors, nested-`Self` demotion).
- Adversarially reviewed (multi-agent: TIR soundness / MIR De Bruijn alignment / emit fix / blast radius): 2 confirmed findings, both addressed in this PR.

## Known remaining (pre-existing, intentionally out of scope)

- The interface-dispatch switch does not thread a dispatched method's **own** inferred fn-level generics (interface method with its own `<U>` reading `U` at runtime).
- Function **values** (`let f = ArrA.of; f([1])`) stay unseeded — no resolution at the call site.
- The dispatch switch's last candidate arm is still an unguarded else; a guarded-miss panic would be a better failure mode than silent fallthrough if type args ever regress.
- Test-block `let` bindings consumed by a later statement in the block lower to `Constant(Null)` — separate lowering bug discovered during this work.

## Perf note

Every inferred generic call now carries `LoadType` seeds. The existing bench corpus is **monomorphic and cannot observe this path**, so a green bench run is not evidence — this PR adds a `compute/generic-apply-inferred-1m` speedtest workload that exercises it; a release-mode A/B (total cycles + allocs/iter) against canary is the meaningful pre-merge measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generic function and method calls now automatically infer missing type arguments at call sites and properly propagate them to callees at runtime, enabling more flexible generic code without explicit type specifications.

* **Tests**
  * Added comprehensive test coverage for inferred generic type argument dispatch, including interface methods, default methods, and nested generic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->