### PR TITLE
Report `[project]` baml.toml table as `[package]` typo

### DIFF
--- a/baml_language/crates/baml_cli/src/agent_command.rs
+++ b/baml_language/crates/baml_cli/src/agent_command.rs
@@ -257,7 +257,43 @@ fn normalize_direct_skill_references(mut content: String, _spec: SkillSpec) -> S
         content = content.replace(&format!("baml:{}", skill.legacy_name), skill.direct_name);
     }
     content = content.replace("baml:*", "baml-*");
+    content = normalize_baml_toml_package_table(content);
     content
+}
+
+fn normalize_baml_toml_package_table(content: String) -> String {
+    let mut out = String::with_capacity(content.len());
+    let mut recent_context = Vec::new();
+
+    for segment in content.split_inclusive('\n') {
+        let (line, newline) = segment
+            .strip_suffix('\n')
+            .map_or((segment, ""), |line| (line, "\n"));
+        let (line, carriage_return) = line
+            .strip_suffix('\r')
+            .map_or((line, ""), |line| (line, "\r"));
+
+        if line.trim() == "[project]"
+            && recent_context
+                .iter()
+                .rev()
+                .take(6)
+                .any(|line: &String| line.contains("baml.toml"))
+        {
+            out.push_str("[package]");
+            out.push_str(carriage_return);
+            out.push_str(newline);
+        } else {
+            out.push_str(segment);
+        }
+
+        recent_context.push(line.to_string());
+        if recent_context.len() > 6 {
+            recent_context.remove(0);
+        }
+    }
+
+    out
 }
 
 fn split_frontmatter(content: &str) -> Result<(&str, &str)> {
@@ -469,6 +505,18 @@ mod tests {
             .unwrap();
         assert!(core.content.contains("name: baml-core"));
         assert!(!core.content.contains("baml:testing"));
+    }
+
+    #[test]
+    fn skill_baml_toml_template_uses_package_table() {
+        let content = format!(
+            "{}\nCreate `baml.toml`:\n\n```toml\n[project]\nname = \"test\"\nversion = \"0.1.0\"\n```\n",
+            skill("baml-core")
+        );
+
+        let normalized = normalize_direct_skill_references(content, SKILLS[0]);
+        assert!(normalized.contains("[package]\nname = \"test\""));
+        assert!(!normalized.contains("[project]\nname = \"test\""));
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -65,8 +65,10 @@ pub(crate) fn load_project_from_reporting(
 ///    or `baml_src/`. If one is found, load that project exactly as
 ///    [`load_project_from`] would — so running `baml describe` from a
 ///    subdirectory resolves the enclosing project. Manifest validation is
-///    intentionally skipped: introspection doesn't need a valid
-///    `[package].name`, and a malformed manifest shouldn't block it.
+///    intentionally skipped except for the common `[project]` typo:
+///    introspection doesn't need a valid `[package].name`, but when a user
+///    clearly wrote the wrong table header, the actionable diagnostic is
+///    more useful than silently loading a broken project.
 /// 2. If no project marker exists anywhere up the tree, return a **default
 ///    state**: a [`ProjectDatabase`] holding only the BAML stdlib
 ///    (`baml.*`, loaded by `set_project_root` regardless of user files)
@@ -97,10 +99,13 @@ pub(crate) fn load_project_or_default(
 
     match find_project_root(&canonical) {
         // Walk-up: load the ancestor project. Manifest validation is
-        // intentionally skipped (see the docstring on point 1) — unlike the
-        // strict `load_project_from` path, introspection doesn't need a
-        // valid `[package].name`.
-        Some(root) => build_project_db(root, |_| {}),
+        // intentionally skipped except for the known `[project]` typo (see
+        // the docstring on point 1) — unlike the strict `load_project_from`
+        // path, introspection doesn't need a valid `[package].name`.
+        Some(root) => {
+            reject_project_table_without_package(&root.join("baml.toml"))?;
+            build_project_db(root, |_| {})
+        }
         None => {
             let mut db = ProjectDatabase::new();
             db.set_project_root(&canonical);
@@ -201,11 +206,13 @@ pub(crate) fn validate_baml_toml(toml_path: &Path) -> Result<String> {
         .get("package")
         .and_then(|v| v.as_table())
         .ok_or_else(|| {
-            anyhow::anyhow!(
-                "{}: missing `[package]` table.\n\
+            project_table_without_package_error(toml_path, &table).unwrap_or_else(|| {
+                anyhow::anyhow!(
+                    "{}: missing `[package]` table.\n\
              Add:\n\n    [package]\n    name = \"<your-project-name>\"\n",
-                toml_path.display()
-            )
+                    toml_path.display()
+                )
+            })
         })?;
     let name = package
         .get("name")
@@ -220,6 +227,37 @@ pub(crate) fn validate_baml_toml(toml_path: &Path) -> Result<String> {
         anyhow::bail!("{}: `[package].name` cannot be empty.", toml_path.display());
     }
     Ok(name.to_string())
+}
+
+fn reject_project_table_without_package(toml_path: &Path) -> Result<()> {
+    if !toml_path.is_file() {
+        return Ok(());
+    }
+    let Ok(content) = std::fs::read_to_string(toml_path) else {
+        return Ok(());
+    };
+    let Ok(table) = content.parse::<toml::Table>() else {
+        return Ok(());
+    };
+    if let Some(err) = project_table_without_package_error(toml_path, &table) {
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn project_table_without_package_error(
+    toml_path: &Path,
+    table: &toml::Table,
+) -> Option<anyhow::Error> {
+    let has_package_table = table.get("package").is_some_and(|v| v.is_table());
+    let has_project_table = table.get("project").is_some_and(|v| v.is_table());
+    if has_project_table && !has_package_table {
+        return Some(anyhow::anyhow!(
+            "{}: `[project]` is not a recognized table in baml.toml; did you mean `[package]`?",
+            toml_path.display()
+        ));
+    }
+    None
 }
 
 /// Resolve the project's name for output-artifact naming (used by `baml
@@ -327,6 +365,23 @@ mod tests {
         let err = load_project_from(tmp.path()).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("[package]"), "got: {msg}");
+    }
+
+    /// `baml.toml` with `[project]` instead of `[package]` gets the targeted
+    /// typo diagnostic instead of the generic missing-table message.
+    #[test]
+    fn rejects_project_table_with_package_hint() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("baml.toml"),
+            "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let err = load_project_from(tmp.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("[project]"), "got: {msg}");
+        assert!(msg.contains("did you mean `[package]`"), "got: {msg}");
+        assert!(!msg.contains("missing `[package]` table"), "got: {msg}");
     }
 
     /// `baml.toml` with `[package]` but no `name` field → likewise.
@@ -507,6 +562,24 @@ mod tests {
         // ...but the introspection loader still loads the files.
         let (_db, _root, files) = load_project_or_default(tmp.path()).unwrap();
         assert_eq!(files.len(), 1, "got files: {files:?}");
+    }
+
+    /// The lenient `describe`/introspection loader still reports the known
+    /// `[project]` typo, because silently loading it hides the broken manifest.
+    #[test]
+    fn walk_up_reports_project_table_typo() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("baml.toml"),
+            "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("a.baml"), "function main() -> int { 1 }").unwrap();
+
+        let err = load_project_or_default(tmp.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("[project]"), "got: {msg}");
+        assert!(msg.contains("did you mean `[package]`"), "got: {msg}");
     }
 
     /// `baml.toml` + `baml_src/` project layout: only the `baml_src/`

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -350,6 +350,41 @@ fn describe_stdlib_without_baml_toml_succeeds() {
     );
 }
 
+/// `baml describe` should not hide the common `baml.toml` typo where users
+/// write `[project]` (from Python packaging muscle memory) instead of
+/// BAML's `[package]`.
+#[test]
+fn describe_with_project_table_reports_package_hint() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("baml.toml"),
+        "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["describe", "String", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected describe to reject `[project]`, got exit {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("[project]"), "got:\n{stderr}");
+    assert!(
+        stderr.contains("did you mean `[package]`"),
+        "got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("missing `[package]` table"),
+        "got:\n{stderr}"
+    );
+}
+
 /// `baml describe` walks up to an ancestor `baml.toml`, so introspection
 /// from a project subdirectory resolves a user-defined symbol.
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The error

A `baml.toml` copied with a Python-style `[project]` table is not a valid BAML manifest:

```toml
[project]
name = "test"
version = "0.1.0"
```

Before this change, running:

```bash
baml describe String
```

failed with a generic manifest error like:

```text
error: .../baml.toml: missing `[package]` table.
```

That message did not mention that `[project]` was present, so the user/agent had no direct hint that the intended BAML table is `[package]`.

## Root cause

`baml_language/crates/baml_cli/src/project_load.rs::validate_baml_toml` only looked up `table.get("package")` and emitted the generic missing-table diagnostic when it was absent. It did not inspect the parsed TOML for a top-level `[project]` table before producing that fallback.

The read-only/introspection path, `load_project_or_default`, intentionally skips most manifest validation for commands like `baml describe`, so it also needed a narrow check for this known typo to avoid silently loading a project with a broken manifest header.

Separately, `baml_language/crates/baml_cli/src/agent_command.rs::normalize_direct_skill_references` normalized skill names from the external BAML skill archive but did not correct a bad `baml.toml` template if one contains `[project]`.

## The fix

- Added a shared `[project]`-without-`[package]` diagnostic helper in `project_load.rs`:

  ```text
  `[project]` is not a recognized table in baml.toml; did you mean `[package]`?
  ```

- Used that helper in strict manifest validation so `run`/`test`/`generate`/`pack` get the targeted error instead of the generic missing `[package]` message.
- Added the same narrow typo check to `load_project_or_default`, preserving general `describe` leniency while still surfacing this actionable manifest mistake.
- Added context-aware skill content normalization so an installed BAML skill template that mentions `baml.toml` rewrites `[project]` to `[package]` without changing unrelated TOML snippets like `pyproject.toml`.
- Added unit and e2e coverage for the strict loader, the introspection loader, the skill normalization, and the CLI `describe` reproduction.

## Verification

Focused regressions:

```bash
cd baml_language
cargo fmt
cargo test -p baml_cli project_table
```

Output:

```text
running 2 tests
test project_load::tests::rejects_project_table_with_package_hint ... ok
test project_load::tests::walk_up_reports_project_table_typo ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 211 filtered out; finished in 0.00s
```

```bash
cargo test -p baml_cli skill_baml_toml_template_uses_package_table
```

Output:

```text
test agent_command::tests::skill_baml_toml_template_uses_package_table ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 212 filtered out; finished in 0.00s
```

```bash
cargo test -p baml_cli --test exit_code_e2e describe_with_project_table_reports_package_hint
```

Output:

```text
test describe_with_project_table_reports_package_hint ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.30s
```

Required Rust library tests:

```bash
RUSTFLAGS="-L native=/usr/lib/x86_64-linux-gnu -l node" cargo test --lib
```

Output ended with all library test binaries passing, including:

```text
test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Full workspace suite (using the repository's configured nextest setup scripts for SDK fixtures):

```bash
cargo nextest run
```

Output:

```text
Summary [1367.433s] 5635 tests run: 5635 passed (2 slow), 40 skipped
```

Manual reproduction after the change:

```bash
tmp=$(mktemp -d /tmp/baml-project-header.XXXXXX)
printf '[project]\nname = "test"\nversion = "0.1.0"\n' > "$tmp/baml.toml"
BAML_CLI_ALLOW_DIRECT=1 ./target/debug/baml-cli describe String --from "$tmp"
```

Output:

```text
error: /tmp/baml-project-header.f2BM1Y/baml.toml: `[project]` is not a recognized table in baml.toml; did you mean `[package]`?

exit=4
```

## Issue Reference

- [ ] This PR fixes/closes #[issue number]

## Changes

See **The fix** above.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in Linux/Cursor Cloud

## Screenshots

Not applicable.

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

All source changes are scoped to `baml_language/`. The legacy `engine/` directory was not modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be249b34-fa0a-5cc6-8903-0096fbbd8a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be249b34-fa0a-5cc6-8903-0096fbbd8a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

