### PR TITLE
chore: speed up windows builds (use lld)

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -50,6 +50,7 @@ env:
   # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
   # .envrc itself so it stays the single source of truth across CI and local.
   # The R2 credentials .envrc maps to AWS_* for sccache (mapped to AWS_*).
+  # Native Cargo linker overrides live in baml_language/.cargo/config.toml.
   BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
   BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -230,19 +230,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: "Install LLVM tools (llvm-strip)"
-        run: |
-          choco install llvm -y
-          echo 'C:\Program Files\LLVM\bin' >> $GITHUB_PATH
-
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
 
-      - name: "Install sccache and direnv"
+      # Cargo linking uses rust-lld from the Rust toolchain on Windows. The
+      # extra clang tool is installed through mise for llvm-strip, replacing
+      # the previous Chocolatey LLVM install.
+      - name: "Install sccache, direnv, and clang"
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache direnv"
+          install_args: "sccache direnv clang"
 
       - name: "Verify sccache"
         run: sccache --version

--- a/baml_language/.cargo/config.toml
+++ b/baml_language/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,7 @@ java = "temurin-23"
 uv = "0.11.3"
 direnv = "2.37.1"
 sccache = "0.10.0"
+clang = "22.1.7" # LLVM tools for CI, including llvm-strip
 
 # Rust tools
 "cargo:bacon" = "latest"


### PR DESCRIPTION
## Summary

- Add Cargo config for the `baml_language` workspace so Windows MSVC links through Rust's bundled `rust-lld`.
- Leave Linux and macOS on their default platform linkers.
- Track LLVM tooling in `mise.toml` via `clang = "22.1.7"` and install it only in Windows size-gate, where `llvm-strip` replaces the previous Chocolatey LLVM install.

## Validation

- `python3 -c 'import tomllib; [tomllib.load(open(p, "rb")) for p in ("mise.toml", "baml_language/.cargo/config.toml")]; print("toml ok")'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); YAML.load_file(".github/workflows/cargo-tests.reusable.yaml"); YAML.load_file(".github/workflows/size-gate.reusable.yaml"); puts "yaml ok"'`
- `cargo build -p tools_sccache -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build configuration to streamline native compiler toolchain setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->